### PR TITLE
Measure native/wasm parity per FUNCTION, and start the bytes semantics matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,12 @@ jobs:
       - name: WASM coverage ratchet (the native-fallback set only shrinks — wasm is a first-class target)
         run: ALMIDE_BIN=/tmp/almide-bin/almide bash proofs/check-wasm-fallback.sh
 
+      # Per-FUNCTION parity. The ratchet above measures which spec FILES fall back,
+      # so a stdlib fn no test touches is invisible to it — datetime.monotonic_ns
+      # had no wasm body at all while that gate read a clean 18/18. ~70s.
+      - name: WASM reachability ratchet (every stdlib fn builds on both legs, or is listed)
+        run: ALMIDE_BIN=/tmp/almide-bin/almide bash proofs/check-wasm-reachability.sh
+
       # The dogfood program (Unit 0.46, #1001). Its own tests cover the decision rules
       # extracted from the shell gates — the parity verdict, the nightly streak fold, the
       # contract link symmetry — which in bash are reachable only through their I/O. Gated

--- a/docs/stdlib/semantics-manifest.toml
+++ b/docs/stdlib/semantics-manifest.toml
@@ -664,3 +664,100 @@ setup = [
 ]
 probe = 'combined'
 expect = "7/abc"
+
+# The `_array` ELEMENT-COUNT family — the trap this table exists to catch.
+# `count` counts ELEMENTS of the decoded type, not bytes:
+# `read_i32_be_array(b, 0, 2)` consumes EIGHT bytes. Nothing in the name, the
+# signature or the prose says so, and the sibling `pos` argument immediately
+# above it IS a byte offset — so the two Ints in one call have different units.
+# The i64 probes need a 16-byte fixture for the same reason.
+
+[[bytes.fn]]
+name = "read_i16_be_array"
+index_unit = "element-count"
+probe = 'bytes.read_i16_be_array(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0, 2)'
+expect = "[258, 772]"
+
+[[bytes.fn]]
+name = "read_i16_le_array"
+index_unit = "element-count"
+probe = 'bytes.read_i16_le_array(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0, 2)'
+expect = "[513, 1027]"
+
+[[bytes.fn]]
+name = "read_u16_be_array"
+index_unit = "element-count"
+probe = 'bytes.read_u16_be_array(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0, 2)'
+expect = "[258, 772]"
+
+[[bytes.fn]]
+name = "read_u16_le_array"
+index_unit = "element-count"
+probe = 'bytes.read_u16_le_array(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0, 2)'
+expect = "[513, 1027]"
+
+[[bytes.fn]]
+name = "read_i32_be_array"
+index_unit = "element-count"
+probe = 'bytes.read_i32_be_array(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0, 2)'
+expect = "[16909060, 84281096]"
+
+[[bytes.fn]]
+name = "read_i32_le_array"
+index_unit = "element-count"
+probe = 'bytes.read_i32_le_array(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0, 2)'
+expect = "[67305985, 134678021]"
+
+[[bytes.fn]]
+name = "read_u32_be_array"
+index_unit = "element-count"
+probe = 'bytes.read_u32_be_array(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0, 2)'
+expect = "[16909060, 84281096]"
+
+[[bytes.fn]]
+name = "read_u32_le_array"
+index_unit = "element-count"
+probe = 'bytes.read_u32_le_array(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0, 2)'
+expect = "[67305985, 134678021]"
+
+[[bytes.fn]]
+name = "read_i64_be_array"
+index_unit = "element-count"
+probe = 'bytes.read_i64_be_array(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]), 0, 2)'
+expect = "[72623859790382856, 651345242494996240]"
+
+[[bytes.fn]]
+name = "read_i64_le_array"
+index_unit = "element-count"
+probe = 'bytes.read_i64_le_array(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]), 0, 2)'
+expect = "[578437695752307201, 1157159078456920585]"
+
+[[bytes.fn]]
+name = "read_f32_be_array"
+index_unit = "element-count"
+probe = 'bytes.read_f32_be_array(bytes.from_list([63, 192, 0, 0, 64, 32, 0, 0]), 0, 2)'
+expect = "[1.5, 2.5]"
+
+[[bytes.fn]]
+name = "read_f32_le_array"
+index_unit = "element-count"
+probe = 'bytes.read_f32_le_array(bytes.from_list([0, 0, 192, 63, 0, 0, 32, 64]), 0, 2)'
+expect = "[1.5, 2.5]"
+
+[[bytes.fn]]
+name = "read_f64_be_array"
+index_unit = "element-count"
+probe = 'bytes.read_f64_be_array(bytes.from_list([63, 248, 0, 0, 0, 0, 0, 0, 64, 4, 0, 0, 0, 0, 0, 0]), 0, 2)'
+expect = "[1.5, 2.5]"
+
+[[bytes.fn]]
+name = "read_f64_le_array"
+index_unit = "element-count"
+probe = 'bytes.read_f64_le_array(bytes.from_list([0, 0, 0, 0, 0, 0, 248, 63, 0, 0, 0, 0, 0, 0, 4, 64]), 0, 2)'
+expect = "[1.5, 2.5]"
+
+[[bytes.fn]]
+name = "read_f16_le_array"
+index_unit = "element-count"
+probe = 'bytes.read_f16_le_array(bytes.from_list([0, 62, 0, 65]), 0, 2)'
+expect = "[1.5, 2.5]"

--- a/docs/stdlib/semantics-manifest.toml
+++ b/docs/stdlib/semantics-manifest.toml
@@ -355,3 +355,124 @@ name = "year"
 index_unit = "civil-field"
 probe = 'datetime.year(1705322096)'
 expect = "2024"
