### PR TITLE
#912 lens instruments: portable LOUD-leg cap + pinned diag-lens emit protocol

### DIFF
--- a/scripts/lens-diag-emit.sh
+++ b/scripts/lens-diag-emit.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# #912 diagnostic-divergence lens: every check-accepted
+# tests/diagnostics/*/fixed.almd must EMIT `--target rust` cleanly
+# (`almide <file> --target rust`, the source-emit form).
+#
+# EMIT, not `almide build`: the lens hunts check-accepts-but-EMIT-REINTERPRETS
+# (a silent divergence between the checker's reading and codegen's). `build`
+# additionally runs capability gates — e.g. fan.bounded/fan.race's v1-native
+# requirement — whose failures are LOUD declared refusals, not silent
+# divergences; measuring through `build` mixes that wall class into the lens
+# (3 fan fixtures fail `build` on every release back to 0.56.0). Round 3
+# re-derived this the hard way — the protocol is pinned here so it cannot
+# drift again.
+set -u
+BIN=${ALMIDE_BIN:-./target/release/almide}
+fails=0; total=0
+for f in tests/diagnostics/*/fixed.almd; do
+  total=$((total+1))
+  if ! "$BIN" "$f" --target rust >/dev/null 2>&1; then
+    fails=$((fails+1)); echo "DIVERGE: $f"
+  fi
+done
+echo "diag lens: $((total-fails))/$total emit-ok, $fails divergences"
+[ "$fails" -eq 0 ]

--- a/scripts/lens-pass-order.sh
+++ b/scripts/lens-pass-order.sh
@@ -20,10 +20,42 @@ echo "lens-pass-order: suite=$SUITE bin=$BIN logs=$out_dir"
 overall=0
 for p in $OPTIONAL; do
   log="$out_dir/skip_$p.log"
-  ALMIDE_SKIP_PASS=$p "$BIN" test "$SUITE" >"$log" 2>&1
-  code=$?
+  # A LOUD pass (per-file dep-panics) makes the suite CRAWL — round 2's
+  # EggSaturation leg ground for 2h before the verdict was read off the log.
+  # The verdict needs only the SIGNATURE, not a finished suite: cap the leg
+  # and classify from the log (a capped leg without the loud signature is
+  # reported for a manual rerun, never silently classified). Pure-bash
+  # watchdog — macOS ships no `timeout`(1).
+  LENS_LEG_TIMEOUT=${LENS_LEG_TIMEOUT:-900}
+  ALMIDE_SKIP_PASS=$p "$BIN" test "$SUITE" >"$log" 2>&1 &
+  leg_pid=$!
+  waited=0
+  code=""
+  while kill -0 "$leg_pid" 2>/dev/null; do
+    if [ "$waited" -ge "$LENS_LEG_TIMEOUT" ]; then
+      kill "$leg_pid" 2>/dev/null
+      wait "$leg_pid" 2>/dev/null
+      code=124
+      break
+    fi
+    sleep 5
+    waited=$((waited + 5))
+  done
+  if [ -z "$code" ]; then
+    wait "$leg_pid"
+    code=$?
+  fi
   if [ $code -eq 0 ]; then
     echo "CLEAN    $p"
+    continue
+  fi
+  if [ $code -eq 124 ]; then
+    if grep -qE "Compile error|panicked|error\[" "$log"; then
+      echo "LOUD     $p  (leg capped at ${LENS_LEG_TIMEOUT}s; loud signature in log — see $log)"
+    else
+      echo "TIMEOUT  $p  — no loud signature; rerun this leg manually (see $log)"
+      overall=1
+    fi
     continue
   fi
   # Distinguish loud refusals (compile errors, dep panics) from silent value


### PR DESCRIPTION
Two instrument hardenings from the #912 round-3 rotation (the round that closed the issue):

- **`scripts/lens-pass-order.sh`**: a LOUD pass (per-file dep-panics) made round 2's EggSaturation leg crawl for 2h before the verdict was read off the log. The leg is now capped (default 900s, `LENS_LEG_TIMEOUT`) with a pure-bash watchdog — macOS ships no `timeout`(1) — and classified from the log's loud signature; a capped leg WITHOUT the signature reports for a manual rerun, never a silent classification. Round 3 resolved the same leg in 15 minutes with the identical verdict.
- **`scripts/lens-diag-emit.sh`** (new): pins the diagnostic-divergence lens protocol — every check-accepted `tests/diagnostics/*/fixed.almd` through the EMIT form (`almide <file> --target rust`), NOT `almide build`. Round 3 re-derived why the hard way: `build` additionally runs capability gates (fan.bounded/race's v1-native requirement), whose failures are loud declared refusals — 3 fan fixtures fail `build` identically back to released 0.56.0 — and measuring through `build` mixes that wall class into a lens that hunts SILENT reinterpretations. Protocol drift between rounds cost a bisection; it is now in-tree.

Round-3 verdict table (all lenses clean, 2 of 2 consecutive → #912 closed) is on the issue.