### PR TITLE
The nightly verdict must survive a killed shard — a zero-finding night was recorded as a divergence

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -215,6 +215,23 @@ jobs:
     if: always() && github.server_url == 'https://github.com'
     name: Night verdict
     needs: fuzz
+    # ALWAYS, even when a shard was killed. A runner shutdown (exit 143, the
+    # documented ~1-in-6 event this workflow shards to survive) fails its matrix
+    # leg, and without `always()` that skips this job entirely — so a night with
+    # ZERO findings was recorded as a failure, indistinguishable from a real
+    # divergence. Tonight (2026-08-11) was exactly that: no findings artifact,
+    # no `findings=N>0` in any shard log, two shards SIGTERMed, night = failure.
+    #
+    # With 4 shards at a ~1/6 per-shard kill rate, P(all survive) ~= 48%, so
+    # about half of all nights failed for infrastructure alone — which makes any
+    # "N consecutive clean nights" closure condition unreachable by arithmetic
+    # rather than by a property of the compiler (the exact trap #924 documented
+    # and sharding was meant to escape; the escape was incomplete).
+    #
+    # The verdict below already fails ONLY on findings and the coverage line
+    # already reports how many shards reported, so running it unconditionally
+    # keeps a kill honest — it costs recorded COVERAGE, not correctness.
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/scripts/fuzz-green-streak.sh
+++ b/scripts/fuzz-green-streak.sh
@@ -7,7 +7,19 @@
 # counts as clean only when EVERY run that day concluded `success`; any
 # failure/cancellation breaks the streak; a day with no run is skipped (the
 # streak neither grows nor resets — scheduler gaps are not evidence either
-# way). With --update, the dated ledger at
+# way).
+#
+# WHAT "success" MEANS HERE (corrected 2026-08-11): the night verdict fails on
+# FINDINGS only. A shard killed by a runner shutdown (exit 143, the documented
+# ~1-in-6 event) costs that shard's coverage and is reported in the night
+# summary, but no longer fails the night — until today the verdict job was
+# SKIPPED whenever any shard died, so a zero-finding night was recorded exactly
+# like a real divergence, and with 4 shards ~half of all nights failed for
+# infrastructure alone. A streak only measures correctness if the thing it
+# counts is correctness; before the fix "90 consecutive" was unreachable by
+# arithmetic (0.48^90), not by any property of the compiler.
+#
+# With --update, the dated ledger at
 # research/benchmark/fuzz-green/README.md is refreshed (BENCHMARKS.md
 # discipline: measurements are dated, never overwritten silently).
 #


### PR DESCRIPTION
Found while reading tonight's red nightly (2026-08-11) for the Stage 4 streak meter.

**Tonight found NOTHING and was recorded as a failure.** No findings artifact was produced, no shard logged `findings=N>0` — but shards 2 and 4 exited **143 (SIGTERM)**, the runner-shutdown kill this workflow's own header documents at a ~1-in-6 rate. `Night verdict` declares `needs: fuzz`, so a dead matrix leg SKIPPED the whole verdict job, and the run concluded failure — indistinguishable, to every consumer, from a real cross-target divergence.

**The escape sharding was meant to provide was incomplete.** The header explains the design intent exactly: "a kill costs 1/N of the night's coverage instead of the night, and the surviving shards still produce a verdict". The verdict step is already written to match — it fails on FINDINGS only (`|| true; exit 0`, then a separate `Fail the night on findings` gated on `findings != '0'`). The one missing piece was `if: always()` on the job, without which none of that logic ever runs.

**Why this matters beyond one red night.** With 4 shards at ~1/6 per-shard kill, P(all four survive) ≈ 48%. So roughly HALF of all nights failed for infrastructure alone, which makes any "N consecutive clean nights" closure condition unreachable by arithmetic rather than by a property of the compiler — precisely the trap #924 documented for its 14-night condition, reappearing one level up. The Stage 4 milestone I set (90 consecutive) was 0.48^90 before this fix: not a hard target, an impossible one.

**What changes**
- `Night verdict` gets `if: always()`, with the reasoning recorded inline so it is not "cleaned up" later.
- `scripts/fuzz-green-streak.sh` states what its `success` now means: findings-only failure, with a killed shard costing recorded COVERAGE (already reported in the night summary line) and not correctness. A streak only measures correctness if the thing it counts is correctness.

Nothing about the fuzzer's sensitivity changes: a real finding still fails the night, still uploads its minimized repro, and still opens the tracking issue.