+
+# ---------------------------------------------------------------------------
+# bytes — the third module on the ratchet, and the widest API FAMILY in the
+# stdlib: read/set/append x {i16,i32,i64,u16,u32,u8,f16,f32,f64} x {be,le}.
+# CLAUDE.md's rule is that a family is extended BY MATRIX, never point-wise —
+# this table is that matrix for the semantic axis, so a cell whose byte order
+# or width silently disagrees with its NAME cannot survive.
+#
+# The scalar-read probes use the fixture [255,254,253,252,251,250,249,248]:
+# with the high bit SET, signed and unsigned disagree (i16_be = -2 vs
+# u16_be = 65534) and big- and little-endian disagree (i16_be = -2 vs
+# i16_le = -257), so one probe pins width, signedness and byte order at once.
+# A low-byte fixture like [1,2,3,4] would have let a signed/unsigned mixup
+# through. Every expectation below is computed independently by Python's
+# `struct` and then checked against the implementation, never transcribed
+# from a run.
+#
+# The float probes invert that: the byte PATTERN is derived from 1.5 for the
+# target order, so the expectation is 1.5 by construction and a byte-order
+# regression shows up as a garbage float rather than a value someone has to
+# recognise.
+# ---------------------------------------------------------------------------
+
+[bytes]
+default_index_unit = "byte-offset"
+
+[[bytes.fn]]
+name = "read_i16_be"
+index_unit = "value"
+probe = 'bytes.read_i16_be(bytes.from_list([255, 254, 253, 252, 251, 250, 249, 248]), 0)'
+expect = "-2"
+
+[[bytes.fn]]
+name = "read_i16_le"
+index_unit = "value"
+probe = 'bytes.read_i16_le(bytes.from_list([255, 254, 253, 252, 251, 250, 249, 248]), 0)'
+expect = "-257"
+
+[[bytes.fn]]
+name = "read_u16_be"
+index_unit = "value"
+probe = 'bytes.read_u16_be(bytes.from_list([255, 254, 253, 252, 251, 250, 249, 248]), 0)'
+expect = "65534"
+
+[[bytes.fn]]
+name = "read_u16_le"
+index_unit = "value"
+probe = 'bytes.read_u16_le(bytes.from_list([255, 254, 253, 252, 251, 250, 249, 248]), 0)'
+expect = "65279"
+
+[[bytes.fn]]
+name = "read_i32_be"
+index_unit = "value"
+probe = 'bytes.read_i32_be(bytes.from_list([255, 254, 253, 252, 251, 250, 249, 248]), 0)'
+expect = "-66052"
+
+[[bytes.fn]]
+name = "read_i32_le"
+index_unit = "value"
+probe = 'bytes.read_i32_le(bytes.from_list([255, 254, 253, 252, 251, 250, 249, 248]), 0)'
+expect = "-50462977"
+
+[[bytes.fn]]
+name = "read_u32_be"
+index_unit = "value"
+probe = 'bytes.read_u32_be(bytes.from_list([255, 254, 253, 252, 251, 250, 249, 248]), 0)'
+expect = "4294901244"
+
+[[bytes.fn]]
+name = "read_u32_le"
+index_unit = "value"
+probe = 'bytes.read_u32_le(bytes.from_list([255, 254, 253, 252, 251, 250, 249, 248]), 0)'
+expect = "4244504319"
+
+[[bytes.fn]]
+name = "read_i64_be"
+index_unit = "value"
+probe = 'bytes.read_i64_be(bytes.from_list([255, 254, 253, 252, 251, 250, 249, 248]), 0)'
+expect = "-283686952306184"
+
+[[bytes.fn]]
+name = "read_i64_le"
+index_unit = "value"
+probe = 'bytes.read_i64_le(bytes.from_list([255, 254, 253, 252, 251, 250, 249, 248]), 0)'
+expect = "-506097522914230529"
+
+[[bytes.fn]]
+name = "read_u8"
+index_unit = "byte-value"
+probe = 'bytes.read_u8(bytes.from_list([255, 254, 253, 252, 251, 250, 249, 248]), 1)'
+expect = "254"
+
+[[bytes.fn]]
+name = "read_f32_be"
+index_unit = "value"
+probe = 'bytes.read_f32_be(bytes.from_list([63, 192, 0, 0]), 0)'
+expect = "1.5"
+
+[[bytes.fn]]
+name = "read_f32_le"
+index_unit = "value"
+probe = 'bytes.read_f32_le(bytes.from_list([0, 0, 192, 63]), 0)'
+expect = "1.5"
+
+[[bytes.fn]]
+name = "read_f64_be"
+index_unit = "value"
+probe = 'bytes.read_f64_be(bytes.from_list([63, 248, 0, 0, 0, 0, 0, 0]), 0)'
+expect = "1.5"
+
+[[bytes.fn]]
+name = "read_f64_le"
+index_unit = "value"
+probe = 'bytes.read_f64_le(bytes.from_list([0, 0, 0, 0, 0, 0, 248, 63]), 0)'
+expect = "1.5"
+
+[[bytes.fn]]
+name = "read_f16_le"
+index_unit = "value"
+probe = 'bytes.read_f16_le(bytes.from_list([0, 62]), 0)'
+expect = "1.5"

--- a/docs/stdlib/semantics-manifest.toml
+++ b/docs/stdlib/semantics-manifest.toml
@@ -476,3 +476,191 @@ name = "read_f16_le"
 index_unit = "value"
 probe = 'bytes.read_f16_le(bytes.from_list([0, 62]), 0)'
 expect = "1.5"
+
+# The `_at` CURSOR family. The returned Int is the NEXT byte offset, not a
+# length — `read_i32_be_at(b, 0)` is `(4, some(…))`, and a caller who reads it
+# as "4 bytes consumed" happens to be right here and wrong for a
+# length-prefixed string, where the cursor jumps the prefix too (7, not 3).
+# The probe destructures instead of stringifying the whole tuple: `(Int, T?)`
+# in interpolation position walls the wasm renderer, and the destructured form
+# both lowers AND pins the decoded value alongside the cursor.
+
+[[bytes.fn]]
+name = "read_i16_be_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_i16_be_at(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0)',
+  'let combined = "${cur}/${v ?? -1}"',
+]
+probe = 'combined'
+expect = "2/258"
+
+[[bytes.fn]]
+name = "read_i16_le_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_i16_le_at(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0)',
+  'let combined = "${cur}/${v ?? -1}"',
+]
+probe = 'combined'
+expect = "2/513"
+
+[[bytes.fn]]
+name = "read_u16_be_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_u16_be_at(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0)',
+  'let combined = "${cur}/${v ?? -1}"',
+]
+probe = 'combined'
+expect = "2/258"
+
+[[bytes.fn]]
+name = "read_u16_le_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_u16_le_at(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0)',
+  'let combined = "${cur}/${v ?? -1}"',
+]
+probe = 'combined'
+expect = "2/513"
+
+[[bytes.fn]]
+name = "read_i32_be_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_i32_be_at(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0)',
+  'let combined = "${cur}/${v ?? -1}"',
+]
+probe = 'combined'
+expect = "4/16909060"
+
+[[bytes.fn]]
+name = "read_i32_le_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_i32_le_at(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0)',
+  'let combined = "${cur}/${v ?? -1}"',
+]
+probe = 'combined'
+expect = "4/67305985"
+
+[[bytes.fn]]
+name = "read_u32_be_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_u32_be_at(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0)',
+  'let combined = "${cur}/${v ?? -1}"',
+]
+probe = 'combined'
+expect = "4/16909060"
+
+[[bytes.fn]]
+name = "read_u32_le_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_u32_le_at(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0)',
+  'let combined = "${cur}/${v ?? -1}"',
+]
+probe = 'combined'
+expect = "4/67305985"
+
+[[bytes.fn]]
+name = "read_i64_be_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_i64_be_at(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0)',
+  'let combined = "${cur}/${v ?? -1}"',
+]
+probe = 'combined'
+expect = "8/72623859790382856"
+
+[[bytes.fn]]
+name = "read_i64_le_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_i64_le_at(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0)',
+  'let combined = "${cur}/${v ?? -1}"',
+]
+probe = 'combined'
+expect = "8/578437695752307201"
+
+[[bytes.fn]]
+name = "read_u8_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_u8_at(bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8]), 0)',
+  'let combined = "${cur}/${v ?? -1}"',
+]
+probe = 'combined'
+expect = "1/1"
+
+[[bytes.fn]]
+name = "read_f32_be_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_f32_be_at(bytes.from_list([63, 192, 0, 0]), 0)',
+  'let combined = "${cur}/${v ?? -1.0}"',
+]
+probe = 'combined'
+expect = "4/1.5"
+
+[[bytes.fn]]
+name = "read_f32_le_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_f32_le_at(bytes.from_list([0, 0, 192, 63]), 0)',
+  'let combined = "${cur}/${v ?? -1.0}"',
+]
+probe = 'combined'
+expect = "4/1.5"
+
+[[bytes.fn]]
+name = "read_f64_be_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_f64_be_at(bytes.from_list([63, 248, 0, 0, 0, 0, 0, 0]), 0)',
+  'let combined = "${cur}/${v ?? -1.0}"',
+]
+probe = 'combined'
+expect = "8/1.5"
+
+[[bytes.fn]]
+name = "read_f64_le_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_f64_le_at(bytes.from_list([0, 0, 0, 0, 0, 0, 248, 63]), 0)',
+  'let combined = "${cur}/${v ?? -1.0}"',
+]
+probe = 'combined'
+expect = "8/1.5"
+
+[[bytes.fn]]
+name = "read_f16_le_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_f16_le_at(bytes.from_list([0, 62]), 0)',
+  'let combined = "${cur}/${v ?? -1.0}"',
+]
+probe = 'combined'
+expect = "2/1.5"
+
+[[bytes.fn]]
+name = "read_bool_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_bool_at(bytes.from_list([1, 0]), 0)',
+  'let combined = "${cur}/${v ?? false}"',
+]
+probe = 'combined'
+expect = "1/true"
+
+[[bytes.fn]]
+name = "read_string_be_at"
+index_unit = "cursor"
+setup = [
+  'let (cur, v) = bytes.read_string_be_at(bytes.from_list([0, 0, 0, 3, 97, 98, 99]), 0)',
+  'let combined = "${cur}/${v ?? \"?\"}"',
+]
+probe = 'combined'
+expect = "7/abc"

