### PR TITLE
Surface wasm-leg traps that diverge from the native verdict in almide test (#1166)

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -662,14 +662,28 @@ pub fn cmd_test_fast(file: &str, no_check: bool, run_filter: Option<&str>) {
 
     let mut wasm_pass = 0usize;
     let mut fallback: Vec<String> = Vec::new();
+    let mut trapped: Vec<(String, String)> = Vec::new();
     for o in wasm_outcomes {
         match o {
             WasmTestOutcome::Pass { .. } => wasm_pass += 1,
+            // A `Fail` is DIFFERENT IN KIND from the benign fallback classes
+            // (#1166): the wasm leg COMPILED the file, claimed it, and produced
+            // a runtime failure. Whether that is a plain failing test or a
+            // MISCOMPILE only the native re-run can say — so hold the detail
+            // and judge after phase 2: native red → an ordinary FAILED (no
+            // wasm-specific noise); native green → the divergence class the
+            // walls exist to prevent, reported loudly below. Silently folding
+            // it into "via native fallback" hid the #1165 `indirect call type
+            // mismatch` for its whole life locally while CI's Test WASM failed
+            // the PR.
+            WasmTestOutcome::Fail { file, detail } => {
+                trapped.push((file.clone(), detail));
+                fallback.push(file);
+            }
             // CompileError routes to the fallback like everything else here:
             // the native leg re-runs it and reports the diagnostics
             // authoritatively (#862), turning it into a counted FAILED.
-            WasmTestOutcome::Fail { file, .. }
-            | WasmTestOutcome::CompileError { file, .. }
+            WasmTestOutcome::CompileError { file, .. }
             | WasmTestOutcome::Skip { file, .. } => fallback.push(file),
         }
     }
@@ -686,9 +700,40 @@ pub fn cmd_test_fast(file: &str, no_check: bool, run_filter: Option<&str>) {
     for (file, code) in &native_results {
         if *code != 0 { err(&format!("FAILED: {}", file)); failed += 1; }
     }
-    err(&format!("\n{} via WASM, {} via native fallback, {} failed (of {} files)",
-        wasm_pass, fallback.len().saturating_sub(failed), failed, test_files.len()));
+    // The #1166 divergence class: the wasm leg compiled the file and failed at
+    // runtime, but the AUTHORITATIVE native re-run passed — a wasm-only
+    // miscompile signal, exactly what CI's Test WASM job reds a PR for. Report
+    // each one loudly (still counted "via native fallback": the suite verdict
+    // is native's). A trap whose native re-run ALSO failed is a plain FAILED
+    // test — no wasm-specific noise for those.
+    let native_code: std::collections::HashMap<&String, i32> =
+        native_results.iter().map(|(f, c)| (f, *c)).collect();
+    let diverged: Vec<&(String, String)> = trapped
+        .iter()
+        .filter(|(f, _)| native_code.get(f).copied() == Some(0))
+        .collect();
+    for (file, detail) in &diverged {
+        err(&format!("WASM TRAP {} (compiled for wasm, failed at runtime; native re-run PASSED — CI's Test WASM will fail this)", file));
+        err_no_nl(detail);
+    }
+    let trap_note = if diverged.is_empty() {
+        String::new()
+    } else {
+        format!(" ({} after a wasm TRAP)", diverged.len())
+    };
+    err(&format!("\n{} via WASM, {} via native fallback{}, {} failed (of {} files)",
+        wasm_pass, fallback.len().saturating_sub(failed), trap_note, failed, test_files.len()));
     if failed > 0 {
+        std::process::exit(1);
+    }
+    // Pre-push strict mode: a diverged trap fails the run even though the
+    // native re-run passed — CI's Test WASM verdict, surfaced locally instead
+    // of on the PR (#1166).
+    if !diverged.is_empty() && std::env::var_os("ALMIDE_TEST_STRICT_WASM").is_some() {
+        err(&format!(
+            "STRICT WASM: {} file(s) trapped on the wasm leg (native re-run passed; CI's Test WASM will fail)",
+            diverged.len()
+        ));
         std::process::exit(1);
     }
     err(&format!("All {} test file(s) passed", test_files.len()));


### PR DESCRIPTION
Closes #1166.

`cmd_test_fast` folded EVERY wasm outcome it couldn't pass — emitter wall, `wasm:skip`, compile error, and a **runtime trap** — into one silent "via native fallback" count. A trap is different in kind: the wasm leg compiled the file, claimed it, and produced wrong behavior at runtime — the miscompile class that ran `fallible_hof_test`'s `indirect call type mismatch` silently native for its whole life locally while CI's Test WASM redded the PR (#1165).

**What changes**
- A wasm `Fail` outcome is now held with its trap detail and judged AFTER the authoritative native re-run:
  - native red → an ordinary FAILED test (no wasm-specific noise — a plain failing test fails both legs);
  - native green → the divergence class, reported loudly per file (`WASM TRAP <file> … native re-run PASSED — CI's Test WASM will fail this` + the trapped-at detail) and counted in the summary: `N via WASM, M via native fallback (K after a wasm TRAP), 0 failed`.
- `ALMIDE_TEST_STRICT_WASM=1` makes a diverged trap fail the run (exit 1) even though native passed — CI's Test WASM verdict, available pre-push.

**Verification**: an aborting probe test (fails both legs) shows a plain FAILED with no trap note — before the divergence-judging refinement the same probe exercised the full trap plumbing end to end (`(1 after a wasm TRAP)` in the summary + the loud line). Full suite unchanged: 348 via WASM, 18 via native fallback, 0 failed; `All 366 test file(s) passed`; cargo suites green.