### PR TITLE
Stage 1c: audit the hand-written WAT prelude — 63 fns classified, evidence re-measured in CI, 2 dead fns deleted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,18 @@ jobs:
       - name: WASM reachability ratchet (every stdlib fn builds on both legs, or is listed)
         run: ALMIDE_BIN=/tmp/almide-bin/almide bash proofs/check-wasm-reachability.sh
 
+      # Stage 1c. The two ratchets above measure code rendered FROM the shared MIR —
+      # the half the 3-way oracle can differ native against wasm. The prelude is the
+      # other half: hand-written wasm with no native counterpart, so its assurance has
+      # to be named per function. CI runs the reachability re-measurement (the `via`
+      # column is measured here, not trusted), which is why the example is built —
+      # debug on purpose: it shares the registry-regen step's dep cache, and
+      # rendering 47 fixtures is cheap even unoptimized.
+      - name: WAT prelude audit (every hand-written wasm fn's evidence named and re-measured)
+        run: |
+          cargo build -p almide-mir --example render_program
+          ALMIDE_RENDER=target/debug/examples/render_program bash scripts/check-wat-prelude-audit.sh
+
       # The dogfood program (Unit 0.46, #1001). Its own tests cover the decision rules
       # extracted from the shell gates — the parity verdict, the nightly streak fold, the
       # contract link symmetry — which in bash are reachable only through their I/O. Gated

--- a/crates/almide-mir/src/render_wasm_p3.rs
+++ b/crates/almide-mir/src/render_wasm_p3.rs
@@ -9,6 +9,22 @@ pub(crate) fn preamble() -> String {
 /// [`preamble`] with the bump allocator starting at `bump_base` (`HEAP_BASE +
 /// 8*mutable_global_count`), so the mutable-global slots `[HEAP_BASE, bump_base)`
 /// are never allocated over. With no mutable globals this IS `preamble()`.
+///
+/// Every `(func $…)` below is HAND-WRITTEN wasm — the one part of the wasm leg
+/// that is not rendered from the shared MIR, so the 3-way oracle has no native
+/// counterpart to differ it against. Each one therefore carries a row in
+/// `proofs/wat-prelude-audit.toml` naming the evidence that reaches it, gated by
+/// `scripts/check-wat-prelude-audit.sh`. Add a function here ⇒ add its row.
+///
+/// `$__chk_div`/`$__chk_rem` sat here until that audit: #806 inline-expanded the
+/// checked division/remainder at every `/`/`%` site (`render_wasm_calls.rs`) and
+/// left the two functions behind with zero callers repo-wide. DCE already dropped
+/// their BODIES from every shipped module, so removing them is instruction-identical
+/// on all 367 corpus fixtures; the only textual delta is the three dead comment
+/// lines above them, which DCE keeps (it removes `(func …)` blocks, and the text
+/// between blocks is fixed). What they cost was audit surface: hand-written wasm no
+/// evidence could reach. The divisor-0 / MIN÷-1 abort bytes (C-001/C-035) are
+/// carried by the inline expansion and its fixtures, not by these two.
 pub(crate) fn preamble_with_bump_base(bump_base: u32) -> String {
     // Stage 2 fuel core: present when the program uses fan.bounded OR the
     // probe is on. Counters count DOWN from i64::MAX (consumed = MAX - fuel).
@@ -146,22 +162,6 @@ pub(crate) fn preamble_with_bump_base(bump_base: u32) -> String {
     (call $__div_trap (i32.add (local.get $s) (i32.const 12))
       (i32.load (i32.add (local.get $s) (i32.const 4))))
     (unreachable))
-  ;; CHECKED i64 division/remainder: divisor 0 and the MIN/-1 overflow abort with
-  ;; the SAME bytes + exit code as native (never a bare wasm hard trap = exit 134).
-  (func $__chk_div (param $a i64) (param $b i64) (result i64)
-    (if (i64.eqz (local.get $b))
-      (then (call $__div_trap (i32.const {DIVZERO_MSG_ADDR}) (i32.const 24))))
-    (if (i32.and (i64.eq (local.get $a) (i64.const -9223372036854775808))
-                 (i64.eq (local.get $b) (i64.const -1)))
-      (then (call $__div_trap (i32.const {OVERFLOW_MSG_ADDR}) (i32.const 24))))
-    (i64.div_s (local.get $a) (local.get $b)))
-  (func $__chk_rem (param $a i64) (param $b i64) (result i64)
-    (if (i64.eqz (local.get $b))
-      (then (call $__div_trap (i32.const {DIVZERO_MSG_ADDR}) (i32.const 24))))
-    (if (i32.and (i64.eq (local.get $a) (i64.const -9223372036854775808))
-                 (i64.eq (local.get $b) (i64.const -1)))
-      (then (call $__div_trap (i32.const {OVERFLOW_MSG_ADDR}) (i32.const 24))))
-    (i64.rem_s (local.get $a) (local.get $b)))
   ;; the free-list head (0 = empty) — physical reclamation (A1.2-render), the
   ;; realization of proofs/FreeList.v. A freed block is pushed here; $alloc reuses
   ;; the head when it is EXACTLY the requested size. The link is stored in the dead

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,6 +18,12 @@ pre-commit:
     scalar-read-audit:
       glob: "{crates/almide-mir/src/lower/*.rs,proofs/scalar-read-audit.toml,scripts/check-scalar-read-audit.sh,scripts/lib/scalar-read-enumerate.py}"
       run: bash scripts/check-scalar-read-audit.sh
+    wat-prelude-audit:
+      # STRUCTURE only pre-commit (no reachability re-render — that needs the
+      # render_program example binary and runs in CI). Catches the common local
+      # failure: a `(func $…)` added or edited without its ledger row.
+      glob: "{crates/almide-mir/src/render_wasm*.rs,proofs/wat-prelude-audit.toml,scripts/check-wat-prelude-audit.sh,scripts/lib/wat-prelude-enumerate.py}"
+      run: bash scripts/check-wat-prelude-audit.sh
     ratchet-separation:
       run: scripts/check-ratchet-separation.sh
     semantics-manifest:

--- a/proofs/wat-prelude-audit.toml
+++ b/proofs/wat-prelude-audit.toml
@@ -1,0 +1,500 @@
+# The hand-written WAT prelude audit (Stage 1c).
+#
+# Almide renders BOTH first-class targets from the same MIR, so the 3-way oracle
+# (native <-> wasm <-> interp) differs every corpus fixture's two legs against
+# each other. The prelude is the one place that escapes it: `$alloc`, `$rc_dec`,
+# the free-list, the WASI shims and the rest are hand-written wasm with NO native
+# counterpart to be differed against. Whatever assurance they carry has to be
+# stated, per function — that is this file.
+#
+# One row per `(func $NAME` in the renderer sources (scripts/lib/wat-prelude-enumerate.py,
+# shared with the gate so the two cannot drift — the #1176 one-instrument rule).
+#
+#   PROVEN         a machine-checked proof covers the algorithm, AND a fixture
+#                  reaches it. `proof` names the file, `via` the fixture.
+#   CORPUS         >=1 spec/wasm_cross fixture reaches it, so its observable
+#                  behavior is pinned by native<->wasm byte identity. `via` names
+#                  the fixture; the gate RE-RENDERS it and fails if it does not.
+#   FALLBACK_ONLY  reachable, but only from source constructs whose fixtures are
+#                  in proofs/wasm-fallback-baseline.txt — those run on the native
+#                  leg, so the byte oracle never renders this wasm. Debt that
+#                  shrinks with the fallback ratchet, not a steady state.
+#   PROBE_ONLY     emitted only under a compile-time flag (ALMIDE_FUEL_PROBE=1).
+#   MIR_ONLY       no frontend lowering constructs the op — only hand-built MIR
+#                  in the proof/validation layer reaches it. Emission is checked;
+#                  the BODY is not. `ref` names the issue to close it out.
+#   TEMPLATE       not a fixed name: a `{}`-interpolated rendering template whose
+#                  instances carry a user function's identity.
+#
+# UNREACHED is the failing verdict: hand-written wasm that NOTHING can reach —
+# DO-178C dead code. It must stay 0. `$__chk_div`/`$__chk_rem` were exactly that
+# (superseded by the #806 inline expansion, zero callers repo-wide) and were
+# deleted when this audit first ran; removing them is instruction-identical on
+# all 367 fixtures.
+#
+# The gate (scripts/check-wat-prelude-audit.sh) fails on: an unclassified name (a
+# prelude function added without a row), a stale row, a changed `digest` (the
+# hand-written wasm was edited — re-confirm its evidence rather than inherit it),
+# an unknown class, a CORPUS/PROVEN row whose `via` fixture does not actually
+# reach it, and any UNREACHED row.
+#
+# Counts at the first measurement (2026-08-11, 63 functions):
+#   PROVEN 5 / CORPUS 41 / FALLBACK_ONLY 6 / PROBE_ONLY 2 / MIR_ONLY 5 / TEMPLATE 4
+
+[[fn]]
+name = "__die"
+site = "crates/almide-mir/src/render_wasm_p3.rs:161"
+digest = "99fb3c2e69e7"
+class = "CORPUS"
+via = "alias_combinator_rc.almd"
+
+[[fn]]
+name = "__div_trap"
+site = "crates/almide-mir/src/render_wasm_p3.rs:124"
+digest = "4495e0fb3c83"
+class = "CORPUS"
+via = "alias_combinator_rc.almd"
+
+[[fn]]
+name = "__export_"
+site = "crates/almide-mir/src/render_wasm.rs:668"
+digest = "d1959ff9df04"
+class = "TEMPLATE"
+why = "`(func $__export_{internal}…)` — the export-wrapper TEMPLATE; each instance carries a user function's name."
+
+[[fn]]
+name = "__import_"
+site = "crates/almide-mir/src/render_wasm.rs:538"
+digest = "e7030093815d"
+class = "TEMPLATE"
+why = "`(import … (func $__import_{sym}…))` — the extern-import TEMPLATE, one instance per declared import."
+
+[[fn]]
+name = "__main_err"
+site = "crates/almide-mir/src/render_wasm_p3.rs:142"
+digest = "4f2cf058ce91"
+class = "CORPUS"
+via = "args_surface.almd"
+
+[[fn]]
+name = "__mg_take"
+site = "crates/almide-mir/src/render_wasm.rs:685"
+digest = "4185da3f48a0"
+class = "CORPUS"
+via = "mg_rebuild_two_phase.almd"
+
+[[fn]]
+name = "__probe_digits"
+site = "crates/almide-mir/src/render_wasm_p3.rs:38"
+digest = "c63c0b92bcb1"
+class = "PROBE_ONLY"
+why = "emitted only when ALMIDE_FUEL_PROBE=1 (charge_probe::probe_enabled). Measured: the flag makes it appear in any program's module."
+
+[[fn]]
+name = "__probe_print"
+site = "crates/almide-mir/src/render_wasm_p3.rs:38"
+digest = "ed1128607382"
+class = "PROBE_ONLY"
+why = "emitted only when ALMIDE_FUEL_PROBE=1 (charge_probe::probe_enabled). Measured: the flag makes it appear in any program's module."
+
+[[fn]]
+name = "__wall_hit"
+site = "crates/almide-mir/src/render_wasm_p3.rs:51"
+digest = "bddcd35c51ce"
+class = "CORPUS"
+via = "fuel_timeout_ends.almd"
+
+[[fn]]
+name = "__wall_now"
+site = "crates/almide-mir/src/render_wasm_p3.rs:51"
+digest = "57b85fd6d4de"
+class = "CORPUS"
+via = "fuel_timeout_ends.almd"
+
+[[fn]]
+name = "alloc"
+site = "crates/almide-mir/src/render_wasm_p3.rs:172"
+digest = "63591a64eb5c"
+class = "PROVEN"
+via = "alias_combinator_rc.almd"
+proof = "proofs/FreeList.v"
+
+[[fn]]
+name = "alloc8"
+site = "crates/almide-mir/src/render_wasm_p3.rs:237"
+digest = "04b05ec82dda"
+class = "PROVEN"
+via = "fan_settle_tuple.almd"
+proof = "proofs/FreeList.v"
+
+[[fn]]
+name = "args_get"
+site = "crates/almide-mir/src/render_wasm_p3.rs:65"
+digest = "b50cc5f342d7"
+class = "CORPUS"
+via = "args_surface.almd"
+
+[[fn]]
+name = "args_get_list"
+site = "crates/almide-mir/src/render_wasm_p3.rs:450"
+digest = "32c1abadb7b6"
+class = "CORPUS"
+via = "args_surface.almd"
+
+[[fn]]
+name = "args_sizes_get"
+site = "crates/almide-mir/src/render_wasm_p3.rs:63"
+digest = "715c73fdb520"
+class = "CORPUS"
+via = "args_surface.almd"
+
+[[fn]]
+name = "clock_time_get"
+site = "crates/almide-mir/src/render_wasm_p3.rs:89"
+digest = "c36972df37dc"
+class = "CORPUS"
+via = "fuel_timeout_ends.almd"
+
+[[fn]]
+name = "elem_addr"
+site = "crates/almide-mir/src/render_wasm_p3.rs:297"
+digest = "da906ab99826"
+class = "CORPUS"
+via = "alias_combinator_rc.almd"
+
+[[fn]]
+name = "elem_addr_chk"
+site = "crates/almide-mir/src/render_wasm_p3.rs:316"
+digest = "b557581e5fcf"
+class = "CORPUS"
+via = "call_closure_lambda_param.almd"
+
+[[fn]]
+name = "env_get"
+site = "crates/almide-mir/src/render_wasm_p3.rs:508"
+digest = "6d99767442b6"
+class = "CORPUS"
+via = "env_get.almd"
+
+[[fn]]
+name = "environ_get"
+site = "crates/almide-mir/src/render_wasm_p3.rs:69"
+digest = "09df9c7f2b50"
+class = "CORPUS"
+via = "env_get.almd"
+
+[[fn]]
+name = "environ_sizes_get"
+site = "crates/almide-mir/src/render_wasm_p3.rs:67"
+digest = "ff8cb2edc6b3"
+class = "CORPUS"
+via = "env_get.almd"
+
+[[fn]]
+name = "fd_close"
+site = "crates/almide-mir/src/render_wasm_p3.rs:75"
+digest = "fdce94b818bf"
+class = "CORPUS"
+via = "fan_settle_tuple.almd"
+
+[[fn]]
+name = "fd_filestat_get"
+site = "crates/almide-mir/src/render_wasm_p3.rs:77"
+digest = "a4be912262c9"
+class = "CORPUS"
+via = "fan_settle_tuple.almd"
+
+[[fn]]
+name = "fd_read"
+site = "crates/almide-mir/src/render_wasm_p3.rs:73"
+digest = "250a0bc852cb"
+class = "CORPUS"
+via = "fan_settle_tuple.almd"
+
+[[fn]]
+name = "fd_readdir"
+site = "crates/almide-mir/src/render_wasm_p3.rs:79"
+digest = "8138391eb8eb"
+class = "CORPUS"
+via = "fs_relative_path.almd"
+
+[[fn]]
+name = "fd_write"
+site = "crates/almide-mir/src/render_wasm_p3.rs:59"
+digest = "a898e4ffed9c"
+class = "CORPUS"
+via = "alias_combinator_rc.almd"
+
+[[fn]]
+name = "is_dot_entry"
+site = "crates/almide-mir/src/render_wasm_fs_wat.rs:674"
+digest = "c3ca7c77e168"
+class = "CORPUS"
+via = "fs_relative_path.almd"
+
+[[fn]]
+name = "itoa_append"
+site = "crates/almide-mir/src/render_wasm_p3.rs:363"
+digest = "c6037df97b58"
+class = "MIR_ONLY"
+ref = "#1208"
+why = "called only by $print_int/$print_list is constructed only by hand-built MIR (certificate_p2.rs, translation_validation.rs) — no frontend lowering emits it, so no .almd program reaches this wasm. Emission is checked (translation_validation mutation test); the BODY is not."
+
+[[fn]]
+name = "list_copy"
+site = "crates/almide-mir/src/render_wasm_p3.rs:339"
+digest = "dd4b194ca2f0"
+class = "CORPUS"
+via = "alias_cow.almd"
+
+[[fn]]
+name = "list_get"
+site = "crates/almide-mir/src/render_wasm_p3.rs:327"
+digest = "47515830f246"
+class = "FALLBACK_ONLY"
+via = "fs.list_dir"
+why = "reached through dirent list build; every fixture that would exercise it is in proofs/wasm-fallback-baseline.txt, so it runs on the NATIVE leg and the byte oracle never renders it. Shrinks with that ratchet."
+
+[[fn]]
+name = "list_len"
+site = "crates/almide-mir/src/render_wasm_p3.rs:330"
+digest = "a594d53bf87c"
+class = "MIR_ONLY"
+ref = "#1208"
+why = "called only by $print_list is constructed only by hand-built MIR (certificate_p2.rs, translation_validation.rs) — no frontend lowering emits it, so no .almd program reaches this wasm. Emission is checked (translation_validation mutation test); the BODY is not."
+
+[[fn]]
+name = "list_new"
+site = "crates/almide-mir/src/render_wasm_p3.rs:258"
+digest = "67c00ad80bac"
+class = "CORPUS"
+via = "alias_combinator_rc.almd"
+
+[[fn]]
+name = "list_push"
+site = "crates/almide-mir/src/render_wasm_p3.rs:354"
+digest = "376724cbb191"
+class = "MIR_ONLY"
+ref = "#1208"
+why = "RtFn::ListPush is constructed only by hand-built MIR (certificate_p2.rs, translation_validation.rs) — no frontend lowering emits it, so no .almd program reaches this wasm. Emission is checked (translation_validation mutation test); the BODY is not."
+
+[[fn]]
+name = "list_set"
+site = "crates/almide-mir/src/render_wasm_p3.rs:324"
+digest = "c691b3f13f11"
+class = "CORPUS"
+via = "alias_combinator_rc.almd"
+
+[[fn]]
+name = "main"
+site = "crates/almide-mir/src/pipeline_c.rs:347"
+digest = "f29bc94be267"
+class = "CORPUS"
+via = "alias_combinator_rc.almd"
+
+[[fn]]
+name = "make_dir"
+site = "crates/almide-mir/src/render_wasm_fs_wat.rs:298"
+digest = "2f37d179fc39"
+class = "CORPUS"
+via = "fs_relative_path.almd"
+
+[[fn]]
+name = "name"
+site = "crates/almide-mir/src/render_wasm.rs:191"
+digest = "fa03a4a87d6a"
+class = "TEMPLATE"
+why = "`(func ${}` — the MirFunction rendering template (render_wasm_b.rs); every program function is an instance."
+
+[[fn]]
+name = "oom"
+site = "crates/almide-mir/src/render_wasm_p3.rs:137"
+digest = "bcb5d1388f9b"
+class = "PROVEN"
+via = "alias_combinator_rc.almd"
+proof = "proofs/FreeList.v"
+
+[[fn]]
+name = "path_create_directory"
+site = "crates/almide-mir/src/render_wasm_p3.rs:83"
+digest = "7811a3f30bb9"
+class = "CORPUS"
+via = "fs_relative_path.almd"
+
+[[fn]]
+name = "path_exists"
+site = "crates/almide-mir/src/render_wasm_fs_wat.rs:368"
+digest = "89e689310bd8"
+class = "CORPUS"
+via = "fs_preopen_resolve.almd"
+
+[[fn]]
+name = "path_filestat_get"
+site = "crates/almide-mir/src/render_wasm_p3.rs:81"
+digest = "abb7f8098cc0"
+class = "CORPUS"
+via = "fs_preopen_resolve.almd"
+
+[[fn]]
+name = "path_filestat_q"
+site = "crates/almide-mir/src/render_wasm_fs_wat.rs:346"
+digest = "87cd0805641b"
+class = "FALLBACK_ONLY"
+via = "fs.stat"
+why = "reached through prim.path_filestat; every fixture that would exercise it is in proofs/wasm-fallback-baseline.txt, so it runs on the NATIVE leg and the byte oracle never renders it. Shrinks with that ratchet."
+
+[[fn]]
+name = "path_norm"
+site = "crates/almide-mir/src/render_wasm_fs_wat.rs:38"
+digest = "54e7c0414c0a"
+class = "CORPUS"
+via = "fan_settle_tuple.almd"
+
+[[fn]]
+name = "path_open"
+site = "crates/almide-mir/src/render_wasm_p3.rs:71"
+digest = "1b54f5848d0e"
+class = "CORPUS"
+via = "fan_settle_tuple.almd"
+
+[[fn]]
+name = "path_remove_directory"
+site = "crates/almide-mir/src/render_wasm_p3.rs:85"
+digest = "483e5bc3243e"
+class = "CORPUS"
+via = "fs_relative_path.almd"
+
+[[fn]]
+name = "path_unlink_file"
+site = "crates/almide-mir/src/render_wasm_p3.rs:87"
+digest = "2fe62b017aff"
+class = "CORPUS"
+via = "fs_relative_path.almd"
+
+[[fn]]
+name = "print_int"
+site = "crates/almide-mir/src/render_wasm_p3.rs:428"
+digest = "5f544cd9d766"
+class = "MIR_ONLY"
+ref = "#1208"
+why = "RtFn::PrintInt is constructed only by hand-built MIR (certificate_p2.rs, translation_validation.rs) — no frontend lowering emits it, so no .almd program reaches this wasm. Emission is checked (translation_validation mutation test); the BODY is not."
+
+[[fn]]
+name = "print_list"
+site = "crates/almide-mir/src/render_wasm_p3.rs:388"
+digest = "c3b1a1fbb217"
+class = "MIR_ONLY"
+ref = "#1208"
+why = "RtFn::PrintList is constructed only by hand-built MIR (certificate_p2.rs, translation_validation.rs) — no frontend lowering emits it, so no .almd program reaches this wasm. Emission is checked (translation_validation mutation test); the BODY is not."
+
+[[fn]]
+name = "proc_exit"
+site = "crates/almide-mir/src/render_wasm_p3.rs:91"
+digest = "6e440ccb7814"
+class = "CORPUS"
+via = "alias_combinator_rc.almd"
+
+[[fn]]
+name = "random_get"
+site = "crates/almide-mir/src/render_wasm_p3.rs:61"
+digest = "82206e79c279"
+class = "CORPUS"
+via = "random_int_entropy.almd"
+
+[[fn]]
+name = "rc_dec"
+site = "crates/almide-mir/src/render_wasm_p3.rs:278"
+digest = "08a8b2207fd9"
+class = "PROVEN"
+via = "alias_combinator_rc.almd"
+proof = "proofs/FreeList.v"
+
+[[fn]]
+name = "rc_inc"
+site = "crates/almide-mir/src/render_wasm_p3.rs:291"
+digest = "95ffa64bdf13"
+class = "PROVEN"
+via = "alias_combinator_rc.almd"
+proof = "proofs/FreeList.v"
+
+[[fn]]
+name = "read_dir"
+site = "crates/almide-mir/src/render_wasm_fs_wat.rs:585"
+digest = "db5c55e61af0"
+class = "FALLBACK_ONLY"
+via = "fs.list_dir"
+why = "reached through prim.read_dir; every fixture that would exercise it is in proofs/wasm-fallback-baseline.txt, so it runs on the NATIVE leg and the byte oracle never renders it. Shrinks with that ratchet."
+
+[[fn]]
+name = "read_line"
+site = "crates/almide-mir/src/render_wasm_fs_wat.rs:388"
+digest = "a2f59da171ed"
+class = "FALLBACK_ONLY"
+via = "io.read_line"
+why = "reached through prim.read_line; every fixture that would exercise it is in proofs/wasm-fallback-baseline.txt, so it runs on the NATIVE leg and the byte oracle never renders it. Shrinks with that ratchet."
+
+[[fn]]
+name = "read_n_bytes"
+site = "crates/almide-mir/src/render_wasm_fs_wat.rs:420"
+digest = "212672a20dec"
+class = "FALLBACK_ONLY"
+via = "io.read_all"
+why = "reached through prim.read_n_bytes; every fixture that would exercise it is in proofs/wasm-fallback-baseline.txt, so it runs on the NATIVE leg and the byte oracle never renders it. Shrinks with that ratchet."
+
+[[fn]]
+name = "read_text_file"
+site = "crates/almide-mir/src/render_wasm_fs_wat.rs:140"
+digest = "1350cfbd08cc"
+class = "CORPUS"
+via = "fan_settle_tuple.almd"
+
+[[fn]]
+name = "remove_all"
+site = "crates/almide-mir/src/render_wasm_fs_wat.rs:537"
+digest = "02224ca5d6c9"
+class = "CORPUS"
+via = "fs_relative_path.almd"
+
+[[fn]]
+name = "remove_path"
+site = "crates/almide-mir/src/render_wasm_fs_wat.rs:455"
+digest = "9c468a1b6f2e"
+class = "CORPUS"
+via = "fs_relative_path.almd"
+
+[[fn]]
+name = "rtf_result"
+site = "crates/almide-mir/src/render_wasm_fs_wat.rs:232"
+digest = "28f779ae7f2d"
+class = "CORPUS"
+via = "fan_settle_tuple.almd"
+
+[[fn]]
+name = "rtf_str"
+site = "crates/almide-mir/src/render_wasm_fs_wat.rs:215"
+digest = "c9fe904ab5dd"
+class = "CORPUS"
+via = "args_surface.almd"
+
+[[fn]]
+name = "str_lt"
+site = "crates/almide-mir/src/render_wasm_fs_wat.rs:559"
+digest = "8a2c5967004c"
+class = "FALLBACK_ONLY"
+via = "fs.list_dir"
+why = "reached through dirent name ordering; every fixture that would exercise it is in proofs/wasm-fallback-baseline.txt, so it runs on the NATIVE leg and the byte oracle never renders it. Shrinks with that ratchet."
+
+[[fn]]
+name = "sym"
+site = "crates/almide-mir/src/render_wasm_dce.rs:37"
+digest = "802752f63915"
+class = "TEMPLATE"
+why = "`(import … (func ${sym}…))` — the import-symbol template, and a doc mention in render_wasm_dce.rs."
+
+[[fn]]
+name = "write_text_file"
+site = "crates/almide-mir/src/render_wasm_fs_wat.rs:251"
+digest = "23be9d847319"
+class = "CORPUS"
+via = "fs_preopen_resolve.almd"
+

--- a/scripts/check-wat-prelude-audit.sh
+++ b/scripts/check-wat-prelude-audit.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# The hand-written WAT prelude gate (Stage 1c).
+#
+# The prelude is the only wasm-side code NOT rendered from the shared MIR, so the
+# 3-way oracle has no native counterpart to differ it against. Every `(func $…)`
+# in it must therefore carry a row in proofs/wat-prelude-audit.toml naming the
+# evidence that reaches it. See that file's header for the class vocabulary.
+#
+# Two layers, deliberately:
+#   STRUCTURE (always, cheap) — every enumerated name has exactly one row, no
+#     stale rows, valid class, digest matches the current source, no UNREACHED,
+#     and every CORPUS/PROVEN row names a fixture that EXISTS.
+#   REACHABILITY (CI, or ALMIDE_WAT_PRELUDE_REACH=1) — re-renders each named
+#     fixture and fails if it does not actually define that function. Without
+#     this the `via` column is a claim; with it, it is a measurement.
+#
+# Enumeration is scripts/lib/wat-prelude-enumerate.py, shared with the ledger so
+# the two cannot drift (the #1176 one-instrument rule).
+set -uo pipefail
+export LC_ALL=C
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LEDGER="$ROOT/proofs/wat-prelude-audit.toml"
+# Overridable so CI can point at a debug build (it shares the job's existing
+# debug dep cache; rendering 47 fixtures is cheap even unoptimized).
+RENDER="${ALMIDE_RENDER:-$ROOT/target/release/examples/render_program}"
+
+python3 - "$ROOT" "$LEDGER" <<'EOF'
+import importlib.util
+import re
+import sys
+
+root, ledger_path = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location(
+    "enum", f"{root}/scripts/lib/wat-prelude-enumerate.py")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+units = mod.enumerate_units(root)
+
+VOCAB = {"PROVEN", "CORPUS", "FALLBACK_ONLY", "PROBE_ONLY", "MIR_ONLY", "TEMPLATE"}
+NEEDS_FIXTURE = {"PROVEN", "CORPUS"}
+
+rows, cur = [], {}
+for raw in open(ledger_path, encoding="utf-8"):
+    line = raw.strip()
+    if line == "[[fn]]":
+        if cur:
+            rows.append(cur)
+        cur = {}
+        continue
+    m = re.match(r'([a-z_]+)\s*=\s*"(.*)"$', line)
+    if m and cur is not None:
+        cur[m.group(1)] = m.group(2)
+if cur:
+    rows.append(cur)
+
+errs = []
+seen = set()
+for r in rows:
+    n = r.get("name")
+    if not n:
+        errs.append(f"row without a name: {r}")
+        continue
+    if n in seen:
+        errs.append(f"{n}: duplicate row")
+    seen.add(n)
+    cls = r.get("class", "")
+    if cls == "UNREACHED":
+        errs.append(
+            f"{n}: UNREACHED — hand-written wasm nothing can reach (DO-178C dead "
+            f"code). Delete it, or wire it to something and reclassify.")
+    elif cls not in VOCAB:
+        errs.append(f"{n}: unknown class {cls!r} (expected one of {sorted(VOCAB)})")
+    if n not in units:
+        errs.append(f"{n}: STALE row — no `(func ${n}` in the renderer sources any more")
+        continue
+    site, digest = units[n]
+    if r.get("digest") != digest:
+        errs.append(
+            f"{n}: digest {r.get('digest')} != {digest} — the hand-written wasm at "
+            f"{site} changed. Re-confirm its evidence and update the row; evidence "
+            f"is not inherited across an edit.")
+    if r.get("site") != site:
+        errs.append(f"{n}: site moved to {site} (row says {r.get('site')})")
+    if cls in NEEDS_FIXTURE:
+        fx = r.get("via", "")
+        if not fx:
+            errs.append(f"{n}: {cls} needs `via = \"<fixture>.almd\"`")
+        elif not (__import__("os").path.exists(f"{root}/spec/wasm_cross/{fx}")):
+            errs.append(f"{n}: via names spec/wasm_cross/{fx}, which does not exist")
+    if cls == "PROVEN" and not r.get("proof"):
+        errs.append(f"{n}: PROVEN needs `proof = \"<file>\"`")
+    if cls == "MIR_ONLY" and not r.get("ref"):
+        errs.append(f"{n}: MIR_ONLY needs `ref = \"#NNNN\"` — unreachable-from-source "
+                    f"wasm is debt, and debt needs an issue")
+    if cls in {"FALLBACK_ONLY", "PROBE_ONLY", "TEMPLATE", "MIR_ONLY"} and not r.get("why"):
+        errs.append(f"{n}: {cls} needs `why = \"…\"`")
+
+for n in sorted(units):
+    if n not in seen:
+        errs.append(
+            f"{n}: UNCLASSIFIED — a prelude function at {units[n][0]} with no row. "
+            f"Hand-written wasm the oracle cannot see needs its evidence named.")
+
+if errs:
+    print("WAT PRELUDE AUDIT FAIL —", file=sys.stderr)
+    for e in errs:
+        print(f"  {e}", file=sys.stderr)
+    sys.exit(1)
+
+by = {}
+for r in rows:
+    by[r["class"]] = by.get(r["class"], 0) + 1
+print("WAT PRELUDE AUDIT OK: " + str(len(rows)) + " fn(s) — "
+      + " / ".join(f"{k} {v}" for k, v in sorted(by.items())))
+EOF
+STRUCT=$?
+[ $STRUCT -ne 0 ] && exit $STRUCT
+
+# --- REACHABILITY: the `via` column re-measured, not trusted -----------------
+if [ "${CI:-}" != "true" ] && [ "${ALMIDE_WAT_PRELUDE_REACH:-}" != "1" ]; then
+  echo "wat-prelude: reachability re-measurement SKIPPED (set ALMIDE_WAT_PRELUDE_REACH=1)"
+  exit 0
+fi
+if [ ! -x "$RENDER" ]; then
+  if [ "${CI:-}" = "true" ]; then
+    echo "::error::wat-prelude: no render_program at $RENDER — in CI a missing oracle is a failure (#978)" >&2
+    exit 1
+  fi
+  echo "wat-prelude: no render_program at $RENDER — build it with" \
+       "\`cargo build --release -p almide-mir --example render_program\`" >&2
+  exit 1
+fi
+
+fail=0
+while IFS='|' read -r name fx; do
+  [ -z "$name" ] && continue
+  # Rendered to a VARIABLE, not piped: render_program exits non-zero whenever a
+  # fixture has any function outside the MIR-lowering subset (it reports those to
+  # stderr and emits the rest), and under `pipefail` that would sink the whole
+  # pipeline even when grep matched — every row would read as "evidence is not
+  # real". `</dev/null` keeps a dep-resolving child from eating the work list.
+  # `\b` is a GNU extension BSD grep does not honour, so spell the boundary out
+  # or the check passes vacuously on macOS and this gate becomes decorative.
+  wat="$("$RENDER" "$ROOT/spec/wasm_cross/$fx" </dev/null 2>/dev/null || true)"
+  # `grep -c`, never `grep -q`: `-q` exits at the FIRST match, the ~150 KB still
+  # in `printf`'s pipe becomes EPIPE, printf returns non-zero, and `pipefail`
+  # sinks the pipeline — every row would report "evidence is not real" while the
+  # evidence was in fact there. `-c` consumes the whole stream.
+  hits="$(printf '%s' "$wat" | grep -cE "\(func \\\$$name([^A-Za-z0-9_]|$)" || true)"
+  if [ "${hits:-0}" -eq 0 ]; then
+    echo "  $name: via=$fx does NOT define it — the row's evidence is not real" >&2
+    fail=1
+  fi
+done < <(python3 - "$LEDGER" <<'EOF'
+import re, sys
+cur = {}
+for raw in open(sys.argv[1], encoding="utf-8"):
+    line = raw.strip()
+    if line == "[[fn]]":
+        if cur.get("class") in {"CORPUS", "PROVEN"}:
+            print(f"{cur['name']}|{cur['via']}")
+        cur = {}
+        continue
+    m = re.match(r'([a-z_]+)\s*=\s*"(.*)"$', line)
+    if m:
+        cur[m.group(1)] = m.group(2)
+if cur.get("class") in {"CORPUS", "PROVEN"}:
+    print(f"{cur['name']}|{cur['via']}")
+EOF
+)
+if [ $fail -ne 0 ]; then
+  echo "WAT PRELUDE REACHABILITY FAIL — a \`via\` fixture stopped reaching its function." >&2
+  exit 1
+fi
+echo "wat-prelude: every CORPUS/PROVEN \`via\` re-measured and confirmed"

--- a/scripts/lib/wat-prelude-enumerate.py
+++ b/scripts/lib/wat-prelude-enumerate.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Enumerate the HAND-WRITTEN WAT functions of the wasm prelude (Stage 1c).
+
+Almide's wasm leg is rendered from the same MIR as the native leg, so the 3-way
+oracle (native <-> wasm <-> interp) differs the two against each other on every
+corpus fixture. The prelude is the exception: `$alloc`, `$rc_dec`, the free-list,
+the WASI shims and the rest are hand-written wasm with NO native counterpart to
+be differed against. Whatever assurance they carry has to be named explicitly —
+which is what `proofs/wat-prelude-audit.toml` does, one row per function.
+
+A unit is a `(func $NAME` occurrence in a renderer source string. Scanning is by
+TEXT, over every non-test `crates/almide-mir/src/*.rs`, so a prelude function
+added in a new file is picked up without touching this script. Over-inclusion is
+safe (a `(func $NAME` in a doc comment or an assertion just earns a row saying
+so); under-inclusion is the dangerous direction, and a fixed file list is exactly
+how you get it.
+
+`digest` is a hash of the function's source text (from `(func $` to its matching
+close paren). It changes iff the hand-written wasm changes, which forces the
+row's evidence to be re-confirmed rather than inherited — the same "count
+changed => re-audit" trick as the libm ledger.
+
+Output: `name :: file:line :: digest`, sorted.
+"""
+import glob
+import hashlib
+import re
+import sys
+
+FUNC = re.compile(r"\(func \$([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def scanned_files(root: str):
+    """The wasm renderer sources. `render_wasm/` is the unit-test tree — its
+    `(func $…)` occurrences are expectation strings, not emitted wasm."""
+    out = []
+    for p in sorted(glob.glob(f"{root}/crates/almide-mir/src/*.rs")):
+        if p.split("/")[-1].startswith("tests"):
+            continue
+        out.append(p)
+    return out
+
+
+def _digest(text: str, start: int) -> str:
+    """Hash `text[start..]` up to the paren matching the one at `start`. WAT
+    comments can hold unbalanced parens, so `;;`-to-newline is skipped; an
+    unterminated block (a `(func $…)` mentioned in prose) hashes to the rest of
+    the line, which is stable and still change-detecting."""
+    depth, i, n = 0, start, len(text)
+    while i < n:
+        c = text[i]
+        if c == ";" and text.startswith(";;", i):
+            j = text.find("\n", i)
+            if j < 0:
+                break
+            i = j
+            continue
+        if c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                body = text[start : i + 1]
+                return hashlib.sha256(" ".join(body.split()).encode()).hexdigest()[:12]
+        i += 1
+    line_end = text.find("\n", start)
+    body = text[start : line_end if line_end > 0 else n]
+    return hashlib.sha256(" ".join(body.split()).encode()).hexdigest()[:12]
+
+
+def enumerate_units(root: str):
+    """{name: (rel_path:line, digest)}. A name defined more than once keeps the
+    FIRST site and folds the rest into the digest, so a duplicate definition is
+    visible as a digest change rather than silently shadowing."""
+    units = {}
+    for path in scanned_files(root):
+        rel = path[len(root) + 1 :]
+        text = open(path, encoding="utf-8").read()
+        for m in FUNC.finditer(text):
+            name = m.group(1)
+            line = text.count("\n", 0, m.start()) + 1
+            d = _digest(text, m.start())
+            if name in units:
+                prev_site, prev_d = units[name]
+                units[name] = (
+                    prev_site,
+                    hashlib.sha256(f"{prev_d}+{d}".encode()).hexdigest()[:12],
+                )
+            else:
+                units[name] = (f"{rel}:{line}", d)
+    return units
+
+
+if __name__ == "__main__":
+    root = sys.argv[1] if len(sys.argv) > 1 else "."
+    for name, (site, d) in sorted(enumerate_units(root).items()):
+        print(f"{name} :: {site} :: {d}")


### PR DESCRIPTION
## Why

The wasm leg is rendered from the same MIR as native, so the 3-way oracle differs the two on every corpus fixture — **except the prelude**: `$alloc`, `$rc_dec`, the free-list, the WASI shims are hand-written wasm with **no native counterpart to differ against**. The oracle's detection power there is structurally zero. Stage 1c (from the mission-critical goal, the scalar-read audit's sibling) names what covers each of them instead.

## What

- **`proofs/wat-prelude-audit.toml`** — one row per `(func $…` (63 at first measurement): PROVEN 5 (FreeList.v) / CORPUS 41 / FALLBACK_ONLY 6 / PROBE_ONLY 2 / MIR_ONLY 5 / TEMPLATE 4. Rows carry a **digest of the WAT source text** — editing hand-written wasm invalidates its row, so evidence is re-confirmed, never inherited.
- **`scripts/check-wat-prelude-audit.sh`** — structure always (pre-commit); in CI it **re-renders every CORPUS/PROVEN row's `via` fixture and fails unless the function is actually defined there**. The `via` column is a measurement, not a claim.
- **`scripts/lib/wat-prelude-enumerate.py`** — shared by ledger and gate (the #1176 one-instrument rule).
- **Deleted `$__chk_div` / `$__chk_rem`** — superseded by the #806 inline expansion, zero callers repo-wide, DO-178C dead code. A/B: instruction-identical on all 367 fixtures (only their 3 dead comment lines disappear).
- Filed **#1208** for the MIR_ONLY five (`$print_int` family — reachable only from hand-built certificate MIR, no .almd program can reach them); their rows carry the ref and the gate enforces it.

## Detection power (negative-tested, 5/5)

| mutation | verdict |
|---|---|
| new `(func $…` with no row | UNCLASSIFIED, fail |
| hand-written wasm edited (digest) | stale digest, fail |
| `via` names a fixture that doesn't reach the fn | reachability fail |
| row declared UNREACHED | fail (dead wasm must be deleted) |
| row deleted while fn remains | UNCLASSIFIED, fail |

Gate found two instrument bugs in itself while being built (BSD grep `\b`, and `grep -q` EPIPE × `pipefail` = every row false-negative) — both fixed and commented.

## Ladder

369/369 tests (351 WASM), walled-real 0, fallback 18, contracts 367/367 symmetric, scalar-read 63 clean, libm 5 clean, abstain 129 classified, new gate green in both modes.