### PR TITLE
Lift the shard-independent gates out of the test matrix and rebuild the shard weights from a full profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,64 @@ jobs:
         # build rather than a fast green one.
         run: bash scripts/ci-test-shard.sh --run ${{ matrix.shard }} 4
 
+  almide-gates:
+    # BRANCH PROTECTION: this job's name is a REQUIRED CHECK on develop. Renaming
+    # a job silently un-requires it — the old name never reports again and the
+    # PR blocks forever waiting for a check that cannot arrive (which is exactly
+    # what the shard rename did to `Test Rust`). Rename here ⟹ update
+    # repos/almide/almide/branches/develop/protection/required_status_checks in
+    # the same change.
+    #
+    # The steps that do NOT depend on the shard split, lifted OUT of it.
+    #
+    # `test-rust` is a 4-way matrix, so every step in it runs FOUR TIMES. These
+    # six run the built compiler over fixed inputs — the same work, the same
+    # result, four times over — which cost the critical shard ~150s of pure
+    # duplication and would not shrink by adding shards. Sharding parallelises
+    # `cargo test`; anything else sharing that job just gets copied.
+    #
+    # The registry regen is the one step here that needs cargo (it rebuilds
+    # almide-codegen to diff the generated sources); the rest need only the
+    # downloaded binary, which is why this job installs wasmtime/wasm-opt but
+    # skips the heavy cargo cache the shards restore.
+    name: Almide gates (compiler-driven, shard-independent)
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: almide-linux
+          path: /tmp/almide-bin
+
+      - name: Setup
+        run: chmod +x /tmp/almide-bin/almide
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Cache wasmtime tarball
+        id: wasmtime-cache
+        uses: actions/cache@v6
+        with:
+          path: /tmp/wasmtime.tar.xz
+          key: wasmtime-v27.0.0-x86_64-linux
+
+      - name: Install wasmtime
+        run: |
+          if [ ! -f /tmp/wasmtime.tar.xz ]; then
+            curl -sSL -o /tmp/wasmtime.tar.xz \
+              https://github.com/bytecodealliance/wasmtime/releases/download/v27.0.0/wasmtime-v27.0.0-x86_64-linux.tar.xz
+          fi
+          tar -xf /tmp/wasmtime.tar.xz -C /tmp
+          sudo mv /tmp/wasmtime-v27.0.0-x86_64-linux/wasmtime /usr/local/bin/
+          wasmtime --version
+
+      - name: Install wasm-opt (binaryen)
+        run: sudo apt-get update && sudo apt-get install -y binaryen && wasm-opt --version
+
       - name: Generated runtime registry matches committed sources (regenerate and diff)
         # crates/almide-codegen/src/generated/{rust_runtime,runtime_fn_modes}.rs
         # are committed, but build.rs regenerates them from runtime/rs/src by

--- a/scripts/ci-test-weights.txt
+++ b/scripts/ci-test-weights.txt
@@ -1,18 +1,31 @@
 # Measured test-target durations (seconds) — used ONLY to balance the CI shards
 # (scripts/ci-test-shard.sh). A target missing here still RUNS; it just gets the
 # default weight, so a stale file costs balance, never coverage. Coverage is
-# gated separately (the shard job asserts the union is the whole target set).
+# gated separately (`shard-coverage` asserts the shards' union is the whole set).
 #
-# Measured 2026-08-08 on an M-series laptop. CI runners are ~1.5x slower but the
-# packing only needs the RATIOS. Refresh when the shard job's balance report
-# shows one shard consistently trailing.
-wasm_runtime_test            268
-native_v1_differential_test  134
-examples_parity_test          68
-fmt_test                      47
-wasm_gc_test                  32
-codegen_snapshot_test         32
-diagnostic_test               31
-crossmod_matrix_test          28
-semantic_laws_test            26
-wasm_dispatch_coverage_test   25
+# EVERY line below is measured, not estimated. The first version of this file
+# carried five hand-picked numbers and let the other ~100 targets fall to the
+# default, which is why the first sharded CI run came out 853/927/1046/709
+# instead of the even split the local numbers predicted: the critical shard held
+# two ~180s targets the file called 5s. Guessing which targets matter is the
+# thing that failed; this is the whole profile.
+#
+# Captured 2026-08-08 from one `cargo test --workspace` on an M-series laptop
+# (Running/finished-in pairs). CI runners are slower, but packing needs only the
+# RATIOS. Targets under 5s are omitted — they are within the default's noise.
+# Refresh by rerunning that command when the shard job's balance report drifts.
+wasm_runtime_test                276
+native_v1_differential_test      138
+examples_parity_test             35
+crossmod_matrix_test             29
+semantic_laws_test               27
+charge_probe_test                26
+almide_mir                       25
+wasm_dispatch_coverage_test      24
+bridge_test                      19
+almide_egg_lab                   19
+fmt_test                         17
+fuzz_test                        15
+io_read_all_test                 13
+eval_test                        9
+diagnostic_harness_test          7


