### PR TITLE
Gate-verification ledger: classify how every gate can fail (Stage 5, tool-verification)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -791,6 +791,9 @@ jobs:
       - name: Release evidence seals (every seal re-measured against its tag — the audit freeze)
         run: bash scripts/release-seal.sh check
 
+      - name: Gate verification ledger (every gate classified by how it can fail — no decorative gates)
+        run: bash scripts/check-gate-verification.sh
+
       - name: Scalar-read audit (every raw-load arm classified, zero unguarded — the #1183 class stays extinct)
         run: scripts/check-scalar-read-audit.sh
 

--- a/docs/roadmap/active/flight-evidence-gaps.md
+++ b/docs/roadmap/active/flight-evidence-gaps.md
@@ -330,7 +330,7 @@ rank を明示して限定的に行う**こと（無限定の "flight-grade" 表
 | 成果物 | 現状 | 評価 |
 |---|---|---|
 | ツール運用要求(TOR) | CLAUDE.md の Usage 節 + TRUSTED_BASE.md が断片的に相当。DO-330 の様式(想定運用環境・入力制約・既知制限の運用回避)としては**未編纂** | **MISSING** — G-F6 キット(flight-qualification §G-F6)の一章として編纂するのが自然 |
-| 検証ツール自身の検証 | checker = Coq 証明(qualified-by-proof、45 定理 + coqchk + cross-version)。**ゲートスクリプト群は負テスト文化が定着**(check-contracts は mutation テスト、監査ゲート 3 本は負テスト済み、release-seal も偽造/未記入の負テスト付き)。fuzz ハーネスに単体テスト(分類器の純関数化) | **PARTIAL** — 「どのゲートがどう自己検証されるか」の一覧表が未作成(各 PR に散在) |
+| 検証ツール自身の検証 | checker = Coq 証明(qualified-by-proof、45 定理 + coqchk + cross-version)。**ゲートスクリプト群は負テスト文化が定着**(check-contracts は mutation テスト、監査ゲート 3 本は負テスト済み、release-seal も偽造/未記入の負テスト付き)。fuzz ハーネスに単体テスト(分類器の純関数化) | **一覧表は稼働**(proofs/gate-verification.toml + check-gate-verification.sh — 30 ゲート 5 分類、UNVERIFIED 18 は shrink-only 天井で直視)。残余 = UNVERIFIED 18 の焼却 |
 | 既知問題台帳の正式化 | GitHub issues + リリースノート既知制限(0.57.0 の #1229)+ `fuzz-perf` ラベル + flagged-for-revision 機構 + **リリース封印**(proofs/releases/ — v0.57.0 から、証拠のタグ束縛) | **PARTIAL** — 散在。リリース封印の `[recorded]` に known-problems 節を追加すれば形式が閉じる |
 
 **総評の更新**: 7 月の「哲学は DAL-A、証拠は DAL-D 相当」から、証拠体系は

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,6 +15,9 @@ pre-commit:
     release-seals:
       glob: "{proofs/releases/*.toml,scripts/release-seal.sh}"
       run: bash scripts/release-seal.sh check
+    gate-verification:
+      glob: "{proofs/gate-verification.toml,scripts/check-*.sh,proofs/*.sh}"
+      run: bash scripts/check-gate-verification.sh
     libm-determinism:
       glob: "{runtime/rs/src/*.rs,crates/almide-kernel/src/*.rs,proofs/libm-determinism-audit.toml,scripts/check-libm-determinism.sh,scripts/lib/libm-call-enumerate.py}"
       run: bash scripts/check-libm-determinism.sh

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -1,0 +1,152 @@
+# GATE VERIFICATION LEDGER — who watches the watchmen (Stage 5:「検証ツール
+# 自身の検証」). Every verdict-bearing gate script carries a row classifying
+# HOW we know the gate itself can fail correctly, with a durable evidence
+# pointer. Enforced by scripts/check-gate-verification.sh: every enumerated
+# gate needs exactly one row, stale rows fail, a non-UNVERIFIED row needs
+# `evidence`, and the UNVERIFIED count may only SHRINK (ceiling below).
+#
+# Classes:
+#   KERNEL_PROVEN   — the verdict-bearing core is the Coq-extracted checker
+#                     (or the proof-check itself); the shell is plumbing.
+#   MUTATION_TESTED — a deliberate corruption of the gate's ledger/input was
+#                     demonstrated to FAIL the gate (recorded where).
+#   NEGATIVE_TESTED — a forged/violating input was demonstrated to FAIL.
+#   EXERCISED       — both verdict directions observed in real operation
+#                     (a genuine catch, or a recorded multi-mode exercise).
+#   UNVERIFIED      — no recorded evidence the gate can fail correctly.
+#                     Honest debt: the gate may be decorative and we would
+#                     not know. Burn-down tracked by the ceiling.
+#
+# unverified_ceiling = "18"
+
+[[gate]]
+path = "scripts/check-contracts.sh"
+class = "MUTATION_TESTED"
+evidence = "flight-evidence-gaps.md F1 progress-2 (2026-07-04): spec-resolution mutation test (nonexistent ALS section reference => FAIL)"
+
+[[gate]]
+path = "scripts/check-scalar-read-audit.sh"
+class = "NEGATIVE_TESTED"
+evidence = "PR #1185 (Stage 1 landing): unclassified/stale/UNGUARDED negative cases demonstrated to fail"
+
+[[gate]]
+path = "scripts/check-wat-prelude-audit.sh"
+class = "NEGATIVE_TESTED"
+evidence = "PR #1209 (Stage 1c landing): 5/5 negative tests (unclassified fn, stale row, digest drift, missing via, UNREACHED)"
+
+[[gate]]
+path = "scripts/check-ratchet-separation.sh"
+class = "NEGATIVE_TESTED"
+evidence = "flight-evidence-gaps.md F5 close (2026-07-03): mixed impl+baseline commit => exit 1, clean => exit 0"
+
+[[gate]]
+path = "scripts/release-seal.sh"
+class = "NEGATIVE_TESTED"
+evidence = "PR #1241 + #1243: forged derived count and unfilled [recorded] field each demonstrated to FAIL check"
+
+[[gate]]
+path = "scripts/fuzz-night-verdict.sh"
+class = "EXERCISED"
+evidence = "PR #1238: slow-only/mixed/legacy 3-mode local exercise; production class-split verdict on run 31515916427 (correctness=1 => red)"
+
+[[gate]]
+path = "proofs/check-wasm-fallback.sh"
+class = "EXERCISED"
+evidence = "2026-08-12: fail direction fired on a stale-binary measurement, pass direction on the #1240 prune (18->17)"
+
+[[gate]]
+path = "proofs/check.sh"
+class = "KERNEL_PROVEN"
+evidence = "the object under check IS the proof: coqchk De-Bruijn re-check + Print Assumptions closed + cross-version 9.1.1/9.2 (TRUSTED_BASE.md)"
+
+[[gate]]
+path = "proofs/gate.sh"
+class = "KERNEL_PROVEN"
+evidence = "verdict core = extracted checker (qualified-by-proof); toolchain stamp FATAL demonstrated live 2026-08-12 (PATH != workspace build)"
+
+[[gate]]
+path = "proofs/corpus-wall.sh"
+class = "KERNEL_PROVEN"
+evidence = "checker-phase ACCEPTs are kernel-proven; flight-evidence-gaps.md F8: a live REJECT exposed the via_if miscompile (the fail direction caught a real bug)"
+
+[[gate]]
+path = "proofs/output-parity.sh"
+class = "EXERCISED"
+evidence = "flight-evidence-gaps.md F4 close: 5 consecutive full-run greens after the LC_ALL root-cause; regression direction fired throughout the parity war"
+
+[[gate]]
+path = "proofs/build-checker.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "proofs/coverage.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "proofs/diff-fuzz.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "proofs/receipt.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "proofs/check-stdlib-purity-registry.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "proofs/check-wasm-bytes.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "proofs/check-wasm-exec.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "proofs/check-wasm-reachability.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "scripts/check-abstain-classes.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "scripts/check-browser-determinism.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "scripts/check-embedded-size.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "scripts/check-forbidden-impurities.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "scripts/check-frees-churn.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "scripts/check-host-determinism.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "scripts/check-libm-determinism.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "scripts/check-perf-ratio.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "scripts/check-rt-oracle-registry.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "scripts/check-semantics-manifest.sh"
+class = "UNVERIFIED"
+
+[[gate]]
+path = "scripts/check-gate-verification.sh"
+class = "NEGATIVE_TESTED"
+evidence = "bootstrap run (PR that landed this ledger): a mis-pathed row failed as STALE and this script's own missing row failed as UNCLASSIFIED — both fail directions demonstrated before first green"

--- a/scripts/check-gate-verification.sh
+++ b/scripts/check-gate-verification.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# GATE-VERIFICATION LEDGER GATE (Stage 5:「検証ツール自身の検証」).
+#
+# Every verdict-bearing gate script must carry a row in
+# proofs/gate-verification.toml classifying HOW we know the gate can fail
+# correctly (see that file's class vocabulary). A gate nobody has ever seen
+# fail is possibly decorative — this ledger makes that debt visible and
+# shrink-only, the same 直視-then-ratchet pattern as coverage and the
+# abstain classes.
+set -euo pipefail
+export LC_ALL=C
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LEDGER="$ROOT/proofs/gate-verification.toml"
+
+# ── enumerate the verdict-bearing gates (same set the ledger was built from:
+# every check-* script plus the named verdict/verify scripts; lib/ helpers and
+# generated-doc helpers are not verdict-bearing) ──
+enumerate() {
+  (
+    cd "$ROOT"
+    ls scripts/check-*.sh
+    ls scripts/release-seal.sh scripts/fuzz-night-verdict.sh
+    ls proofs/*.sh | grep -v '^proofs/lib/'
+  ) | sort -u
+}
+
+python3 - "$ROOT" "$LEDGER" <<'EOF'
+import re
+import subprocess
+import sys
+
+root, ledger_path = sys.argv[1], sys.argv[2]
+enumerated = set(
+    subprocess.run(
+        ["bash", "-c",
+         "cd \"$1\" && { ls scripts/check-*.sh; ls scripts/release-seal.sh "
+         "scripts/fuzz-night-verdict.sh; ls proofs/*.sh | grep -v '^proofs/lib/'; } | sort -u",
+         "_", root],
+        capture_output=True, text=True, check=True).stdout.split())
+
+VOCAB = {"KERNEL_PROVEN", "MUTATION_TESTED", "NEGATIVE_TESTED", "EXERCISED", "UNVERIFIED"}
+
+ceiling = None
+rows, cur = [], None
+for raw in open(ledger_path, encoding="utf-8"):
+    line = raw.strip()
+    m = re.match(r'#\s*unverified_ceiling\s*=\s*"(\d+)"', line)
+    if m:
+        ceiling = int(m.group(1))
+    if line == "[[gate]]":
+        if cur:
+            rows.append(cur)
+        cur = {}
+        continue
+    m = re.match(r'([a-z_]+)\s*=\s*"(.*)"$', line)
+    if m and cur is not None:
+        cur[m.group(1)] = m.group(2)
+if cur:
+    rows.append(cur)
+
+errs = []
+if ceiling is None:
+    errs.append("ledger header is missing `# unverified_ceiling = \"N\"`")
+seen = set()
+unverified = 0
+for r in rows:
+    p = r.get("path")
+    if not p:
+        errs.append(f"row without a path: {r}")
+        continue
+    if p in seen:
+        errs.append(f"{p}: duplicate row")
+    seen.add(p)
+    if p not in enumerated:
+        errs.append(f"{p}: STALE row — the script no longer exists (or left the enumerated set)")
+    cls = r.get("class", "")
+    if cls not in VOCAB:
+        errs.append(f"{p}: unknown class {cls!r} (expected one of {sorted(VOCAB)})")
+    if cls == "UNVERIFIED":
+        unverified += 1
+        if r.get("evidence"):
+            errs.append(f"{p}: UNVERIFIED must not carry `evidence` — either it has evidence "
+                        f"(then classify it) or it does not (then the row is bare)")
+    elif not r.get("evidence"):
+        errs.append(f"{p}: {cls} needs a durable `evidence` pointer — an unevidenced "
+                    f"classification is exactly the drift this ledger exists to prevent")
+
+for p in sorted(enumerated - seen):
+    errs.append(f"{p}: UNCLASSIFIED — a verdict-bearing gate with no row. How would we "
+                f"know if this gate can no longer fail?")
+
+if ceiling is not None:
+    if unverified > ceiling:
+        errs.append(f"UNVERIFIED count {unverified} exceeds the ceiling {ceiling} — new gates "
+                    f"must land with their self-verification evidence")
+    elif unverified < ceiling:
+        errs.append(f"UNVERIFIED count {unverified} is BELOW the ceiling {ceiling} — ratchet "
+                    f"it down in the ledger header (the debt may only shrink, and the "
+                    f"ledger must say so)")
+
+if errs:
+    print("GATE VERIFICATION LEDGER FAIL —", file=sys.stderr)
+    for e in errs:
+        print(f"  {e}", file=sys.stderr)
+    sys.exit(1)
+
+by = {}
+for r in rows:
+    by[r["class"]] = by.get(r["class"], 0) + 1
+print("gate-verification OK: " + str(len(rows)) + " gate(s) — "
+      + " / ".join(f"{k} {v}" for k, v in sorted(by.items()))
+      + f" (unverified ceiling {ceiling})")
+EOF


### PR DESCRIPTION
The Stage 5 gap analysis (PR #1243) rated 「検証ツール自身の検証」 as PARTIAL: a negative-test culture exists but no unified table — the evidence was scattered across PR bodies. This lands the table as an INSTRUMENT, the house audit pattern (enumerate + classify + gate) applied to the gates themselves.

**proofs/gate-verification.toml** — all 30 verdict-bearing scripts (`scripts/check-*.sh`, the seal/verdict scripts, `proofs/*.sh`), each classified by how we know its FAIL direction works: `KERNEL_PROVEN` 3 (the Coq-checker-backed trio) / `MUTATION_TESTED` 1 / `NEGATIVE_TESTED` 5 / `EXERCISED` 3 (both verdict directions observed in real operation) / **`UNVERIFIED` 18 — the honest debt, under a shrink-only ceiling**. Non-UNVERIFIED rows require a durable evidence pointer; UNVERIFIED rows must stay bare (evidence-without-classification is the drift this prevents).

**scripts/check-gate-verification.sh** — every enumerated gate needs exactly one row, stale rows fail, unknown classes fail, ceiling breach fails, below-ceiling demands the ratchet-down. **Bootstrap was its own negative test**: the first run caught a mis-pathed row (STALE) and the checker's own missing row (UNCLASSIFIED — the self-reference works); the ceiling-breach and bogus-class directions were then demonstrated explicitly.

Wired into the CI checks job and lefthook; the gap ledger's tool-verification row now points here. Burn-down issue filed for the 18.

A gate nobody has ever seen fail is possibly decorative — #1201's fuzz workflow was exactly that for three nights. This ledger makes that class of debt enumerable, visible, and shrink-only.