### PR TITLE
Release evidence seals: per-release audit freeze, v0.57.0 sealed first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -788,6 +788,9 @@ jobs:
       - name: Contract ledger traceability (every contract evidenced, every fixture contracted)
         run: scripts/check-contracts.sh
 
+      - name: Release evidence seals (every seal re-measured against its tag — the audit freeze)
+        run: bash scripts/release-seal.sh check
+
       - name: Scalar-read audit (every raw-load arm classified, zero unguarded — the #1183 class stays extinct)
         run: scripts/check-scalar-read-audit.sh
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,10 @@ Correct flow:
 4. `git tag vX.Y.Z <merge-commit>` and `git push origin vX.Y.Z`
 5. **Let the workflow create the release.** It auto-generates notes from commits.
 6. If you want custom notes, edit after the workflow completes: `gh release edit vX.Y.Z --notes "..."`
+7. **Seal the release evidence** (audit freeze): `bash scripts/release-seal.sh gen vX.Y.Z`,
+   fill the `[recorded]` fields (the release-gate fuzz run, the asset inventory), commit
+   `proofs/releases/vX.Y.Z.toml` on `develop`. CI re-measures every `[derived]` field
+   against the tag forever after — the seal is the release's immutable evidence record.
 
 If you already shipped a broken release:
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -12,6 +12,9 @@ pre-commit:
     contracts:
       glob: "{docs/contracts/contracts.toml,docs/contracts/*.md,spec/wasm_cross/*.almd,scripts/check-contracts.sh,scripts/lib/contract-classes.txt,scripts/gen-claims.sh,README.md}"
       run: bash scripts/gen-claims.sh && git add README.md && scripts/check-contracts.sh && bash docs/contracts/generate-readme.sh > docs/contracts/README.md && git add docs/contracts/README.md
+    release-seals:
+      glob: "{proofs/releases/*.toml,scripts/release-seal.sh}"
+      run: bash scripts/release-seal.sh check
     libm-determinism:
       glob: "{runtime/rs/src/*.rs,crates/almide-kernel/src/*.rs,proofs/libm-determinism-audit.toml,scripts/check-libm-determinism.sh,scripts/lib/libm-call-enumerate.py}"
       run: bash scripts/check-libm-determinism.sh

--- a/proofs/releases/v0.57.0.toml
+++ b/proofs/releases/v0.57.0.toml
@@ -1,0 +1,26 @@
+# Release evidence seal — v0.57.0. IMMUTABLE: every [derived] field is
+# re-measured from the tag's tree by `scripts/release-seal.sh check`;
+# an edit that disagrees with the tag fails CI. [recorded] fields are
+# facts the tag cannot re-derive (fill them in before committing).
+
+[release]
+version = "0.57.0"
+tag = "v0.57.0"
+tag_commit = "f246ab32ade91f2faac2e9ee81a97413a565ba3f"
+date = "2026-08-11"
+url = "https://github.com/almide/almide/releases/tag/v0.57.0"
+
+[derived]
+cargo_version = "0.57.0"
+contracts_sha256 = "090894fbc12639b645097ddadde8e5c1ea5faef50c48c7ebfa122b3ff0fcf96e"
+contracts_total = "228"
+contracts_flagged = "0"
+abstain_ledger_sha256 = "cb2777c60277ab181960351f36c4515f910b1c30c2afe22325f43864e4e3f5ab"
+abstain_ledger_entries = "119"
+wasm_cross_fixtures = "372"
+rust_toolchain = "1.89.0"
+wasmtime = "v47.0.3"
+
+[recorded]
+release_gate = "manual fuzz dispatch, actions run 31486558420: 4/4 shards survived, ~4,000 programs, 0 correctness findings; the 1 finding (Hang__wasm_run_hung) was triaged to quadratic-slow perf debt (#1229) and recorded as a known limitation in the release notes"
+assets = "6: almide-linux-x86_64, almide-linux-aarch64, almide-macos-x86_64, almide-macos-aarch64, almide-windows-x86_64.exe, SHA256SUMS"

--- a/scripts/release-seal.sh
+++ b/scripts/release-seal.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# RELEASE EVIDENCE SEALS — the per-release audit-freeze the mission-critical
+# goal calls for ("リリースごとに証拠を不変固定するアーカイブ").
+#
+# A seal (proofs/releases/vX.Y.Z.toml) binds a release TAG to the measured
+# state of its assurance evidence: the contract ledger's digest and counts,
+# the interp abstain ledger, the cross-target fixture corpus, and the pinned
+# toolchain — plus hand-recorded facts (the release-gate fuzz run) an auditor
+# can follow while the CI artifacts live.
+#
+# IMMUTABILITY MODEL: git tags are the immutability root. Every `[derived]`
+# field is RE-MEASURED from the tag's tree (`git show TAG:path`) by `check`
+# using the SAME functions `gen` used to write it (one instrument, the #1176
+# rule — the two cannot drift). Editing a seal to disagree with its tag fails
+# CI; the only way to "change" a seal is to change the tag, which git forbids
+# quietly and the release workflow never does. `[recorded]` fields are not
+# re-derivable (run URLs, asset counts) — check enforces presence, not value.
+#
+# Usage:
+#   scripts/release-seal.sh gen vX.Y.Z    # measure the tag, write the seal
+#   scripts/release-seal.sh check         # verify every seal (CI gate)
+set -euo pipefail
+export LC_ALL=C
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SEALS_DIR="$ROOT/proofs/releases"
+
+# ── shared measurement functions (gen and check both call EXACTLY these) ──
+
+tag_file() { git -C "$ROOT" show "$1:$2" 2>/dev/null; }
+
+m_cargo_version()   { tag_file "$1" Cargo.toml | sed -n 's/^version = "\(.*\)"/\1/p' | head -1; }
+m_contracts_sha()   { tag_file "$1" docs/contracts/contracts.toml | shasum -a 256 | cut -d' ' -f1; }
+m_contracts_total() { tag_file "$1" docs/contracts/contracts.toml | grep -c '^\[\[contract\]\]'; }
+m_contracts_flagged() {
+  # `status` LINES only — the phrase also appears in header docs and contract
+  # prose (3 hits at v0.57.0 with 0 actual flagged rows), matching
+  # check-contracts.sh's semantic.
+  tag_file "$1" docs/contracts/contracts.toml | grep -c '^status.*"flagged-for-revision"' || true
+}
+m_abstain_sha()     { tag_file "$1" crates/almide-interp/interp-abstain-ledger.txt | shasum -a 256 | cut -d' ' -f1; }
+m_abstain_entries() { tag_file "$1" crates/almide-interp/interp-abstain-ledger.txt | grep -vc '^#\|^$'; }
+m_fixture_count()   { git -C "$ROOT" ls-tree "$1" spec/wasm_cross/ | grep -c '\.almd$'; }
+m_rust_toolchain()  { tag_file "$1" .github/workflows/ci.yml | sed -n 's/.*RUST_TOOLCHAIN: "\(.*\)".*/\1/p' | head -1; }
+m_wasmtime() {
+  tag_file "$1" .github/workflows/ci.yml | sed -n 's/.*VERSION=\(v[0-9.]*\).*/\1/p' | head -1
+}
+
+# Ensure the tag is present (CI clones are shallow and tagless).
+ensure_tag() {
+  local tag="$1"
+  if git -C "$ROOT" rev-parse -q --verify "$tag^{commit}" >/dev/null 2>&1; then
+    return 0
+  fi
+  git -C "$ROOT" fetch --quiet --depth=1 origin "refs/tags/$tag:refs/tags/$tag" 2>/dev/null || true
+  git -C "$ROOT" rev-parse -q --verify "$tag^{commit}" >/dev/null 2>&1
+}
+
+derived_fields() { # tag -> "key value" lines, one per derived field
+  local t="$1"
+  echo "cargo_version $(m_cargo_version "$t")"
+  echo "contracts_sha256 $(m_contracts_sha "$t")"
+  echo "contracts_total $(m_contracts_total "$t")"
+  echo "contracts_flagged $(m_contracts_flagged "$t")"
+  echo "abstain_ledger_sha256 $(m_abstain_sha "$t")"
+  echo "abstain_ledger_entries $(m_abstain_entries "$t")"
+  echo "wasm_cross_fixtures $(m_fixture_count "$t")"
+  echo "rust_toolchain $(m_rust_toolchain "$t")"
+  echo "wasmtime $(m_wasmtime "$t")"
+}
+
+cmd="${1:?usage: release-seal.sh gen vX.Y.Z | check}"
+
+if [ "$cmd" = "gen" ]; then
+  tag="${2:?gen needs a tag (vX.Y.Z)}"
+  ensure_tag "$tag" || { echo "release-seal: tag $tag not found" >&2; exit 1; }
+  version="${tag#v}"
+  commit=$(git -C "$ROOT" rev-parse "$tag^{commit}")
+  # Committer date of the tagged commit — deterministic, not "today".
+  date=$(git -C "$ROOT" show -s --format=%cs "$tag^{commit}")
+  mkdir -p "$SEALS_DIR"
+  out="$SEALS_DIR/$tag.toml"
+  {
+    echo "# Release evidence seal — $tag. IMMUTABLE: every [derived] field is"
+    echo "# re-measured from the tag's tree by \`scripts/release-seal.sh check\`;"
+    echo "# an edit that disagrees with the tag fails CI. [recorded] fields are"
+    echo "# facts the tag cannot re-derive (fill them in before committing)."
+    echo ""
+    echo "[release]"
+    echo "version = \"$version\""
+    echo "tag = \"$tag\""
+    echo "tag_commit = \"$commit\""
+    echo "date = \"$date\""
+    echo "url = \"https://github.com/almide/almide/releases/tag/$tag\""
+    echo ""
+    echo "[derived]"
+    derived_fields "$tag" | while read -r k v; do echo "$k = \"$v\""; done
+    echo ""
+    echo "[recorded]"
+    echo "release_gate = \"FILL: the gate evidence (fuzz run id, shards, findings disposition)\""
+    echo "assets = \"FILL: released asset inventory\""
+  } > "$out"
+  echo "release-seal: wrote $out — fill the [recorded] fields, then commit"
+  exit 0
+fi
+
+if [ "$cmd" != "check" ]; then
+  echo "release-seal: unknown command $cmd" >&2
+  exit 2
+fi
+
+# ── check: every seal re-measured against its tag ──
+shopt -s nullglob
+seals=("$SEALS_DIR"/v*.toml)
+if [ ${#seals[@]} -eq 0 ]; then
+  echo "release-seal: no seals to check"
+  exit 0
+fi
+fail=0
+for seal in "${seals[@]}"; do
+  tag=$(basename "$seal" .toml)
+  if ! ensure_tag "$tag"; then
+    if [ "${CI:-}" = "true" ]; then
+      echo "::error::release-seal: tag $tag (for $(basename "$seal")) is unfetchable — a seal without its tag is unverifiable" >&2
+      fail=1
+    else
+      echo "release-seal: SKIP $tag (tag not available locally; CI enforces)"
+    fi
+    continue
+  fi
+  # Parse the seal's flat `key = "value"` lines.
+  declare -A want=()
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^([a-z0-9_]+)\ =\ \"(.*)\"$ ]]; then
+      want["${BASH_REMATCH[1]}"]="${BASH_REMATCH[2]}"
+    fi
+  done < "$seal"
+  # Structural: version/tag agreement + recorded fields actually filled.
+  [ "${want[tag]:-}" = "$tag" ] || { echo "  $tag: seal names tag '${want[tag]:-}'" >&2; fail=1; }
+  [ "${want[version]:-}" = "${tag#v}" ] || { echo "  $tag: version '${want[version]:-}' != '${tag#v}'" >&2; fail=1; }
+  commit=$(git -C "$ROOT" rev-parse "$tag^{commit}")
+  [ "${want[tag_commit]:-}" = "$commit" ] || { echo "  $tag: tag_commit '${want[tag_commit]:-}' != measured '$commit'" >&2; fail=1; }
+  for rk in release_gate assets; do
+    case "${want[$rk]:-}" in
+      ""|FILL:*) echo "  $tag: [recorded] $rk is unfilled — a seal without its gate evidence is not a seal" >&2; fail=1 ;;
+    esac
+  done
+  # Derived: re-measure with the SAME functions gen used.
+  while read -r k v; do
+    if [ "${want[$k]:-}" != "$v" ]; then
+      echo "  $tag: $k sealed as '${want[$k]:-}' but the tag measures '$v'" >&2
+      fail=1
+    fi
+  done < <(derived_fields "$tag")
+  unset want
+done
+if [ $fail -ne 0 ]; then
+  echo "RELEASE SEAL CHECK FAILED — a seal disagrees with its tag (or is incomplete)." >&2
+  exit 1
+fi
+echo "release-seal: ${#seals[@]} seal(s) verified against their tags"


### PR DESCRIPTION
The mission-critical goal text calls for starting this now, ahead of Stage 3: 「リリースごとに証拠を不変固定するアーカイブ(契約台帳のバージョン封印)を今から始めておくと、後で監査可能性を遡って作る羽目になりません」.

**The model**: `proofs/releases/vX.Y.Z.toml` binds a release tag to its measured assurance evidence. Git tags are the immutability root — every `[derived]` field (contract-ledger sha256 + counts, abstain-ledger sha256 + entries, fixture-corpus size, pinned toolchain versions, Cargo version) is **re-measured from the tag's tree** by `scripts/release-seal.sh check` using the SAME functions `gen` used to write it (one instrument, the #1176 rule). A seal edited to disagree with its tag fails CI forever. `[recorded]` fields carry the facts a tag cannot re-derive (the release-gate fuzz run and disposition, the asset inventory) — check enforces they are filled, never templated.

**First seal — v0.57.0**: contracts 228 (flagged 0), abstain ledger 119 entries, 372 cross-target fixtures, Rust 1.89.0 / wasmtime v47.0.3, release gate = fuzz run 31486558420 (4/4 shards, 0 correctness findings, 1 perf finding → #1229).

Wiring: CI `checks` job step (the script self-fetches the tag into the shallow clone), a lefthook row on seal/script changes, and step 7 in CLAUDE.md's release procedure. Verified: positive check green, two negative tests (a forged derived count, an unfilled recorded field) both caught, edited YAML strict-parsed (duplicate-key loader — the #1201 class).