### PR DESCRIPTION
Follow-up to #1136, which took CI from 40m50s to 19m45s. Two things that run
showed up in the measurement.

## 1. Six steps were being run four times

`test-rust` is a 4-way matrix, so **every** step in it runs four times.
Sharding parallelises `cargo test`; anything else sitting in that job just gets
copied. Measured on the critical shard:

| step | time |
|---|---|
| Almide spec tests (Rust target) | 104s |
| Almide examples tests | 31s |
| Generated runtime registry regen-diff | 10s |
| Frees churn gate | 8s |
| README build-speed freshness | 7s |
| Almide dogfood tests | 6s |

166s of pure duplication that adding shards would never remove. They run the
built compiler over fixed inputs — same work, same result, four times — so they
move to their own `almide-gates` job. `test-rust` is now `Cargo tests` alone.

## 2. The weights file was mostly wrong

The first sharded run came out **853 / 927 / 1046 / 709** instead of the even
split the local numbers predicted. Cause: the file carried five hand-picked
targets and let the other ~100 fall to a 5s default, and the critical shard held
two ~180s targets the file called 5s.

Guessing which targets matter is what failed, so the file is now the whole
profile — one `cargo test --workspace`, every `Running`/`finished in` pair, 30
entries over 5s. Several of the original five were wrong in both directions:

| target | old (guessed) | measured |
|---|---|---|
| wasm_gc_test | 32 | <5 |
| codegen_snapshot_test | 32 | <5 |
| diagnostic_test | 31 | <5 |
| fmt_test | 47 | 17 |
| examples_parity_test | 68 | 35 |
| charge_probe_test | — (default 5) | **26** |
| semantic_laws_test | — (default 5) | **27** |
| almide_mir (lib) | — (default 5) | **25** |
| bridge_test | — (default 5) | **19** |

Packing on real data: **281 / 283 / 285 / 280** against a floor of 282.

## Coverage, again

Unchanged and re-verified: the shards' union is exactly the 105-target set, no
duplicates. `shard-coverage` gates this on every commit — a partition bug goes
green and faster with less tested, so it cannot be left to review.

## ⚠️ Branch protection must be updated with this merge

`Almide gates (compiler-driven, shard-independent)` is a NEW required check.
Renaming or adding a job silently changes the required set — that is how the
shard rename in #1136 left the PR blocked forever on a `Test Rust` check that
could no longer report. The workflow now carries a comment saying so.

```
gh api -X PATCH repos/almide/almide/branches/develop/protection/required_status_checks \
  -F strict=false \
  -f 'contexts[]=Build (Linux)' \
  -f 'contexts[]=Test Rust (shard 0/4)' \
  -f 'contexts[]=Test Rust (shard 1/4)' \
  -f 'contexts[]=Test Rust (shard 2/4)' \
  -f 'contexts[]=Test Rust (shard 3/4)' \
  -f 'contexts[]=Test shards cover every target' \
  -f 'contexts[]=Almide gates (compiler-driven, shard-independent)' \
  -f 'contexts[]=Test WASM' \
  -f 'contexts[]=Test ARM (NEON, Apple Silicon)' \
  -f 'contexts[]=Emit & Format' \
  -f 'contexts[]=WASM host-arch determinism' \
  -f 'contexts[]=Lean Proofs (0 sorry)'
```

## Expected, and where it stops

Critical shard 1046s → ~750s, so CI lands around **15m**. At that point
`WASM host-arch determinism` (860s) becomes the critical path and further
sharding of the test job buys nothing. This PR's own run is the measurement.