--- a/docs/stdlib/semantics-manifest.toml
+++ b/docs/stdlib/semantics-manifest.toml
@@ -43,6 +43,26 @@
 #                 duration and not a position. The probes pin the ORIGIN
 #                 (month of 2024-01-15 is 1, so months are 1-based)
 #
+# index_unit vocabulary — bytes (every value below verified by execution over
+# the fixed buffer [1,2,3,4,5,6,7,8], not read off the prose):
+#   byte-offset   — the Int is a position in BYTES from the start, 0-based.
+#                   `read_i32_be(b, 4)` starts at byte 4, NOT at the 4th i32
+#   byte-count    — the Int counts BYTES: a length, a chunk size, a pad target
+#   element-count — the Int counts ELEMENTS of the decoded type, NOT bytes.
+#                   The `_array` trap: `read_i32_be_array(b, 0, 2)` consumes 8
+#                   bytes, and nothing in the name or the prose says so
+#   cursor        — the RETURNED Int is the next byte offset after the read,
+#                   not a length. The `_at` family returns `(cursor, T?)`:
+#                   `read_i32_be_at(b, 0)` is `(4, some(…))`
+#   byte-value    — the Int is one byte's value, 0–255 (`read_u8`, `set_at`'s
+#                   val, `fill`'s val)
+#   value         — the Int is the number encoded/decoded at exactly the width
+#                   AND byte order the name declares. `_be` vs `_le` is the
+#                   whole point: 0x0102 reads 258 big-endian, 513 little-endian
+#   ordering      — the Int is a comparison sign (-1 / 0 / 1), not a magnitude
+#   address       — the Int is a raw address or an opaque heap token
+#                   (`data_ptr`, `heap_save`) — meaningless to arithmetic on
+#
 # OPTIONAL `note` key: prose recording what the probe does NOT prove, for the
 # rare entry whose declared dimension is not fully probe-reachable. It is never
 # a substitute for a probe — an entry still needs one — and it exists so a

--- a/proofs/check-wasm-reachability.sh
+++ b/proofs/check-wasm-reachability.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# The per-FUNCTION wasm reachability ratchet.
+#
+# Runs tools/wasm_reachability_sweep.py and diffs the observed verdicts against
+# proofs/wasm-reachability-baseline.txt:
+#   - a fn that WALLS on wasm and is NOT in the baseline -> FAIL (parity
+#     regression: a stdlib fn stopped existing on one of the two first-class
+#     targets, or a new intrinsic landed native-only);
+#   - a baseline fn that now builds on wasm -> FAIL as STALE (prune it in the
+#     same change — the set only shrinks);
+#   - a fn that became UNPROBEABLE without being listed -> FAIL. The sweep's own
+#     coverage is ratcheted too: a synthesizer that quietly stops being able to
+#     build a call would otherwise shrink what the gate can see while still
+#     printing green.
+#
+# This gate is CI-only, not a pre-commit hook: it builds ~550 programs twice and
+# takes minutes. `check-wasm-fallback.sh` stays the fast per-file signal.
+set -uo pipefail
+# Pin collation (#1031): the ratchet diff must not depend on the machine's sort.
+export LC_ALL=C
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BASELINE="$ROOT/proofs/wasm-reachability-baseline.txt"
+BIN="${ALMIDE_BIN:-$ROOT/target/release/almide}"
+
+if [ ! -x "$BIN" ]; then
+  if [ "${CI:-}" = "true" ]; then
+    echo "::error::wasm-reachability: no almide at $BIN — in CI a missing oracle is a failure (#978)" >&2
+    exit 1
+  fi
+  echo "wasm-reachability: no almide at $BIN — SKIP"; exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+ALMIDE_BIN="$BIN" python3 "$ROOT/tools/wasm_reachability_sweep.py" --json "$TMP/sweep.json" \
+  >"$TMP/out.txt" 2>"$TMP/progress.txt" || { echo "::error::sweep failed" >&2; cat "$TMP/progress.txt" >&2; exit 1; }
+
+python3 - "$TMP/sweep.json" "$BASELINE" <<'PYEOF'
+import json, sys
+rows = json.load(open(sys.argv[1]))
+listed = {}
+for line in open(sys.argv[2]):
+    line = line.strip()
+    if not line or line.startswith("#"):
+        continue
+    fn, cls = (p.strip() for p in line.split("::")[:2])
+    listed[fn] = cls
+
+observed = {f"{r['module']}.{r['name']}": r["verdict"]
+            for r in rows if r["verdict"] in ("GAP", "UNPROBEABLE")}
+fail = 0
+new = sorted(k for k in observed if k not in listed)
+if new:
+    print("WASM PARITY REGRESSION — fn(s) that do not reach wasm and are NOT in the baseline:", file=sys.stderr)
+    for k in new:
+        print(f"  + {k} ({observed[k]})", file=sys.stderr)
+    fail = 1
+stale = sorted(k for k in listed if k not in observed)
+if stale:
+    print("STALE baseline entr(ies) — these now build on wasm; prune them (the set only shrinks):", file=sys.stderr)
+    for k in stale:
+        print(f"  - {k}", file=sys.stderr)
+    fail = 1
+if fail:
+    sys.exit(1)
+parity = sum(1 for r in rows if r["verdict"] == "PARITY")
+frontier = sum(1 for v in listed.values() if v == "COMPILER_FRONTIER")
+host = sum(1 for v in listed.values() if v == "HOST_CAPABILITY")
+unprobe = sum(1 for v in listed.values() if v == "UNPROBEABLE")
+print(f"WASM REACHABILITY RATCHET OK: {parity} fn(s) at parity; "
+      f"{frontier} frontier debt, {host} host-capability, {unprobe} unprobeable "
+      f"(targets: frontier 0, unprobeable 0).")
+PYEOF

