### PR TITLE
Fix the fuzz nightly: #1201's second if: key failed the whole workflow's parse

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -231,7 +231,11 @@ jobs:
     # The verdict below already fails ONLY on findings and the coverage line
     # already reports how many shards reported, so running it unconditionally
     # keeps a kill honest — it costs recorded COVERAGE, not correctness.
-    if: always()
+    #
+    # (That `always()` lives in the job-top `if` above — #1201's first cut
+    # added it as a SECOND `if:` key here, which fails the whole workflow's
+    # parse: Actions never validates these files until a trigger fires, so
+    # the breakage surfaced as three instant "failure" runs, not in CI.)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
## What

#1201 added `if: always()` to the verdict job — but the job already had `if: always() && github.server_url == 'https://github.com'` at its top, and a duplicate `if:` key fails the ENTIRE workflow's parse. Actions never validates workflow files until a trigger fires, so the breakage surfaced as three instant-`failure` runs today (10:14/10:33/10:46 UTC), and tonight's 03:00 UTC schedule would have died the same way — the release-gating instrument was dark.

The intended semantics (#1201: verdict runs even when a shard is killed, fails only on findings) were ALREADY carried by the job-top `if` — the second key added nothing but the parse failure. Removed, with a comment pinning the trap.

Verified: `yaml.safe_load` clean; the job-top `always()` condition is untouched.

Found while manually dispatching the nightly as the 0.57.0 release gate (the dispatch API rejected the file with the parse error — which is the only reason this surfaced before tonight's silent dead schedule).