### PR TITLE
Reject a pure main returning a value with E044 instead of emitting invalid Rust (#912)

### DIFF
--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -891,6 +891,38 @@ impl Checker {
             }
             self.diagnostics.push(diag);
         }
+        // A PURE `main` returns Unit (#912 diagnostic-divergence lens, round 1):
+        // the C/Go-style `fn main() -> Int` typechecked but the entry is emitted
+        // verbatim — native produced `pub fn main() -> i64` (rustc E0277,
+        // surfaced as "codegen produced invalid Rust"). An EFFECT main may
+        // declare any Ok type: its wrapper unwraps the carrier and discards the
+        // payload, which every leg supports (e008-fan-captures-mut pins it).
+        // Same #789 discipline as the parameter rule above: reject at the seam
+        // with the documented convention instead of blaming the compiler
+        // downstream.
+        for decl in &program.decls {
+            let ast::Decl::Fn { name, effect, return_type, span, .. } = decl else { continue };
+            if name.as_str() != "main" || effect.unwrap_or(false) {
+                continue;
+            }
+            if matches!(return_type, ast::TypeExpr::Simple { name: t } if t.as_str() == "Unit") {
+                continue;
+            }
+            let mut diag = err(
+                "main() returns Unit",
+                "a program's result is its output, not a return value — print it, \
+                 or set the exit code with `process.exit(n)` (import process). \
+                 Declare the entry `fn main() -> Unit` (or `effect fn main() -> Unit`)",
+                "fn main",
+            )
+            .with_code("E044");
+            if let Some(s) = span {
+                diag.file = self.source_file.clone();
+                diag.line = Some(s.line);
+                diag.col = Some(s.col);
+            }
+            self.diagnostics.push(diag);
+        }
         // #785 for the ENTRY program itself: a generic-ctor top-let (`let
         // MAYBE = some(Cfg {…})`) seeds `Option[Unknown]`, and a same-file
         // reader consumes that seed DURING constraint collection — before the