--- a/proofs/wasm-reachability-baseline.txt
+++ b/proofs/wasm-reachability-baseline.txt
@@ -1,0 +1,214 @@
+# ── WASM REACHABILITY RATCHET (per FUNCTION, not per test file) ──────────────
+#
+# For every @intrinsic-backed stdlib fn, one minimal program is built on BOTH
+# legs. The NATIVE build is the control: a call that does not type or does not
+# build natively says nothing about wasm and is recorded as UNPROBEABLE, never
+# as a gap. Data feed: tools/wasm_reachability_sweep.py. Gate:
+# proofs/check-wasm-reachability.sh — a fn that walls and is NOT listed here
+# fails (a parity regression); a listed fn that now builds fails as STALE
+# (prune it — both sets only shrink).
+#
+# WHY PER-FUNCTION: proofs/check-wasm-fallback.sh measures which spec FILES the
+# wasm leg cannot run, so a stdlib fn no test touches is invisible to it.
+# `datetime.monotonic_ns` had no wasm body and no spec test, so no file fell
+# back and that ratchet read a clean 18/18 while the fn did not exist on wasm.
+#
+# Classes:
+#   HOST_CAPABILITY   — the WASI preview1 floor genuinely lacks the primitive
+#                       (sockets, subprocess spawn, a native zlib binding).
+#                       Out of wasm scope BY DESIGN until the WASI story changes.
+#   COMPILER_FRONTIER — WASI CAN do it and the compiler cannot yet. This is the
+#                       DEBT: `fs.write` is self-hosted and reaches parity while
+#                       `fs.write_bytes` right next to it does not.
+#
+# The class is a human judgment recorded here; the GATE enforces the SET.
+#
+# Counts at last regen: 369 parity, 65 gap (39 host, 26 frontier),
+# 113 unprobeable.
+#
+# COMPILER_FRONTIER (26) — the burn-down:
+env.cwd :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call env.cwd needs a declared capabili
+env.get :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: match over an UNTRACKED subject with a call-bearing arm cannot take t
+env.set :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call env.set needs a declared capabili
+fs.append :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.append needs a declared capabi
+fs.copy :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.copy needs a declared capabili
+fs.create_temp_file :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.create_temp_file needs a decla
+fs.file_size :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.file_size needs a declared cap
+fs.glob :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.glob needs a declared capabili
+fs.is_dir :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: scalar binding outside the value subset cannot be faithfully computed
+fs.is_file :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: scalar binding outside the value subset cannot be faithfully computed
+fs.is_symlink :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: scalar binding outside the value subset cannot be faithfully computed
+fs.modified_at :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.modified_at needs a declared c
+fs.read_bytes_if_exists :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.read_bytes_if_exists needs a d
+fs.read_bytes_raw_if_exists :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.read_bytes_raw_if_exists needs
+fs.read_lines :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.read_lines needs a declared ca
+fs.read_lines_if_exists :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.read_lines_if_exists needs a d
+fs.read_text_if_exists :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.read_text_if_exists needs a de
+fs.remove :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.remove needs a declared capabi
+fs.rename :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.rename needs a declared capabi
+fs.walk :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.walk needs a declared capabili
+fs.write_bytes :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.write_bytes needs a declared c
+fs.write_bytes_raw :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call fs.write_bytes_raw needs a declar
+io.read_byte :: COMPILER_FRONTIER :: main is outside the MIR-lowering subset: scalar binding outside the value subset cannot be faithfully computed
+matrix.select_rows_f32 :: COMPILER_FRONTIER :: unlinked stdlib/runtime call(s) with no wasm definition: matrix.select_rows_f32 — rendering them would emit a 
+matrix.select_rows_q1_0 :: COMPILER_FRONTIER :: unlinked stdlib/runtime call(s) with no wasm definition: matrix.select_rows_q1_0 — rendering them would emit a
+matrix.select_rows_q8_0_dq :: COMPILER_FRONTIER :: unlinked stdlib/runtime call(s) with no wasm definition: matrix.select_rows_q8_0_dq — rendering them would emi
+#
+# HOST_CAPABILITY (39) — out of scope by design:
+env.sleep_ms :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call env.sleep_ms needs a declared cap
+http.delete :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call http.delete needs a declared capa
+http.get :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call http.get needs a declared capabil
+http.patch :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call http.patch needs a declared capab
+http.post :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call http.post needs a declared capabi
+http.put :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call http.put needs a declared capabil
+net.tcp_accept :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call net.tcp_accept needs a declared c
+net.tcp_available :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call net.tcp_available needs a declare
+net.tcp_close :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call net.tcp_close needs a declared ca
+net.tcp_close_listener :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call net.tcp_close_listener needs a de
+net.tcp_connect :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call net.tcp_connect needs a declared 
+net.tcp_is_open :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: scalar binding outside the value subset cannot be faithfully computed
+net.tcp_listen :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call net.tcp_listen needs a declared c
+net.tcp_read :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call net.tcp_read needs a declared cap
+net.tcp_read_exact :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call net.tcp_read_exact needs a declar
+net.tcp_read_timeout :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call net.tcp_read_timeout needs a decl
+net.tcp_set_timeout :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call net.tcp_set_timeout needs a decla
+net.tcp_write :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call net.tcp_write needs a declared ca
+process.env :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call process.env needs a declared capa
+process.exec :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call process.exec needs a declared cap
+process.exec_in :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call process.exec_in needs a declared 
+process.exec_status :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call process.exec_status needs a decla
+process.exec_status_timeout :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call process.exec_status_timeout needs
+process.exec_with_stdin :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call process.exec_with_stdin needs a d
+process.exit :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: scalar binding outside the value subset cannot be faithfully computed
+process.is_alive :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: scalar binding outside the value subset cannot be faithfully computed
+process.kill :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call process.kill needs a declared cap
+process.pid :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: scalar binding outside the value subset cannot be faithfully computed
+process.sleep :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call process.sleep needs a declared ca
+process.spawn :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call process.spawn needs a declared ca
+process.stdin_lines :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call process.stdin_lines needs a decla
+zlib.compress :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call zlib.compress needs a declared ca
+zlib.compress_level :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call zlib.compress_level needs a decla
+zlib.decompress :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call zlib.decompress needs a declared 
+zlib.deflate :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call zlib.deflate needs a declared cap
+zlib.deflate_level :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call zlib.deflate_level needs a declar
+zlib.gunzip :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call zlib.gunzip needs a declared capa
+zlib.gzip :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call zlib.gzip needs a declared capabi
+zlib.inflate :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call zlib.inflate needs a declared cap
+#
+# UNPROBEABLE (113) — the sweep's OWN coverage hole, not a compiler
+# verdict: the argument synthesizer has no literal for these parameter types
+# (Matrix, Value, Json, RawPtr, closures). Shrinking this list widens what
+# the ratchet can see, so it is listed and ratcheted too.
+bytes.copy_to_ptr :: UNPROBEABLE :: parameter type outside the literal table
+bytes.copy_within :: UNPROBEABLE :: no candidate shape builds natively
+bytes.from_raw_ptr :: UNPROBEABLE :: parameter type outside the literal table
+bytes.map_each :: UNPROBEABLE :: no candidate shape builds natively
+bytes.push :: UNPROBEABLE :: no candidate shape builds natively
+bytes.read_float32 :: UNPROBEABLE :: parameter type outside the literal table
+bytes.read_int32 :: UNPROBEABLE :: parameter type outside the literal table
+bytes.read_uint16 :: UNPROBEABLE :: parameter type outside the literal table
+bytes.read_uint32 :: UNPROBEABLE :: parameter type outside the literal table
+bytes.set_at :: UNPROBEABLE :: no candidate shape builds natively
+bytes.set_float32 :: UNPROBEABLE :: parameter type outside the literal table
+bytes.set_int32 :: UNPROBEABLE :: parameter type outside the literal table
+bytes.set_uint16 :: UNPROBEABLE :: parameter type outside the literal table
+bytes.set_uint32 :: UNPROBEABLE :: parameter type outside the literal table
+bytes.write_float32 :: UNPROBEABLE :: parameter type outside the literal table
+bytes.write_int32 :: UNPROBEABLE :: parameter type outside the literal table
+bytes.write_uint16 :: UNPROBEABLE :: parameter type outside the literal table
+bytes.write_uint32 :: UNPROBEABLE :: parameter type outside the literal table
+fs.for_each_line :: UNPROBEABLE :: no candidate shape builds natively
+http.anthropic_streaming_call :: UNPROBEABLE :: no candidate shape builds natively
+http.get_bytes :: UNPROBEABLE :: no candidate shape builds natively
+http.openai_streaming_call :: UNPROBEABLE :: no candidate shape builds natively
+http.serve :: UNPROBEABLE :: no candidate shape builds natively
+json.field :: UNPROBEABLE :: parameter type outside the literal table
+json.get_array :: UNPROBEABLE :: parameter type outside the literal table
+json.get_bool :: UNPROBEABLE :: parameter type outside the literal table
+json.get_float :: UNPROBEABLE :: parameter type outside the literal table
+json.get_int :: UNPROBEABLE :: parameter type outside the literal table
+json.get_string :: UNPROBEABLE :: parameter type outside the literal table
+json.index :: UNPROBEABLE :: parameter type outside the literal table
+json.stringify :: UNPROBEABLE :: parameter type outside the literal table
+json.stringify_pretty :: UNPROBEABLE :: parameter type outside the literal table
+json.to_map :: UNPROBEABLE :: parameter type outside the literal table
+matrix.add :: UNPROBEABLE :: parameter type outside the literal table
+matrix.append_rows :: UNPROBEABLE :: parameter type outside the literal table
+matrix.attention_weights :: UNPROBEABLE :: parameter type outside the literal table
+matrix.broadcast_add_row :: UNPROBEABLE :: parameter type outside the literal table
+matrix.causal_mask_add :: UNPROBEABLE :: parameter type outside the literal table
+matrix.cols :: UNPROBEABLE :: parameter type outside the literal table
+matrix.concat_cols :: UNPROBEABLE :: parameter type outside the literal table
+matrix.concat_cols_many :: UNPROBEABLE :: parameter type outside the literal table
+matrix.conv1d :: UNPROBEABLE :: parameter type outside the literal table
+matrix.div :: UNPROBEABLE :: parameter type outside the literal table
+matrix.dot_row :: UNPROBEABLE :: parameter type outside the literal table
+matrix.fma :: UNPROBEABLE :: parameter type outside the literal table
+matrix.fma3 :: UNPROBEABLE :: parameter type outside the literal table
+matrix.from_lists :: UNPROBEABLE :: parameter type outside the literal table
+matrix.fused_gemm_bias_scale_gelu :: UNPROBEABLE :: parameter type outside the literal table
+matrix.gather_rows :: UNPROBEABLE :: parameter type outside the literal table
+matrix.gelu :: UNPROBEABLE :: parameter type outside the literal table
+matrix.get :: UNPROBEABLE :: parameter type outside the literal table
+matrix.layer_norm_rows :: UNPROBEABLE :: parameter type outside the literal table
+matrix.linear_f32_row_no_bias :: UNPROBEABLE :: parameter type outside the literal table
+matrix.linear_q1_0_row_no_bias :: UNPROBEABLE :: parameter type outside the literal table
+matrix.linear_q8_0_row_no_bias :: UNPROBEABLE :: parameter type outside the literal table
+matrix.linear_row :: UNPROBEABLE :: parameter type outside the literal table
+matrix.linear_row_gelu :: UNPROBEABLE :: parameter type outside the literal table
+matrix.linear_row_no_bias :: UNPROBEABLE :: parameter type outside the literal table
+matrix.map :: UNPROBEABLE :: parameter type outside the literal table
+matrix.masked_multi_head_attention :: UNPROBEABLE :: parameter type outside the literal table
+matrix.mul :: UNPROBEABLE :: parameter type outside the literal table
+matrix.mul_f32 :: UNPROBEABLE :: parameter type outside the literal table
+matrix.mul_f32_scaled :: UNPROBEABLE :: parameter type outside the literal table
+matrix.mul_f32_t :: UNPROBEABLE :: parameter type outside the literal table
+matrix.mul_f32_t_scaled :: UNPROBEABLE :: parameter type outside the literal table
+matrix.mul_scaled :: UNPROBEABLE :: parameter type outside the literal table
+matrix.multi_head_attention :: UNPROBEABLE :: parameter type outside the literal table
+matrix.neg :: UNPROBEABLE :: parameter type outside the literal table
+matrix.pow :: UNPROBEABLE :: parameter type outside the literal table
+matrix.pre_norm_linear :: UNPROBEABLE :: parameter type outside the literal table
+matrix.qwen3_block_f32_kv :: UNPROBEABLE :: parameter type outside the literal table
+matrix.qwen3_block_q1_0_kv :: UNPROBEABLE :: parameter type outside the literal table
+matrix.qwen3_block_q8_0_kv :: UNPROBEABLE :: parameter type outside the literal table
+matrix.rms_norm_rows :: UNPROBEABLE :: parameter type outside the literal table
+matrix.rope_rotate :: UNPROBEABLE :: parameter type outside the literal table
+matrix.rope_rotate_at :: UNPROBEABLE :: parameter type outside the literal table
+matrix.rope_rotate_neox_at :: UNPROBEABLE :: parameter type outside the literal table
+matrix.row_dot :: UNPROBEABLE :: parameter type outside the literal table
+matrix.rows :: UNPROBEABLE :: parameter type outside the literal table
+matrix.scale :: UNPROBEABLE :: parameter type outside the literal table
+matrix.scaled_dot_product_attention :: UNPROBEABLE :: parameter type outside the literal table
+matrix.select_rows :: UNPROBEABLE :: parameter type outside the literal table
+matrix.shape :: UNPROBEABLE :: parameter type outside the literal table
+matrix.silu_mul :: UNPROBEABLE :: parameter type outside the literal table
+matrix.slice_rows :: UNPROBEABLE :: parameter type outside the literal table
+matrix.softmax_rows :: UNPROBEABLE :: parameter type outside the literal table
+matrix.split_cols_even :: UNPROBEABLE :: parameter type outside the literal table
+matrix.sub :: UNPROBEABLE :: parameter type outside the literal table
+matrix.swiglu_gate :: UNPROBEABLE :: parameter type outside the literal table
+matrix.to_bytes_f32_le :: UNPROBEABLE :: parameter type outside the literal table
+matrix.to_bytes_f64_le :: UNPROBEABLE :: parameter type outside the literal table
+matrix.to_lists :: UNPROBEABLE :: parameter type outside the literal table
+matrix.transpose :: UNPROBEABLE :: parameter type outside the literal table
+mem.restore :: UNPROBEABLE :: no candidate shape builds natively
+mem.save :: UNPROBEABLE :: no candidate shape builds natively
+string.clear :: UNPROBEABLE :: no candidate shape builds natively
+string.push :: UNPROBEABLE :: no candidate shape builds natively
+string.slice :: UNPROBEABLE :: parameter type outside the literal table
+testing.assert_throws :: UNPROBEABLE :: no candidate shape builds natively
+value.array :: UNPROBEABLE :: parameter type outside the literal table
+value.as_array :: UNPROBEABLE :: parameter type outside the literal table
+value.as_bool :: UNPROBEABLE :: parameter type outside the literal table
+value.as_float :: UNPROBEABLE :: parameter type outside the literal table
+value.as_int :: UNPROBEABLE :: parameter type outside the literal table
+value.as_string :: UNPROBEABLE :: parameter type outside the literal table
+value.field :: UNPROBEABLE :: parameter type outside the literal table
+value.keys :: UNPROBEABLE :: parameter type outside the literal table
+value.merge :: UNPROBEABLE :: parameter type outside the literal table
+value.omit :: UNPROBEABLE :: parameter type outside the literal table
+value.pick :: UNPROBEABLE :: parameter type outside the literal table
+value.stringify :: UNPROBEABLE :: parameter type outside the literal table
+value.to_camel_case :: UNPROBEABLE :: parameter type outside the literal table
+value.to_snake_case :: UNPROBEABLE :: parameter type outside the literal table

