### PR TITLE
Shape 2 second batch: bind-position Result heap unwrap-or executes via the proven tail match (#1134)

### DIFF
--- a/crates/almide-mir/src/lower/binds_p2_c.rs
+++ b/crates/almide-mir/src/lower/binds_p2_c.rs
@@ -432,7 +432,12 @@ impl LowerCtx {
         // owned rc=1 block (released-merge-dst `i` credit) — then bind +
         // scope-track it and SEED its variant read-shape so a following
         // `match $r` / `$r!` takes the executing tag-read path.
-        if is_variant_ty(ty) {
+        // ALSO entered for a VARIANT SUBJECT with a non-variant HEAP result (`let a =
+        // match <Result[List[Int],String]> { ok(p) => p, err(_) => [0] }` — the
+        // fallible-HOF `??` bind rewrite, #1134 Shape 2): the tail position runs the
+        // SAME routers with no result-type gate, and the merge is the one owned rc=1
+        // block either way — only the variant read-shape seeding is variant-only.
+        if is_variant_ty(ty) || is_variant_ty(&subject.ty) {
             let mark = self.ops.len();
             let lhh_mark = self.live_heap_handles.len();
             let mut dst = self.try_lower_custom_variant_match(subject, arms, ty);
@@ -450,7 +455,16 @@ impl LowerCtx {
                 if !self.live_heap_handles.contains(&obj) {
                     self.live_heap_handles.push(obj);
                 }
-                self.seed_variant_param(obj, ty);
+                if is_variant_ty(ty) {
+                    self.seed_variant_param(obj, ty);
+                } else if crate::lower::is_heap_elem_list_ty(ty)
+                    || matches!(ty, Ty::Applied(almide_lang::types::constructor::TypeConstructorId::List, a)
+                        if a.len() == 1 && !is_heap_ty(&a[0]))
+                {
+                    // A List-valued merge binds as a REAL populated block —
+                    // register it so later element reads take the executing path.
+                    self.materialized_lists.insert(obj);
+                }
                 return Ok(());
             }
             self.ops.truncate(mark);

--- a/crates/almide-mir/src/lower/binds_p2_heap.rs
+++ b/crates/almide-mir/src/lower/binds_p2_heap.rs
@@ -5,7 +5,7 @@ impl LowerCtx {
     /// The HEAP half of [`Self::lower_bind`]: the heap-`??` executable subset,
     /// then the fresh-vs-alias match over every heap producer. Verbatim text move.
     fn lower_bind_heap(&mut self, var: VarId, ty: &Ty, value: &IrExpr) -> Result<(), LowerError> {
-        if self.try_lower_bind_heap_unwrap_or_precheck(var, value)? {
+        if self.try_lower_bind_heap_unwrap_or_precheck(var, ty, value)? {
             return Ok(());
         }
         self.lower_bind_heap_kind(var, ty, value)
@@ -17,6 +17,7 @@ impl LowerCtx {
     fn try_lower_bind_heap_unwrap_or_precheck(
         &mut self,
         var: VarId,
+        ty: &Ty,
         value: &IrExpr,
     ) -> Result<bool, LowerError> {
         // `let s = opt ?? "default"` — a HEAP-String `??` over a materialized Option[String]
@@ -27,9 +28,35 @@ impl LowerCtx {
         // (a non-String heap payload, a non-materialized operand) it falls through to the deferred
         // `Alloc{Opaque}` arm below — unchanged, the existing memory-safe incompleteness.
         if let IrExprKind::UnwrapOr { expr, fallback } = &value.kind {
+            let lifted_mark = self.lifted.len();
             if let Some(dst) = self.try_lower_option_unwrap_or(expr, fallback, true) {
                 self.value_of.insert(var, dst);
                 return Ok(true);
+            }
+            // The declined attempt above rolled its OPS back but a lambda it lifted
+            // while resolving the operand (a fallible-HOF closure arg) SURVIVES in
+            // `lifted` — the match rewrite below would lift it AGAIN, and the twin
+            // lambda bodies double-count the callback's calls (a mir>ir caps breach,
+            // not just waste). Roll the lift back before re-lowering.
+            self.lifted.truncate(lifted_mark);
+            // A RESULT-polarity heap `??` the direct route declined (`let a = list.map(xs,
+            // (s) => f(s)!) ?? [0]` — the fallible-HOF bind, #1134 Shape 2): rewrite to the
+            // SAME `match expr { ok(p) => p, err(_) => fallback }` the TAIL position proved
+            // (lower_tail_heap_unwrap_or) and route it through the bind-position heap-match
+            // machinery. Result polarity ONLY, exactly as the tail rewrite gates it — an
+            // Option operand keeps its proven `option.unwrap_or_str` route above, and a
+            // decline inside the match ROLLS BACK to the honest wall below (never wrong
+            // bytes; the rewrite is speculative, ops truncated on failure).
+            if expr.ty.is_result() {
+                let ops_mark = self.ops.len();
+                let lhh_mark = self.live_heap_handles.len();
+                let rewritten = Self::unwrap_or_as_result_match(value, expr, fallback);
+                if self.lower_bind(var, ty, &rewritten).is_ok() {
+                    return Ok(true);
+                }
+                self.ops.truncate(ops_mark);
+                self.live_heap_handles.truncate(lhh_mark);
+                self.lifted.truncate(lifted_mark);
             }
             // A HEAP-result `??` over an Option/Result operand that `try_lower_option_unwrap_or`
             // declined (e.g. `Option[record]` — no faithful record-payload unwrap-or yet) must
@@ -45,6 +72,42 @@ impl LowerCtx {
             }
         }
         Ok(false)
+    }
+
+    /// The `e ?? d` → `match e { ok(p) => p, err(_) => d }` rewrite, shared shape with
+    /// [`Self::lower_tail_heap_unwrap_or`]'s inline version (Result polarity only —
+    /// the caller gates).
+    fn unwrap_or_as_result_match(value: &IrExpr, expr: &IrExpr, fallback: &IrExpr) -> IrExpr {
+        use almide_ir::{IrMatchArm, IrPattern};
+        let payload_ty = value.ty.clone();
+        let p = VarId(crate::lower::max_var_id(value) + 1);
+        let bind = IrPattern::Bind { var: p, ty: payload_ty.clone() };
+        let payload = IrExpr {
+            kind: IrExprKind::Var { id: p },
+            ty: payload_ty,
+            span: value.span.clone(),
+            def_id: None,
+        };
+        IrExpr {
+            kind: IrExprKind::Match {
+                subject: Box::new(expr.clone()),
+                arms: vec![
+                    IrMatchArm {
+                        pattern: IrPattern::Ok { inner: Box::new(bind) },
+                        guard: None,
+                        body: payload,
+                    },
+                    IrMatchArm {
+                        pattern: IrPattern::Err { inner: Box::new(IrPattern::Wildcard) },
+                        guard: None,
+                        body: fallback.clone(),
+                    },
+                ],
+            },
+            ty: value.ty.clone(),
+            span: value.span.clone(),
+            def_id: value.def_id,
+        }
     }
 
     /// Extracted from `Self::lower_bind_heap` (third-round split, cog reduction): the

--- a/crates/almide-mir/src/lower/control_p3.rs
+++ b/crates/almide-mir/src/lower/control_p3.rs
@@ -212,6 +212,24 @@ impl LowerCtx {
         if matches!(&expr.kind, IrExprKind::Member { .. } | IrExprKind::TupleIndex { .. }) {
             return self.field_unwrap_or_operand(expr);
         }
+        // A NESTED `??` operand (`(list.find(..) ?? none) ?? -1` — the fallible-HOF
+        // find shape, #1134 Shape 2): ANF it — bind the INNER `??` to a synthetic
+        // temp through the ordinary bind machinery (which owns + scope-tracks it and
+        // seeds its variant read shape), then resolve the temp exactly like a
+        // user-written two-step `let inner = ..; inner ?? d`. The bind declining
+        // rolls back to None (the wall stays honest).
+        if matches!(&expr.kind, IrExprKind::UnwrapOr { .. }) {
+            let tmp = self.fresh_synth_var();
+            if self.lower_bind(tmp, &expr.ty, expr).is_err() {
+                self.unwrap_or_rollback(cx);
+                return None;
+            }
+            let Ok(v) = self.value_for(tmp) else {
+                self.unwrap_or_rollback(cx);
+                return None;
+            };
+            return self.var_unwrap_or_operand_value(v, &expr.ty);
+        }
         if is_self_host_option_call(expr)
             || is_self_host_result_call(expr)
             || (is_self_host_result_str_call(expr)
@@ -273,28 +291,30 @@ impl LowerCtx {
     /// borrowed variant PARAM (`param_values` — same calling-convention soundness as the
     /// match): a deferred Opaque Var (len 0) would MISREAD as None/Err, so it is excluded.
     fn var_unwrap_or_operand(&self, id: VarId, expr_ty: &Ty) -> Option<ValueId> {
-        match self.value_for(id) {
-            Ok(v)
-                if self.materialized_options.contains(&v)
-                    || self.materialized_results.contains(&v)
-                    // a Value/List-Ok Result Var (`value.get`/`value.as_array` result) — its `??`
-                    // routes to the value_unwrap helper route. A String-Ok Result (heap_elem_lists)
-                    // is NOT admitted here: it keeps its original path (the String branch is for
-                    // OPTION[String], and counting a str-Result there falsely taints mir>ir).
-                    || self.value_result_results.contains(&v)
-                    || self.value_result_lists.contains(&v)
-                    // A `Result[String, String]` Var (cap-as-tag, materialized_results_str)
-                    // routes to the `result.str_unwrap_or` helper route — admitted ONLY for
-                    // that type (any other _str-set shape would mis-take the len-as-tag
-                    // String branch, reading an Err payload as Some).
-                    || (self.materialized_results_str.contains(&v)
-                        && crate::lower::is_result_str_str_ty(expr_ty))
-                    || self.param_values.contains(&v) =>
-            {
-                Some(v)
-            }
-            _ => None,
-        }
+        let v = self.value_for(id).ok()?;
+        self.var_unwrap_or_operand_value(v, expr_ty)
+    }
+
+    /// The admission half of [`Self::var_unwrap_or_operand`], keyed on the resolved
+    /// `ValueId` — shared with the nested-`??` ANF route, whose synthetic temp has a
+    /// value but no user-facing var lookup to repeat.
+    fn var_unwrap_or_operand_value(&self, v: ValueId, expr_ty: &Ty) -> Option<ValueId> {
+        let admitted = self.materialized_options.contains(&v)
+            || self.materialized_results.contains(&v)
+            // a Value/List-Ok Result Var (`value.get`/`value.as_array` result) — its `??`
+            // routes to the value_unwrap helper route. A String-Ok Result (heap_elem_lists)
+            // is NOT admitted here: it keeps its original path (the String branch is for
+            // OPTION[String], and counting a str-Result there falsely taints mir>ir).
+            || self.value_result_results.contains(&v)
+            || self.value_result_lists.contains(&v)
+            // A `Result[String, String]` Var (cap-as-tag, materialized_results_str)
+            // routes to the `result.str_unwrap_or` helper route — admitted ONLY for
+            // that type (any other _str-set shape would mis-take the len-as-tag
+            // String branch, reading an Err payload as Some).
+            || (self.materialized_results_str.contains(&v)
+                && crate::lower::is_result_str_str_ty(expr_ty))
+            || self.param_values.contains(&v);
+        admitted.then_some(v)
     }
 
     /// `r.opt ?? d` — an `Option[scalar/String]` FIELD of a materialized record: BORROW the

--- a/proofs/walled-real-baseline.txt
+++ b/proofs/walled-real-baseline.txt
@@ -64,15 +64,18 @@ spec/stdlib/codec_field_matrix_test.almd :: __test_almd_nested containers: List[
 # keep the pre-#1108 world), and the L-battery landed — the helpers sit on the
 # same bundled-generic closure-lifting frontier as the twins; pruned by the
 # same defunctionalization brick.
+# (2026-08-10, #1134 Shape 2 second batch) m_pipe_qq / fm_cells / marker_cells /
+# find_cells are PRUNED: the bind-position Result-polarity heap `??` now takes
+# the SAME `match ok/err` rewrite the tail position proved (routed through the
+# bind heap-match machinery, whose variant router gate widened to variant
+# SUBJECTS with non-variant heap results), and a NESTED `??` operand ANFs its
+# inner `??` to a synthetic bind. The marker test fn's cond entry below stays:
+# its blocker is the `List[Result[Int,String]]` eq engine cell, not the `??`s.
 spec/lang/fallible_hof_test.almd :: __test_almd_the marker, not the type, carries the callback bit
 # (2026-08-07, #1130) The branch-lift clone-scope regression: its driver is a
 # tail-recursive effect fn over a heap accumulator, the shape the v1 renderer
 # hands to the native leg.
 spec/lang/branch_lift_clone_test.almd :: __test_almd_a lifted in-loop branch clones what it reuses
-spec/lang/fallible_hof_test.almd :: find_cells
-spec/lang/fallible_hof_test.almd :: fm_cells
-spec/lang/fallible_hof_test.almd :: m_pipe_qq
-spec/lang/fallible_hof_test.almd :: marker_cells
 # (2026-08-10, #1134 Shape 2) The three fallible_lambda use_* fns are PRUNED:
 # the `??` operand machinery gained the fallible-CLOSURE call route (the
 # ADR-0009 carrier — dispatch through the tracked closure block, inverse tag


### PR DESCRIPTION
Second batch of the Shape 2 burn-down. One cell family, four walls pruned — walled-real ratchet **12 → 8**, `almide test` 364/364 (342 via WASM), corpus totality + mir≤ir gates green over 6000 fns, 87 cargo suites ok.

**The cell** (kills `m_pipe_qq`, `fm_cells`, `marker_cells`, `find_cells`): a bind-position Result-polarity heap `??` (`let a = list.map(xs, (s) => f(s)!) ?? [0]` — the fallible-HOF bind) had no route: the direct operand machinery declined and the bind fell to the honest wall. Three pieces, each the smallest step that reuses proven machinery:

1. **The tail's rewrite, at bind position**: `e ?? d` (Result polarity only) rewrites to `match e { ok(p) => p, err(_) => d }` — the exact rewrite `lower_tail_heap_unwrap_or` proved — and routes through the bind heap-match machinery, speculative with full rollback to the wall.
2. **The bind heap-match variant-router gate widens** from "variant RESULT type" to "variant result OR variant SUBJECT": the tail runs the same routers ungated, and the merge is the one owned rc=1 block either way. A List-valued merge registers in `materialized_lists` so later element reads execute.
3. **Nested `??` operands ANF** (`(list.find(..) ?? none) ?? -1`): the inner `??` binds to a synthetic temp through the ordinary bind machinery, then resolves like the user-written two-step spelling.

**The gate catch worth reading**: the first version double-lifted the callback lambda — the declined speculative attempt rolled back its ops but left the lifted lambda in `lifted`, and the rewrite lifted a twin, double-counting the callback's calls. The corpus gate's `mir>ir` check caught it as exactly the caps-masking breach it exists for (4 fns, +1 per rewritten `??`). The fix rolls `lifted` back on both decline paths; the probe now shows one lifted body and `mir == ir`.

**A/B evidence** (native ⇄ wasm byte-identical, ok and err paths): the pipe-bind, direct-bind, tuple-of-lists, and nested-`??` spellings, plus the err-path `?? [0]` / `?? -1` fallbacks.

Remaining 8: `par_counts` (heap-result match over an fs streaming subject), the Option[record] recursive-drop pair (`Inner_go` + Deep test fn), `collect_partition` (UnOp cond + fs capability), `seq_counts` (fs.fold_lines capability), branch_lift (heap-`??` in call arg), marker test-fn cond (`List[Result]` eq), custom-E (untracked match subject).