### PR TITLE
Borrow the captured cell in place for statement-proven-safe closure reads (#1143)

### DIFF
--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -31,6 +31,7 @@ pub mod pass_borrow_inference;
 pub mod pass_box_deref;
 pub mod pass_builtin_lowering;
 pub mod pass_capture_clone;
+pub mod pass_shared_cell_borrow;
 pub mod pass_clone;
 pub mod pass_top_let_storage;
 pub mod pass_fan_lowering;

--- a/crates/almide-codegen/src/pass_shared_cell_borrow.rs
+++ b/crates/almide-codegen/src/pass_shared_cell_borrow.rs
@@ -1,0 +1,353 @@
+//! SharedCellBorrowPass (#1143): borrow a captured cell's value in place for
+//! reads a statement proves safe, instead of `.get()`-cloning it per read.
+//!
+//! A closure-captured mutable heap local (`var stats: Map[...]` used from a
+//! lambda) lowers to a `SharedMut` cell (`Rc<RefCell<T>>`). A READ of it in
+//! borrow position emitted `&cap.get()` — a deep clone of the whole value
+//! per read, which made every `map.get` through a closure clone the Map
+//! (~5x on the onebrc aggregation loop). A mutating access already writes
+//! in place (`&mut *cap.borrow_mut()`); this pass lets the safe reads do
+//! the same (`&*cap.borrow()`).
+//!
+//! MARKER, not a schema change: a qualifying read `Borrow { Var v }` is
+//! rewritten to `Borrow { Deref { Var v } }` — a shape that cannot
+//! otherwise occur on a `SharedMut` var (the cell type has no `Deref`
+//! impl, so the generic `&*v` render would not compile) — and the walker's
+//! borrow renderer turns exactly that shape into `&*v.borrow()`. Unmarked
+//! reads keep the owned `.get()` snapshot.
+//!
+//! Safety argument — a marked statement cannot RefCell-panic:
+//! - marking requires EVERY use of the var in the statement's subtree to be
+//!   a shared, non-mutable `Borrow` in direct call-argument position; the
+//!   resulting guards are all shared borrows of the same cell, `RefCell`
+//!   admits any number of overlapping shared borrows, and every guard dies
+//!   at the statement's semicolon.
+//! - the statement's subtree must contain no lambda literal, no
+//!   computed-callee call, no `for`/`while`, no `match` with a non-Var
+//!   subject, and no pre-rendered code — the shapes under which a closure
+//!   aliasing the same cell could run (and take a mut borrow) while a
+//!   guard is live, or whose temporary-lifetime extension keeps a guard
+//!   alive into arm/body code. Named user fns cannot hold the cell:
+//!   `SharedMut` exists only as a closure-capture representation, and a
+//!   nested statement (its own semicolon scope) is still visited and
+//!   marked independently.
+//! - a `match f(read) { .. }` whose SUBJECT holds the reads is first
+//!   hoisted to `{ let s = f(read); match s { .. } }`: the bind ends the
+//!   guard before the arms run, and the bind statement then qualifies on
+//!   its own.
+//!
+//! v0/Rust-target only: the v1 MIR path has its own ownership model, and
+//! the interpreter consumes the pre-codegen IR — neither sees this marker.
+
+use std::collections::HashSet;
+use almide_ir::*;
+use almide_ir::visit::{walk_expr, walk_stmt, IrVisitor};
+use almide_ir::visit_mut::{walk_expr_mut, walk_stmt_mut, IrMutVisitor};
+use almide_base::intern::sym;
+use super::pass::{NanoPass, PassResult, Target};
+
+#[derive(Debug)]
+pub struct SharedCellBorrowPass;
+
+impl NanoPass for SharedCellBorrowPass {
+    fn name(&self) -> &str { "SharedCellBorrow" }
+
+    fn targets(&self) -> Option<Vec<Target>> {
+        Some(vec![Target::Rust])
+    }
+
+    fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
+        let cells: HashSet<VarId> = program
+            .codegen_annotations
+            .shared_mut_vars
+            .iter()
+            .filter(|v| {
+                let ty = &program.var_table.get(**v).ty;
+                // Copy cells stay on the cheap `Cell.get()` path; String cells
+                // stay on `.get()` because their borrow sites may need `&str`
+                // (`as_str`), which `&*cell.borrow()` does not produce.
+                !top_let_storage::capture_copy_cell(ty)
+                    && !matches!(ty, almide_lang::types::Ty::String)
+            })
+            .copied()
+            .collect();
+        if cells.is_empty() {
+            return PassResult { program, changed: false };
+        }
+        let mut changed = false;
+        let mut fns = std::mem::take(&mut program.functions);
+        for f in fns.iter_mut() {
+            // Fn-local truth: `optimize/branch_lift.rs` helpers KEEP the
+            // captured free vars' ids as their params, where the binding is
+            // a plain snapshot, not a cell — never mark those.
+            let fn_cells: HashSet<VarId> = cells
+                .iter()
+                .filter(|v| !f.params.iter().any(|p| p.var == **v))
+                .copied()
+                .collect();
+            if fn_cells.is_empty() {
+                continue;
+            }
+            let body = std::mem::take(&mut f.body);
+            f.body = hoist_match_subjects(body, &fn_cells, &mut program.var_table, &mut changed);
+            let mut scopes = ScopeWalker { cells: &fn_cells, changed: &mut changed };
+            scopes.visit_expr_mut(&mut f.body);
+        }
+        program.functions = fns;
+        PassResult { program, changed }
+    }
+}
+
+// ── Step 1: hoist match subjects that hold cell reads ────────────────────
+
+/// `match f(&cell) { arms }` extends the subject's temporaries across the
+/// arms, so a borrow guard in the subject would overlap the arms'
+/// `borrow_mut`. Rewrite to `{ let __scb = f(&cell); match __scb { arms } }`
+/// — the guard ends at the bind, and the bind statement can then qualify
+/// for the borrow marking on its own.
+fn hoist_match_subjects(
+    expr: IrExpr,
+    cells: &HashSet<VarId>,
+    vt: &mut VarTable,
+    changed: &mut bool,
+) -> IrExpr {
+    let rebuilt = expr.map_children(&mut |c| hoist_match_subjects(c, cells, vt, changed));
+    let needs_hoist = matches!(
+        &rebuilt.kind,
+        IrExprKind::Match { subject, .. }
+            if !matches!(subject.kind, IrExprKind::Var { .. })
+                && touches_any(subject, cells)
+    );
+    if !needs_hoist {
+        return rebuilt;
+    }
+    let IrExpr { kind: IrExprKind::Match { subject, arms }, ty, span, def_id } = rebuilt else {
+        unreachable!("needs_hoist checked the Match shape")
+    };
+    let subj_ty = subject.ty.clone();
+    let v = vt.alloc(sym("__scb_subj"), subj_ty.clone(), Mutability::Let, span);
+    let bind = IrStmt {
+        kind: IrStmtKind::Bind { var: v, mutability: Mutability::Let, ty: subj_ty.clone(), value: *subject },
+        span,
+    };
+    let subj_var = IrExpr { kind: IrExprKind::Var { id: v }, ty: subj_ty, span, def_id: None };
+    let hoisted = IrExpr {
+        kind: IrExprKind::Match { subject: Box::new(subj_var), arms },
+        ty: ty.clone(),
+        span,
+        def_id,
+    };
+    *changed = true;
+    IrExpr {
+        kind: IrExprKind::Block { stmts: vec![bind], expr: Some(Box::new(hoisted)) },
+        ty,
+        span,
+        def_id: None,
+    }
+}
+
+/// Does the subtree contain a `Var` naming any of the cell vars?
+fn touches_any(expr: &IrExpr, cells: &HashSet<VarId>) -> bool {
+    struct Touch<'a> {
+        cells: &'a HashSet<VarId>,
+        found: bool,
+    }
+    impl IrVisitor for Touch<'_> {
+        fn visit_expr(&mut self, e: &IrExpr) {
+            if self.found {
+                return;
+            }
+            if let IrExprKind::Var { id } = &e.kind {
+                if self.cells.contains(id) {
+                    self.found = true;
+                    return;
+                }
+            }
+            walk_expr(self, e);
+        }
+    }
+    let mut t = Touch { cells, found: false };
+    t.visit_expr(expr);
+    t.found
+}
+
+// ── Step 2: per-statement analysis + marking ─────────────────────────────
+
+/// Visits every statement in the body (any nesting level — lambda bodies,
+/// loop bodies, match arms) and tries to mark its cell reads.
+struct ScopeWalker<'a> {
+    cells: &'a HashSet<VarId>,
+    changed: &'a mut bool,
+}
+
+impl IrMutVisitor for ScopeWalker<'_> {
+    fn visit_stmt_mut(&mut self, stmt: &mut IrStmt) {
+        try_mark_stmt(stmt, self.cells, self.changed);
+        walk_stmt_mut(self, stmt);
+    }
+}
+
+/// The per-statement decision: reject on any hard-to-reason shape in the
+/// subtree, then, per cell var, require every use to be a shared borrow in
+/// direct call-arg position before rewriting those reads to the marker.
+fn try_mark_stmt(stmt: &mut IrStmt, cells: &HashSet<VarId>, changed: &mut bool) {
+    if stmt_has_disqualifying_shape(stmt) {
+        return;
+    }
+    for v in cells {
+        if stmt_writes_var(stmt, *v) {
+            continue;
+        }
+        let uses = count_uses(stmt, *v);
+        if uses.total > 0 && uses.good == uses.total {
+            let mut m = MarkReads { v: *v, changed };
+            m.visit_stmt_mut(stmt);
+        }
+    }
+}
+
+/// Shapes this pass refuses to reason about within one statement scope.
+fn stmt_has_disqualifying_shape(stmt: &IrStmt) -> bool {
+    struct Scan {
+        disq: bool,
+    }
+    impl IrVisitor for Scan {
+        fn visit_expr(&mut self, e: &IrExpr) {
+            if self.disq {
+                return;
+            }
+            if matches!(
+                &e.kind,
+                IrExprKind::Lambda { .. }
+                    | IrExprKind::ForIn { .. }
+                    | IrExprKind::While { .. }
+                    | IrExprKind::RenderedCall { .. }
+            ) {
+                self.disq = true;
+                return;
+            }
+            if let IrExprKind::Call { target: CallTarget::Computed { .. }, .. } = &e.kind {
+                self.disq = true;
+                return;
+            }
+            if let IrExprKind::Match { subject, .. } = &e.kind {
+                if !matches!(subject.kind, IrExprKind::Var { .. }) {
+                    self.disq = true;
+                    return;
+                }
+            }
+            walk_expr(self, e);
+        }
+    }
+    let mut s = Scan { disq: false };
+    s.visit_stmt(stmt);
+    s.disq
+}
+
+/// Statement-kind write targets are VarIds, invisible to the expr walk.
+fn stmt_writes_var(stmt: &IrStmt, v: VarId) -> bool {
+    if let IrStmtKind::Assign { var, .. } = &stmt.kind {
+        return *var == v;
+    }
+    if let IrStmtKind::Bind { var, .. } = &stmt.kind {
+        return *var == v;
+    }
+    if let IrStmtKind::IndexAssign { target, .. } = &stmt.kind {
+        return *target == v;
+    }
+    if let IrStmtKind::MapInsert { target, .. } = &stmt.kind {
+        return *target == v;
+    }
+    if let IrStmtKind::FieldAssign { target, .. } = &stmt.kind {
+        return *target == v;
+    }
+    false
+}
+
+struct Uses {
+    total: usize,
+    good: usize,
+}
+
+/// `total` counts every `Var v` node; `good` counts the ones sitting in the
+/// exact safe shape (a shared `Borrow` that is a direct call argument).
+/// Each good argument contains exactly one `Var v` node, so
+/// `good == total` means no use escapes the safe shape.
+fn count_uses(stmt: &IrStmt, v: VarId) -> Uses {
+    struct Count {
+        v: VarId,
+        total: usize,
+        good: usize,
+    }
+    impl Count {
+        fn scan_args(&mut self, args: &[IrExpr]) {
+            for a in args {
+                if is_shared_cell_read(a, self.v) {
+                    self.good += 1;
+                }
+            }
+        }
+    }
+    impl IrVisitor for Count {
+        fn visit_expr(&mut self, e: &IrExpr) {
+            if let IrExprKind::Var { id } = &e.kind {
+                if *id == self.v {
+                    self.total += 1;
+                }
+            }
+            if let IrExprKind::Call { args, .. } = &e.kind {
+                self.scan_args(args);
+            } else if let IrExprKind::RuntimeCall { args, .. } = &e.kind {
+                self.scan_args(args);
+            } else if let IrExprKind::TailCall { args, .. } = &e.kind {
+                self.scan_args(args);
+            }
+            walk_expr(self, e);
+        }
+    }
+    let mut c = Count { v, total: 0, good: 0 };
+    c.visit_stmt(stmt);
+    Uses { total: c.total, good: c.good }
+}
+
+/// `&v` (shared, not `&mut`) directly on the cell var — or the already
+/// marked `&*v` form from an enclosing scope's earlier visit.
+fn is_shared_cell_read(arg: &IrExpr, v: VarId) -> bool {
+    let IrExprKind::Borrow { expr: inner, mutable: false, .. } = &arg.kind else {
+        return false;
+    };
+    if matches!(&inner.kind, IrExprKind::Var { id } if *id == v) {
+        return true;
+    }
+    if let IrExprKind::Deref { expr: dinner } = &inner.kind {
+        return matches!(&dinner.kind, IrExprKind::Var { id } if *id == v);
+    }
+    false
+}
+
+/// Rewrite every shared `Borrow { Var v }` in the statement into the
+/// `Borrow { Deref { Var v } }` marker. Only run when the statement
+/// qualified, so every such site is a shared call-arg read.
+struct MarkReads<'a> {
+    v: VarId,
+    changed: &'a mut bool,
+}
+
+impl IrMutVisitor for MarkReads<'_> {
+    fn visit_expr_mut(&mut self, expr: &mut IrExpr) {
+        if let IrExprKind::Borrow { expr: inner, mutable: false, .. } = &mut expr.kind {
+            if matches!(&inner.kind, IrExprKind::Var { id } if *id == self.v) {
+                let var_expr = std::mem::take(inner.as_mut());
+                **inner = IrExpr {
+                    ty: var_expr.ty.clone(),
+                    span: var_expr.span,
+                    def_id: None,
+                    kind: IrExprKind::Deref { expr: Box::new(var_expr) },
+                };
+                *self.changed = true;
+                return;
+            }
+        }
+        walk_expr_mut(self, expr);
+    }
+}