--- a/tools/wasm_reachability_sweep.py
+++ b/tools/wasm_reachability_sweep.py
@@ -77,7 +77,7 @@ def surface(module_filter=None):
 def synth_args(params):
     """Literals for a parameter list, or None when a type is outside the table."""
     if not params.strip():
-        return ""
+        return []
     args = []
     depth, cur = 0, ""
     for ch in params + ",":          # split on top-level commas only
@@ -98,15 +98,34 @@ def synth_args(params):
         if ty not in LITERALS:
             return None
         lits.append(LITERALS[ty])
-    return ", ".join(lits)
+    return lits
 
 
-def program(f, args):
+def programs(f, args):
+    """Candidate probe shapes, tried in order until one builds NATIVELY.
+
+    A single fixed shape produces false GAPs: `let _ = <Unit-returning call>`
+    walls the wasm renderer on its own ("scalar binding outside the value
+    subset"), which reported all 40 of the bytes mutators — append_*, set_*,
+    fill, clear — as missing on wasm when the bare statement form lowers fine.
+    The verdict must describe the FUNCTION, not the wrapper, so the shape is
+    chosen by what the control leg accepts rather than assumed.
+    """
     imp = f"import {f['module']}\n\n" if f["module"] in NEEDS_IMPORT else ""
-    call = f"{f['module']}.{f['name']}({args})"
-    if f["effect"]:
-        return f"{imp}effect fn main() -> Unit = {{\n  let _ = {call}!\n}}\n"
-    return f"{imp}fn main() -> Unit = {{\n  let _ = {call}\n}}\n"
+    # Every argument is HOISTED to a local binding. Passing a literal inline
+    # made the in-place mutators (set_*/write_*) report as gaps: the wasm
+    # renderer requires a writable receiver to be a binding, so
+    # `bytes.set_u8(bytes.from_list([…]), 0, 7)` walls on the RECEIVER SHAPE
+    # while the hoisted form lowers. Hoisting is also how real code is written.
+    binds = "".join(f"  let a{i} = {a}\n" for i, a in enumerate(args))
+    names = ", ".join(f"a{i}" for i in range(len(args)))
+    call = f"{f['module']}.{f['name']}({names})"
+    bang = "!" if f["effect"] else ""
+    head = "effect fn" if f["effect"] else "fn"
+    bodies = [f"  let _ = {call}{bang}", f"  {call}{bang}"]
+    if f["ret"] == "Unit":                       # a Unit result binds to nothing useful
+        bodies.reverse()
+    return [f"{imp}{head} main() -> Unit = {{\n{binds}{b}\n}}\n" for b in bodies]
 
 
 def run(cmd):
