### PR TITLE
Wall result.zip honestly when either argument's Ok payload is heap instead of linking the scalar shim (#1154)

### DIFF
--- a/crates/almide-mir/src/lower/mod_p4_c.rs
+++ b/crates/almide-mir/src/lower/mod_p4_c.rs
@@ -89,6 +89,18 @@ fn result_call_name(func: &str, arg_tys: &[Ty], result_ty: &Ty) -> Option<String
         {
             Some(format!("result.{func}_h"))
         }
+        // zip reads BOTH results' tags, and the scalar shim is len-as-tag on
+        // EACH side — so a heap-Ok SECOND argument misreads exactly like a
+        // heap-Ok first: `zip(ok(1.0), ok("abc"))` linked the shim through the
+        // first-arg-only guard below and took the err path on ok inputs (fuzz
+        // seed 500705518628 index 738, #1154 — a wall-escape, silent wrong
+        // output). EITHER side heap-Ok routes to the UNLINKED `_x` — a
+        // deterministic render wall, never a wrong-typed link.
+        "zip" if arg_tys.iter().take(2).any(|t| matches!(t, Ty::Applied(TC::Result, a)
+                if a.len() == 2 && is_heap_ty(&a[0]))) =>
+        {
+            Some("result.zip_x".to_string())
+        }
         // The VALUE combinators over a HEAP-Ok Result — same cap-as-tag misread as
         // is_ok/is_err, but the scalar impls also REBUILT the wrong layout: every
         // `ok(x)` took the Err path and the result printed as a swapped/zeroed value

--- a/spec/lang/result_zip_test.almd
+++ b/spec/lang/result_zip_test.almd
@@ -1,0 +1,39 @@
+// result_zip_test — result.zip over mixed scalar/heap Ok payloads (#1154).
+// The wasm leg walls the heap-Ok instantiations honestly (routing pinned in
+// tests/result_zip_routing_test.rs); these pin the VALUE semantics on the
+// executing legs: both-ok zips, and the FIRST err wins.
+test "zip of two oks pairs the payloads" {
+  let y: Result[Int, String] = ok(7)
+  let t: Result[Int, String] = ok(9)
+  let r = result.unwrap_or_else(result.zip(y, t), ((e) => (-1, -2)))
+  let (a, b) = r
+  assert_eq(a, 7)
+  assert_eq(b, 9)
+}
+
+test "zip mixed scalar and heap payloads takes the ok path" {
+  let y: Result[Float, String] = ok(1.5)
+  let t: Result[String, String] = ok("abc")
+  let r = result.unwrap_or_else(result.zip(y, t), ((e) => (-42.5, "fallback")))
+  let (a, b) = r
+  assert_eq(a, 1.5)
+  assert_eq(b, "abc")
+}
+
+test "zip returns the FIRST err when both fail" {
+  let y: Result[Int, String] = err("first")
+  let t: Result[Int, String] = err("second")
+  match result.zip(y, t) {
+    ok(_) => assert_eq("took ok", "unreachable"),
+    err(e) => assert_eq(e, "first"),
+  }
+}
+
+test "zip returns the second err when only the second fails" {
+  let y: Result[Float, String] = ok(2.0)
+  let t: Result[String, String] = err("late")
+  match result.zip(y, t) {
+    ok(_) => assert_eq("took ok", "unreachable"),
+    err(e) => assert_eq(e, "late"),
+  }
+}

