### PR TITLE
Execute the MIR-only prelude bodies — and fix the itoa sign defect the first run found (#1208)

### DIFF
--- a/crates/almide-mir/src/render_wasm.rs
+++ b/crates/almide-mir/src/render_wasm.rs
@@ -121,6 +121,7 @@ const ASCII_EQUALS: u32 = 61;
 const ASCII_COMMA: u32 = 44;
 const ASCII_NEWLINE: u32 = 10;
 const ASCII_SLASH: u32 = 47; // '/' — stripped from an absolute fs.read_text path
+const ASCII_MINUS: u32 = 45; // '-' — the itoa sign byte
 
 /// The line buffer for printing lives in `[SCRATCH_ADDR, HEAP_BASE)`; one element
 /// appends at most a separator comma plus the digits of a u64 (≤ 20). The print

--- a/crates/almide-mir/src/render_wasm/tests_part3.rs
+++ b/crates/almide-mir/src/render_wasm/tests_part3.rs
@@ -722,5 +722,76 @@
         }
     }
 
+    /// The five MIR_ONLY prelude fns EXECUTED with pinned stdout (#1208, the
+    /// Stage 1c ledger's evidence upgrade). `$print_int`, `$print_list`,
+    /// `$list_push`, and through them `$itoa_append` + `$list_len` are
+    /// hand-written wasm reachable only from hand-built MIR — no .almd program
+    /// can reach them, so no corpus fixture pins their BODIES; the
+    /// translation-validation mutation test checks only their EMISSION. This
+    /// runs the bytes: negative int through the itoa sign path, a push that
+    /// rebinds the handle, and the labeled list print walking len + per-element
+    /// itoa. The expected bytes were MEASURED on wasmtime, not reasoned.
+    #[test]
+    fn mir_only_prelude_fns_execute_with_pinned_stdout() {
+        use crate::{CallArg, Init, MirFunction, Op, Repr, RtFn, ValueId, PLACEHOLDER_LAYOUT};
+        let (xs, n, m) = (ValueId(0), ValueId(1), ValueId(2));
+        let mir = MirFunction {
+            name: "main".into(),
+            ops: vec![
+                Op::Alloc {
+                    dst: xs,
+                    repr: Repr::Ptr { layout: PLACEHOLDER_LAYOUT },
+                    init: Init::IntList(vec![1, 2, 3]),
+                },
+                Op::ConstInt { dst: n, value: -42 },
+                Op::Call {
+                    dst: None,
+                    func: RtFn::PrintInt,
+                    args: vec![CallArg::Scalar(n)],
+                    result: None,
+                },
+                // i64::MIN — the sign path's wrap-negation edge (2^63 has no
+                // positive i64 twin; the magnitude must still print exactly).
+                Op::ConstInt { dst: m, value: i64::MIN },
+                Op::Call {
+                    dst: None,
+                    func: RtFn::PrintInt,
+                    args: vec![CallArg::Scalar(m)],
+                    result: None,
+                },
+                // push may move the buffer — dst rebinds the SAME handle local.
+                Op::Call {
+                    dst: Some(xs),
+                    func: RtFn::ListPush,
+                    args: vec![CallArg::Handle(xs), CallArg::Imm(9)],
+                    result: None,
+                },
+                Op::Call {
+                    dst: None,
+                    func: RtFn::PrintList,
+                    args: vec![CallArg::Handle(xs), CallArg::Label("xs".into())],
+                    result: None,
+                },
+                Op::Drop { v: xs },
+            ],
+            ..Default::default()
+        };
+        let prog = crate::MirProgram { functions: vec![mir], ..Default::default() };
+        let wat = render_wasm_program(&prog);
+        for f in ["$print_int", "$print_list", "$list_push", "$itoa_append", "$list_len"] {
+            assert!(
+                wat.contains(&format!("(func {f} ")),
+                "{f} must be rendered for this MIR (the ledger's MIR_ONLY claim)"
+            );
+        }
+        if let Some(out) = build_and_run("mir_only_prelude", &wat) {
+            assert_eq!(
+                out,
+                "-42\n-9223372036854775808\nxs=1,2,3,9",
+                "the five bodies' observable bytes"
+            );
+        }
+    }
+
     include!("tests_part3_b.rs");
     include!("tests_part3_c.rs");

