### PR TITLE
wasm is a first-class mission-critical target: the native-fallback set becomes a shrink-only ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,9 @@ jobs:
           ALMIDE=/tmp/almide-bin/almide
           $ALMIDE test examples/
 
+      - name: WASM coverage ratchet (the native-fallback set only shrinks — wasm is a first-class target)
+        run: ALMIDE_BIN=/tmp/almide-bin/almide bash proofs/check-wasm-fallback.sh
+
       # The dogfood program (Unit 0.46, #1001). Its own tests cover the decision rules
       # extracted from the shell gates — the parity verdict, the nightly streak fold, the
       # contract link symmetry — which in bash are reachable only through their I/O. Gated

--- a/proofs/check-wasm-fallback.sh
+++ b/proofs/check-wasm-fallback.sh
@@ -6,6 +6,9 @@
 #   - a baseline entry whose file now runs the wasm leg -> FAIL as STALE
 #     (prune it in the same change — the set only shrinks).
 set -euo pipefail
+# Pin the collation locale (#1031): the ratchet diff must not depend on the
+# machine's sort order.
+export LC_ALL=C
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BASELINE="$ROOT/proofs/wasm-fallback-baseline.txt"
 BIN="${ALMIDE_BIN:-almide}"

--- a/proofs/check-wasm-fallback.sh
+++ b/proofs/check-wasm-fallback.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# The wasm coverage ratchet gate (mission-critical arc). Runs the hybrid
+# suite with ALMIDE_FALLBACK_NAMES=1 and diffs the observed fallback set
+# against proofs/wasm-fallback-baseline.txt:
+#   - a fallback file NOT in the baseline  -> FAIL (wasm coverage regressed);
+#   - a baseline entry whose file now runs the wasm leg -> FAIL as STALE
+#     (prune it in the same change — the set only shrinks).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BASELINE="$ROOT/proofs/wasm-fallback-baseline.txt"
+BIN="${ALMIDE_BIN:-almide}"
+
+observed=$(cd "$ROOT" && ALMIDE_FALLBACK_NAMES=1 "$BIN" test 2>&1 | sed -n 's/^FALLBACK //p' | sort)
+listed=$(grep -v '^#' "$BASELINE" | awk -F' :: ' 'NF>=2 {print $1}' | sort)
+
+new=$(comm -23 <(echo "$observed") <(echo "$listed") | sed '/^$/d' || true)
+stale=$(comm -13 <(echo "$observed") <(echo "$listed") | sed '/^$/d' || true)
+
+fail=0
+if [ -n "$new" ]; then
+  echo "WASM COVERAGE REGRESSION — file(s) fell off the wasm leg and are NOT in the baseline:" >&2
+  echo "$new" | sed 's/^/  + /' >&2
+  fail=1
+fi
+if [ -n "$stale" ]; then
+  echo "STALE baseline entr(ies) — these files now run the wasm leg; prune them (the set only shrinks):" >&2
+  echo "$stale" | sed 's/^/  - /' >&2
+  fail=1
+fi
+if [ "$fail" -ne 0 ]; then exit 1; fi
+n=$(echo "$listed" | sed '/^$/d' | wc -l | tr -d ' ')
+echo "WASM COVERAGE RATCHET OK: $n fallback file(s), all enumerated in the baseline (target: 0/empty)."

