### PR TITLE
Stage 2 burn-down opener: bridge map.fold and list.update in the interp (voting 225 → 226)

### DIFF
--- a/crates/almide-interp/interp-abstain-ledger.txt
+++ b/crates/almide-interp/interp-abstain-ledger.txt
@@ -67,9 +67,8 @@ let_unwrap_propagation  out-of-interp-scope capability: prim.alloc_value
 list_chunk_windows  out-of-interp-scope capability: prim.handle
 list_chunk_zero  out-of-interp-scope capability: prim.handle
 list_comprehensive  out-of-interp-scope capability: prim.alloc_list
-list_count_index_truncation  out-of-interp-scope capability: HOF list.update
+list_count_index_truncation  out-of-interp-scope capability: prim.handle
 list_flatten_borrow  out-of-interp-scope capability: prim.handle
-list_heapelem_rc  out-of-interp-scope capability: HOF list.update
 list_modify_heap  out-of-interp-scope capability: prim.alloc_value
 list_repeat_size_ceiling  out-of-interp-scope capability: prim.alloc_list
 list_set_value  out-of-interp-scope capability: prim.alloc_value
@@ -81,8 +80,8 @@ list_windows_zero  out-of-interp-scope capability: prim.handle
 list_with_capacity  out-of-interp-scope capability: prim.alloc_list
 map_filter  out-of-interp-scope capability: prim.alloc_map
 map_fold  out-of-interp-scope capability: prim.alloc_map
-map_fold_heap_acc  out-of-interp-scope capability: HOF map.fold
-map_fold_heap_acc_skv  out-of-interp-scope capability: HOF map.fold
+map_fold_heap_acc  out-of-interp-scope capability: prim.handle
+map_fold_heap_acc_skv  out-of-interp-scope capability: prim.handle
 map_insertion_order  out-of-interp-scope capability: prim.handle
 map_set_eq  out-of-interp-scope capability: prim.alloc_map
 map_set_ops  out-of-interp-scope capability: prim.alloc_map

