### PR TITLE
Split Slow from Hang in the nightly fuzzer (#1235)

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -254,6 +254,14 @@ jobs:
       # finding after its kind + minimized summary, so two shards that trip the
       # same bug from different seeds produce the same name. Counting those
       # twice would inflate the night and file a duplicate issue.
+      #
+      # The name's KIND prefix also carries the class split (#1235): `Slow__*`
+      # findings are perf-class — one leg outran the budget but completed,
+      # byte-identical, at the fuzzer's 10x confirm re-run. They are recorded,
+      # uploaded, and issue-tracked under the perf label, but they do NOT fail
+      # the night: the correctness gate is for divergence and nontermination,
+      # and the 0.57.0 release gate showed a quadratic-slow run (#1229) going
+      # red as a phantom "Hang".
       - name: Aggregate findings
         id: agg
         run: |
@@ -265,7 +273,10 @@ jobs:
             done
           fi
           COUNT=$(find night-findings -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+          SLOW=$(find night-findings -mindepth 1 -maxdepth 1 -type d -name 'Slow__*' | wc -l | tr -d ' ')
           echo "findings=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "slow=$SLOW" >> "$GITHUB_OUTPUT"
+          echo "correctness=$((COUNT - SLOW))" >> "$GITHUB_OUTPUT"
 
       - name: Campaign verdict
         run: |
@@ -273,6 +284,7 @@ jobs:
             "${{ github.event.inputs.minutes || env.FUZZ_MINUTES }}" \
             "${{ env.FUZZ_SHARDS }}" \
             "${{ steps.agg.outputs.findings }}" \
+            "${{ steps.agg.outputs.slow }}" \
             >> "$GITHUB_STEP_SUMMARY" || true
           exit 0
 
@@ -285,13 +297,14 @@ jobs:
           retention-days: 30
 
       - name: Open / update tracking issue
-        if: steps.agg.outputs.findings != '0'
+        if: steps.agg.outputs.correctness != '0'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          COUNT="${{ steps.agg.outputs.findings }}"
+          COUNT="${{ steps.agg.outputs.correctness }}"
           TITLE="Nightly fuzz: $COUNT cross-target finding(s)"
-          SUMMARY=$(find night-findings -name meta.txt -exec cat {} \; \
+          SUMMARY=$(find night-findings -mindepth 1 -maxdepth 1 -type d ! -name 'Slow__*' \
+            -exec cat {}/meta.txt \; \
             | grep -E '^(kind|summary|reproduce)' | head -60 || true)
           BODY=$(cat <<EOF
           The nightly generative differential fuzzer recorded **$COUNT** unique finding(s)
@@ -320,14 +333,56 @@ jobs:
             gh issue create --title "$TITLE" --body "$BODY" --label fuzz
           fi
 
-      # FINDINGS, and only findings, make the night red. Coverage lost to a
-      # reclaimed runner is reported by the verdict as `shards=k/N` and is NOT
-      # fatal — failing on it would put the infra noise the sharding exists to
-      # absorb straight back into the signal, which is how #924 got stuck.
-      - name: Fail the night on findings
-        if: steps.agg.outputs.findings != '0'
+      # Perf-class Slow findings route to their OWN issue under their own
+      # label (#1235): they are real findings — an order-of-magnitude budget
+      # overrun on one leg — but they are perf debt (the #1229 discipline),
+      # not correctness, and mixing them into the correctness issue would
+      # re-red the metric the class split exists to keep honest.
+      - name: Open / update perf (slow) tracking issue
+        if: steps.agg.outputs.slow != '0'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "::error::the campaign recorded ${{ steps.agg.outputs.findings }} finding(s) — see the uploaded artifacts and the tracking issue"
+          COUNT="${{ steps.agg.outputs.slow }}"
+          TITLE="Nightly fuzz: $COUNT slow finding(s) (perf-class)"
+          SUMMARY=$(find night-findings -mindepth 1 -maxdepth 1 -type d -name 'Slow__*' \
+            -exec cat {}/meta.txt \; \
+            | grep -E '^(kind|summary|reproduce)' | head -60 || true)
+          BODY=$(cat <<EOF
+          The nightly fuzzer recorded **$COUNT** perf-class Slow finding(s): a leg
+          outran the per-program budget but completed byte-identical at the 10x
+          confirm re-run. Not correctness — the night stays green — but each is a
+          real order-of-magnitude perf gap (the #1229 class).
+
+          Artifacts are attached to
+          [run #${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+          <details><summary>Finding summaries</summary>
+
+          \`\`\`
+          $SUMMARY
+          \`\`\`
+
+          </details>
+          EOF
+          )
+          EXISTING=$(gh issue list --label fuzz-perf --state open --json number --jq '.[0].number' || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh label create fuzz-perf --color D93F0B --description "Perf-class (Slow) findings from the nightly fuzzer" 2>/dev/null || true
+            gh issue create --title "$TITLE" --body "$BODY" --label fuzz-perf
+          fi
+
+      # CORRECTNESS findings, and only those, make the night red. Coverage lost
+      # to a reclaimed runner is reported by the verdict as `shards=k/N` and is
+      # NOT fatal — failing on it would put the infra noise the sharding exists
+      # to absorb straight back into the signal, which is how #924 got stuck.
+      # Slow findings are tracked above and do not fail the night (#1235).
+      - name: Fail the night on correctness findings
+        if: steps.agg.outputs.correctness != '0'
+        run: |
+          echo "::error::the campaign recorded ${{ steps.agg.outputs.correctness }} correctness finding(s) — see the uploaded artifacts and the tracking issue"
           exit 1
 
   coverage-ratchet:

--- a/scripts/fuzz-night-verdict.sh
+++ b/scripts/fuzz-night-verdict.sh
@@ -28,9 +28,14 @@
 # ran. That absence is the signal, and it is reported as `shards=k/N` rather
 # than being confused with a finding.
 #
-# WHAT MAKES A NIGHT RED. Findings, and only findings. Coverage lost to a
-# reclaimed runner is reported, never fatal — otherwise the infra noise the
-# sharding exists to absorb would come straight back in through the verdict.
+# WHAT MAKES A NIGHT RED. Correctness findings, and only those. Coverage lost
+# to a reclaimed runner is reported, never fatal — otherwise the infra noise
+# the sharding exists to absorb would come straight back in through the
+# verdict. Perf-class `Slow` findings (#1235: a leg that outran the budget but
+# completed byte-identical at the fuzzer's 10x confirm re-run) are reported on
+# the record line and tracked under the perf label, but they do not fail the
+# night either — the 0.57.0 release gate showed a quadratic-slow run (#1229)
+# going red as a phantom "Hang".
 #
 # budget_completed per shard is read from the presence of the fuzzer's own
 # `=== campaign summary ===` block: print_summary (tools/xtarget-fuzz) only
@@ -41,10 +46,12 @@
 # Division of labour: scripts/fuzz-track-record.sh scores nights ACROSS runs
 # from job conclusions; this aggregates the shards WITHIN one night.
 #
-# Usage: fuzz-night-verdict.sh <shard-dir> <minutes-per-shard> <shards-planned> <findings>
+# Usage: fuzz-night-verdict.sh <shard-dir> <minutes-per-shard> <shards-planned> <findings> [<slow>]
 #   <shard-dir> holds one subdirectory per reporting shard, each containing
 #   fuzz-output.txt (the layout `actions/download-artifact` produces when
 #   several artifacts are downloaded without a `name:`).
+#   <slow> is the perf-class subset of <findings> (defaults to 0 so pre-#1235
+#   callers keep working); the record line splits the two.
 
 set -euo pipefail
 # Byte-order collation, pinned (#1031): the shard walk below is `find | sort`,
@@ -53,10 +60,12 @@ set -euo pipefail
 # docs/roadmap/README.md churn with no content change.
 export LC_ALL=C
 
-DIR="${1:?usage: fuzz-night-verdict.sh <shard-dir> <minutes-per-shard> <shards-planned> <findings>}"
+DIR="${1:?usage: fuzz-night-verdict.sh <shard-dir> <minutes-per-shard> <shards-planned> <findings> [<slow>]}"
 MINUTES="${2:?minutes-per-shard}"
 PLANNED="${3:?shards-planned}"
 FINDINGS="${4:?findings}"
+SLOW="${5:-0}"
+CORRECTNESS=$((FINDINGS - SLOW))
 
 echo "## Nightly fuzz verdict"
 echo ""
@@ -67,7 +76,7 @@ mapfile -t OUTS < <(find "$DIR" -name fuzz-output.txt -type f 2>/dev/null | sort
 REPORTING=${#OUTS[@]}
 
 if [ "$REPORTING" -eq 0 ]; then
-  LINE="fuzz-night: shards=0/$PLANNED minutes_planned=$((MINUTES * PLANNED)) minutes_delivered=0 generated=0 findings=$FINDINGS"
+  LINE="fuzz-night: shards=0/$PLANNED minutes_planned=$((MINUTES * PLANNED)) minutes_delivered=0 generated=0 findings=$FINDINGS correctness=$CORRECTNESS slow=$SLOW"
   echo "$LINE" >&2
   echo '```'; echo "$LINE"; echo '```'
   echo ""
@@ -104,7 +113,7 @@ done
 
 DELIVERED=$(awk -v e="$ELAPSED" 'BEGIN{printf "%.1f", e/60}')
 THROUGHPUT=$(awk -v g="$GENERATED" -v e="$ELAPSED" 'BEGIN{printf "%.1f", (e>0)? g*60/e : 0}')
-LINE="fuzz-night: shards=$COMPLETED/$PLANNED reporting=$REPORTING minutes_planned=$((MINUTES * PLANNED)) minutes_delivered=$DELIVERED generated=$GENERATED throughput=${THROUGHPUT}prog/min findings=$FINDINGS"
+LINE="fuzz-night: shards=$COMPLETED/$PLANNED reporting=$REPORTING minutes_planned=$((MINUTES * PLANNED)) minutes_delivered=$DELIVERED generated=$GENERATED throughput=${THROUGHPUT}prog/min findings=$FINDINGS correctness=$CORRECTNESS slow=$SLOW"
 
 echo "$LINE" >&2
 echo '```'
@@ -115,6 +124,11 @@ if [ "$COMPLETED" -lt "$PLANNED" ]; then
   echo "**$((PLANNED - COMPLETED))** of **$PLANNED** shard(s) did not finish their budget"
   echo "(runner reclaimed). The night still has a verdict — coverage is reduced,"
   echo "not absent. This is reported, never fatal: only findings fail the night."
+  echo ""
+fi
+if [ "$SLOW" -gt 0 ] && [ "$CORRECTNESS" -eq 0 ]; then
+  echo "**$SLOW** perf-class Slow finding(s) (#1235: over budget but completed"
+  echo "byte-identical at 10x) — tracked under the perf label, night stays green."
   echo ""
 fi
 echo "| seed | budget | programs | elapsed |"

--- a/tools/xtarget-fuzz/Cargo.lock
+++ b/tools/xtarget-fuzz/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "almide"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "almide-base",
  "almide-codegen",
@@ -44,7 +44,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
- "wasmparser 0.254.0",
+ "wasmparser 0.255.0",
  "wat",
 ]
 
@@ -68,7 +68,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
- "wasmparser 0.254.0",
+ "wasmparser 0.255.0",
 ]
 
 [[package]]
@@ -982,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.254.0"
+version = "0.255.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5769a29f799fbab136aaf65b4fe5384cd7d93fe6fc9ba0dcb6c8382a1f16e27"
+checksum = "e8e329ef4b5d46e73b91d3ac6924417cad55a8cbbf869c199283383427c3320b"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.17.1",

--- a/tools/xtarget-fuzz/src/findings.rs
+++ b/tools/xtarget-fuzz/src/findings.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 
 use crate::generator::Origin;
-use crate::oracle::{Finding, RunEvidence};
+use crate::oracle::{Finding, FindingKind, RunEvidence};
 
 /// Sink that owns the findings directory and the dedup set. Shared
 /// across worker threads behind a mutex (findings are rare, so the lock
@@ -25,6 +25,10 @@ pub struct FindingSink {
     seen: Mutex<HashSet<String>>,
     /// Count of *unique* findings written (after dedup).
     written: Mutex<usize>,
+    /// The perf-class subset of `written` (#1235): unique `Slow` findings.
+    /// The campaign's exit code fails on `written - slow` — correctness
+    /// classes only.
+    slow: Mutex<usize>,
 }
 
 impl FindingSink {
@@ -34,12 +38,18 @@ impl FindingSink {
             dir,
             seen: Mutex::new(HashSet::new()),
             written: Mutex::new(0),
+            slow: Mutex::new(0),
         })
     }
 
     /// Number of unique findings written so far.
     pub fn count(&self) -> usize {
         *self.written.lock().unwrap()
+    }
+
+    /// Number of unique perf-class (`Slow`) findings written so far.
+    pub fn slow_count(&self) -> usize {
+        *self.slow.lock().unwrap()
     }
 
     /// Record a finding. Returns `true` if it was new (written), `false`
@@ -77,6 +87,9 @@ impl FindingSink {
         }
 
         *self.written.lock().unwrap() += 1;
+        if finding.kind == FindingKind::Slow {
+            *self.slow.lock().unwrap() += 1;
+        }
         true
     }
 }
@@ -125,7 +138,7 @@ fn render_meta(seed: u64, index: u64, origin: &Origin, f: &Finding) -> String {
 
 fn render_evidence(ev: &RunEvidence) -> String {
     format!(
-        "exit_code = {:?}\ntimed_out = {}\n\n--- stdout ---\n{}\n--- stderr ---\n{}\n",
-        ev.exit_code, ev.timed_out, ev.stdout, ev.stderr
+        "exit_code = {:?}\ntimed_out = {}\nduration  = {:.1}s\n\n--- stdout ---\n{}\n--- stderr ---\n{}\n",
+        ev.exit_code, ev.timed_out, ev.duration_secs, ev.stdout, ev.stderr
     )
 }

--- a/tools/xtarget-fuzz/src/main.rs
+++ b/tools/xtarget-fuzz/src/main.rs
@@ -25,10 +25,12 @@ use std::time::{Duration, Instant};
 
 use findings::FindingSink;
 use generator::Engine;
-use oracle::{run_ladder, Outcome, Rung, Toolchain};
+use oracle::{run_ladder, FindingKind, Outcome, Rung, Toolchain};
 
 /// Default per-program timeout. Generated programs are tiny and finite;
-/// anything slower than this is hanging.
+/// outrunning this budget makes a leg a SUSPECT, which one confirm re-run
+/// at 10x then classifies: completed = Slow (perf-class), still over =
+/// Hang (#1235 — the 0.57.0 release gate hit exactly this boundary).
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 
 /// Default campaign duration when `--minutes` is given without a value
@@ -214,10 +216,17 @@ fn cmd_run(args: &[String]) {
     let elapsed = start.elapsed();
     print_summary(&stats, &sink, elapsed, &out_dir);
 
-    // Non-zero exit if any finding was recorded — the nightly CI gates on
-    // this to open an issue.
-    if sink.count() > 0 {
+    // Exit code carries the finding CLASS split (#1235): correctness
+    // findings exit 1; a campaign whose only findings are perf-class Slow
+    // exits 3, so a local caller can branch on it. (The nightly verdict
+    // does its own split from the finding directory-name prefixes and
+    // fails the night on correctness classes only.)
+    let slow = sink.slow_count();
+    if sink.count() > slow {
         std::process::exit(1);
+    }
+    if slow > 0 {
+        std::process::exit(3);
     }
 }
 
@@ -322,8 +331,17 @@ fn worker_loop(
                 // whenever it shrank — `repro.almd` and `native.out` /
                 // `wasm.out` must describe the same program, or a triager
                 // reasons about output the repro never produced.
-                let minimized =
-                    minimize::minimize(&tc, &gen.source, finding.kind, &work_dir, Some(&reference));
+                //
+                // Timeout-class findings are NOT minimized: with the #1235
+                // confirm re-run, every shrink candidate that still blows
+                // the budget costs (1 + 10)x the timeout — one pass would
+                // eat the whole shard. Generated programs are small by
+                // construction, so the original stands as the repro.
+                let minimized = if matches!(finding.kind, FindingKind::Hang | FindingKind::Slow) {
+                    minimize::Minimized { source: gen.source.clone(), finding: None }
+                } else {
+                    minimize::minimize(&tc, &gen.source, finding.kind, &work_dir, Some(&reference))
+                };
                 let evidence = minimized.finding.as_ref().unwrap_or(&finding);
                 let was_new = sink.record(
                     cfg.seed,
@@ -546,7 +564,17 @@ fn print_summary(stats: &Stats, sink: &FindingSink, elapsed: Duration, out_dir: 
     eprintln!("  skipped          = {}", stats.skipped.load(Ordering::Relaxed));
     let walls = stats.walled.load(Ordering::Relaxed);
     eprintln!("  walls (subset)   = {walls}");
-    eprintln!("  unique findings  = {}", sink.count());
+    let slow = sink.slow_count();
+    if slow > 0 {
+        eprintln!(
+            "  unique findings  = {} ({} correctness, {} perf-slow)",
+            sink.count(),
+            sink.count() - slow,
+            slow
+        );
+    } else {
+        eprintln!("  unique findings  = {}", sink.count());
+    }
     eprintln!("  throughput       = {:.1} programs/min", g as f64 / secs * 60.0);
     if walls > 0 {
         let reasons = stats.wall_reasons.lock().unwrap();
@@ -575,10 +603,10 @@ fn print_outcome(outcome: &Outcome) {
         Outcome::Finding(f) => {
             eprintln!("FINDING [{:?}] at rung {:?}: {}", f.kind, f.rung, f.summary);
             if let Some(n) = &f.native {
-                eprintln!("--- native stdout ---\n{}", n.stdout);
+                eprintln!("--- native stdout ({:.1}s) ---\n{}", n.duration_secs, n.stdout);
             }
             if let Some(w) = &f.wasm {
-                eprintln!("--- wasm stdout ---\n{}", w.stdout);
+                eprintln!("--- wasm stdout ({:.1}s) ---\n{}", w.duration_secs, w.stdout);
             }
         }
     }

--- a/tools/xtarget-fuzz/src/main.rs
+++ b/tools/xtarget-fuzz/src/main.rs
@@ -44,6 +44,7 @@ fn main() {
     match cmd {
         "run" => cmd_run(&args[2..]),
         "replay" => cmd_replay(&args[2..]),
+        "ladder" => cmd_ladder(&args[2..]),
         "gen" => cmd_gen(&args[2..]),
         "stats" => cmd_stats(),
         "-h" | "--help" | "help" => print_usage(),
@@ -61,6 +62,7 @@ fn print_usage() {
          USAGE:\n\
          \x20 xtarget-fuzz run    [--seed N] [--minutes M | --count N] [--jobs J] [--timeout S]\n\
          \x20 xtarget-fuzz replay --seed N --index I\n\
+         \x20 xtarget-fuzz ladder <file.almd> [--timeout S]\n\
          \x20 xtarget-fuzz gen    --seed N --index I\n\
          \x20 xtarget-fuzz stats\n\n\
          The repo root is autodetected from the binary location; override with --repo PATH.\n\
@@ -464,6 +466,51 @@ fn cmd_replay(args: &[String]) {
     let outcome = run_ladder(&tc, &gen.source, &file, &wasm, Some(&reference));
     eprintln!("\n=== ladder outcome ===");
     print_outcome(&outcome);
+}
+
+// ── ladder ──
+
+/// Run the full oracle ladder on an EXISTING `.almd` file — the triage
+/// instrument (#1235). A recorded finding's `repro.almd` can be re-judged
+/// after a classifier change without going through `(seed, index)` replay,
+/// which silently drifts whenever the mutation corpus changes underneath
+/// the seed. Exits 1 on any finding, 0 otherwise.
+fn cmd_ladder(args: &[String]) {
+    let Some(file_arg) = args.first().filter(|a| !a.starts_with("--")) else {
+        eprintln!("usage: xtarget-fuzz ladder <file.almd> [--timeout S]");
+        std::process::exit(2);
+    };
+    let source = match std::fs::read_to_string(file_arg) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("cannot read {file_arg}: {e}");
+            std::process::exit(2);
+        }
+    };
+    let repo = resolve_repo(args);
+    let almide = resolve_almide(&repo, args);
+    let timeout = flag_value(args, "--timeout")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_TIMEOUT_SECS);
+
+    let work_dir = repo.join("tools/xtarget-fuzz/.scratch/ladder");
+    let _ = std::fs::create_dir_all(&work_dir);
+    let file = work_dir.join("ladder.almd");
+    let wasm = work_dir.join("ladder.wasm");
+    let _ = std::fs::write(&file, &source);
+
+    let reference = crate::oracle::InterpOracle::new();
+    let tc = Toolchain {
+        almide,
+        wasmtime: resolve_wasmtime(),
+        scratch: repo.join("tools/xtarget-fuzz/.scratch/ladder-build"),
+        timeout: Duration::from_secs(timeout),
+    };
+    let outcome = run_ladder(&tc, &source, &file, &wasm, Some(&reference));
+    print_outcome(&outcome);
+    if matches!(outcome, Outcome::Finding(_)) {
+        std::process::exit(1);
+    }
 }
 
 // ── gen ──

--- a/tools/xtarget-fuzz/src/oracle/ladder.rs
+++ b/tools/xtarget-fuzz/src/oracle/ladder.rs
@@ -74,8 +74,15 @@ pub enum FindingKind {
     NativeBuildFailure,
     /// WASM build failed or the module did not validate.
     WasmBuildFailure,
-    /// One side hung (timed out).
+    /// One side outran the budget AND a confirm re-run at
+    /// [`SLOW_CONFIRM_FACTOR`]× the budget still did not finish.
     Hang,
+    /// One side outran the budget but COMPLETED, byte-identical, within the
+    /// [`SLOW_CONFIRM_FACTOR`]× confirm re-run (#1235). Perf-class: the night
+    /// verdict routes it to the perf ledger instead of failing on it — the
+    /// 0.57.0 release gate classified a 21.7s quadratic-concat run (#1229)
+    /// as a Hang, a wrong CLASSIFIER verdict on a right detector.
+    Slow,
     /// Native and WASM produced different observable output.
     OutputDivergence,
     /// One side ran, the other failed to run though it built.
@@ -92,6 +99,9 @@ pub struct RunEvidence {
     pub stderr: String,
     pub exit_code: Option<i32>,
     pub timed_out: bool,
+    /// Measured wall clock of this execution — the load-bearing number on
+    /// a Slow finding (#1235), informational elsewhere.
+    pub duration_secs: f64,
 }
 
 impl RunEvidence {
@@ -101,9 +111,21 @@ impl RunEvidence {
             stderr: String::from_utf8_lossy(&p.stderr).into_owned(),
             exit_code: p.exit_code,
             timed_out: p.timed_out,
+            duration_secs: p.duration.as_secs_f64(),
         }
     }
 }
+
+/// The hang-vs-slow confirm multiplier (#1235): a leg that outruns the
+/// per-program budget is re-run ONCE at this multiple of it before being
+/// classified. Completing there is an order-of-magnitude perf regression
+/// ([`FindingKind::Slow`]) — a real finding, but not nontermination.
+/// Outrunning even that stays a [`FindingKind::Hang`]. The re-run only
+/// fires on legs that already blew the budget, so its cost lands on the
+/// rare suspect, not the campaign; genuinely non-terminating mutants are
+/// mostly absorbed EARLIER (double-hang skip, interp fuel skip) and never
+/// reach it.
+const SLOW_CONFIRM_FACTOR: u32 = 10;
 
 /// Run the full ladder against a program already written to `file`.
 /// `wasm_out` is a scratch path for the WASM build artifact. `reference`
@@ -115,9 +137,26 @@ pub fn run_ladder(
     wasm_out: &Path,
     reference: Option<&dyn ReferenceOracle>,
 ) -> Outcome {
+    let tc_confirm = tc.with_timeout(tc.timeout * SLOW_CONFIRM_FACTOR);
+
     // ── Rung (a): check ──
     let check = tc.check(file);
     if check.timed_out {
+        // Hung, or merely slow? One confirm re-run decides (#1235). A check
+        // that completes only at 10× the budget is a frontend perf finding,
+        // not nontermination — the ladder stops either way, because a
+        // program the frontend cannot process in budget yields no run legs.
+        let check2 = tc_confirm.check(file);
+        if !check2.timed_out && !check2.spawn_failed {
+            return Outcome::Finding(Finding {
+                rung: Rung::Check,
+                kind: FindingKind::Slow,
+                summary: "almide check outlived the budget but completed at 10x (slow, not hung)"
+                    .into(),
+                native: Some(RunEvidence::from(&check2)),
+                wasm: None,
+            });
+        }
         return Outcome::Finding(Finding {
             rung: Rung::Check,
             kind: FindingKind::Hang,
@@ -200,6 +239,26 @@ pub fn run_ladder(
         if wasm_build.success() {
             let wasm_run = tc.run_wasm(wasm_out);
             if native_hang_is_finding(true, wasm_run.timed_out, wasm_run.success()) {
+                // wasm cleanly succeeded — hung, or merely slow (#1235)? The
+                // confirm re-run decides; a completed re-run has real
+                // observables, so it flows through the SAME comparison as a
+                // normal run (inheriting every skip rule and divergence
+                // class), with agreement mapping to Slow instead of Clean.
+                let native2 = tc_confirm.run_native_bin(&native_bin);
+                if !native2.timed_out && !native2.spawn_failed {
+                    return match compare_runs(source, &native2, &wasm_run, reference) {
+                        Outcome::Clean { .. } => Outcome::Finding(Finding {
+                            rung: Rung::Run,
+                            kind: FindingKind::Slow,
+                            summary: "native run outlived the budget but completed at 10x, \
+                                      byte-identical to wasm (slow, not hung)"
+                                .into(),
+                            native: Some(RunEvidence::from(&native2)),
+                            wasm: Some(RunEvidence::from(&wasm_run)),
+                        }),
+                        other => other,
+                    };
+                }
                 return Outcome::Finding(Finding {
                     rung: Rung::Run,
                     kind: FindingKind::Hang,
@@ -300,6 +359,27 @@ pub fn run_ladder(
                     .into(),
             };
         }
+        // Native succeeded and the interp terminates it, so the program IS
+        // finite — hung, or merely slow (#1235)? This is the exact site of
+        // the 0.57.0 release-gate misclassification: a quadratic
+        // string-concat run (#1229) completed at 21.7s, byte-identical,
+        // and was minted a Hang. The fuel skip above runs FIRST so
+        // interp-provable non-terminators never pay the 10× re-run.
+        let wasm2 = tc_confirm.run_wasm(wasm_out);
+        if !wasm2.timed_out && !wasm2.spawn_failed {
+            return match compare_runs(source, &native, &wasm2, reference) {
+                Outcome::Clean { .. } => Outcome::Finding(Finding {
+                    rung: Rung::Run,
+                    kind: FindingKind::Slow,
+                    summary: "wasm run outlived the budget but completed at 10x, \
+                              byte-identical to native (slow, not hung)"
+                        .into(),
+                    native: Some(RunEvidence::from(&native)),
+                    wasm: Some(RunEvidence::from(&wasm2)),
+                }),
+                other => other,
+            };
+        }
         return Outcome::Finding(Finding {
             rung: Rung::Run,
             kind: FindingKind::Hang,
@@ -309,9 +389,25 @@ pub fn run_ladder(
         });
     }
 
+    compare_runs(source, &native, &wasm, reference)
+}
+
+/// The differential comparison of two COMPLETED runs — every rule between
+/// "both legs produced observables" and the verdict. Pure over the two
+/// [`ProcResult`]s and the reference oracle (no toolchain), so the confirm
+/// re-run (#1235) can reuse it verbatim: a suspect leg that completes at
+/// 10× flows through the same skip rules (C-196 stack, C-197 memory) and
+/// the same divergence classes as any other run, with `Clean` mapped to
+/// `Slow` at the call site.
+fn compare_runs(
+    source: &str,
+    native: &super::runner::ProcResult,
+    wasm: &super::runner::ProcResult,
+    reference: Option<&dyn ReferenceOracle>,
+) -> Outcome {
     // Compare observable behaviour: stdout, exit code, and run-success.
-    let nat_ev = RunEvidence::from(&native);
-    let wasm_ev = RunEvidence::from(&wasm);
+    let nat_ev = RunEvidence::from(native);
+    let wasm_ev = RunEvidence::from(wasm);
 
     // BOTH legs died of CALL-STACK exhaustion (a mutation-synthesized unbounded
     // recursion): native hits Rust's guard page ("fatal runtime error: stack
@@ -580,6 +676,50 @@ mod stack_exhaustion_classification_tests {
     #[test]
     fn both_ok_is_not_this_rule() {
         assert!(!one_sided_stack_exhaustion(true, true, false, false));
+    }
+}
+
+#[cfg(test)]
+mod compare_runs_tests {
+    use super::super::runner::ProcResult;
+    use super::{compare_runs, FindingKind, Outcome};
+
+    fn run(stdout: &str, stderr: &str, exit: i32) -> ProcResult {
+        ProcResult {
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: stderr.as_bytes().to_vec(),
+            exit_code: Some(exit),
+            timed_out: false,
+            spawn_failed: false,
+            duration: std::time::Duration::from_millis(5),
+        }
+    }
+
+    #[test]
+    fn identical_completed_runs_are_clean() {
+        // The confirm re-run's agreement case (#1235): the call site maps
+        // THIS outcome to a Slow finding, so Clean here is load-bearing.
+        let out = compare_runs("", &run("a\n", "", 0), &run("a\n", "", 0), None);
+        assert!(matches!(out, Outcome::Clean { .. }));
+    }
+
+    #[test]
+    fn differing_stdout_is_an_output_divergence() {
+        let out = compare_runs("", &run("a\n", "", 0), &run("b\n", "", 0), None);
+        let Outcome::Finding(f) = out else { panic!("expected a finding") };
+        assert_eq!(f.kind, FindingKind::OutputDivergence);
+    }
+
+    #[test]
+    fn wasm_oom_skip_survives_the_extraction() {
+        // C-197 must apply to a confirm re-run exactly as to a first run.
+        let out = compare_runs(
+            "",
+            &run("a\n", "", 0),
+            &run("", "Error: out of memory", 134),
+            None,
+        );
+        assert!(matches!(out, Outcome::Skipped { .. }));
     }
 }
 

--- a/tools/xtarget-fuzz/src/oracle/runner.rs
+++ b/tools/xtarget-fuzz/src/oracle/runner.rs
@@ -30,6 +30,10 @@ pub struct ProcResult {
     /// `true` if the binary could not be spawned at all (e.g. `wasmtime`
     /// not installed). The ladder treats this as a *skip*, not a finding.
     pub spawn_failed: bool,
+    /// Wall clock the child actually consumed (up to the kill on a
+    /// timeout). The hang-vs-slow split (#1235) reports this, so a Slow
+    /// finding carries its measured time instead of just "over budget".
+    pub duration: Duration,
 }
 
 impl ProcResult {
@@ -55,6 +59,15 @@ pub struct Toolchain {
 }
 
 impl Toolchain {
+    /// This toolchain with a different per-run budget. The hang-vs-slow
+    /// confirm re-run (#1235) is the only caller.
+    pub fn with_timeout(&self, timeout: Duration) -> Toolchain {
+        Toolchain {
+            timeout,
+            ..self.clone()
+        }
+    }
+
     /// `almide check <file>` — type-check only.
     pub fn check(&self, file: &Path) -> ProcResult {
         self.run_almide(&["check", &file.to_string_lossy()])
@@ -140,6 +153,7 @@ impl Toolchain {
             cmd.process_group(0);
         }
 
+        let started = Instant::now();
         let mut child = match cmd.spawn() {
             Ok(c) => c,
             Err(e) => {
@@ -149,6 +163,7 @@ impl Toolchain {
                     exit_code: None,
                     timed_out: false,
                     spawn_failed: true,
+                    duration: Duration::ZERO,
                 };
             }
         };
@@ -173,7 +188,7 @@ impl Toolchain {
             })
         });
 
-        let deadline = Instant::now() + self.timeout;
+        let deadline = started + self.timeout;
         let poll_interval = Duration::from_millis(POLL_INTERVAL_MS);
 
         let timed_out = loop {
@@ -198,6 +213,10 @@ impl Toolchain {
             }
         };
 
+        // The child is done (or killed) HERE — measure before the reader
+        // joins, which cost nothing extra but are not the program.
+        let duration = started.elapsed();
+
         // Join the readers (they finish once the child's pipe ends close,
         // which the kill above guarantees).
         let stdout = out_handle.and_then(|h| h.join().ok()).unwrap_or_default();
@@ -210,6 +229,7 @@ impl Toolchain {
             exit_code,
             timed_out,
             spawn_failed: false,
+            duration,
         }
     }
 }


### PR DESCRIPTION
Closes #1235.

The 0.57.0 release gate classified a 21.7s quadratic-concat wasm run (#1229) as \`Hang__wasm_run_hung\` — the per-run timeout is a fine detector but was a wrong classifier, and every future night that draws a quadratic-slow program would go red on it. This puts the class split the release triage applied by hand into the instrument itself.

**Harness (tools/xtarget-fuzz)**
- A leg that outruns the budget is re-run ONCE at 10x (`SLOW_CONFIRM_FACTOR`) before classifying: completes byte-identical → new `FindingKind::Slow` (perf-class, with measured durations in the evidence); still over → `Hang` as before. Applied at all three timeout sites (check, native-hang-with-wasm-ok, wasm-hang-with-native-ok); the interp fuel skip stays FIRST so provable non-terminators never pay the 10x re-run.
- The differential comparison is extracted to a pure `compare_runs` so a completed confirm re-run inherits every skip rule (C-196 stack / C-197 memory) and divergence class unchanged — `Clean` maps to `Slow` at the call site. Pinned by 3 new unit tests.
- Timeout-class findings (Hang/Slow) are no longer minimized: with the confirm, each shrink candidate that still times out costs 11x the budget — one pass would eat a whole shard.
- Campaign exit code splits by class (1 = correctness, 3 = slow-only); durations land in `native.out`/`wasm.out` evidence.
- New `ladder <file.almd>` subcommand re-judges a recorded `repro.almd` directly — `(seed, index)` replay drifts when the mutation corpus changes.

**Night verdict (workflow + script)**
- The verdict aggregates the class split from finding directory-name prefixes (`Slow__*`), fails the night on **correctness findings only**, and routes Slow findings to their own `fuzz-perf`-labeled issue. The record line now reads `findings=N correctness=C slow=S` (5th arg optional — legacy calls unchanged). Workflow YAML parse-validated locally (#1234 lesson); verdict script exercised in slow-only / mixed / legacy modes.

**A/B on the real artifact** (run 31486558420's `repro.almd`, `--timeout 10`):
- A (production, old classifier): `Hang__wasm_run_hung`
- B (this branch): `FINDING [Slow] — wasm run outlived the budget but completed at 10x, byte-identical to native` (native 0.3s)

This unblocks the #796/#924 nightly-green streak from being held hostage by the known #1229 perf debt while keeping every real hang red.