### PR TITLE
#1134 ENDGAME: walled-real ratchet 1 → 0 — the classify drift falls, fold_lines_range links (#1176)

### DIFF
--- a/crates/almide-mir/examples/classify_corpus_parts/classify_corpus_c.rs
+++ b/crates/almide-mir/examples/classify_corpus_parts/classify_corpus_c.rs
@@ -83,8 +83,15 @@ fn classify_lower_one_fn(
             // BOTH the MIR and this counted IR — `mir == ir` by construction. A subset
             // (only guard + heap-branches) missed `desugar_tuple_unwrap_or`, so a
             // `let r = opt.unwrap_or((tuple)); f(r.0)` mir>ir-breached.
+            // The AUTO_WRAP synthetic-Result retype FIRST — the same root-ty adjustment
+            // `lower_function_all_impl` makes before ITS desugar ladder, via the same
+            // helper (single source of truth). `desugar_loop_unwrap`'s root gate keys on
+            // the Result carrier ty; counting the bare-sugar-typed body instead declined
+            // the loop-`!` flag rewrite the lowering applied, so its injected owned-copy
+            // concat was a MIR op with no counted IR node (#1176).
+            let abi_body = almide_mir::lower::auto_wrap_abi_body(func);
             let eff_body = almide_mir::lower::desugar_all(
-                &func.body,
+                abi_body.as_ref().unwrap_or(&func.body),
                 func.name.as_str() == "main",
                 ctx.variant_layouts,
                 ctx.record_layouts,

--- a/crates/almide-mir/src/lower/calls.rs
+++ b/crates/almide-mir/src/lower/calls.rs
@@ -786,7 +786,7 @@ fn is_admitted_effectful_fs(module: &str, func: &str) -> bool {
         // acc to an unregistered name that walls cleanly at render. Their
         // CLOSURE argument rides the same lift machinery every pure fold twin
         // uses — the callback's own capabilities are captured by the lift.
-        || (module == "fs" && matches!(func, "fold_lines" | "fold_lines_chunked"))
+        || (module == "fs" && matches!(func, "fold_lines" | "fold_lines_chunked" | "fold_lines_range"))
 }
 
 /// Extracted from `is_admitted_effectful_pure_module_call` (codopsy8 follow-up, group 3

--- a/crates/almide-mir/src/lower/mod_c.rs
+++ b/crates/almide-mir/src/lower/mod_c.rs
@@ -502,6 +502,22 @@ fn new_lower_ctx(
     }
 }
 
+/// The synthetic-Result ABI retype the lowering applies before its desugar ladder: an
+/// `AUTO_WRAP_ABI_FNS` member's root body is retyped to the TRUE compiled carrier
+/// `Result[<declared>, String]` (`func.ret_ty` keeps the bare sugar type). `pub` because
+/// the classify count-side must apply the SAME retype before `desugar_all` —
+/// desugar-before-both means BOTH: without it `desugar_loop_unwrap`'s `Result[T, String]`
+/// root gate declines on the count side while the lowering fires it, and the rewrite's
+/// injected owned-copy concat becomes a MIR op with no counted IR node (a false
+/// `mir > ir` breach on every in-profile loop-`!` fn — the #1176 drift).
+pub fn auto_wrap_abi_body(func: &IrFunction) -> Option<IrExpr> {
+    if crate::lower::AUTO_WRAP_ABI_FNS.with(|s| s.borrow().contains(func.name.as_str())) {
+        Some(IrExpr { ty: Ty::result(func.ret_ty.clone(), Ty::String), ..func.body.clone() })
+    } else {
+        None
+    }
+}
+
 fn lower_function_all_impl(
     func: &IrFunction,
     globals: &HashMap<VarId, Ty>,
@@ -544,10 +560,8 @@ fn lower_function_all_impl(
     // SAME desugared tree (desugar-before-both), so mir == ir. Unblocks base64 encode/decode_chunks +
     // toml read_basic/parse_val (the let-bound-heap-`if`-in-a-loop frontier).
     let owned_body;
-    let func_body: &IrExpr = if crate::lower::AUTO_WRAP_ABI_FNS
-        .with(|s| s.borrow().contains(func.name.as_str()))
-    {
-        owned_body = IrExpr { ty: Ty::result(func.ret_ty.clone(), Ty::String), ..func.body.clone() };
+    let func_body: &IrExpr = if let Some(b) = auto_wrap_abi_body(func) {
+        owned_body = b;
         &owned_body
     } else {
         &func.body

--- a/crates/almide-mir/src/lower/mod_p4_h.rs
+++ b/crates/almide-mir/src/lower/mod_p4_h.rs
@@ -223,24 +223,24 @@ fn list_heap_call_name_special_cases(
     // the `Map[String, Int]` accumulator routes to the `_msi` self-host twin
     // (fs_fold_lines.almd); any other accumulator routes to an unregistered
     // `_x` name and walls cleanly at render (never a wrong-typed link).
-    // `fs.fold_lines` / `fs.fold_lines_chunked` (#1134, the C-220 streaming trio):
-    // the `Map[String, Int]` accumulator routes to the `_msi` self-host twin
-    // (fs_fold_lines.almd); any other accumulator routes to an unregistered
-    // `_x` name and walls cleanly at render (never a wrong-typed link).
-    // `fold_lines_range` is deliberately NOT admitted yet: its consumer
-    // (collect_partition) carries an in-loop `!`, whose flag-rewrite owned-copy
-    // concat trips the classify chain's mir>ir drift (the count-side
-    // desugar_all does not run desugar_loop_unwrap) — the `_ls` twin sits
-    // ready in fs_fold_lines.almd; flip the routing once the instrument is
-    // aligned. See the walled-real baseline's Shape 5 note.
-    if module == "fs" && matches!(func, "fold_lines" | "fold_lines_chunked") {
+    // The C-220 streaming trio (#1134): typed routing to the self-host twins in
+    // fs_fold_lines.almd — `Map[String, Int]` accumulators to `_msi`
+    // (fold_lines / fold_lines_chunked), the `List[String]` accumulator to
+    // `_ls` (fold_lines_range, the collect_partition shape). Any other
+    // accumulator type routes to an unregistered `_x` name and walls cleanly
+    // at render — never a wrong-typed link.
+    if module == "fs" && matches!(func, "fold_lines" | "fold_lines_chunked" | "fold_lines_range") {
         use almide_lang::types::constructor::TypeConstructorId as TC;
-        let init_idx = if func == "fold_lines" { 1 } else { 2 };
+        let init_idx = match func { "fold_lines" => 1, "fold_lines_chunked" => 2, _ => 3 };
         let msi_acc = matches!(arg_tys.get(init_idx),
             Some(Ty::Applied(TC::Map, a)) if a.len() == 2
                 && matches!(a[0], Ty::String) && matches!(a[1], Ty::Int));
-        return Some(if msi_acc {
+        let ls_acc = matches!(arg_tys.get(init_idx),
+            Some(Ty::Applied(TC::List, a)) if a.len() == 1 && matches!(a[0], Ty::String));
+        return Some(if msi_acc && func != "fold_lines_range" {
             format!("fs.{func}_msi")
+        } else if ls_acc && func == "fold_lines_range" {
+            format!("fs.{func}_ls")
         } else {
             format!("fs.{func}_x")
         });

--- a/crates/almide-mir/src/lower/mod_p5.rs
+++ b/crates/almide-mir/src/lower/mod_p5.rs
@@ -69,6 +69,7 @@ pub fn is_self_host_result_str_module_fn(module: &str, func: &str) -> bool {
             // tag @16); a `match`/`!` over them reads tag @16.
             | ("fs", "fold_lines")
             | ("fs", "fold_lines_chunked")
+            | ("fs", "fold_lines_range")
             // `fs.stat` returns the cap-as-tag `Result[FileStat, String]` (the self-host builds
             // it with the ordinary ok()/err() ctors — payload @12, tag @16). The Ok payload is a
             // SCALAR-ONLY record block (size/is_dir/is_file/modified — no heap fields), so the

--- a/proofs/walled-real-baseline.txt
+++ b/proofs/walled-real-baseline.txt
@@ -98,18 +98,12 @@
 # WILDCARD arm now takes whichever side the ctor arm did not — so the
 # desugared `match r { err(e) => …, _ => … }` executes on the wasm leg.
 #
-# (2026-08-11, #1134 Shape 5 — FUNCTIONALLY DONE, gate-blocked) The fs streaming
-# trio LOWERS AND RUNS byte-identical on both targets (wip-fs-streaming-msi:
-# fold_lines/chunked/range self-hosts over prim.read_text_file with
-# BufRead::read_line's exact semantics + the native byte-partition transcribed;
-# map.upsert_skv; the $__drop_res_msi/_lmsi wrapper drops) — the A/B evidence
-# incl. chunks=3 parity and partition invariance is on the branch. The entries
-# STAY because landing them trips the mir>ir caps gate on collect_partition:
-# the count-side desugar_all does NOT apply desugar_loop_unwrap's flag rewrite
-# while the lowering ladder does, so the injected `$x ++ ""` owned-copy concat
-# is a MIR op with no counted IR node — the classify-chain drift previously
-# noted as rot, now material for the first in-profile loop-`!` fn. Fix the
-# instrument (align desugar_all with the ladder), then flip the routing and
-# prune the last entry. seq_counts and par_counts ARE pruned — their `!`s are
-# top-level binds, clear of the drift.
-spec/stdlib/fs_fold_lines_range_test.almd :: collect_partition
+# (2026-08-11, #1134 Shape 5 ENDGAME — the set is EMPTY)
+# All walls burned. The last entry (collect_partition, the in-loop `!` consumer
+# of fs.fold_lines_range) fell when the classify count-side gained the SAME
+# AUTO_WRAP synthetic-Result root retype the lowering applies before its desugar
+# ladder (auto_wrap_abi_body, one helper both sides — #1176): desugar_loop_unwrap's
+# Result[T, String] root gate then fires count-side too, and the loop-`!` flag
+# rewrite's injected owned-copy concat is counted 1:1 (mir == ir).
+# The ratchet target is now permanently 0: ANY new walled-real entry is a
+# regression and fails the gate.

--- a/spec/stdlib/fs_fold_lines_chunked_test.almd
+++ b/spec/stdlib/fs_fold_lines_chunked_test.almd
@@ -1,6 +1,8 @@
 // @contract: C-220
-// wasm:skip — same defunctionalization frontier as the rest of the streaming
-// family (#1134); the wasm render walls honestly.
+// wasm:skip — the test fixture's tmp() rides fs.create_temp_dir, which has no
+// WASI self-host yet (its own brick). The streaming fns under test themselves
+// LOWER (#1134 endgame, walled-real = 0); A/B parity is probe-verified. Remove
+// this skip when the create_temp_dir brick lands.
 // fs.fold_lines_chunked — one range worker per chunk on real threads inside
 // the runtime, partials returned in CHUNK ORDER. Merging the partials with
 // any associative fold must equal the sequential fold_lines result for every

--- a/spec/stdlib/fs_fold_lines_range_test.almd
+++ b/spec/stdlib/fs_fold_lines_range_test.almd
@@ -1,6 +1,8 @@
 // @contract: C-220
-// wasm:skip — same defunctionalization frontier as the rest of the streaming
-// family (#1134); the wasm render walls honestly.
+// wasm:skip — the test fixture's tmp() rides fs.create_temp_dir, which has no
+// WASI self-host yet (its own brick). The streaming fns under test themselves
+// LOWER (#1134 endgame, walled-real = 0); A/B parity is probe-verified. Remove
+// this skip when the create_temp_dir brick lands.
 // fs.fold_lines_range — the chunk-parallel worker's walker. Ownership rule:
 // a line belongs to the chunk containing the byte BEFORE its first byte
 // (line 0 to the chunk containing byte 0), so folding any partition of

--- a/spec/stdlib/fs_streaming_test.almd
+++ b/spec/stdlib/fs_streaming_test.almd
@@ -1,7 +1,8 @@
 // @contract: C-220
-// wasm:skip — the streaming line walkers are native-only today: the callback
-// crosses the runtime boundary, and generic HOF closures are the wasm
-// defunctionalization frontier (#1134). The wasm render walls honestly;
+// wasm:skip — this file's accumulator shapes (String/Int/List[String] fold_lines,
+// for_each_line) have no self-host twins yet — only the Map[String, Int] msi pair
+// and fold_lines_range_ls landed (#1134 endgame) — and tmp() rides
+// fs.create_temp_dir (its own brick). The wasm render walls honestly;
 // remove this skip when the wasm leg lands.
 // Streaming line walkers {fold_lines, for_each_line}: line-by-line over a
 // file with O(longest line) memory, line semantics byte-matching read_lines.


### PR DESCRIPTION
The last wall falls. Walled-real ratchet **1 → 0**; the baseline is EMPTY and the target is now permanently 0 — any new walled-real entry fails CI. Corpus totality 6009 fns; `almide test` 366/366; 87 cargo suites.

**The instrument fix (#1176, the real work)**
`lower_function_all_impl` retypes an `AUTO_WRAP_ABI_FNS` member's root body to its true compiled carrier `Result[<declared>, String]` BEFORE its desugar ladder — but the classify count side fed `desugar_all` the raw bare-sugar-typed body (measured: `collect_partition`'s counted root was `List[String]`). `desugar_loop_unwrap`'s `Result[T, String]` root gate therefore declined count-side while the lowering fired it, and the loop-`!` flag rewrite's injected owned-copy concat (`$x ++ ""`) was a MIR op with no counted IR node — a false `mir > ir` breach on every in-profile loop-`!` fn. The retype is now extracted into one `pub fn auto_wrap_abi_body` helper called by BOTH sides (desugar-before-both means both, by construction, single source of truth).

**What that unblocks, same PR**
- `fs.fold_lines_range` routes to its `_ls` self-host twin (already in the tree since #1175, proven at parity) — `collect_partition` lowers, and the last baseline entry is pruned.
- The stale `wasm:skip` markers on the two fold_lines spec files claimed the defunctionalization frontier; the measured wall is actually the fixture's `fs.create_temp_dir` (no WASI self-host yet — its own brick). Markers rewritten to the true reason; `fs_streaming_test`'s marker likewise corrected (its remaining accumulator shapes have no twins yet).

**A/B evidence (current build)**: collect_partition over 3 cut patterns and fold_lines+chunked counts (incl. `chunks=3` partials) — byte-identical native ⇄ wasm.

Closes #1176.