### PR TITLE
Parse brackets after an uppercase binding as index access unless a type application follows (#1142)

### DIFF
--- a/crates/almide-syntax/src/parser/primary.rs
+++ b/crates/almide-syntax/src/parser/primary.rs
@@ -301,19 +301,22 @@ impl Parser {
         let name = sym(&tok.value);
         self.advance();
 
-        if self.check(TokenType::LBracket) {
+        // `Name[...]` is a type application ONLY when the brackets name a type
+        // and a call follows (`Pair[Int, String](a, b)`). Uppercase VALUE
+        // bindings are house style (`let STATIONS = [...]`), so `STATIONS[i]`
+        // must stay an index: fall through to the bare TypeName and let the
+        // postfix loop read the brackets, with the same gate the postfix
+        // position already uses for `fs[0]()` (#1142).
+        if self.check(TokenType::LBracket) && self.peek_type_args_call() {
             let ta = self.parse_type_args()?;
-            if self.check(TokenType::LParen) {
-                let open_call = self.current().clone();
-                self.advance();
-                let (args, named_args) = self.parse_call_args()?;
-                self.expect_closing(TokenType::RParen, open_call.line, open_call.col, "constructor call")?;
-                return Ok(Expr::new(self.next_id(), span, ExprKind::Call {
-                    callee: Box::new(Expr::new(self.next_id(), span, ExprKind::TypeName { name })),
-                    args, named_args, type_args: Some(ta),
-                }));
-            }
-            return Ok(Expr::new(self.next_id(), span, ExprKind::TypeName { name }));
+            let open_call = self.current().clone();
+            self.advance();
+            let (args, named_args) = self.parse_call_args()?;
+            self.expect_closing(TokenType::RParen, open_call.line, open_call.col, "constructor call")?;
+            return Ok(Expr::new(self.next_id(), span, ExprKind::Call {
+                callee: Box::new(Expr::new(self.next_id(), span, ExprKind::TypeName { name })),
+                args, named_args, type_args: Some(ta),
+            }));
         }
         if self.check(TokenType::LParen) {
             let open_call = self.current().clone();

--- a/spec/lang/uppercase_index_test.almd
+++ b/spec/lang/uppercase_index_test.almd
@@ -1,0 +1,35 @@
+// uppercase_index_test — indexing an uppercase (SCREAMING_CASE) binding (#1142).
+// `STATIONS[i]` must parse as index access, not generic type application:
+// `Name[...]` is a type application only when the brackets name a type AND a
+// call follows (`parse[Int](s)`), same gate the postfix position uses for
+// `fs[0]()`.
+let STATIONS = ["Abha", "Accra", "Adelaide"]
+
+let WEIGHTS = [10, 20, 30]
+
+test "index an uppercase binding with a variable" {
+  let i = 1
+  assert_eq(STATIONS[i], "Accra")
+}
+
+test "index an uppercase binding with a computed expression" {
+  let seed = 42
+  let n = list.len(STATIONS)
+  assert_eq(STATIONS[seed % n], "Abha")
+}
+
+test "uppercase index result feeds arithmetic" {
+  let j = 2
+  // Bound first: an `assert_eq(a[i] + b[j], lit)` condition (Int-Eq over a
+  // BinOp vs literal with a call-bearing arm) has no v1 branch brick yet.
+  let sum = WEIGHTS[j] + WEIGHTS[0]
+  assert_eq(sum, 40)
+}
+
+test "uppercase binding indexed inside a loop" {
+  var total = 0
+  for k in 0..<list.len(WEIGHTS) {
+    total = total + WEIGHTS[k]
+  }
+  assert_eq(total, 60)
+}


### PR DESCRIPTION
Fixes #1142.

## What

`STATIONS[seed % n]` failed to parse: in expression position the parser committed to generic type application on any `TypeName [`, then died on the first non-type token with an inverted hint ("Type names must start with an uppercase letter" — pointing at the index variable).

The primary position now uses the same gate the postfix position already uses for `fs[0]()` (`peek_type_args_call`): `Name[...]` is read as a type application ONLY when the brackets actually name a type AND a call follows (`Pair[Int, String](a, b)`). Otherwise the bare `TypeName` falls through and the postfix loop reads the brackets as ordinary index access.

This also removes the silent-drop branch: `Type[Args]` NOT followed by `(` used to consume and discard the bracketed args entirely.

## Why this shape

- `SCREAMING_CASE` value bindings are house style (`fasta.almd`'s `ALU`/`IM`), and `CONSTANTS[i]` is the universal idiom every LLM carries in — the misparse was a direct writability mine with an actively misleading diagnostic.
- The corpus has zero uses of a bare `Type[Args]` expression (grep over spec/, stdlib/, exercises/), and `Box[Int] { ... }` generic record construction was already broken before this change (fails identically on the released binary), so no supported form changes meaning.

## Verification

- New `spec/lang/uppercase_index_test.almd` (4 tests: variable index, computed index, arithmetic feed, loop) — fails to parse on the released binary, green here (A/B).
- `cargo test --workspace --release` green; full `almide test` 361/361 files green.
- Ctor-with-type-args forms (`parse[Int](s)` shape) still parse via the `peek_type_args_call` gate.
- codopsy on almide-syntax: 95 → 97 (A maintained).