--- a/crates/almide-codegen/src/target.rs
+++ b/crates/almide-codegen/src/target.rs
@@ -15,6 +15,7 @@ use super::pass::{
 use super::pass_auto_parallel::AutoParallelPass;
 use super::pass_box_deref::BoxDerefPass;
 use super::pass_capture_clone::CaptureClonePass;
+use super::pass_shared_cell_borrow::SharedCellBorrowPass;
 use super::pass_clone::CloneInsertionPass;
 use super::pass_builtin_lowering::BuiltinLoweringPass;
 use super::pass_result_propagation::ResultPropagationPass;
@@ -150,6 +151,11 @@ fn build_pipeline(target: Target) -> Pipeline {
                 .add(NormalizeRuntimeCallsPass)
                 // Final: flatten modules into root (after UnifyVarTables)
                 .add(IrLinkFlattenPass)
+                // Borrow captured cells in place for statement-proven-safe
+                // reads (#1143). Runs after flatten (all fns in root) and
+                // after every Borrow-shaping pass, so it sees final call
+                // and borrow forms.
+                .add(SharedCellBorrowPass)
                 // §4 Stage 1: compute the unified top-let storage attribute
                 // at pipeline end (VarIds final, modules flattened); the
                 // walker asserts every legacy predicate agrees with it.

--- a/crates/almide-codegen/src/walker/expressions_control.rs
+++ b/crates/almide-codegen/src/walker/expressions_control.rs
@@ -60,7 +60,9 @@ fn render_expr_var(ctx: &RenderContext, expr: &IrExpr) -> String {
     let IrExprKind::Var { id } = &expr.kind else { unreachable!() };
     let raw_name = ctx.var_name(*id).to_string();
     // Shared-mut local (`Rc<Cell<T>>`): read the cell. (Closure v2, P3.)
-    if ctx.ann.is_shared_mut(id) {
+    // Fn-local truth first: a branch-lift helper's param KEEPS the captured
+    // var's id, and there the binding is a plain snapshot, not a cell (#1143).
+    if ctx.ann.is_shared_mut(id) && !ctx.param_vars.contains(id) {
         return format!("{}.get()", raw_name);
     }
     // §4 Stage 2: a module global is decided by ONE alias-resolved
@@ -551,8 +553,27 @@ fn render_expr_clone(ctx: &RenderContext, expr: &IrExpr) -> String {
 /// Extracted from `render_expr_borrow` (cog>30 decomposition): `Some`
 /// mirrors the original's early `return`, `None` falls through.
 fn try_render_borrow_shared_mut(ctx: &RenderContext, inner: &IrExpr, mutable: bool) -> Option<String> {
+    // #1143 marker: `Borrow(Deref(Var cell))` — SharedCellBorrowPass proved
+    // this read can borrow the cell in place (every use in its statement is
+    // a shared call-arg read), so skip the `.get()` whole-value clone. The
+    // shape cannot occur otherwise on a SharedMut var (the cell has no
+    // Deref impl, so the generic `&*v` render would not compile).
+    if let IrExprKind::Deref { expr: dinner } = &inner.kind {
+        if let IrExprKind::Var { id } = &dinner.kind {
+            if !mutable
+                && ctx.ann.is_shared_mut(id)
+                && !ctx.param_vars.contains(id)
+                && !almide_ir::top_let_storage::capture_copy_cell(&ctx.var_table.get(*id).ty)
+            {
+                return Some(format!("&*{}.borrow()", ctx.var_name(*id)));
+            }
+        }
+    }
     let IrExprKind::Var { id } = &inner.kind else { return None; };
     if !ctx.ann.is_shared_mut(id) { return None; }
+    // A branch-lift helper's param keeps the captured var's id but binds a
+    // plain snapshot, not the cell — fn-local truth wins (#1143).
+    if ctx.param_vars.contains(id) { return None; }
     if almide_ir::top_let_storage::capture_copy_cell(&ctx.var_table.get(*id).ty) { return None; }
     let var_name = ctx.var_name(*id).to_string();
     Some(if mutable {

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -95,6 +95,12 @@ pub struct RenderContext<'a> {
     /// `RefMut` param into another `RefMut` callee slot (Rust
     /// auto-reborrows).
     pub ref_mut_params: std::collections::HashSet<VarId>,
+    /// ALL param VarIds of the current fn. Fn-local truth that beats the
+    /// VarId-keyed `shared_mut_vars` annotation: `optimize/branch_lift.rs`
+    /// synthesizes helpers whose params KEEP the captured free vars' ids,
+    /// so a closure-cell var can reappear as a plain snapshot param — a
+    /// cell read (`.get()`/`.borrow()`) on it is a miscompile (#1143).
+    pub param_vars: std::collections::HashSet<VarId>,
     /// Names of user-defined record/variant types that have a generated
     /// `AlmideRepr` impl (see `render_repr_impl`). A `Ty::Named` in a compound
     /// interpolation part routes through `almide_repr` only when it is in this
@@ -111,7 +117,7 @@ pub struct RenderContext<'a> {
 
 impl<'a> RenderContext<'a> {
     pub fn new(templates: &'a TemplateSet, var_table: &'a VarTable) -> Self {
-        Self { templates, var_table, indent: 0, target: Target::Rust, auto_unwrap: false, is_test: false, ann: CodegenAnnotations::default(), type_aliases: std::collections::HashMap::new(), generic_types: std::collections::HashSet::new(), minimal_generic_bounds: false, repr_c: false, ref_params: std::collections::HashSet::new(), ref_mut_params: std::collections::HashSet::new(), repr_named_types: std::collections::HashSet::new(), fn_err_ty: None }
+        Self { templates, var_table, indent: 0, target: Target::Rust, auto_unwrap: false, is_test: false, ann: CodegenAnnotations::default(), type_aliases: std::collections::HashMap::new(), generic_types: std::collections::HashSet::new(), minimal_generic_bounds: false, repr_c: false, ref_params: std::collections::HashSet::new(), ref_mut_params: std::collections::HashSet::new(), param_vars: std::collections::HashSet::new(), repr_named_types: std::collections::HashSet::new(), fn_err_ty: None }
     }
 
     pub fn with_target(mut self, target: Target) -> Self {
@@ -480,6 +486,7 @@ fn fn_render_context<'a>(
         repr_c: ctx.repr_c,
         ref_params,
         ref_mut_params,
+        param_vars: func.params.iter().map(|p| p.var).collect(),
         repr_named_types: ctx.repr_named_types.clone(),
         fn_err_ty,
     }

--- a/crates/almide-codegen/src/walker/program_render.rs
+++ b/crates/almide-codegen/src/walker/program_render.rs
@@ -225,6 +225,7 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
         minimal_generic_bounds: false,
         repr_c: ctx.repr_c,
         ref_params: std::collections::HashSet::new(),
+        param_vars: std::collections::HashSet::new(),
         ref_mut_params: std::collections::HashSet::new(),
         repr_named_types,
         fn_err_ty: None,

--- a/spec/lang/closure_capture_map_test.almd
+++ b/spec/lang/closure_capture_map_test.almd
@@ -1,0 +1,55 @@
+// closure_capture_map_test — a captured `var` Map read through a closure
+// (#1143). The shared-cell READ borrows in place when its statement proves
+// safe (SharedCellBorrowPass); a statement that also mutates the cell keeps
+// the owned snapshot. These pin the RefCell discipline at runtime: any
+// double-borrow regression panics here.
+test "closure bumps a captured map counter" {
+  var stats: Map[String, Int] = map.new()
+  let bump = (k: String) => {
+    let cur = map.get(stats, k) ?? 0
+    map.insert(stats, k, cur + 1)
+  }
+  bump("a")
+  bump("a")
+  bump("b")
+  assert_eq(map.get(stats, "a") ?? -1, 2)
+  assert_eq(map.get(stats, "b") ?? -1, 1)
+}
+
+test "closure reads and writes the cell in one statement" {
+  var m: Map[String, Int] = map.new()
+  map.insert(m, "seed", 5)
+  let bump = (k: String) => {
+    map.insert(m, k, (map.get(m, "seed") ?? 0) + 1)
+  }
+  bump("a")
+  bump("b")
+  assert_eq(map.get(m, "a") ?? -1, 6)
+  assert_eq(map.get(m, "b") ?? -1, 6)
+}
+
+type Acc = { sum: Int, count: Int }
+
+test "closure folds records through a captured map via match" {
+  var stats: Map[String, Acc] = map.new()
+  let feed = (k: String, t: Int) => {
+    match map.get(stats, k) {
+      some(s) => map.insert(stats, k, Acc { sum: s.sum + t, count: s.count + 1 }),
+      none => map.insert(stats, k, Acc { sum: t, count: 1 }),
+    }
+  }
+  feed("x", 10)
+  feed("x", 20)
+  feed("y", 7)
+  let x = match map.get(stats, "x") {
+    some(s) => s,
+    none => Acc { sum: -1, count: -1 },
+  }
+  assert_eq(x.sum, 30)
+  assert_eq(x.count, 2)
+  let y = match map.get(stats, "y") {
+    some(s) => s,
+    none => Acc { sum: -1, count: -1 },
+  }
+  assert_eq(y.sum, 7)
+}

--- a/tests/shared_cell_borrow_test.rs
+++ b/tests/shared_cell_borrow_test.rs
@@ -1,0 +1,128 @@
+/// SharedCellBorrowPass emission pins (#1143): a closure-captured Map read
+/// borrows the cell in place when its statement proves safe, keeps the
+/// owned `.get()` snapshot when it does not, and a branch-lift helper's
+/// snapshot param is never treated as a cell.
+
+use almide::lexer::Lexer;
+use almide::parser::Parser;
+use almide::canonicalize;
+use almide::check::Checker;
+use almide::lower::lower_program;
+use almide::codegen::{self, pass::Target, CodegenOutput};
+
+fn compile_to_rust(src: &str) -> String {
+    let tokens = Lexer::tokenize(src);
+    let mut parser = Parser::new(tokens);
+    let mut prog = parser.parse().expect("parse failed");
+    let canon = canonicalize::canonicalize_program(&prog, std::iter::empty());
+    let mut checker = Checker::from_env(canon.env);
+    checker.diagnostics = canon.diagnostics;
+    let diags = checker.infer_program(&mut prog);
+    let errors: Vec<_> = diags.iter().filter(|d| d.level == almide::diagnostic::Level::Error).collect();
+    assert!(errors.is_empty(), "Type errors: {:?}", errors.iter().map(|e| &e.message).collect::<Vec<_>>());
+    let mut ir = lower_program(&prog, &checker.env, &checker.type_map);
+    almide::optimize::optimize_program(&mut ir);
+    almide::mono::monomorphize(&mut ir);
+    match codegen::codegen(&mut ir, Target::Rust) {
+        CodegenOutput::Source(s) => s,
+        CodegenOutput::Binary(_) => unreachable!(),
+    }
+}
+
+/// The user-code half of the emission (after the runtime preamble), so the
+/// assertions can't accidentally match runtime library text.
+fn user_code(full: &str) -> String {
+    full.rsplit("//__ALMIDE_RT_BOUNDARY__").next().unwrap().to_string()
+}
+
+const COUNTER_LOOP: &str = r#"
+effect fn main() -> Unit = {
+  var stats: Map[String, Int] = map.new()
+  let keys = ["a", "b"]
+  let bump = (k: String) => {
+    let cur = map.get(stats, k) ?? 0
+    map.insert(stats, k, cur + 1)
+  }
+  for i in 0..<10 {
+    bump(keys[i % 2])
+  }
+  println("a=${map.get(stats, "a") ?? 0}")
+}
+"#;
+
+#[test]
+fn closure_map_read_borrows_the_cell_in_place() {
+    let out = user_code(&compile_to_rust(COUNTER_LOOP));
+    // The read statement (`let cur = ...`) holds only shared borrows, so it
+    // borrows instead of snapshotting the whole Map per call.
+    assert!(
+        out.contains(".borrow(),") || out.contains(".borrow()"),
+        "expected an in-place cell borrow in the closure read:\n{out}"
+    );
+    // The closure body must not deep-clone the cell per read any more.
+    let closure = out.split("Rc::new(move").nth(1).expect("closure body present");
+    let closure_body = closure.split("})").next().unwrap();
+    assert!(
+        !closure_body.contains(".get()"),
+        "closure read still snapshots the cell:\n{closure_body}"
+    );
+}
+
+const MATCH_SUBJECT: &str = r#"
+type Acc = { sum: Int, count: Int }
+
+effect fn main() -> Unit = {
+  var stats: Map[String, Acc] = map.new()
+  let feed = (k: String, t: Int) => {
+    match map.get(stats, k) {
+      some(s) => map.insert(stats, k, Acc { sum: s.sum + t, count: s.count + 1 }),
+      none => map.insert(stats, k, Acc { sum: t, count: 1 }),
+    }
+  }
+  feed("x", 3)
+  println("done")
+}
+"#;
+
+#[test]
+fn match_subject_read_is_hoisted_before_the_arms() {
+    let out = user_code(&compile_to_rust(MATCH_SUBJECT));
+    // The subject read is hoisted to its own bind (guard dies at the `;`),
+    // then the arms take their mut borrows without overlap.
+    assert!(
+        out.contains("__scb_subj"),
+        "expected the hoisted match subject bind:\n{out}"
+    );
+    assert!(
+        out.contains(".borrow(),") || out.contains(".borrow()"),
+        "expected the hoisted subject to borrow, not snapshot:\n{out}"
+    );
+}
+
+const FORIN_HEAD_READ: &str = r#"
+effect fn main() -> Unit = {
+  var m: Map[String, Int] = map.new()
+  map.insert(m, "seed", 1)
+  let sweep = () => {
+    for k in map.keys(m) {
+      map.insert(m, k, 0)
+    }
+  }
+  sweep()
+  println("n=${map.len(m)}")
+}
+"#;
+
+#[test]
+fn forin_head_read_keeps_the_owned_snapshot() {
+    let out = user_code(&compile_to_rust(FORIN_HEAD_READ));
+    // A for-loop head's temporaries live for the whole loop, and the body
+    // mutates the same cell — the head read must stay on the `.get()`
+    // snapshot (a borrow would panic on the body's borrow_mut).
+    let closure = out.split("Rc::new(move").nth(1).expect("closure body present");
+    let head = closure.split("{").collect::<Vec<_>>().join("{");
+    assert!(
+        head.contains(".get()"),
+        "for-head read must keep the owned snapshot:\n{closure}"
+    );
+}


### PR DESCRIPTION
Fixes #1143.

## The cost

A closure-captured mutable heap local (`var stats: Map[...]` mutated from a lambda) lowers to a `SharedMut` cell (`Rc<RefCell<T>>`). A READ of it emitted `&cap.get()` — `SharedMut::get` is `self.0.borrow().clone()`, a deep clone of the whole Map per read. On the onebrc aggregation loop that made every `map.get` clone the 25-entry map once per line (the issue's ~5x); writes were already in-place (`&mut *cap.borrow_mut()`).

## The fix — a statement-scoped proof, then a marker

New nanopass `SharedCellBorrowPass` (after `IrLinkFlatten`, Rust target only):

1. **Hoist**: `match f(&cell) { arms }` extends subject temporaries across the arms, so a subject borrow would overlap the arms' `borrow_mut`. Such subjects are hoisted to `{ let __scb_subj = f(&cell); match __scb_subj { arms } }` — the guard dies at the bind.
2. **Prove per statement**: a cell var's reads may borrow iff EVERY use of it in the statement subtree is a shared, non-mutable `Borrow` in direct call-arg position, and the subtree has no lambda literal, no computed-callee call, no `for`/`while` head, no non-Var match subject, and no pre-rendered code. All resulting guards are shared borrows of one cell (RefCell multi-reader safe) and die at the semicolon — a marked statement cannot RefCell-panic by construction.
3. **Mark without a schema change**: qualifying reads become `Borrow(Deref(Var))` — a shape otherwise impossible on a SharedMut var — which the walker renders as `&*cap.borrow()`. Unmarked reads keep the owned `.get()` snapshot (e.g. a for-head read over a body that mutates — pinned in tests).

## A second, pre-existing miscompile found and fixed

The new spec test's "read the map after the closure" case fails on released 0.56.0 with invalid Rust (`&stats.get()` → E0061): `optimize/branch_lift.rs` synthesizes helpers whose params KEEP the captured free vars' VarIds, and the VarId-keyed `shared_mut_vars` annotation then treats a plain snapshot param as a cell inside the helper. Fixed by making fn-local truth win: `RenderContext.param_vars` (all params of the current fn) guards every shared-mut render site, and the pass excludes per-fn param vars. `spec/lang/closure_capture_map_test.almd` is the A/B regression pin (fails on 0.56.0, green here).

## Measurements (1M-row onebrc-shape, M4 Pro, built binaries)

| shape | before | after |
|---|---|---|
| eager for-loop + Stats records | 0.35 s user | 0.35 s |
| `fs.for_each_line` closure + Stats records | 0.73 s | **0.36 s** |
| 1M closure calls, counter map | 0.16 s | **0.05 s** |

The streaming shape now matches the eager loop — the recommended C-220 surface is no longer the slow one. Full onebrc output (min/mean/max, all stations) is byte-identical eager vs streaming.

## Verification

- `cargo test --workspace --release` green; full `almide test` 362/362 files (the whole suite doubles as the RefCell-discipline net); `tests/shared_cell_borrow_test.rs` pins the three emission shapes (borrow, hoist, snapshot-retention).
- Mixed read+write statements compose with the existing arg-hoist in `RustLoweringPass` (both halves optimal, verified in emission).
- v0-only: the v1 MIR path and the interpreter consume IR before this pass — no cert or cross-target surface changes.
- codopsy almide-codegen: 85/B → **92/A**.