### PR TITLE
Re-measure the flight evidence gap ledger and formalize the known-problems seal field

### DIFF
--- a/docs/roadmap/active/flight-evidence-gaps.md
+++ b/docs/roadmap/active/flight-evidence-gaps.md
@@ -309,3 +309,32 @@ F7 (strtod)         ── 独立 brick、F1 の精度規範が先でも可
 小さく即効の F6-2 → 証拠の信頼性を回復する F4/F5 → 現状を直視する F2-1 → 構造的な
 F3/F1 の順。**F1 と F2 が閉じるまで、「航空品質」を名乗る主張は evidence ladder の
 rank を明示して限定的に行う**こと（無限定の "flight-grade" 表現の自粛）。
+
+---
+
+## 再測定 2026-08-12 — 所見の現在地(1 ヶ月の保証工事後)
+
+7 月の初回監査から 1 ヶ月、Stage 1〜4 の工事(scalar-read/WAT-prelude/libm 監査、
+3-way 投票ゲート、分類器修理、リリース封印、G-F4 アプリ)を経た**再測定**。
+台帳は追記のみ — 上の所見本文は当時の記録として不変。
+
+| # | 7 月時点 | 2026-08-12 実測 | 残余 |
+|---|---|---|---|
+| F1 | 部分(spec-keying 機構稼働、全契約展開が残) | **機構は全数化**: 230/230 契約が `spec =` keyed、check-contracts が両方向を強制(存在しない節参照 = FAIL、全 ALS 正規節が ≥1 契約に引用)。写経 self-host はヘッダを ALS 節参照に張替済み(json_parse → ALS-T3 等)。さらに **interp が実行可能仕様に昇格**: 3-way 投票 254/374 fixture(native==wasm==interp byte 一致)、棄権は分類台帳(HEAP_BOUNDARY 120 / BRIDGEABLE 0)+ shrink-only ラチェット、semantics-manifest 全 20 モジュール実測 | ALS 節の**執筆網羅**(構文要素側の完全性 = Stage 3 ゲートの残半分)と HEAP_BOUNDARY 120 の interp ヒープアーク(#1226) |
+| F2 | 部分(coverage 65.89% 計測、文言修正済) | 文言と検証内容の一致は**構造化**: proven-vs-trusted.md(境界図)が「各ゲートが主張すること/しないこと」を一枚化。coverage は **CI ラチェット化**(fuzz-nightly の coverage-ratchet job #566、baseline 減少のみ許容)。#1183 クラスは scalar-read 監査(63 arm 全分類、UNGUARDED 0、CI ゲート)で**族として絶滅**。同型監査を WAT prelude 63 fn / platform-libm 23 呼び出しへ水平展開済み | **MC/DC は依然ゼロ**(DAL-A の object-code MC/DC どころか branch coverage も未計測 — line のみ)。分岐カバレッジ導入が次の一手 |
+| F3 | 開存(境界図なし、整合ゲートなし) | item 1 **クローズ**: docs/contracts/proven-vs-trusted.md が監査人向け境界図として存在、CLAUDE.md から参照。item 2 部分: mir==ir caps ゲート・rollback lifted_mark 検査・released-merge backing 検査など「今回のバグ 5 クラス」対応ゲートは個別に存在(F8 の根治群)— ただし「追跡集合整合」の**単一の名前付きゲート**としては未統合 | 整合検査群の台帳化(どのバグクラスにどのゲートが対応するかの対応表)。per-function cert 化への合流は長期のまま |
+| F4-F8 | クローズ | **クローズ維持** + 強化: F5 の ratchet-separation は本日も全 PR で機能(baseline 変更は分離コミット)。F6 の刻印は本日 gate.sh が PATH/workspace 不一致を FATAL 捕捉(機能証明)。検証の決定性には **fuzz 分類器の Slow/Hang 分離**(#1235)が加勢 — 既知 perf 債務(#1229)が correctness メトリクスを汚染しない | — |
+
+### Stage 5 欠損成果物リスト(goal 指示の 3 点、実測)
+
+| 成果物 | 現状 | 評価 |
+|---|---|---|
+| ツール運用要求(TOR) | CLAUDE.md の Usage 節 + TRUSTED_BASE.md が断片的に相当。DO-330 の様式(想定運用環境・入力制約・既知制限の運用回避)としては**未編纂** | **MISSING** — G-F6 キット(flight-qualification §G-F6)の一章として編纂するのが自然 |
+| 検証ツール自身の検証 | checker = Coq 証明(qualified-by-proof、45 定理 + coqchk + cross-version)。**ゲートスクリプト群は負テスト文化が定着**(check-contracts は mutation テスト、監査ゲート 3 本は負テスト済み、release-seal も偽造/未記入の負テスト付き)。fuzz ハーネスに単体テスト(分類器の純関数化) | **PARTIAL** — 「どのゲートがどう自己検証されるか」の一覧表が未作成(各 PR に散在) |
+| 既知問題台帳の正式化 | GitHub issues + リリースノート既知制限(0.57.0 の #1229)+ `fuzz-perf` ラベル + flagged-for-revision 機構 + **リリース封印**(proofs/releases/ — v0.57.0 から、証拠のタグ束縛) | **PARTIAL** — 散在。リリース封印の `[recorded]` に known-problems 節を追加すれば形式が閉じる |
+
+**総評の更新**: 7 月の「哲学は DAL-A、証拠は DAL-D 相当」から、証拠体系は
+**「独立規範仕様 + 実行可能仕様 + 網羅監査 + 封印」の骨格が立った状態**へ。残る構造的
+距離は (a) MC/DC(F2 残余)、(b) ALS 執筆網羅(F1 残余 = Stage 3)、(c) TOR 編纂
+(Stage 5)、(d) 外部採用の実績 — (d) は工事でなく市場の時間。無限定の
+"flight-grade" 自粛は**継続**(evidence ladder の rank 明示は維持)。

--- a/proofs/releases/v0.57.0.toml
+++ b/proofs/releases/v0.57.0.toml
@@ -24,3 +24,4 @@ wasmtime = "v47.0.3"
 [recorded]
 release_gate = "manual fuzz dispatch, actions run 31486558420: 4/4 shards survived, ~4,000 programs, 0 correctness findings; the 1 finding (Hang__wasm_run_hung) was triaged to quadratic-slow perf debt (#1229) and recorded as a known limitation in the release notes"
 assets = "6: almide-linux-x86_64, almide-linux-aarch64, almide-macos-x86_64, almide-macos-aarch64, almide-windows-x86_64.exe, SHA256SUMS"
+known_problems = "#1229 quadratic wasm string-accumulator concat — byte-correct output, completes at ~4x the 30s budget on CI hardware; perf-class, disclosed in the release notes and tracked under the fuzz-perf discipline. The env.set wasm cell is HOST_CAPABILITY by design (C-228's ledger row: WASI preview1 has no environ-write)."

--- a/scripts/release-seal.sh
+++ b/scripts/release-seal.sh
@@ -98,6 +98,7 @@ if [ "$cmd" = "gen" ]; then
     echo "[recorded]"
     echo "release_gate = \"FILL: the gate evidence (fuzz run id, shards, findings disposition)\""
     echo "assets = \"FILL: released asset inventory\""
+    echo "known_problems = \"FILL: the release's known-problem ledger (issue refs + dispositions), or 'none'\""
   } > "$out"
   echo "release-seal: wrote $out — fill the [recorded] fields, then commit"
   exit 0
@@ -139,7 +140,7 @@ for seal in "${seals[@]}"; do
   [ "${want[version]:-}" = "${tag#v}" ] || { echo "  $tag: version '${want[version]:-}' != '${tag#v}'" >&2; fail=1; }
   commit=$(git -C "$ROOT" rev-parse "$tag^{commit}")
   [ "${want[tag_commit]:-}" = "$commit" ] || { echo "  $tag: tag_commit '${want[tag_commit]:-}' != measured '$commit'" >&2; fail=1; }
-  for rk in release_gate assets; do
+  for rk in release_gate assets known_problems; do
     case "${want[$rk]:-}" in
       ""|FILL:*) echo "  $tag: [recorded] $rk is unfilled — a seal without its gate evidence is not a seal" >&2; fail=1 ;;
     esac


### PR DESCRIPTION
Stage 5 unit (goal text: 既存ゲート→TQL の対応 + 欠損成果物の列挙): the audit findings ledger (docs/roadmap/active/flight-evidence-gaps.md) dated from the 2026-07-03 hands-on audit and no longer described the tree — an audit ledger that OVERSTATES gaps misleads exactly like one that understates them.

**Appended a dated re-measurement section** (append-only — the July findings stay as the historical record), every claim verified against the tree:

- **F1** (spec = implementation circularity): the mechanism side is DONE — 230/230 contracts spec-keyed with bidirectional enforcement, transcribed self-hosts re-keyed to ALS sections, and the interp promoted to executable spec (3-way voting 254/374, shrink-only abstain ledger, 20-module semantics manifest). Remaining: ALS authoring completeness (= the Stage 3 gate's other half) + the HEAP_BOUNDARY interp arc (#1226).
- **F2** (coverage illusion): claims-vs-verification now structured via proven-vs-trusted.md; line coverage is a CI ratchet; the #1183 class is extinct by audit (63 arms, 0 unguarded) with the audit pattern replicated to WAT-prelude and libm surfaces. Honest remainder: **MC/DC is still zero** — not even branch coverage; named as the next move.
- **F3**: item 1 (boundary map) closed by proven-vs-trusted.md; item 2 partial — the per-bug-class gates from F8 exist but lack a unifying correspondence table.
- **F4-F8**: closed in July, still holding — with tonight's live proof (the toolchain stamp caught a real PATH/workspace mismatch; ratchet-separation ran on every PR).

**Stage 5 missing-artifact list** (the goal text's three): TOR = MISSING (a G-F6 kit chapter), verification-of-verification-tools = PARTIAL (Coq-proven checker + a negative-test culture, but no unified table), known-problems ledger = PARTIAL → **narrowed in this PR**: every release seal now REQUIRES a `known_problems` entry (checker-enforced, negative-tested; v0.57.0's filled with the #1229 disposition and the C-228 env.set carve-out).

(The seal change also gives this otherwise docs-only PR a CI-visible surface — the docs/** path filter would leave required checks unreported forever, the #1160 auto-merge hang.)