@@ -121,26 +140,27 @@ def classify(f):
     args = synth_args(f["params"])
     if args is None:
         return "UNPROBEABLE", "parameter type outside the literal table"
-    src = program(f, args)
-    tf = tempfile.NamedTemporaryFile("w", suffix=".almd", delete=False, dir="/tmp")
-    tf.write(src); tf.close()
-    try:
-        rc, out = run([ALMIDE, "check", tf.name])
-        if rc != 0:
-            return "UNPROBEABLE", "synthesized call does not type"
-        rc, out = run([ALMIDE, "build", tf.name, "-o", tf.name + ".bin"])
-        if rc != 0:
-            return "UNPROBEABLE", "native build failed (no control)"
-        rc, out = run([ALMIDE, "build", tf.name, "--target", "wasm", "-o", tf.name + ".wasm"])
-        if rc == 0:
-            return "PARITY", ""
-        reason = "wasm renderer wall" if WALL_RX.search(out) else "wasm build failed"
-        m = re.search(r"wall: (.+)", out)
-        return "GAP", (m.group(1)[:160] if m else reason)
-    finally:
-        for ext in ("", ".bin", ".wasm"):
-            try: os.unlink(tf.name + ext)
-            except OSError: pass
+    for src in programs(f, args):
+        tf = tempfile.NamedTemporaryFile("w", suffix=".almd", delete=False, dir="/tmp")
+        tf.write(src); tf.close()
+        try:
+            # The CONTROL: this shape has to type and build natively, or it says
+            # nothing about the function and the next shape gets a turn.
+            if run([ALMIDE, "check", tf.name])[0] != 0:
+                continue
+            if run([ALMIDE, "build", tf.name, "-o", tf.name + ".bin"])[0] != 0:
+                continue
+            rc, out = run([ALMIDE, "build", tf.name, "--target", "wasm", "-o", tf.name + ".wasm"])
+            if rc == 0:
+                return "PARITY", ""
+            m = re.search(r"wall: (.+)", out)
+            return "GAP", (m.group(1)[:160] if m else
+                           "wasm renderer wall" if WALL_RX.search(out) else "wasm build failed")
+        finally:
+            for ext in ("", ".bin", ".wasm"):
+                try: os.unlink(tf.name + ext)
+                except OSError: pass
+    return "UNPROBEABLE", "no candidate shape builds natively"
 
 
 def main():

