### PR TITLE
Add the pass-ordering lens: skip any nanopass by env and hunt for silent dependencies (#912)

### DIFF
--- a/crates/almide-codegen/src/pass.rs
+++ b/crates/almide-codegen/src/pass.rs
@@ -381,6 +381,17 @@ impl Pipeline {
         // Run it only in debug (cargo test / CI) or when explicitly requested.
         let verify_ir = hard_fail || std::env::var_os("ALMIDE_VERIFY_IR").is_some();
 
+        // #912 pass-ordering lens: `ALMIDE_SKIP_PASS=Name[,Name…]` skips the
+        // named passes. A hunt instrument, not a user feature: the spec suite
+        // run with an OPTIONAL pass skipped must not change program OUTPUT —
+        // a silent value diff is a pass-dependency hole, while a dep-edge
+        // panic or compile error is the system refusing loudly. Zero-cost
+        // when unset (parsed once, out of the loop).
+        let skip_passes: Vec<String> = std::env::var("ALMIDE_SKIP_PASS")
+            .ok()
+            .map(|s| s.split(',').map(|x| x.trim().to_string()).collect())
+            .unwrap_or_default();
+
         // #559: the names of passes that WILL run in THIS target's pipeline.
         // Dep edges are enforced ONLY against this set, so a wasm-arm pass can
         // depend on a Rust-only pass (absent here) without panicking — the edge
@@ -395,6 +406,13 @@ impl Pipeline {
                 if !targets.contains(&target) {
                     continue;
                 }
+            }
+            // #912 lens skip: the skipped pass stays OUT of `executed`, so a
+            // later pass that declared a dep edge on it panics loudly in
+            // `validate_pass_deps` — an undeclared dependency is exactly what
+            // the hunt is for.
+            if skip_passes.iter().any(|s| s.eq_ignore_ascii_case(pass.name())) {
+                continue;
             }
             Self::validate_pass_deps(pass.as_ref(), &self.passes, target, &executed, &in_pipeline);
 

--- a/crates/almide-codegen/src/pass_matrix_shape_spec.rs
+++ b/crates/almide-codegen/src/pass_matrix_shape_spec.rs
@@ -61,7 +61,12 @@ pub struct MatrixShapeSpecPass;
 impl NanoPass for MatrixShapeSpecPass {
     fn name(&self) -> &str { "MatrixShapeSpec" }
     fn targets(&self) -> Option<Vec<Target>> { Some(vec![Target::Rust]) }
-    fn depends_on(&self) -> Vec<&'static str> { vec![] }
+    // The small-shape unrolls type-expect the fused matrix forms
+    // EggSaturation produces — without it, 4 matrix fusion spec files fail
+    // rustc (E0308, RcCow vs AlmideMatrix). Found by the #912 pass-ordering
+    // lens round 1: the dep was real but undeclared; declaring it turns the
+    // late rustc refusal into an immediate pipeline panic.
+    fn depends_on(&self) -> Vec<&'static str> { vec!["EggSaturation"] }
 
     fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
         let mut changed = false;

--- a/scripts/lens-pass-order.sh
+++ b/scripts/lens-pass-order.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# #912 pass-ordering lens: run the spec suite with each OPTIONAL nanopass
+# skipped (ALMIDE_SKIP_PASS), one at a time.
+#
+# Verdicts per pass:
+#   CLEAN   — suite fully green without the pass: it is a pure optimization,
+#             nothing downstream silently depends on it.
+#   LOUD    — dep-edge panic or compile errors: the dependency is declared or
+#             surfaces at build time. Not a finding; the system refused.
+#   FINDING — tests fail BY VALUE with the pass skipped: something downstream
+#             silently depends on the pass's rewrite for CORRECTNESS. File it.
+#
+# Record the round's verdict table (including all-CLEAN) as a comment on #912.
+set -u
+BIN=${ALMIDE_BIN:-./target/release/almide}
+SUITE=${LENS_SUITE:-spec/}
+OPTIONAL=${LENS_PASSES:-"LICM EggSaturation ConstFold Peephole MatrixShapeSpec AutoParallel TailCallOpt SharedCellBorrow"}
+out_dir=$(mktemp -d)
+echo "lens-pass-order: suite=$SUITE bin=$BIN logs=$out_dir"
+overall=0
+for p in $OPTIONAL; do
+  log="$out_dir/skip_$p.log"
+  ALMIDE_SKIP_PASS=$p "$BIN" test "$SUITE" >"$log" 2>&1
+  code=$?
+  if [ $code -eq 0 ]; then
+    echo "CLEAN    $p"
+    continue
+  fi
+  # Distinguish loud refusals (compile errors, dep panics) from silent value
+  # diffs (assert failures in tests that compiled).
+  if grep -qE "Compile error|panicked|error\[" "$log"; then
+    echo "LOUD     $p  (see $log)"
+  else
+    echo "FINDING  $p  — tests failed by value; see $log"
+    overall=1
+  fi
+done
+exit $overall


### PR DESCRIPTION
Part of #912 — the pass-ordering lens, the first of the three remaining rotations the nightly fuzzer structurally cannot see.

## The instrument

- `ALMIDE_SKIP_PASS=Name[,Name…]` skips the named passes in the codegen pipeline. Zero-cost when unset. A skipped pass stays out of `executed`, so any pass that DECLARED a dep edge on it panics immediately in `validate_pass_deps` — an undeclared dependency is exactly what the hunt is for.
- `scripts/lens-pass-order.sh` runs the spec suite once per optional pass with that pass skipped, and classifies each run: CLEAN (pure optimization), LOUD (dep panic / compile error — the system refused), FINDING (tests fail by value — a silent correctness dependency).

## Round 1 result (recorded on #912)

| pass | verdict |
|---|---|
| LICM | CLEAN |
| ConstFold | CLEAN |
| Peephole | CLEAN |
| MatrixShapeSpec | CLEAN |
| AutoParallel | CLEAN |
| TailCallOpt | CLEAN |
| EggSaturation | LOUD — 4 matrix fusion spec files fail rustc E0308 |

**Zero silent findings.** The one LOUD case was a REAL but undeclared dep: `MatrixShapeSpec`'s small-shape unrolls type-expect the fused forms `EggSaturation` produces. This PR declares that edge (`depends_on`), turning the late rustc refusal into an immediate, self-documenting pipeline panic — verified both ways (skip now panics with the pipeline message; normal builds unchanged, suite green).