### PR TITLE
Shape 3 completion: variant-Err Result binds track through match, killing the custom-E wall (#1134)

### DIFF
--- a/crates/almide-mir/src/lower/binds_p2_c.rs
+++ b/crates/almide-mir/src/lower/binds_p2_c.rs
@@ -161,6 +161,29 @@ impl LowerCtx {
         // so a later `match r { Ok(v) => …, Err(e) => … }` over the var EXECUTES.
         if is_self_host_result_module_fn(module, func) {
             self.materialized_results.insert(dst);
+            // A VARIANT-Err payload (`option.to_result(o, Missing("cfg"))` →
+            // `Result[Int, LoadError]`, #1114's typed-error route): route the drop —
+            // a RICH variant (heap fields) through the generated `$__drop_res_<V>`
+            // (a flat rc_dec would leak the payload's fields), a FLAT one through
+            // the one-level `DropListStr` — which is ALSO what admits the
+            // `err(e)` payload BIND in the statement-position Result match
+            // (`result_err_bind` keys on exactly these two sets). Without this the
+            // bound subject was tracked but its Err bind declined, and the whole
+            // match fell to the untracked-subject wall.
+            if let Ty::Applied(almide_lang::types::constructor::TypeConstructorId::Result, a) = ty {
+                if a.len() == 2 && !is_heap_ty(&a[0]) {
+                    if let Some(vname) = self.custom_variant_type_name(&a[1]) {
+                        let needs_rec = self.variant_layouts.needs_recursive_drop(&vname, &|rn| {
+                            crate::lower::canonical_record_key(&self.record_layouts, rn).is_some()
+                        });
+                        if needs_rec {
+                            self.variant_drop_handles.insert(dst, format!("res_{vname}"));
+                        } else {
+                            self.heap_elem_lists.insert(dst);
+                        }
+                    }
+                }
+            }
         }
         // A self-host HEAP-Ok Result fn (`value.as_string`/`value.as_array`) — track it in the
         // cap-as-tag set so a `match` reads tag @16 + binds the @12 payload. The DROP differs

--- a/crates/almide-mir/src/lower/control_p2.rs
+++ b/crates/almide-mir/src/lower/control_p2.rs
@@ -309,7 +309,18 @@ impl LowerCtx {
                     let bind = self.result_err_bind(subj, inner).ok()?;
                     fill_once(&mut err, (&arm.body, bind))?;
                 }
-                IrPattern::Wildcard => fill_once(&mut err, (&arm.body, Option::None))?,
+                // A WILDCARD takes whichever side the ctor arm did NOT: after an Ok
+                // arm it is the not-Ok (err) side — the original behavior; after an
+                // ERR arm (`match r { err(e) => …, _ => … }`, the desugared
+                // nested-pattern custom-E shape) it is the not-Err (ok) side,
+                // binding nothing. A wildcard BEFORE any ctor arm is ambiguous —
+                // reject (same rule as `classify_variant_arm`).
+                IrPattern::Wildcard if err.is_some() && ok.is_none() => {
+                    fill_once(&mut ok, (&arm.body, Option::None))?
+                }
+                IrPattern::Wildcard if ok.is_some() => {
+                    fill_once(&mut err, (&arm.body, Option::None))?
+                }
                 _ => return None,
             }
         }

--- a/proofs/walled-real-baseline.txt
+++ b/proofs/walled-real-baseline.txt
@@ -85,15 +85,13 @@ spec/lang/branch_lift_clone_test.almd :: __test_almd_a lifted in-loop branch clo
 # "heap-result Tuple" label. The fallible_hof entries above stay: their `??`
 # operands are fallible-HOF Module calls with HEAP fallbacks — the next cell.
 #
-# (2026-08-06, #1114) option.to_result became an E-GENERIC pure bundled body
-# (ADR-0003 D1's typed-error route needs Option -> Result[T, CustomE]). The
-# custom-E instantiation binds a match over Result[Int, <variant>] whose
-# variant payload sits outside the heap-result ctor zoo — the same
-# feature-frontier family as the Codec-matrix class above. The String
-# instantiation (the overwhelmingly common form) stays IN the wasm corpus and
-# passes; this one cell runs on the native leg. Prune with the same
-# heap-result-arm brick.
-spec/stdlib/option_to_result_generic_test.almd :: __test_almd_custom E flows through
+# (2026-08-10, #1134 Shape 3) The #1114 custom-E test fn is PRUNED: the `_ve`
+# twin routes the scalar-A custom-E instantiation (killing the silent
+# `__copy_str` corruption of the two-step spelling), the module-call bind seed
+# registers the `res_<V>`/flat drop route for a variant-Err Result (which is
+# also the `err(e)` bind admission), and the statement-position Result match's
+# WILDCARD arm now takes whichever side the ctor arm did not — so the
+# desugared `match r { err(e) => …, _ => … }` executes on the wasm leg.
 #
 # (2026-08-09, #1146) Four lowering walls the C-220 fs streaming landing
 # introduced but could not enumerate: the UNBACKED certificate breach aborted


### PR DESCRIPTION
Completes the custom-E cell #1167 opened. The nested-pattern test spelling (`match r { err(Missing(k)) => …, _ => … }`) turned out to desugar in the FRONTEND to the two-step form (`err($e)` + an inner variant match) — so no new match machinery was needed, just two admission gaps:

1. **Variant-Err drop-route seeding on module-call binds**: `let r: Result[Int, LoadError] = option.to_result(…)` tracked the Result but registered no Err-payload route — a RICH variant (heap fields) now routes `res_<V>` (the generated `$__drop_res_<V>`, the #1114 structured-error discipline), a FLAT one the one-level `DropListStr`. This is simultaneously the drop-correctness fix and the `err(e)` bind admission (`result_err_bind` keys on exactly these sets).
2. **The statement-position Result match's WILDCARD arm takes whichever side the ctor arm did NOT** — `[err(e), _]` previously jammed both arms into the err slot (the parse required an explicit ok arm), so the desugared form fell to the untracked-subject wall. Same flexible-wildcard rule `classify_variant_arm` already had; a wildcard before any ctor arm stays rejected as ambiguous.

A dead-end explored and removed in the same session: a bespoke nested-variant-pattern match helper — unnecessary once the desugar was understood (the C1 discipline's "reuse proven machinery" applied to my own first attempt).

**Verification**: the one-match nested spelling now runs byte-identical native ⇄ wasm on ok/err×Missing/Broken; `option_to_result_generic_test` walls 0 and runs the wasm leg; walled-real ratchet **6 → 5** (baseline pruned same change); `almide test` 364/364 (**345 via WASM**); corpus totality 6002 fns; 87 cargo suites.

Remaining 5 walls, all one family now: the fs streaming capability trio + the Option[record] recursive-drop pair.