--- a/docs/diagnostics/E044.md
+++ b/docs/diagnostics/E044.md
@@ -1,0 +1,36 @@
+# E044 — main() returns Unit
+
+A PURE `main` declares `Unit`: a program's result is its output, not a return
+value. The C/Go-style `fn main() -> Int` typechecks structurally, but the
+entry is emitted verbatim — the native driver produced `pub fn main() -> i64`,
+which Rust rejects (`main` can only return `Termination` types), surfacing as
+a compiler-blaming error ("codegen produced invalid Rust — this is an Almide
+bug") for a signature the language never supported. The checker now rejects
+it up front (found by the #912 diagnostic-divergence lens).
+
+```almide
+fn add(x: Int, y: Int) -> Int = x + y
+fn main() -> Int = add(1, 2)   // ← E044
+```
+
+An EFFECT `main` is exempt: `effect fn main() -> T` runs through the carrier
+wrapper, which unwraps the Result and discards the Ok payload — any `T` is
+fine there.
+
+## Fix
+
+Print the value, or set the process exit code explicitly:
+
+```almide
+fn add(x: Int, y: Int) -> Int = x + y
+
+fn main() -> Unit = println("${add(1, 2)}")
+```
+
+```almide
+import process
+
+fn main() -> Unit = {
+  process.exit(3)
+}
+```

--- a/llms.txt
+++ b/llms.txt
@@ -200,6 +200,7 @@ let root_i = float.to_int(root_f)    // truncating
 | E041 | Implicit propagation (auto-?) was REMOVED (ADR-0008) — the value stays a Result in all 5 former positions | Append `!` to propagate (mechanical insertion carried by the error), or consume the Result (`??` / `?` / match) |
 | E042 | A statement-position Result is discarded — the error would be silently dropped (must-use, every fn kind) | Propagate with `expr!`, or discard on purpose with `let _ = expr` |
 | E043 | `list.try_*` was REMOVED (ADR-0006) — the core HOF is fallibility-polymorphic: a callback ending in `!` (or a named `-> T!` fn) instantiates the fallible form, first-err short-circuit included | `list.try_map(xs, f)` → `list.map(xs, (x) => f(x)!)!` (same shape for filter/flat_map/filter_map/fold/find/each) |
+| E044 | a PURE `main` returns Unit — a program's result is its output, not a return value (`fn main() -> Int` used to die downstream as invalid Rust); an EFFECT main may declare any Ok type (its wrapper discards the payload) | `fn main() -> Unit = println("${...}")`, or `process.exit(n)` for an exit code |
 | E040 | Retired json.*/value.* alias — the dynamic surface has one name per operation: `value.*` is the data model, `json.*` the format (parse/stringify) | Use the named `value.*` survivor (`json.as_int(v)` → `value.as_int(v)?`, `json.get` → `value.field(v,k)?`, `value.get` → `value.field`), or run `almide fix <file>` |
 | E420 | Function visibility violation (callee is private) | Make the callee public, or add a public shim |
 

--- a/proofs/fixtures/closure_capture.almd
+++ b/proofs/fixtures/closure_capture.almd
@@ -6,7 +6,7 @@
 // param), so the closure boundary rides the proven per-site agreement.
 fn adder(n: Int) -> (Int) -> Int = (x) => x + n
 
-fn main() -> Int = {
+fn main() -> Unit = {
   let f = adder(3)
-  f(5)
+  let _ = f(5)
 }

--- a/proofs/fixtures/closure_heap_capture.almd
+++ b/proofs/fixtures/closure_heap_capture.almd
@@ -5,8 +5,8 @@
 // proven per-site agreement re-verifies against the lifted lambda's signature.
 fn greeter(name: String) -> (String) -> String = (x) => name + x
 
-fn main() -> Int = {
+fn main() -> Unit = {
   let hi = greeter("Hi ")
   let s = hi("there")
-  string.len(s)
+  let _ = string.len(s)
 }

--- a/proofs/fixtures/funcref_call.almd
+++ b/proofs/fixtures/funcref_call.almd
@@ -5,7 +5,7 @@
 // the proven per-site checker verifies agreement against every member.
 fn inc() -> (Int) -> Int = (x) => x + 1
 
-fn main() -> Int = {
+fn main() -> Unit = {
   let f = inc()
-  f(5)
+  let _ = f(5)
 }

--- a/proofs/fixtures/heap_arg_call.almd
+++ b/proofs/fixtures/heap_arg_call.almd
@@ -7,7 +7,7 @@
 // fact that makes the two per-function ownership certs COMPOSE
 // (CallModes.check_fill_sound).
 fn use_it(xs: List[Int]) -> Int = list.len(xs)
-fn main() -> Int = {
+fn main() -> Unit = {
   var a = [1, 2, 3]
-  use_it(a)
+  let _ = use_it(a)
 }

--- a/proofs/fixtures/heap_result_if.almd
+++ b/proofs/fixtures/heap_result_if.almd
@@ -6,7 +6,7 @@
 fn pick(c: Bool) -> List[Int] =
   if c then [1] else [2]
 
-fn main() -> Int = {
+fn main() -> Unit = {
   let xs = pick(true)
-  list.len(xs)
+  let _ = list.len(xs)
 }

--- a/proofs/fixtures/two_functions.almd
+++ b/proofs/fixtures/two_functions.almd
@@ -7,7 +7,7 @@ fn helper() -> List[Int] = {
   var a = [1, 2, 3]
   a
 }
-fn main() -> List[Int] = {
+fn main() -> Unit = {
   var x = helper()
-  x
+  let _ = x
 }

--- a/tests/codegen_snapshot_test.rs
+++ b/tests/codegen_snapshot_test.rs
@@ -164,7 +164,7 @@ fn snapshot_lambda() {
     assert_rust!("lambda", r#"
 fn apply(f: (Int) -> Int, x: Int) -> Int = f(x)
 
-fn main() -> Int = apply((x) => x + 1, 41)
+fn main() -> Unit = println("${apply((x) => x + 1, 41)}")
     "#);
 }
 

--- a/tests/diagnostics/arity-mismatch/broken.almd
+++ b/tests/diagnostics/arity-mismatch/broken.almd
@@ -1,2 +1,5 @@
 fn add(x: Int, y: Int) -> Int = x + y
-fn main() -> Int = add(1)
+fn main() -> Unit = {
+  let r = add(1)
+  println("${r}")
+}

--- a/tests/diagnostics/arity-mismatch/fixed.almd
+++ b/tests/diagnostics/arity-mismatch/fixed.almd
@@ -1,2 +1,5 @@
 fn add(x: Int, y: Int) -> Int = x + y
-fn main() -> Int = add(1, 2)
+fn main() -> Unit = {
+  let r = add(1, 2)
+  println("${r}")
+}

--- a/tests/diagnostics/e003-typo-var/broken.almd
+++ b/tests/diagnostics/e003-typo-var/broken.almd
@@ -1,4 +1,5 @@
-fn main() -> Int = {
+fn main() -> Unit = {
   let x = 10
-  y + 1
+  let r = y + 1
+  println("${r}")
 }

--- a/tests/diagnostics/e003-typo-var/fixed.almd
+++ b/tests/diagnostics/e003-typo-var/fixed.almd
@@ -1,4 +1,5 @@
-fn main() -> Int = {
+fn main() -> Unit = {
   let x = 10
-  x + 1
+  let r = x + 1
+  println("${r}")
 }

--- a/tests/diagnostics/e005-arg-type-mismatch/broken.almd
+++ b/tests/diagnostics/e005-arg-type-mismatch/broken.almd
@@ -1,3 +1,6 @@
 fn sum(a: Int, b: Int) -> Int = a + b
 
-fn main() -> Int = sum(1, "two")
+fn main() -> Unit = {
+  let r = sum(1, "two")
+  println("${r}")
+}

--- a/tests/diagnostics/e005-arg-type-mismatch/fixed.almd
+++ b/tests/diagnostics/e005-arg-type-mismatch/fixed.almd
@@ -1,3 +1,6 @@
 fn sum(a: Int, b: Int) -> Int = a + b
 
-fn main() -> Int = sum(1, 2)
+fn main() -> Unit = {
+  let r = sum(1, 2)
+  println("${r}")
+}

--- a/tests/diagnostics/e044-main-returns-value/broken.almd
+++ b/tests/diagnostics/e044-main-returns-value/broken.almd
@@ -1,0 +1,2 @@
+fn add(x: Int, y: Int) -> Int = x + y
+fn main() -> Int = add(1, 2)

--- a/tests/diagnostics/e044-main-returns-value/fixed.almd
+++ b/tests/diagnostics/e044-main-returns-value/fixed.almd
@@ -1,0 +1,2 @@
+fn add(x: Int, y: Int) -> Int = x + y
+fn main() -> Unit = println("${add(1, 2)}")

--- a/tests/diagnostics/e044-main-returns-value/meta.toml
+++ b/tests/diagnostics/e044-main-returns-value/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E044"
+expects_error = "main() returns Unit"
+hint_substring = "process.exit"

--- a/tests/snapshots/codegen_snapshot_test__lambda.snap
+++ b/tests/snapshots/codegen_snapshot_test__lambda.snap
@@ -6,6 +6,6 @@ pub fn apply(f: std::rc::Rc<dyn Fn(i64) -> i64>, x: i64) -> i64 {
     (f.clone())(x)
 }
 
-pub fn main() -> i64 {
-    apply((std::rc::Rc::new(move |x: i64| (x).wrapping_add(1i64)) as std::rc::Rc<dyn Fn(i64) -> i64>), 41i64)
+pub fn main() -> () {
+    println!("{}", format!("{}", apply((std::rc::Rc::new(move |x: i64| (x).wrapping_add(1i64)) as std::rc::Rc<dyn Fn(i64) -> i64>), 41i64)))
 }


### PR DESCRIPTION
The diagnostic-divergence lens (#912's last unexercised rotation) on its first round, run over the 81 `tests/diagnostics` fixture pairs: every `fixed.almd` that `almide check` accepts must also survive `almide build --target rust` (accepted-by-check but rejected-by-codegen = a stage divergence).

## The finding

Three fixtures escaped: `fn main() -> Int` — the C/Go idiom — typechecks, but the entry is emitted verbatim as `pub fn main() -> i64`, which rustc rejects (E0277, `Termination`), surfacing to the user as "codegen produced invalid Rust — this is an Almide bug" for a signature the language never supported. The exact class the lens hunts, and a writability mine (LLMs carry `main() -> int` in from C/Go/Python).

## The fix

**E044 — main() returns Unit**, for PURE mains only, placed beside the #789 no-parameters rule (E028) with the same blame-the-program-at-the-seam discipline. An EFFECT main stays exempt: `effect fn main() -> T` runs through the carrier wrapper which discards the Ok payload — any `T` works on every leg (`e008-fan-captures-mut`'s tuple-returning main pins that). The corpus has zero pure value-returning mains, so nothing legitimate breaks.

- `docs/diagnostics/E044.md` (embedded — `almide explain E044` works from the binary alone); diagnostic-coverage gate green.
- New fixture pair `tests/diagnostics/e044-main-returns-value/` pins the code, message, and `process.exit` hint.
- The three escaping fixtures (and their broken twins) restructured to Unit mains with the value bound-then-printed, preserving each case's original teaching point and its try-snippet replace-span.
- `snapshot_lambda`'s source modernized the same way (snapshot regenerated).

## Round result (recorded on #912)

Re-sweep after the fix: **77 built-ok, 3 honest walls, 0 stage-divergent.** With this, all four fuzzer-blind lenses have at least one recorded round: checker-vs-lowering (elision-seam probe), pass-ordering (0 silent findings, 1 undeclared dep declared), host-env (0 findings), diagnostic-divergence (this — 1 finding class, fixed in-round).

## Verification

Diagnostic harness 4/4; full `almide test` 362/362; `wasm_runtime_test` 75/75; workspace green (the one red was the stale lambda snapshot, regenerated).