### PR TITLE
Stop warning 'unused variable' on fn-typed bindings the code calls by name (#1158)

### DIFF
--- a/crates/almide-ir/src/use_count.rs
+++ b/crates/almide-ir/src/use_count.rs
@@ -556,11 +556,43 @@ pub fn collect_assigned_vars(expr: &IrExpr, assigned: &mut HashSet<u32>) {
 /// Skips: `_` prefixed names, function parameters, pattern bindings (span is None).
 pub fn collect_unused_var_warnings(program: &IrProgram, file: &str) -> Vec<almide_base::Diagnostic> {
     let (param_ids, mutated) = collect_params_and_mutations(program);
+    let named_callees = collect_named_callee_names(program);
     (0..program.var_table.len())
         .filter_map(|i| {
-            unused_var_warning(&program.var_table.entries[i], i as u32, &param_ids, &mutated, file)
+            unused_var_warning(
+                &program.var_table.entries[i], i as u32, &param_ids, &mutated, &named_callees, file,
+            )
         })
         .collect()
+}
+
+/// Callee names of every `CallTarget::Named` call in the program. A call to a
+/// LOCAL fn-typed value (`let f = adder(3); f(5)`) lowers with a `Named`
+/// target — a Sym, not a VarId — so `compute_use_counts` cannot credit the
+/// binding and `f` reads as unused (#1158). Matching by NAME over-suppresses
+/// under shadowing (a local named after a real free fn), which is the safe
+/// direction for a warning — the #857 mutated-set precedent.
+fn collect_named_callee_names(program: &IrProgram) -> HashSet<String> {
+    use crate::visit::{walk_expr, IrVisitor};
+    struct C(HashSet<String>);
+    impl IrVisitor for C {
+        fn visit_expr(&mut self, e: &IrExpr) {
+            if let IrExprKind::Call { target, .. } | IrExprKind::TailCall { target, .. } = &e.kind {
+                if let CallTarget::Named { name } = target {
+                    self.0.insert(name.as_str().to_string());
+                }
+            }
+            walk_expr(self, e);
+        }
+    }
+    let mut c = C(HashSet::new());
+    for func in &program.functions {
+        c.visit_expr(&func.body);
+    }
+    for tl in &program.top_lets {
+        c.visit_expr(&tl.value);
+    }
+    c.0
 }
 
 /// The two exclusion sets consulted by [`unused_var_warning`]: every function
@@ -592,10 +624,14 @@ fn unused_var_warning(
     id: u32,
     param_ids: &HashSet<u32>,
     mutated: &HashSet<u32>,
+    named_callees: &HashSet<String>,
     file: &str,
 ) -> Option<almide_base::Diagnostic> {
     if info.name.starts_with('_') || param_ids.contains(&id) { return None; }
     if info.use_count > 0 || mutated.contains(&id) { return None; }
+    // A fn-typed binding invoked by name (`f(5)`) is a use `use_count` cannot
+    // see — the callee is a name-only `CallTarget::Named` (#1158).
+    if named_callees.contains(info.name.as_str()) { return None; }
     let span = info.span?;
     Some(almide_base::Diagnostic::warning(
         format!("unused variable '{}'", info.name),

--- a/tests/ir_test.rs
+++ b/tests/ir_test.rs
@@ -561,6 +561,39 @@ fn unused_var_warning_basic() {
 }
 
 #[test]
+fn unused_var_warning_named_callee_suppressed() {
+    // #1158: a fn-typed binding invoked BY NAME (`let f = adder(3); f(5)`)
+    // lowers its call with a name-only `CallTarget::Named` — no VarId, so
+    // `compute_use_counts` cannot credit the binding. The warning pass must
+    // treat a named-callee match as a use, not tell the author `f` is unused
+    // on the line before they call it.
+    let mut prog = make_program_with_vars(vec![
+        ("f", Some(Span { line: 3, col: 7, end_col: 8 }), false),
+    ]);
+    if let IrExprKind::Block { stmts, .. } = &mut prog.functions[0].body.kind {
+        stmts.push(IrStmt {
+            kind: IrStmtKind::Expr {
+                expr: IrExpr {
+                    kind: IrExprKind::Call {
+                        target: CallTarget::Named { name: "f".into() },
+                        args: vec![],
+                        type_args: vec![],
+                    },
+                    ty: Ty::Int,
+                    span: None,
+                    def_id: None,
+                },
+            },
+            span: None,
+        });
+    }
+    compute_use_counts(&mut prog);
+    let warnings = collect_unused_var_warnings(&prog, "test.almd");
+    assert_eq!(warnings.len(), 0, "a named-callee use must suppress the warning: {:?}",
+        warnings.iter().map(|w| &w.message).collect::<Vec<_>>());
+}
+
+#[test]
 fn unused_var_warning_underscore_suppressed() {
     let mut prog = make_program_with_vars(vec![
         ("_x", Some(Span { line: 3, col: 7, end_col: 8 }), false),


### PR DESCRIPTION
Closes #1158.

**The real bug is narrower than the issue's framing.** Bisected: the discard bind is irrelevant — `let f = adder(3); let r = f(5); println("${r}")` (no `_` anywhere) false-warns `unused variable 'f'` on the released binary too, while `let _ = string.len(s)` does NOT warn `s` (the arg side is counted correctly). The actual gap: a call to a fn-typed VALUE (`f(5)`) lowers with a name-only `CallTarget::Named` — no VarId — so `compute_use_counts` cannot credit the binding, and the warning fires on the line before the author calls `f`. The issue's `let _ = f(5)` example is the same named-callee shape.

**The fix**: `collect_unused_var_warnings` gathers every `CallTarget::Named` callee name in the program and treats a name match as a use. Name matching over-suppresses under shadowing (a local named after a real free fn) — the safe direction for a warning, same reasoning as the #857 mutated-set exclusion.

**Verification**
- A/B vs released: `~/.local/bin/almide check` warns on both probe shapes; the fixed binary is silent on both and STILL warns a genuinely dead `let dead = 42`.
- New unit regression `unused_var_warning_named_callee_suppressed` (fails without the fix by construction — the suppression set is the only mechanism that can pass it).
- 87 cargo suites, `almide test` 366/366 (348 via WASM) — unchanged.