### PR TITLE
Aviation-quality Stage 2 opener: abstain classification + the 3-way coverage meter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -770,6 +770,9 @@ jobs:
       - name: Scalar-read audit (every raw-load arm classified, zero unguarded — the #1183 class stays extinct)
         run: scripts/check-scalar-read-audit.sh
 
+      - name: Abstain classification (every interp abstain classed; the executable-spec boundary never grows unclassified)
+        run: scripts/check-abstain-classes.sh
+
       - name: Embedded payload size ratchet (#878 — the stdlib every embedder downloads)
         run: scripts/check-embedded-size.sh
 

--- a/crates/almide-interp/interp-abstain-classes.toml
+++ b/crates/almide-interp/interp-abstain-classes.toml
@@ -1,0 +1,52 @@
+# ── ABSTAIN CLASSIFICATION (aviation-quality Stage 2) ──
+#
+# Every reason string in interp-abstain-ledger.txt must match exactly one
+# pattern here (first match wins, checked by scripts/check-abstain-classes.sh).
+# The class answers the auditor's question "WHY is this fixture outside the
+# executable spec, and what would bring it in":
+#
+#   HEAP_BOUNDARY  — the fixture (usually via self-hosted stdlib) does raw
+#                    handle/pointer work (prim.handle / prim.alloc_*). The
+#                    interp models values, not bytes; bringing these in is the
+#                    interp-heap arc (model the block heap), the LARGE half of
+#                    totalization.
+#   BRIDGEABLE     — closable with bounded work, no architectural change:
+#                    dispatch glue (missing HOF arms), argv/env injection,
+#                    sandboxed fs, vendoring the SAME musl-libm the backends
+#                    use (retiring the ULP abstain), sequential fan evaluation
+#                    under the pure-fan determinism contracts, or a bigger
+#                    fuel budget. The Stage 2 near-horizon burn-down list.
+#
+# Coverage arithmetic these classes feed (research/benchmark/three-way/):
+# voting = corpus - abstains; the near-horizon target is voting + BRIDGEABLE.
+
+[[class]]
+name = "HEAP_BOUNDARY"
+patterns = [
+  "capability: prim.handle",
+  "capability: prim.alloc_value",
+  "capability: prim.alloc_map",
+  "capability: prim.alloc_list_str",
+  "capability: prim.alloc_list",
+  "capability: prim.alloc_str",
+  "capability: prim.alloc_set",
+  "capability: prim.alloc_bytes",
+]
+
+[[class]]
+name = "BRIDGEABLE"
+patterns = [
+  "capability: HOF map.fold",
+  "capability: HOF list.update",
+  "capability: list.min/max on non-comparable elements",
+  "capability: prim.args_get_list_full",
+  "capability: prim.args_get_list",
+  "capability: args.flag",
+  "capability: prim.make_dir",
+  "capability: prim.read_text_file",
+  "capability: prim.write_text_file",
+  "capability: fan.any",
+  "transcendental",
+  "float `**`",
+  "interp fuel/recursion budget exhausted",
+]

--- a/research/benchmark/three-way/README.md
+++ b/research/benchmark/three-way/README.md
@@ -1,0 +1,12 @@
+# 3-way oracle coverage (aviation-quality Stage 2)
+
+Translation validation the auditor can count: of the spec/wasm_cross
+corpus, how many fixtures cast a REAL native/wasm/interp 3-way vote
+(`voting`), and what the near-horizon target is once the BRIDGEABLE
+abstains are burned down (the HEAP_BOUNDARY remainder is the
+interp-heap arc). Classes: crates/almide-interp/interp-abstain-classes.toml;
+gate + meter: `scripts/check-abstain-classes.sh` (append a row with `--update`).
+
+| measured (UTC) | corpus | voting | HEAP_BOUNDARY | BRIDGEABLE | near-horizon |
+|---|---|---|---|---|---|
+| 2026-08-10 | 364 | 225 (61.8%) | 107 | 32 | 257 (70.6%) |

--- a/scripts/check-abstain-classes.sh
+++ b/scripts/check-abstain-classes.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Aviation-quality Stage 2: the abstain-classification gate + the 3-way
+# coverage meter.
+#
+# Every abstain reason in crates/almide-interp/interp-abstain-ledger.txt must
+# match exactly one class pattern in interp-abstain-classes.toml (first match
+# wins) — a NEW abstain reason without a class fails, so the executable-spec
+# boundary can never grow unclassified. Prints the coverage arithmetic an
+# auditor reads: voting fixtures / corpus, and the near-horizon target
+# (voting + BRIDGEABLE). With --update, appends a dated row to
+# research/benchmark/three-way/README.md.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+python3 - "$ROOT" "${1:-}" <<'EOF'
+import glob
+import re
+import sys
+from datetime import datetime, timezone
+
+root, flag = sys.argv[1], sys.argv[2]
+ledger = f"{root}/crates/almide-interp/interp-abstain-ledger.txt"
+classes_p = f"{root}/crates/almide-interp/interp-abstain-classes.toml"
+
+classes = []  # (name, [patterns]) in file order
+name = None
+for raw in open(classes_p, encoding="utf-8"):
+    line = raw.strip()
+    m = re.match(r'name\s*=\s*"([A-Z_]+)"', line)
+    if m:
+        name = m.group(1)
+        classes.append((name, []))
+    m = re.match(r'"(.+)",?\s*$', line)
+    if m and classes:
+        classes[-1][1].append(m.group(1))
+
+counts = {n: 0 for n, _ in classes}
+unclassified = []
+entries = 0
+for raw in open(ledger, encoding="utf-8"):
+    line = raw.strip()
+    if not line or line.startswith("#"):
+        continue
+    entries += 1
+    reason = line.split(None, 1)[1] if len(line.split(None, 1)) > 1 else ""
+    for n, pats in classes:
+        if any(p in reason for p in pats):
+            counts[n] += 1
+            break
+    else:
+        unclassified.append(line)
+
+corpus = len(glob.glob(f"{root}/spec/wasm_cross/*.almd"))
+voting = corpus - entries
+near = voting + counts.get("BRIDGEABLE", 0)
+
+if unclassified:
+    for u in unclassified:
+        print(f"::error::unclassified abstain: {u} — add a pattern to interp-abstain-classes.toml")
+    print(f"abstain-classes FAILED — {len(unclassified)} unclassified entr(ies).")
+    sys.exit(1)
+
+pct = lambda n: f"{100.0 * n / corpus:.1f}%"
+breakdown = ", ".join(f"{n}={c}" for n, c in counts.items())
+print(
+    f"abstain-classes OK — corpus {corpus}, voting {voting} ({pct(voting)}), "
+    f"abstaining {entries} ({breakdown}); near-horizon target {near} ({pct(near)})."
+)
+
+if flag == "--update":
+    import os
+    d = f"{root}/research/benchmark/three-way"
+    os.makedirs(d, exist_ok=True)
+    p = f"{d}/README.md"
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    rows = []
+    if os.path.exists(p):
+        rows = [l for l in open(p, encoding="utf-8") if re.match(r"^\| \d{4}-", l)]
+    with open(p, "w", encoding="utf-8") as f:
+        f.write(
+            "# 3-way oracle coverage (aviation-quality Stage 2)\n\n"
+            "Translation validation the auditor can count: of the spec/wasm_cross\n"
+            "corpus, how many fixtures cast a REAL native/wasm/interp 3-way vote\n"
+            "(`voting`), and what the near-horizon target is once the BRIDGEABLE\n"
+            "abstains are burned down (the HEAP_BOUNDARY remainder is the\n"
+            "interp-heap arc). Classes: crates/almide-interp/interp-abstain-classes.toml;\n"
+            "gate + meter: `scripts/check-abstain-classes.sh` (append a row with `--update`).\n\n"
+            "| measured (UTC) | corpus | voting | HEAP_BOUNDARY | BRIDGEABLE | near-horizon |\n"
+            "|---|---|---|---|---|---|\n"
+        )
+        for r in rows:
+            f.write(r)
+        f.write(
+            f"| {today} | {corpus} | {voting} ({pct(voting)}) | "
+            f"{counts.get('HEAP_BOUNDARY', 0)} | {counts.get('BRIDGEABLE', 0)} | "
+            f"{near} ({pct(near)}) |\n"
+        )
+    print(f"ledger updated: {p}")
+EOF


### PR DESCRIPTION
Stage 2 (translation-validation totalization) begins with the same discipline Stage 1 proved twice today: classify the boundary, gate it so it can't grow unclassified, and publish the number.

**Context** (recon this session): the native/wasm/interp 3-way oracle already runs on every PR over the 364-fixture `spec/wasm_cross` corpus — but 139 fixtures abstain (the committed `interp-abstain-ledger.txt`), so only **225 (61.8%) cast a real vote**. The prim-floor `.almd` audit surface (1406 fns / 164 files — 22x the Rust surface PR #1185 covered) is deliberately SUBSUMED by this arc: total differential coverage is the stronger and cheaper assurance for self-hosted stdlib code than hand classification.

**What lands**
- `crates/almide-interp/interp-abstain-classes.toml`: every abstain reason classed —
  - **HEAP_BOUNDARY = 107** (77%): raw handle/pointer work (`prim.handle`, `prim.alloc_*`) — bringing these in is the interp-heap arc, the LARGE half of totalization;
  - **BRIDGEABLE = 32** (23%): bounded work, no architecture change — dispatch glue (map.fold, list.update), argv/env injection, sandboxed fs, **vendoring the same musl-libm the backends use** (retiring the 8 ULP abstains — they are NOT permanent), sequential fan evaluation, fuel budget.
- `scripts/check-abstain-classes.sh` (CI `checks` step): a NEW abstain reason without a class fails — the executable-spec boundary can never grow unclassified. Negative-tested (injected `prim.frobnicate` abstain → fail; restored → green).
- `research/benchmark/three-way/README.md`: the dated coverage ledger — **voting 225/364 (61.8%), near-horizon target 257 (70.6%)** once BRIDGEABLE burns down.

Together with #1185 (scalar-read audit) and #1186 (fuzz true-green meter), every boundary of the "silently wrong is impossible" claim now has a classified ledger, a CI gate, and a dated public number.