### PR TITLE
Aviation-quality Stage 4: the fuzz true-green streak meter (first milestone: 90 clean days)

### DIFF
--- a/research/benchmark/fuzz-green/README.md
+++ b/research/benchmark/fuzz-green/README.md
@@ -1,0 +1,13 @@
+# Fuzz true-green streak (aviation-quality Stage 4)
+
+The metric a mission-critical auditor reads: not "how fast do they fix
+it" but "how long has it stayed unbroken". A calendar day is CLEAN only
+when every Fuzz (nightly) run that day concluded success; any failure
+breaks the streak; a day without a run neither grows nor resets it.
+First milestone: **90 consecutive clean days**.
+
+Meter: `scripts/fuzz-green-streak.sh` (append a dated row with `--update`).
+
+| measured (UTC) | streak (days) | streak start | latest run day |
+|---|---|---|---|
+| 2026-08-10 | 0 | - | 2026-08-10 |

--- a/scripts/fuzz-green-streak.sh
+++ b/scripts/fuzz-green-streak.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Aviation-quality Stage 4: the fuzz true-green streak meter.
+#
+# An auditor of a mission-critical toolchain reads "how long has it stayed
+# unbroken", not "how fast do they fix it". This script computes the current
+# CONSECUTIVE-CLEAN-DAY streak of the Fuzz (nightly) workflow — a calendar day
+# counts as clean only when EVERY run that day concluded `success`; any
+# failure/cancellation breaks the streak; a day with no run is skipped (the
+# streak neither grows nor resets — scheduler gaps are not evidence either
+# way). With --update, the dated ledger at
+# research/benchmark/fuzz-green/README.md is refreshed (BENCHMARKS.md
+# discipline: measurements are dated, never overwritten silently).
+#
+# First milestone: 90 consecutive clean days.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LEDGER_DIR="$ROOT/research/benchmark/fuzz-green"
+LEDGER="$LEDGER_DIR/README.md"
+
+json=$(gh run list --repo almide/almide --workflow fuzz-nightly.yml --limit 200 \
+    --json conclusion,createdAt \
+    --jq '[.[] | {c: .conclusion, d: (.createdAt | split("T")[0])}]')
+
+read -r STREAK FIRST_GREEN LAST_DAY <<EOF
+$(python3 - "$json" <<'PYEOF'
+import json
+import sys
+from collections import OrderedDict
+
+runs = json.loads(sys.argv[1])
+by_day = OrderedDict()
+for r in runs:  # newest first
+    by_day.setdefault(r["d"], []).append(r["c"])
+
+streak = 0
+first_green = "-"
+last_day = next(iter(by_day), "-")
+for day, cs in by_day.items():  # newest -> oldest
+    if all(c == "success" for c in cs):
+        streak += 1
+        first_green = day
+    else:
+        break
+print(streak, first_green, last_day)
+PYEOF
+)
+EOF
+
+echo "fuzz true-green streak: ${STREAK} consecutive clean day(s) (latest run day: ${LAST_DAY}; streak start: ${FIRST_GREEN}; milestone: 90)"
+
+if [ "${1:-}" = "--update" ]; then
+    mkdir -p "$LEDGER_DIR"
+    TODAY=$(date -u +%Y-%m-%d)
+    {
+        echo "# Fuzz true-green streak (aviation-quality Stage 4)"
+        echo
+        echo "The metric a mission-critical auditor reads: not \"how fast do they fix"
+        echo "it\" but \"how long has it stayed unbroken\". A calendar day is CLEAN only"
+        echo "when every Fuzz (nightly) run that day concluded success; any failure"
+        echo "breaks the streak; a day without a run neither grows nor resets it."
+        echo "First milestone: **90 consecutive clean days**."
+        echo
+        echo "Meter: \`scripts/fuzz-green-streak.sh\` (append a dated row with \`--update\`)."
+        echo
+        echo "| measured (UTC) | streak (days) | streak start | latest run day |"
+        echo "|---|---|---|---|"
+        if [ -f "$LEDGER" ]; then
+            grep -E '^\| [0-9]{4}-' "$LEDGER" || true
+        fi
+        echo "| ${TODAY} | ${STREAK} | ${FIRST_GREEN} | ${LAST_DAY} |"
+    } > "$LEDGER.tmp"
+    mv "$LEDGER.tmp" "$LEDGER"
+    echo "ledger updated: $LEDGER"
+fi


### PR DESCRIPTION
Stage 4 of the mission-critical arc, started in parallel per the plan: the metric an auditor of a mission-critical toolchain actually reads — not "how fast do they fix it" but **"how long has it stayed unbroken"**.

- `scripts/fuzz-green-streak.sh`: computes the current consecutive-clean-day streak of the Fuzz (nightly) workflow from the run history. A calendar day is CLEAN only when EVERY run that day concluded success; any failure breaks the streak; a day without a run neither grows nor resets it (scheduler gaps are not evidence either way). `--update` appends a dated row to the ledger — BENCHMARKS.md discipline, measurements dated and never silently overwritten.
- `research/benchmark/fuzz-green/README.md`: the ledger, seeded at the honest current value: **streak = 0** (the last clean night was 2026-08-07; the #796 fix wave landed 2026-08-10, so the next nightly is the first candidate clean night). First milestone: **90 consecutive clean days**.