--- a/crates/almide-interp/src/hofs.rs
+++ b/crates/almide-interp/src/hofs.rs
@@ -53,6 +53,7 @@ impl<'a> Interpreter<'a> {
         // complexity threshold instead of one 30-armed match.
         match m {
             "list" => self.eval_hof_list(f, &evaled),
+            "map" => self.eval_hof_map_mod(f, &evaled),
             "option" => self.eval_hof_option(f, &evaled),
             "result" => self.eval_hof_result(f, &evaled),
             "set" => self.eval_hof_set(f, &evaled),
@@ -87,6 +88,7 @@ impl<'a> Interpreter<'a> {
             "zip_with" => self.hof_zip_with(evaled),
             "unique_by" => self.hof_unique_by(evaled),
             "scan" => self.hof_scan(evaled),
+            "update" => self.hof_list_update(evaled),
             _ => self.eval_hof_list_try(f, evaled),
         }
     }
@@ -113,6 +115,63 @@ impl<'a> Interpreter<'a> {
             "__fallible_each" => self.hof_try_each(evaled),
             _ => Flow::Unsupported(format!("HOF list.{}", f)),
         }
+    }
+
+    /// The Map-MODULE HOFs (`map.fold` — Stage 2 BRIDGEABLE burn-down). The
+    /// receiver is a `Value::Map` of insertion-ordered `(k, v)` entries — the
+    /// AlmideMap determinism contract — so a sequential fold over the backing
+    /// vec IS the spec order. The remaining map HOFs on the `is_hof` allowlist
+    /// keep the explicit Unsupported abstain until a fixture exercises them.
+    fn eval_hof_map_mod(&mut self, f: &str, evaled: &[Value]) -> Flow {
+        match f {
+            "fold" => self.hof_map_fold(evaled),
+            _ => Flow::Unsupported(format!("HOF map.{}", f)),
+        }
+    }
+
+    /// `map.fold(m, init, (acc, k, v) -> acc)` — the 3-ary callback form (the
+    /// list fold's callback is 2-ary, so it cannot be reused).
+    fn hof_map_fold(&mut self, args: &[Value]) -> Flow {
+        let entries = match args.first() {
+            Some(Value::Map(e)) => e.clone(),
+            _ => return Flow::Abort("internal: map.fold receiver not a Map".into()),
+        };
+        let mut acc = match args.get(1) {
+            Some(v) => v.clone(),
+            None => return Flow::Abort("internal: map.fold missing init".into()),
+        };
+        let clo = match Self::recv_closure(args, 2) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        for (k, v) in entries.iter() {
+            acc = val!(self.apply_closure(&clo, vec![acc, k.clone(), v.clone()]));
+        }
+        Flow::val(acc)
+    }
+
+    /// `list.update(xs, i, f)` — a copy with element `i` replaced by `f(xs[i])`;
+    /// an out-of-range index returns the list unchanged (the stdlib's total
+    /// contract — no abort channel in the signature).
+    fn hof_list_update(&mut self, args: &[Value]) -> Flow {
+        let mut items = match Self::recv_items(args) {
+            Ok(i) => i,
+            Err(f) => return f,
+        };
+        let idx = match args.get(1) {
+            Some(Value::Int(i)) => *i,
+            _ => return Flow::Abort("internal: list.update index not an Int".into()),
+        };
+        let clo = match Self::recv_closure(args, 2) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        if idx >= 0 && (idx as usize) < items.len() {
+            let i = idx as usize;
+            let updated = val!(self.apply_closure(&clo, vec![items[i].clone()]));
+            items[i] = updated;
+        }
+        Flow::val(Value::list(items))
     }
 
     fn eval_hof_option(&mut self, f: &str, evaled: &[Value]) -> Flow {

--- a/research/benchmark/three-way/README.md
+++ b/research/benchmark/three-way/README.md
@@ -10,3 +10,4 @@ gate + meter: `scripts/check-abstain-classes.sh` (append a row with `--update`).
 | measured (UTC) | corpus | voting | HEAP_BOUNDARY | BRIDGEABLE | near-horizon |
 |---|---|---|---|---|---|
 | 2026-08-10 | 364 | 225 (61.8%) | 107 | 32 | 257 (70.6%) |
+| 2026-08-11 | 364 | 226 (62.1%) | 110 | 28 | 254 (69.8%) |


### PR DESCRIPTION
First BRIDGEABLE burn-down of the Stage 2 arc (#1187's classification): the two dispatch-glue abstains.

**What lands** (`crates/almide-interp/src/hofs.rs`)
- The Map-MODULE HOF route existed on the `is_hof` allowlist but `eval_hof` had NO `"map"` arm — every map HOF silently abstained. The arm now exists with `map.fold` implemented (3-ary `(acc, k, v)` callback over the insertion-ordered backing vec — the AlmideMap determinism contract makes sequential order THE spec order); the other map HOFs keep an explicit Unsupported until a fixture exercises them.
- `list.update(xs, i, f)` — copy-with-updated-element; out-of-range returns the list unchanged (the stdlib's total contract).

**Verification**: `interp_cross_target_spec` green — the new glue's votes agree with native+wasm on every fixture it now covers (no BOTH-WRONG suspect); `interp_abstain_ledger` regenerated; interp crate suites green (68+23).

**The honest movement** (dated in `research/benchmark/three-way/README.md`): voting **225 → 226 (62.1%)**, abstains 139 → 138. Smaller than the naive "4 fixtures" because abstains are LAYERED: the two `map.fold` fixtures dropped their HOF abstain only to reveal a deeper `prim.handle` abstain underneath (BRIDGEABLE 32 → 28, HEAP_BOUNDARY 107 → 110). The classification meter absorbs this honestly — BRIDGEABLE counts are lower bounds on remaining work, and the interp-heap arc keeps growing as the true big half of totalization.