--- a/crates/almide-mir/src/render_wasm_p3.rs
+++ b/crates/almide-mir/src/render_wasm_p3.rs
@@ -366,6 +366,15 @@ pub(crate) fn preamble_with_bump_base(bump_base: u32) -> String {
       (then
         (i32.store8 (local.get $cur) (i32.const {ASCII_ZERO}))
         (return (i32.add (local.get $cur) (i32.const 1)))))
+    ;; SIGN (#1208's execution pin found this missing: -42 printed as the u64
+    ;; 18446744073709551574): emit '-' and continue on the wrapped negation —
+    ;; for i64::MIN the wrap IS the correct 2^63 magnitude read unsigned, so
+    ;; the u64 digit loop below is exact for every negative including MIN.
+    (if (i64.lt_s (local.get $v) (i64.const 0))
+      (then
+        (i32.store8 (local.get $cur) (i32.const {ASCII_MINUS}))
+        (local.set $cur (i32.add (local.get $cur) (i32.const 1)))
+        (local.set $v (i64.sub (i64.const 0) (local.get $v)))))
     (local.set $n (i32.const 0))
     (block $ddone (loop $dloop
       (br_if $ddone (i64.eqz (local.get $v)))

--- a/proofs/wat-prelude-audit.toml
+++ b/proofs/wat-prelude-audit.toml
@@ -23,6 +23,10 @@
 #   MIR_ONLY       no frontend lowering constructs the op — only hand-built MIR
 #                  in the proof/validation layer reaches it. Emission is checked;
 #                  the BODY is not. `ref` names the issue to close it out.
+#   TEST_PINNED    reachable only from hand-built MIR, and a named cargo test
+#                  EXECUTES the body on wasmtime with pinned stdout (`test`).
+#                  The first such execution found $itoa_append printing
+#                  negatives as u64 — the class's failure mode, live.
 #   TEMPLATE       not a fixed name: a `{}`-interpolated rendering template whose
 #                  instances carry a user function's identity.
 #
@@ -39,7 +43,9 @@
 # reach it, and any UNREACHED row.
 #
 # Counts at the first measurement (2026-08-11, 63 functions):
-#   PROVEN 5 / CORPUS 41 / FALLBACK_ONLY 6 / PROBE_ONLY 2 / MIR_ONLY 5 / TEMPLATE 4
+#   PROVEN 5 / CORPUS 41 / FALLBACK_ONLY 6 / PROBE_ONLY 2 / TEST_PINNED 5 / TEMPLATE 4
+#   (MIR_ONLY 5 at first measurement — upgraded to TEST_PINNED when the
+#   execution pin landed and immediately caught the itoa sign defect)
 
 [[fn]]
 name = "__die"
@@ -57,14 +63,14 @@ via = "alias_combinator_rc.almd"
 
 [[fn]]
 name = "__export_"
-site = "crates/almide-mir/src/render_wasm.rs:668"
+site = "crates/almide-mir/src/render_wasm.rs:669"
 digest = "d1959ff9df04"
 class = "TEMPLATE"
 why = "`(func $__export_{internal}…)` — the export-wrapper TEMPLATE; each instance carries a user function's name."
 
 [[fn]]
 name = "__import_"
-site = "crates/almide-mir/src/render_wasm.rs:538"
+site = "crates/almide-mir/src/render_wasm.rs:539"
 digest = "e7030093815d"
 class = "TEMPLATE"
 why = "`(import … (func $__import_{sym}…))` — the extern-import TEMPLATE, one instance per declared import."
@@ -78,7 +84,7 @@ via = "args_surface.almd"
 
 [[fn]]
 name = "__mg_take"
-site = "crates/almide-mir/src/render_wasm.rs:685"
+site = "crates/almide-mir/src/render_wasm.rs:686"
 digest = "4185da3f48a0"
 class = "CORPUS"
 via = "mg_rebuild_two_phase.almd"
@@ -136,7 +142,7 @@ via = "args_surface.almd"
 
 [[fn]]
 name = "args_get_list"
-site = "crates/almide-mir/src/render_wasm_p3.rs:450"
+site = "crates/almide-mir/src/render_wasm_p3.rs:459"
 digest = "32c1abadb7b6"
 class = "CORPUS"
 via = "args_surface.almd"
@@ -171,7 +177,7 @@ via = "call_closure_lambda_param.almd"
 
 [[fn]]
 name = "env_get"
-site = "crates/almide-mir/src/render_wasm_p3.rs:508"
+site = "crates/almide-mir/src/render_wasm_p3.rs:517"
 digest = "6d99767442b6"
 class = "CORPUS"
 via = "env_get.almd"
@@ -235,10 +241,10 @@ via = "fs_relative_path.almd"
 [[fn]]
 name = "itoa_append"
 site = "crates/almide-mir/src/render_wasm_p3.rs:363"
-digest = "c6037df97b58"
-class = "MIR_ONLY"
-ref = "#1208"
-why = "called only by $print_int/$print_list is constructed only by hand-built MIR (certificate_p2.rs, translation_validation.rs) — no frontend lowering emits it, so no .almd program reaches this wasm. Emission is checked (translation_validation mutation test); the BODY is not."
+digest = "3d4ad99f57b0"
+class = "TEST_PINNED"
+test = "render_wasm::tests::mir_only_prelude_fns_execute_with_pinned_stdout"
+why = "reachable only from hand-built MIR (certificate layer, #1208) — the named cargo test RUNS the body on wasmtime and pins its stdout, incl. the negative/i64::MIN itoa path the first execution immediately found broken."
 
 [[fn]]
 name = "list_copy"
@@ -259,9 +265,9 @@ why = "reached through dirent list build; every fixture that would exercise it i
 name = "list_len"
 site = "crates/almide-mir/src/render_wasm_p3.rs:330"
 digest = "a594d53bf87c"
-class = "MIR_ONLY"
-ref = "#1208"
-why = "called only by $print_list is constructed only by hand-built MIR (certificate_p2.rs, translation_validation.rs) — no frontend lowering emits it, so no .almd program reaches this wasm. Emission is checked (translation_validation mutation test); the BODY is not."
+class = "TEST_PINNED"
+test = "render_wasm::tests::mir_only_prelude_fns_execute_with_pinned_stdout"
+why = "reachable only from hand-built MIR (certificate layer, #1208) — the named cargo test RUNS the body on wasmtime and pins its stdout, incl. the negative/i64::MIN itoa path the first execution immediately found broken."
 
 [[fn]]
 name = "list_new"
@@ -274,9 +280,9 @@ via = "alias_combinator_rc.almd"
 name = "list_push"
 site = "crates/almide-mir/src/render_wasm_p3.rs:354"
 digest = "376724cbb191"
-class = "MIR_ONLY"
-ref = "#1208"
-why = "RtFn::ListPush is constructed only by hand-built MIR (certificate_p2.rs, translation_validation.rs) — no frontend lowering emits it, so no .almd program reaches this wasm. Emission is checked (translation_validation mutation test); the BODY is not."
+class = "TEST_PINNED"
+test = "render_wasm::tests::mir_only_prelude_fns_execute_with_pinned_stdout"
+why = "reachable only from hand-built MIR (certificate layer, #1208) — the named cargo test RUNS the body on wasmtime and pins its stdout, incl. the negative/i64::MIN itoa path the first execution immediately found broken."
 
 [[fn]]
 name = "list_set"
@@ -301,7 +307,7 @@ via = "fs_relative_path.almd"
 
 [[fn]]
 name = "name"
-site = "crates/almide-mir/src/render_wasm.rs:191"
+site = "crates/almide-mir/src/render_wasm.rs:192"
 digest = "fa03a4a87d6a"
 class = "TEMPLATE"
 why = "`(func ${}` — the MirFunction rendering template (render_wasm_b.rs); every program function is an instance."
@@ -373,19 +379,19 @@ via = "fs_relative_path.almd"
 
 [[fn]]
 name = "print_int"
-site = "crates/almide-mir/src/render_wasm_p3.rs:428"
+site = "crates/almide-mir/src/render_wasm_p3.rs:437"
 digest = "5f544cd9d766"
-class = "MIR_ONLY"
-ref = "#1208"
-why = "RtFn::PrintInt is constructed only by hand-built MIR (certificate_p2.rs, translation_validation.rs) — no frontend lowering emits it, so no .almd program reaches this wasm. Emission is checked (translation_validation mutation test); the BODY is not."
+class = "TEST_PINNED"
+test = "render_wasm::tests::mir_only_prelude_fns_execute_with_pinned_stdout"
+why = "reachable only from hand-built MIR (certificate layer, #1208) — the named cargo test RUNS the body on wasmtime and pins its stdout, incl. the negative/i64::MIN itoa path the first execution immediately found broken."
 
 [[fn]]
 name = "print_list"
-site = "crates/almide-mir/src/render_wasm_p3.rs:388"
+site = "crates/almide-mir/src/render_wasm_p3.rs:397"
 digest = "c3b1a1fbb217"
-class = "MIR_ONLY"
-ref = "#1208"
-why = "RtFn::PrintList is constructed only by hand-built MIR (certificate_p2.rs, translation_validation.rs) — no frontend lowering emits it, so no .almd program reaches this wasm. Emission is checked (translation_validation mutation test); the BODY is not."
+class = "TEST_PINNED"
+test = "render_wasm::tests::mir_only_prelude_fns_execute_with_pinned_stdout"
+why = "reachable only from hand-built MIR (certificate layer, #1208) — the named cargo test RUNS the body on wasmtime and pins its stdout, incl. the negative/i64::MIN itoa path the first execution immediately found broken."
 
 [[fn]]
 name = "proc_exit"

--- a/scripts/check-wat-prelude-audit.sh
+++ b/scripts/check-wat-prelude-audit.sh
@@ -36,7 +36,7 @@ mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 units = mod.enumerate_units(root)
 
-VOCAB = {"PROVEN", "CORPUS", "FALLBACK_ONLY", "PROBE_ONLY", "MIR_ONLY", "TEMPLATE"}
+VOCAB = {"PROVEN", "CORPUS", "FALLBACK_ONLY", "PROBE_ONLY", "MIR_ONLY", "TEST_PINNED", "TEMPLATE"}
 NEEDS_FIXTURE = {"PROVEN", "CORPUS"}
 
 rows, cur = [], {}
@@ -92,7 +92,10 @@ for r in rows:
     if cls == "MIR_ONLY" and not r.get("ref"):
         errs.append(f"{n}: MIR_ONLY needs `ref = \"#NNNN\"` — unreachable-from-source "
                     f"wasm is debt, and debt needs an issue")
-    if cls in {"FALLBACK_ONLY", "PROBE_ONLY", "TEMPLATE", "MIR_ONLY"} and not r.get("why"):
+    if cls == "TEST_PINNED" and not r.get("test"):
+        errs.append(f"{n}: TEST_PINNED needs `test = \"<cargo test path>\"` — the class's "
+                    f"whole claim is that a named test executes the body")
+    if cls in {"FALLBACK_ONLY", "PROBE_ONLY", "TEMPLATE", "MIR_ONLY", "TEST_PINNED"} and not r.get("why"):
         errs.append(f"{n}: {cls} needs `why = \"…\"`")
 
 for n in sorted(units):


### PR DESCRIPTION
## What

Stage 1c follow-up on #1208's option 2: the five `MIR_ONLY` prelude fns (`$print_int`, `$print_list`, `$list_push`, `$itoa_append`, `$list_len`) had their **emission** checked but their **bodies** never executed — hand-written wasm reachable only from hand-built certificate MIR, invisible to every corpus fixture. New test `mir_only_prelude_fns_execute_with_pinned_stdout` builds one MIR main exercising all five and runs it on wasmtime with pinned stdout.

## The first execution immediately found a defect

`$itoa_append` had **no sign path** — `i64.rem_u`/`div_u` only — so `print_int(-42)` printed `18446744073709551574` (the u64 reinterpretation). Nothing ever saw it because no .almd program can reach these fns (real programs print through the self-hosted `int.to_string`). That is the MIR_ONLY class's predicted failure mode, live on the first run — the same pattern as every other instrument today.

Fix: emit `'-'` and continue on the wrapped negation — for `i64::MIN` the wrap IS the exact 2^63 magnitude read unsigned, so the u64 digit loop is exact for every negative including MIN (both pinned: `-42`, `-9223372036854775808`).

## Ledger

The five rows upgrade `MIR_ONLY → TEST_PINNED` (new class: reachable only from hand-built MIR AND a named cargo test executes the body; gate requires `test = …`). The audit gate fired on the itoa digest change exactly as designed — evidence re-confirmed, not inherited.

## A/B

- The itoa fix is **invisible to all 367 corpus modules** (instruction-level hash A/B; DCE strips the fn from every real program)
- `almide test` 370/370 (352 WASM / 18 fallback), almide-mir 626/626, WAT prelude audit green (TEST_PINNED 5)

#1208 stays open for the endgame (deleting the five means retiring `RtFn::PrintInt`/`PrintList`/`ListPush` from the Op vocabulary — bigger surgery); this converts "bodies unverified" into "bodies executed and pinned" in the meantime.