--- a/proofs/wasm-fallback-baseline.txt
+++ b/proofs/wasm-fallback-baseline.txt
@@ -1,0 +1,41 @@
+# ── WASM COVERAGE RATCHET (mission-critical arc: wasm is a FIRST-CLASS target) ──
+#
+# Every spec file the wasm leg of `almide test` does not pass, with its wall
+# reason and class. Gate: proofs/check-wasm-fallback.sh — a file falling back
+# that is NOT here fails (a coverage regression); an entry whose file now runs
+# the wasm leg fails as STALE (prune it — the set only shrinks). Data feed:
+# `ALMIDE_FALLBACK_NAMES=1 almide test`.
+#
+# Classes:
+#   COMPILER_FRONTIER — the burn-down DEBT: the wasm pipeline cannot yet
+#                       compile the shape; each entry names its brick.
+#   HOST_CAPABILITY   — the tested API is an OS surface WASI does not provide
+#                       (TCP listen, subprocess, zlib); out of wasm scope BY
+#                       DESIGN until the WASI story changes.
+#   HARNESS_LIMITATION— the TESTING harness needs a mechanism wasm lacks
+#                       (assert_throws requires catching a panic; wasm traps
+#                       are uncatchable in-process).
+#
+# COMPILER_FRONTIER (10) — the debt, in leverage order:
+spec/lang/closure_capture_map_test.almd :: COMPILER_FRONTIER :: 1 fn outside the lowering subset (closure-capture map — the defunc closure frontier)
+spec/stdlib/codec_field_matrix_test.almd :: COMPILER_FRONTIER :: bind-position record brick (#1064)
+spec/integration/modules/cross_module_cell_update_test.almd :: COMPILER_FRONTIER :: test mode: MUTABLE module top-lets need the per-test region bridge
+spec/integration/modules/cross_module_global_state_loop_test.almd :: COMPILER_FRONTIER :: test mode: MUTABLE module top-lets need the per-test region bridge
+spec/lang/result_zip_test.almd :: COMPILER_FRONTIER :: result.zip_x unlinked (typed self-host twin missing)
+spec/stdlib/stdlib-test.almd :: COMPILER_FRONTIER :: list.sort_by_str_key_x unlinked (typed self-host twin missing)
+spec/stdlib/fs_fold_lines_chunked_test.almd :: COMPILER_FRONTIER :: fixture's fs.create_temp_dir has no WASI self-host (trio itself lowers)
+spec/stdlib/fs_fold_lines_range_test.almd :: COMPILER_FRONTIER :: fixture's fs.create_temp_dir has no WASI self-host (trio itself lowers)
+spec/stdlib/fs_streaming_test.almd :: COMPILER_FRONTIER :: non-msi accumulator twins + for_each_line + create_temp_dir
+spec/stdlib/fs_if_exists_test.almd :: COMPILER_FRONTIER :: C-215 errno-carrying read prim not landed
+#
+# HOST_CAPABILITY (6):
+spec/lang/effect_intrinsic_tail_test.almd :: HOST_CAPABILITY :: http.serve is a TCP listener
+spec/stdlib/net_test.almd :: HOST_CAPABILITY :: net is an OS socket API
+spec/stdlib/process_exec_status_test.almd :: HOST_CAPABILITY :: subprocess exec
+spec/stdlib/process_ext_test.almd :: HOST_CAPABILITY :: subprocess exec
+spec/stdlib/process_timeout_test.almd :: HOST_CAPABILITY :: subprocess exec
+spec/stdlib/zlib_test.almd :: HOST_CAPABILITY :: zlib is a native library binding
+#
+# HARNESS_LIMITATION (2):
+spec/stdlib/coverage_assert_throws_test.almd :: HARNESS_LIMITATION :: assert_throws needs panic catching; a wasm trap is uncatchable in-process
+spec/stdlib/testing_polarity_test.almd :: HARNESS_LIMITATION :: assert_throws needs panic catching; a wasm trap is uncatchable in-process

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -716,6 +716,17 @@ pub fn cmd_test_fast(file: &str, no_check: bool, run_filter: Option<&str>) {
         err(&format!("WASM TRAP {} (compiled for wasm, failed at runtime; native re-run PASSED — CI's Test WASM will fail this)", file));
         err_no_nl(detail);
     }
+    // The wasm COVERAGE ratchet's data feed (mission-critical arc): every
+    // file the wasm leg did not pass, one per line, so
+    // proofs/check-wasm-fallback.sh can diff the set against its shrink-only
+    // baseline. Names only under the flag — the summary line stays stable.
+    if std::env::var_os("ALMIDE_FALLBACK_NAMES").is_some() {
+        let mut sorted = fallback.clone();
+        sorted.sort();
+        for f in &sorted {
+            err(&format!("FALLBACK {}", f));
+        }
+    }
     let trap_note = if diverged.is_empty() {
         String::new()
     } else {


### PR DESCRIPTION
Per the arc's standing directive: the wasm leg is not a second-class target, so "honest walls" are DEBT, not steady state. This PR turns the 18 files that ride the native fallback into a classified, shrink-only ledger with a CI gate — the same discipline that took walled-real from 20 to a permanent 0.

**What lands**
- `ALMIDE_FALLBACK_NAMES=1 almide test` prints the fallback file set (the ratchet's data feed; the summary line is unchanged without the flag).
- `proofs/wasm-fallback-baseline.txt`: all 18 files enumerated with measured wall reasons, classified —
  - **COMPILER_FRONTIER (10)** — the burn-down debt, each entry naming its brick: the defunc closure frontier, the #1064 bind-position record brick, the per-test region bridge for mutable module top-lets, two unlinked typed twins (`result.zip`, `list.sort_by_str_key`), the `fs.create_temp_dir` WASI self-host, the C-215 errno prim, the remaining streaming accumulator twins;
  - **HOST_CAPABILITY (6)** — OS surfaces WASI does not provide (TCP listen, subprocess, zlib): out of wasm scope by design until the WASI story changes;
  - **HARNESS_LIMITATION (2)** — `assert_throws` needs panic catching; a wasm trap is uncatchable in-process.
- `proofs/check-wasm-fallback.sh` (CI: the Almide-gates job, which already carries wasmtime): a fallback file not in the baseline fails as a COVERAGE REGRESSION; a baseline entry whose file now runs the wasm leg fails as STALE — the set only shrinks. Negative-tested both directions.

Together with the walled-real ratchet (fn-level, permanent 0) this closes the accounting: every wasm-leg gap is now either an enumerated fn wall (empty) or an enumerated file fallback (18, classified, shrink-only) — nothing can regress silently, and the debt is named brick by brick.