--- a/tools/wasm_reachability_sweep.py
+++ b/tools/wasm_reachability_sweep.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Per-FUNCTION native <-> wasm reachability sweep over the @intrinsic stdlib surface.
+
+WHY THIS EXISTS
+---------------
+`proofs/check-wasm-fallback.sh` measures parity at the TEST-FILE level: which
+spec files the wasm leg cannot run. That makes a stdlib function nobody tests
+INVISIBLE — `datetime.monotonic_ns` had no wasm body at all and no spec test,
+so no file fell back, and the ratchet read a clean 18/18 while a stdlib
+function simply did not exist on one of the two first-class targets.
+
+This sweep closes that blind spot by asking the question per FUNCTION: build one
+minimal program per intrinsic-backed stdlib fn and compare the two legs.
+
+THE THREE-STATE CLASSIFICATION (the native build is the CONTROL)
+----------------------------------------------------------------
+  UNPROBEABLE  `almide check` rejects the synthesized call -> the ARGUMENT
+               SYNTHESIS failed, not the compiler. Never counted as parity and
+               never counted as a gap; reported so the sweep's own coverage is
+               visible. A sweep that silently drops what it cannot build reads
+               as green while measuring nothing.
+  PARITY       checks, builds native, builds wasm.
+  GAP          checks and builds NATIVE, but the wasm renderer walls. This is
+               the signal: the function exists on one target and not the other.
+
+A type error must never be reported as a wall — that is the trap this control
+exists to defeat (`net.tcp_is_open(0)` fails to CHECK because the handle is not
+an Int literal, which looks identical to a wasm wall if you only build wasm).
+"""
+import argparse, json, os, re, subprocess, sys, tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ALMIDE = os.environ.get("ALMIDE_BIN", os.path.join(REPO, "target/release/almide"))
+
+# Modules requiring an explicit `import` (CLAUDE.md); everything else is auto-imported.
+NEEDS_IMPORT = {"json", "fs", "http", "env", "io", "random", "regex", "process",
+                "testing", "net", "zlib", "base64", "hex", "html", "path", "compute"}
+
+# Type -> a literal that inhabits it. Reachability only needs the call to RENDER,
+# so an argument that would panic at runtime (an out-of-range index) is fine; an
+# argument that does not TYPE is not, and lands in UNPROBEABLE.
+LITERALS = {
+    "Int": "0", "Float": "0.0", "Bool": "true", "String": '"a"',
+    "Bytes": "bytes.from_list([1, 2, 3, 4, 5, 6, 7, 8])",
+    "List[Int]": "[1, 2]", "List[Float]": "[1.0, 2.0]", "List[String]": '["a", "b"]',
+    "List[Bytes]": "[bytes.from_list([1])]",
+    "Int8": "(1).to_int8()", "Int16": "(1).to_int16()", "Int32": "(1).to_int32()",
+    "Int64": "(1).to_int64()", "UInt8": "(1).to_uint8()", "UInt16": "(1).to_uint16()",
+    "UInt32": "(1).to_uint32()", "UInt64": "(1).to_uint64()",
+    "Float32": "(1.0).to_float32()", "Float64": "(1.0).to_float64()",
+}
+
+DECL_RX = re.compile(
+    r'@intrinsic\("([^"]+)"\)\s*\n\s*(pub )?(effect )?fn (\w+)\(([^)]*)\)\s*->\s*([^=\n]+?)\s*=',
+    re.M)
+
+
+def surface(module_filter=None):
+    """Every @intrinsic-backed fn on a module's DECLARATION surface (the bare
+    stdlib/<module>.almd; the <module>_*.almd parts are implementations)."""
+    out = []
+    for fn in sorted(os.listdir(os.path.join(REPO, "stdlib"))):
+        if not fn.endswith(".almd"):
+            continue
+        module = fn[:-5]
+        if "_" in module or module == "prim":   # parts are not the surface; prim IS the wasm floor
+            continue
+        if module_filter and module not in module_filter:
+            continue
+        src = open(os.path.join(REPO, "stdlib", fn)).read()
+        for m in DECL_RX.finditer(src):
+            out.append(dict(module=module, name=m.group(4), effect=bool(m.group(3)),
+                            params=m.group(5).strip(), ret=m.group(6).strip()))
+    return out
+
+
+def synth_args(params):
+    """Literals for a parameter list, or None when a type is outside the table."""
+    if not params.strip():
+        return ""
+    args = []
+    depth, cur = 0, ""
+    for ch in params + ",":          # split on top-level commas only
+        if ch == "," and depth == 0:
+            args.append(cur.strip()); cur = ""
+            continue
+        if ch in "[(": depth += 1
+        if ch in "])": depth -= 1
+        cur += ch
+    lits = []
+    for a in args:
+        if not a:
+            continue
+        ty = a.split(":", 1)[1].strip() if ":" in a else None
+        if ty is None:
+            return None
+        ty = ty.removesuffix("?")     # an Option param still accepts the bare value
+        if ty not in LITERALS:
+            return None
+        lits.append(LITERALS[ty])
+    return ", ".join(lits)
+
+
+def program(f, args):
+    imp = f"import {f['module']}\n\n" if f["module"] in NEEDS_IMPORT else ""
+    call = f"{f['module']}.{f['name']}({args})"
+    if f["effect"]:
+        return f"{imp}effect fn main() -> Unit = {{\n  let _ = {call}!\n}}\n"
+    return f"{imp}fn main() -> Unit = {{\n  let _ = {call}\n}}\n"
+
+
+def run(cmd):
+    p = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO)
+    return p.returncode, (p.stdout or "") + (p.stderr or "")
+
+
+WALL_RX = re.compile(r"not yet supported by the verified wasm renderer|^wall:", re.M)
+
+
+def classify(f):
+    args = synth_args(f["params"])
+    if args is None:
+        return "UNPROBEABLE", "parameter type outside the literal table"
+    src = program(f, args)
+    tf = tempfile.NamedTemporaryFile("w", suffix=".almd", delete=False, dir="/tmp")
+    tf.write(src); tf.close()
+    try:
+        rc, out = run([ALMIDE, "check", tf.name])
+        if rc != 0:
+            return "UNPROBEABLE", "synthesized call does not type"
+        rc, out = run([ALMIDE, "build", tf.name, "-o", tf.name + ".bin"])
+        if rc != 0:
+            return "UNPROBEABLE", "native build failed (no control)"
+        rc, out = run([ALMIDE, "build", tf.name, "--target", "wasm", "-o", tf.name + ".wasm"])
+        if rc == 0:
+            return "PARITY", ""
+        reason = "wasm renderer wall" if WALL_RX.search(out) else "wasm build failed"
+        m = re.search(r"wall: (.+)", out)
+        return "GAP", (m.group(1)[:160] if m else reason)
+    finally:
+        for ext in ("", ".bin", ".wasm"):
+            try: os.unlink(tf.name + ext)
+            except OSError: pass
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--modules", nargs="*", help="limit to these modules")
+    ap.add_argument("--json", help="write the raw result rows here")
+    a = ap.parse_args()
+    fns = surface(set(a.modules) if a.modules else None)
+    rows, counts = [], {"PARITY": 0, "GAP": 0, "UNPROBEABLE": 0}
+    for i, f in enumerate(fns, 1):
+        verdict, why = classify(f)
+        counts[verdict] += 1
+        rows.append(dict(**f, verdict=verdict, why=why))
+        print(f"\r  {i}/{len(fns)}  parity={counts['PARITY']} "
+              f"gap={counts['GAP']} unprobeable={counts['UNPROBEABLE']}", end="", file=sys.stderr)
+    print(file=sys.stderr)
+    if a.json:
+        json.dump(rows, open(a.json, "w"), indent=1)
+    for r in rows:
+        if r["verdict"] == "GAP":
+            print(f"GAP  {r['module']}.{r['name']}  :: {r['why']}")
+    n = len(fns)
+    probed = counts["PARITY"] + counts["GAP"]
+    print(f"\n{n} intrinsic fns: {counts['PARITY']} parity, {counts['GAP']} gap, "
+          f"{counts['UNPROBEABLE']} unprobeable "
+          f"({100*probed//n if n else 0}% of the surface actually measured)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

`datetime.monotonic_ns` had no wasm body at all (fixed in #1200). The
uncomfortable part is not the missing function — it is that **nothing was
looking**. `proofs/check-wasm-fallback.sh` measures which spec FILES the wasm
leg cannot run, so a stdlib fn no test touches is invisible to it: no test
touched `monotonic_ns`, no file fell back, and the ratchet read a clean 18/18
while a stdlib function did not exist on one of the two first-class targets.

It only surfaced because the semantics manifest forces a probe per function.
That is a side effect, not a gate. Every module the manifest has not reached
still has the same blind spot.

## What this adds

`tools/wasm_reachability_sweep.py` — one minimal program per @intrinsic stdlib
fn, built on **both** legs, with the **native build as the control**:

| verdict | meaning |
|---|---|
| `PARITY` | checks, builds native, builds wasm |
| `GAP` | builds NATIVE, wasm renderer walls — the signal |
| `UNPROBEABLE` | the synthesized call does not type/build natively — the sweep's own blind spot, never counted either way |

Plus `proofs/wasm-reachability-baseline.txt` (the classified ledger) and
`proofs/check-wasm-reachability.sh` (shrink-only ratchet, ~70s, CI-only).

## The measurement

**547 intrinsic fns: 369 parity, 65 gap, 113 unprobeable (79% measured).**

The 65 gaps split into **39 HOST_CAPABILITY** (net, process, zlib, http — WASI
preview1 has no sockets or spawn) and **26 COMPILER_FRONTIER**, which is the
real debt: `fs` (19), `env` (3), `matrix.select_rows_*` (3), `io.read_byte`.
The `fs` cluster is the sharpest — `fs.write` is self-hosted and reaches parity
while `fs.write_bytes` beside it does not.

## Two false-positive rounds, and why the control exists

The first run reported **112 gaps including 40 in `bytes`**. All 40 were
artifacts of my own probe shape, twice over:

1. `let _ = <Unit-returning call>` walls on its own — the bare statement form
   lowers fine. That was every `append_*` / `set_*` / `fill` / `clear`.
2. After fixing that, 25 remained: passing `bytes.from_list([…])` inline as the
   receiver walls, because the wasm renderer requires a writable receiver to be
   a **binding**. Hoisting every argument to a `let` cleared it.

`bytes` has **zero** parity gaps. Without the native control this would have
shipped a ledger of 40 debts that never existed. The sweep now picks its probe
shape by what the control leg accepts rather than assuming one.

`UNPROBEABLE` is ratcheted for the same reason in the other direction: a
synthesizer that quietly stops being able to build a call would shrink what the
gate can see while still printing green.

## Verification

- A/B: reverting the #1200 `ADMITTED_ENTROPY_ENV_CLOCK` entry makes the sweep
  report `GAP datetime.monotonic_ns` (21 parity / 1 gap); restoring it gives
  22/22. **This gate would have caught it on day one.**
- Gate bites both ways: deleting `fs.glob` from the baseline fails as a parity
  regression; adding a bogus `bytes.read_u8` row fails as STALE.
- Four reported gaps hand-verified with natural idiomatic programs
  (`env.get`, `fs.is_dir`, `io.read_byte`, `matrix.select_rows_f32`) — all
  genuine walls, not probe artifacts.
- `check-semantics-manifest.sh`, `check-ratchet-separation.sh`,
  `almide fmt --check spec/ examples/` all green.

## Also here: bytes semantics matrix, 49/121 (inert)

Four commits continue the manifest ratchet on `bytes`. It is **not** turned on —
`COVERED_MODULES` is unchanged, so these entries are inert and the gate ignores
them. Landed so far: the vocabulary, the scalar-read matrix (width × signedness
× byte order, expectations computed independently by Python's `struct`), the
`_at` cursor family, and the `_array` family.

Two undocumented traps are now pinned: `read_i32_be_array(b, pos, count)` takes
a **byte** offset and an **element** count in the same call, and the `_at`
family returns the **next offset**, not a length — `(7, "abc")` for a
length-prefixed string, not 3.

https://claude.ai/code/session_0113PovgujQAu2qCWbt7kdRS