--- a/tests/result_zip_routing_test.rs
+++ b/tests/result_zip_routing_test.rs
@@ -1,0 +1,122 @@
+//! result.zip routing (#1154): the scalar self-host shim reads BOTH results'
+//! tags len-as-tag, so it is linkable ONLY when both Ok payloads are scalar.
+//! A heap-Ok argument on EITHER side must route to the UNLINKED `_x` — an
+//! honest render wall — never to the shim (which took the err path on ok
+//! inputs: fuzz seed 500705518628 index 738, a silent wrong output on wasm).
+//!
+//! Skips cleanly when the `almide` binary is unavailable (CI builds it in the
+//! build step; locally run `cargo build --release` first).
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn tool_available() -> bool {
+    Command::new(almide_bin()).arg("--version").output().is_ok()
+}
+
+/// The wasm halves execute through wasmtime; environments without it (a bare
+/// `cargo test --workspace` shard) skip them — the routing itself is still
+/// pinned wherever the wasm toolchain exists (the Test WASM job, local runs
+/// with /opt/homebrew on PATH).
+fn wasmtime_available() -> bool {
+    Command::new("wasmtime").arg("--version").output().is_ok()
+}
+
+/// The night's shape: scalar-Ok FIRST argument, heap-Ok second. The first-arg
+/// guard alone linked the shim for this one.
+const MIXED_ZIP: &str = r#"fn main() -> Unit = {
+  let y: Result[Float, String] = ok(1.0)
+  let t: Result[String, String] = ok("abc")
+  let r: (Float, String) = result.unwrap_or_else(result.zip(y, t), ((e) => (-42.5, "fallback")))
+  println("r = ${r}")
+}
+"#;
+
+const SCALAR_ZIP: &str = r#"fn main() -> Unit = {
+  let y: Result[Int, String] = ok(7)
+  let t: Result[Int, String] = ok(9)
+  let r: (Int, Int) = result.unwrap_or_else(result.zip(y, t), ((e) => (-1, -2)))
+  println("r = ${r}")
+}
+"#;
+
+fn write_fixture(name: &str, src: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join("almide-zip-routing-test");
+    std::fs::create_dir_all(&dir).unwrap();
+    let p = dir.join(name);
+    std::fs::write(&p, src).unwrap();
+    p
+}
+
+#[test]
+fn mixed_zip_walls_on_wasm_and_runs_on_native() {
+    if !tool_available() {
+        eprintln!("skipping: almide binary unavailable");
+        return;
+    }
+    let p = write_fixture("mixed_zip.almd", MIXED_ZIP);
+
+    // Native: the properly-typed mono instance runs — the ok tuple, not the
+    // fallback.
+    let native = Command::new(almide_bin()).arg("run").arg(&p).output().unwrap();
+    let stdout = String::from_utf8_lossy(&native.stdout);
+    assert!(
+        stdout.contains("r = (1, \"abc\")"),
+        "native must take the ok path:\n{stdout}"
+    );
+
+    // Wasm: an honest wall — NEVER the shim's wrong value. (The wall fires at
+    // RENDER time, before wasmtime, so this half needs no wasmtime either —
+    // but a missing-wasmtime error would still confuse the assertions.)
+    if !wasmtime_available() {
+        eprintln!("skipping wasm half: wasmtime unavailable");
+        return;
+    }
+    let wasm = Command::new(almide_bin())
+        .arg("run").arg(&p).arg("--target").arg("wasm")
+        .output().unwrap();
+    let out = format!(
+        "{}{}",
+        String::from_utf8_lossy(&wasm.stdout),
+        String::from_utf8_lossy(&wasm.stderr)
+    );
+    // The wall boilerplate itself says "silent fallback", so key on the
+    // fallback tuple's VALUE, which only the mis-linked shim could print.
+    assert!(
+        !out.contains("-42.5"),
+        "wasm must not silently take the err path on ok inputs:\n{out}"
+    );
+    assert!(
+        out.contains("not yet supported") || out.contains("wall"),
+        "wasm must wall the mixed zip instantiation honestly:\n{out}"
+    );
+}
+
+#[test]
+fn scalar_zip_still_links_the_shim_on_wasm() {
+    if !tool_available() || !wasmtime_available() {
+        eprintln!("skipping: almide binary or wasmtime unavailable");
+        return;
+    }
+    let p = write_fixture("scalar_zip.almd", SCALAR_ZIP);
+    let wasm = Command::new(almide_bin())
+        .arg("run").arg(&p).arg("--target").arg("wasm")
+        .output().unwrap();
+    let stdout = String::from_utf8_lossy(&wasm.stdout);
+    assert!(
+        stdout.contains("r = (7, 9)"),
+        "scalar zip must keep executing on wasm:\n{stdout}\n{}",
+        String::from_utf8_lossy(&wasm.stderr)
+    );
+}


### PR DESCRIPTION
Fixes #1154 — the second half of fuzz night 2026-08-09 (seed 500705518628 index 738; the first half was #1155).

## The wall-escape

`stdlib/result_core.almd`'s `result_zip` shim is written for `Result[Int, String]`: it reads BOTH results' tags len-as-tag (`len@4 >= 1 → err`) — correct for the scalar-Ok layout, and documented in the same file as misreading every heap-Ok value as an Err (that's why `is_ok`/`is_err` have `_h` twins).

The router (`result_call_name`, mod_p4_c.rs) guarded zip only on the FIRST argument's Ok payload. `result.zip(ok(1.0), ok("abc"))` — scalar first, heap second — slipped past the guard, linked the shim, misread the second argument's `len@4 == 1` as an Err tag, and returned `err("abc")` for two ok inputs. Composed with `unwrap_or_else`, wasm silently printed the fallback tuple while native printed the correct pair: a trust-spine wall-escape, silent wrong output.

WAT-level trace that pinned it: the module contained BOTH the correctly-typed mono instance (`almide_rt_result_zip__Float_String_String`, dead) and the linked shim (`$result.zip`, live) — the shim's `(i64.ge_s (load b+4) 1)` is the misread.

## The fix

One routing arm: `zip` with a heap-Ok payload on EITHER of its two arguments routes to the UNLINKED `result.zip_x` — the file's own sanctioned pattern ("a deterministic render wall, never a wrong-typed link"). Scalar×scalar keeps the shim.

| shape | before | after |
|---|---|---|
| `zip(ok(1.0), ok("abc"))` wasm | **silent `err` fallback** | honest wall |
| `zip(ok(7), ok("abc"))` wasm | silent `err` fallback | honest wall |
| `zip(ok("xy"), ok("abc"))` wasm | wall (first-arg guard) | wall (unchanged) |
| `zip(ok(7), ok(9))` wasm | correct | correct (unchanged) |
| all shapes, native | correct | correct (unchanged) |

Executing zip on wasm for heap payloads (a `zip_h` twin) is a tracked capability of the #1134 heap-result frontier; this PR closes the soundness hole so the missing capability walls instead of lying.

## Verification

- `tests/result_zip_routing_test.rs`: the night's shape must run on native with the ok pair AND wall on wasm (asserting the fallback VALUE never prints); scalar zip must keep executing on wasm. Wasmtime-gated so bare shards skip cleanly.
- `spec/lang/result_zip_test.almd` (4 tests): both-ok pairing incl. the mixed instantiation, first-err-wins, second-err. Walled-real corpus probe: 0.
- Full `almide test` 363/363; `wasm_runtime_test` 75/75; workspace suite green (the one red in the first run was this new test before its wasmtime gate).
- codopsy almide-mir: **A (91/100)** — every crate this goal batch touched is now A.