### PR TITLE
Shape 2 first batch: Option-ctor concat elements and fallible-closure unwrap-or operands (#1134)

### DIFF
--- a/crates/almide-mir/src/lower/calls_p2.rs
+++ b/crates/almide-mir/src/lower/calls_p2.rs
@@ -32,6 +32,7 @@ struct ConcatListElemShape {
     rich_variant_elem: Option<String>,
     closure_elem: bool,
     list_scalar_aggregate_elem: bool,
+    lenlist_elem: Option<crate::lower::CtorElemClass>,
 }
 
 impl ConcatListElemShape {
@@ -45,6 +46,7 @@ impl ConcatListElemShape {
             && !self.str_int_elem && !self.scalar_aggregate_elem && !self.flat_variant_elem
             && !self.closure_elem && !self.list_scalar_aggregate_elem
             && self.rich_variant_elem.is_none() && self.record_elem.is_none()
+            && self.lenlist_elem.is_none()
     }
 }
 
@@ -263,6 +265,17 @@ impl LowerCtx {
         // element recursively via `__drop_closure` — the SAME route the List[Fn] LITERAL
         // builder registers (`ListElemDrop::Closure`), so build and concat agree on the drop.
         let closure_elem = matches!(elem_ty, Ty::Fn { .. });
+        // An Option/Result CTOR element (`acc + [_x]` where `acc: List[Int?]` /
+        // `List[String?]` — the derived-codec `__dec_list_opt_*_go` accumulator,
+        // #1134 Shape 2): the SAME two classes the list-LITERAL builder admits
+        // (`lenlist_elem_class`). A Flat class element (scalar payload) is a
+        // single flat block — per-element rc_dec IS its full free (the
+        // flat-variant physics); a LenLoop class element (String/List[scalar]
+        // payload) owns its payload through the len-counted slot, freed by the
+        // SAME `$__drop_list_lenlist` route the literal builder registers, so
+        // build and concat agree on the drop. An Option[record] element stays
+        // out (None) on both sides — the recursive-drop brick.
+        let lenlist_elem = crate::lower::lenlist_elem_class(elem_ty);
         ConcatListElemShape {
             scalar_elem,
             heap_elem,
@@ -278,6 +291,7 @@ impl LowerCtx {
             rich_variant_elem,
             closure_elem,
             list_scalar_aggregate_elem: self.is_list_scalar_aggregate_elem(elem_ty),
+            lenlist_elem,
         }
     }
 
@@ -473,6 +487,22 @@ impl LowerCtx {
         }
         if shape.scalar_aggregate_elem {
             self.heap_elem_lists.insert(dst);
+            return true;
+        }
+        // An Option/Result CTOR element (the codec `__dec_list_opt_*_go` accumulator):
+        // Flat (scalar payload) → the per-element-rc_dec `DropListStr` IS its full free
+        // (the flat-variant physics); LenLoop (String/List[scalar] payload) → the SAME
+        // `$__drop_list_lenlist` len-counted sweep the literal builder registers, so
+        // build and concat agree on the drop.
+        if let Some(class) = &shape.lenlist_elem {
+            match class {
+                crate::lower::CtorElemClass::Flat => {
+                    self.heap_elem_lists.insert(dst);
+                }
+                crate::lower::CtorElemClass::LenLoop => {
+                    self.variant_drop_handles.insert(dst, "list_lenlist".to_string());
+                }
+            }
             return true;
         }
         false

--- a/crates/almide-mir/src/lower/control_p3.rs
+++ b/crates/almide-mir/src/lower/control_p3.rs
@@ -177,6 +177,13 @@ impl LowerCtx {
             IrExprKind::Member { .. } | IrExprKind::TupleIndex { .. } => is_result_ty(&expr.ty),
             // A USER function returning Result — read its tag INVERSELY (Ok = tag 0).
             _ if is_named_variant_call => is_result_ty(&expr.ty),
+            // A FALLIBLE-CLOSURE call (`g("21") ?? -1` — the ADR-0009 carrier): the
+            // call's declared type IS the carrier, so a Result carrier reads INVERSELY.
+            // Without this arm a closure-call Result operand fell to the Option read
+            // and would have taken the wrong tag sense.
+            IrExprKind::Call { target: CallTarget::Computed { .. }, .. } => {
+                is_result_ty(&expr.ty)
+            }
             _ => is_self_host_result_call(expr),
         }
     }
@@ -214,6 +221,44 @@ impl LowerCtx {
             || is_named_variant_call
         {
             return self.call_unwrap_or_operand(expr, cx);
+        }
+        // A FALLIBLE-CLOSURE call operand (`g("21") ?? -1` where `g = (x) => parse1(x)! * 2`
+        // — the ADR-0009 first-class fallible lambda, #1134 Shape 2): dispatch through the
+        // tracked closure block exactly like the bind-position Computed arm — the call
+        // returns the fresh OWNED len-as-tag carrier block, tracked + type-routed for the
+        // scope-end drop like any owned call temp, and seeded as a materialized read shape
+        // so the downstream tag read is over a KNOWN layout. Gated to a SCALAR-payload
+        // Option/Result carrier: the scalar route reads tag + payload with no ownership
+        // transfer (a heap-payload carrier stays walled — the recursive-ownership frontier).
+        if let IrExprKind::Call { target: CallTarget::Computed { callee }, args, .. } = &expr.kind {
+            use almide_lang::types::constructor::TypeConstructorId as TC;
+            let scalar_opt = matches!(&expr.ty,
+                Ty::Applied(TC::Option, a) if a.len() == 1 && !is_heap_ty(&a[0]));
+            let scalar_res = matches!(&expr.ty,
+                Ty::Applied(TC::Result, a)
+                    if a.len() == 2 && !is_heap_ty(&a[0]) && matches!(a[1], Ty::String));
+            if !scalar_opt && !scalar_res {
+                return None;
+            }
+            let route = (|s: &mut Self| {
+                let blk = s.closure_block_of_mut(callee)?;
+                let repr = repr_of(&expr.ty).ok()?;
+                let lowered = s.lower_call_args(args).ok()?;
+                let obj = s.fresh_value();
+                s.emit_closure_call(blk, Some(obj), lowered, Some(repr));
+                s.live_heap_handles.push(obj);
+                s.register_owned_heap_eq_drop(obj, &expr.ty);
+                if scalar_res {
+                    s.materialized_results.insert(obj);
+                } else {
+                    s.materialized_options.insert(obj);
+                }
+                Some(obj)
+            })(self);
+            if route.is_none() {
+                self.unwrap_or_rollback(cx);
+            }
+            return route;
         }
         // A `??` over a variant-returning call NOT in the self-host registries — the
         // `json.parse(s) ?? d` (PURE heap-Result) / `process.env(k) ?? d` (IMPURE intrinsic

--- a/proofs/walled-real-baseline.txt
+++ b/proofs/walled-real-baseline.txt
@@ -36,9 +36,13 @@
 # ctor payload arm (`ok(Label{…})`), so both conds lower and A/B byte-identically.
 # The Deep test fn stays: its cond rides the Deep decode helpers' heap-result-if
 # class below plus the bind-position record brick (#1064) — same file, other brick.
+# (2026-08-10, #1134 Shape 2) The int/string opt-list decode workers are PRUNED:
+# the ConcatList element families gained the literal builder's two lenlist ctor
+# classes (Flat scalar payload / LenLoop String payload with the shared
+# $__drop_list_lenlist route), so `acc + [_x]` lowers and both workers run the
+# wasm leg byte-identical. The Inner (Option[record] element) worker stays — the
+# recursive-drop brick, the same cell that walls the List[Inner?] literal.
 spec/stdlib/codec_field_matrix_test.almd :: Deep.__dec_list_opt_Inner_go
-spec/stdlib/codec_field_matrix_test.almd :: Deep.__dec_list_opt_int_go
-spec/stdlib/codec_field_matrix_test.almd :: Deep.__dec_list_opt_string_go
 spec/stdlib/codec_field_matrix_test.almd :: __test_almd_nested containers: List[Option], List[List], deep Option[List[Option]]
 #
 #
@@ -69,9 +73,12 @@ spec/lang/fallible_hof_test.almd :: find_cells
 spec/lang/fallible_hof_test.almd :: fm_cells
 spec/lang/fallible_hof_test.almd :: m_pipe_qq
 spec/lang/fallible_hof_test.almd :: marker_cells
-spec/lang/fallible_lambda_test.almd :: use_first_class
-spec/lang/fallible_lambda_test.almd :: use_guarded
-spec/lang/fallible_lambda_test.almd :: use_option_operand
+# (2026-08-10, #1134 Shape 2) The three fallible_lambda use_* fns are PRUNED:
+# the `??` operand machinery gained the fallible-CLOSURE call route (the
+# ADR-0009 carrier — dispatch through the tracked closure block, inverse tag
+# read for a Result carrier), which was the real blocker behind their
+# "heap-result Tuple" label. The fallible_hof entries above stay: their `??`
+# operands are fallible-HOF Module calls with HEAP fallbacks — the next cell.
 #
 # (2026-08-06, #1114) option.to_result became an E-GENERIC pure bundled body
 # (ADR-0003 D1's typed-error route needs Option -> Result[T, CustomE]). The


### PR DESCRIPTION
First batch of the user-ratified Shape 2 burn-down (the heap-result return cluster). Two cells, five walls pruned — walled-real ratchet **17 → 12**, `almide test` **341 → 342** files on the wasm leg (364/364 pass).

**Cell 1 — Option-ctor list elements in `ConcatList`** (kills `Deep.__dec_list_opt_int_go` + `__dec_list_opt_string_go`)
The derived-codec opt-list decode workers accumulate with `acc + [_x]` over `List[Int?]` / `List[String?]`; the concat's element families had no Option class, so the bind walled (and behind it the whole "heap-result if" label on the workers). The concat classify now routes through the SAME `lenlist_elem_class` the list-LITERAL builder uses — Flat (scalar payload, per-element rc_dec is the full free) and LenLoop (String/List[scalar] payload, the shared `$__drop_list_lenlist` sweep) — so build and concat agree on the drop. `Option[record]` elements stay out on both sides (the recursive-drop brick; `Deep.__dec_list_opt_Inner_go` remains in the baseline with that note). A/B: the hand-written `_go` shape, the concat bind, and the full `D { lo: List[Int?] }` codec roundtrip are byte-identical on both targets.

**Cell 2 — fallible-closure calls as `??` operands** (kills `use_first_class`, `use_guarded`, `use_option_operand`)
Their "heap-result Tuple" label was misdirection: the real blocker was `g("21") ?? -1` where `g` is an ADR-0009 fallible lambda — a Computed (closure) call was not an admitted `??` operand class. The operand route now dispatches through the tracked closure block exactly like the bind-position Computed arm (fresh owned len-as-tag carrier, type-routed scope-end drop, seeded read shape), and `unwrap_or_is_result` learns the Computed case so a Result carrier reads its tag INVERSELY (the err path `g("z") ?? -1 = -1` is pinned in the A/B). Gated to scalar-payload Option/Result carriers; heap-payload carriers stay walled.

**Verification**
- `proofs/corpus-wall.sh`: totality over 6000 fns, ratchet 12, baseline pruned in the same change.
- `almide test`: 364/364, 342 via WASM (fallible_lambda_test flips to the wasm leg).
- `cargo test --release`: 87 suites ok.

Remaining Shape-2 entries and their measured next cells: the fallible-HOF `??` quartet (Module-call operands with HEAP fallbacks), `par_counts` (heap-result match), and the Option[record] recursive-drop brick shared by `Inner_go` + the Deep test fn.