### PR TITLE
Gate burn-down round 1: three UNVERIFIED gates verified, two real holes closed (#1244)

### DIFF
--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -17,7 +17,7 @@
 #                     Honest debt: the gate may be decorative and we would
 #                     not know. Burn-down tracked by the ceiling.
 #
-# unverified_ceiling = "18"
+# unverified_ceiling = "15"
 
 [[gate]]
 path = "scripts/check-contracts.sh"
@@ -108,7 +108,8 @@ class = "UNVERIFIED"
 
 [[gate]]
 path = "scripts/check-abstain-classes.sh"
-class = "UNVERIFIED"
+class = "NEGATIVE_TESTED"
+evidence = "#1244 burn-down PR: the first probe EXPOSED a real hole (a bogus class name sailed through green) — fixed with a pinned vocabulary, then both directions demonstrated (bogus class, unclassified entry)"
 
 [[gate]]
 path = "scripts/check-browser-determinism.sh"
@@ -132,7 +133,8 @@ class = "UNVERIFIED"
 
 [[gate]]
 path = "scripts/check-libm-determinism.sh"
-class = "UNVERIFIED"
+class = "NEGATIVE_TESTED"
+evidence = "#1244 burn-down PR: dropped-site (UNCLASSIFIED) and bogus-verdict (BAD VERDICT) both demonstrated with LANDED forgeries — the first probe round was a dud (wrong block/field names) and wrongly suggested a hole; probes must diff-verify they landed"
 
 [[gate]]
 path = "scripts/check-perf-ratio.sh"
@@ -144,7 +146,8 @@ class = "UNVERIFIED"
 
 [[gate]]
 path = "scripts/check-semantics-manifest.sh"
-class = "UNVERIFIED"
+class = "NEGATIVE_TESTED"
+evidence = "#1244 burn-down PR: a LANDED bogus-unit forge sailed through green (real hole — unit spellings unvalidated); fixed with measured pinned vocabularies (21 entry units, 5 default units, 4 required fields), then default-unit and entry-unit branches each demonstrated to fail"
 
 [[gate]]
 path = "scripts/check-gate-verification.sh"

--- a/scripts/check-abstain-classes.sh
+++ b/scripts/check-abstain-classes.sh
@@ -34,6 +34,25 @@ for raw in open(classes_p, encoding="utf-8"):
     if m and classes:
         classes[-1][1].append(m.group(1))
 
+# The class vocabulary is PINNED (#1244 burn-down: the first negative probe
+# renamed HEAP_BOUNDARY to a bogus class and the gate stayed green — the
+# breakdown printed the bogus name and the near-horizon arithmetic, which
+# reads BRIDGEABLE BY NAME, would silently miscount on any canonical-name
+# drift). A new class is a deliberate taxonomy change: add it HERE and in
+# the toml in the same PR.
+VOCAB = {"HEAP_BOUNDARY", "BRIDGEABLE"}
+bad = [n for n, _ in classes if n not in VOCAB]
+dupes = {n for n, _ in classes if [x for x, _ in classes].count(n) > 1}
+if bad or dupes or not classes:
+    for n in bad:
+        print(f"::error::unknown abstain class {n!r} (vocabulary: {sorted(VOCAB)})")
+    for n in sorted(dupes):
+        print(f"::error::duplicate abstain class {n!r}")
+    if not classes:
+        print("::error::no classes parsed from interp-abstain-classes.toml (anchor drift?)")
+    print("abstain-classes FAILED — class table invalid.")
+    sys.exit(1)
+
 counts = {n: 0 for n, _ in classes}
 unclassified = []
 entries = 0

--- a/scripts/check-semantics-manifest.sh
+++ b/scripts/check-semantics-manifest.sh
@@ -22,8 +22,37 @@ COVERED_MODULES = ["string", "datetime", "bytes", "list", "math", "float", "io",
 with open("docs/stdlib/semantics-manifest.toml", "rb") as f:
     manifest = tomllib.load(f)
 
+# The unit vocabularies are PINNED (#1244 burn-down: a landed forge set
+# `default_index_unit = "bogus_unit"` and the gate stayed green — a typo'd
+# unit spelling would silently declare nothing). Measured from the manifest
+# on 2026-08-12; a NEW spelling is a deliberate taxonomy change made here
+# and in the manifest in the same PR.
+UNIT_VOCAB = {
+    "address", "bit-pattern", "byte", "byte-count", "byte-offset",
+    "byte-value", "civil-field", "codepoint", "count", "cursor", "day",
+    "element-count", "element-index", "hour", "millisecond", "minute",
+    "nanosecond", "ordering", "scalar", "second", "value",
+}
+DEFAULT_UNIT_VOCAB = {"byte-offset", "byte-value", "codepoint", "second", "value"}
+REQUIRED_ENTRY_FIELDS = ("name", "index_unit", "probe", "expect")
+
 failed = False
 for module in COVERED_MODULES:
+    d = manifest[module].get("default_index_unit")
+    if d is not None and d not in DEFAULT_UNIT_VOCAB:
+        print(f"BAD default_index_unit {d!r} on module {module} — vocabulary: "
+              f"{sorted(DEFAULT_UNIT_VOCAB)}")
+        failed = True
+    for e in manifest[module]["fn"]:
+        for k in REQUIRED_ENTRY_FIELDS:
+            if not e.get(k):
+                print(f"MISSING FIELD {k!r} on a {module} entry ({e.get('name', '?')})")
+                failed = True
+        u = e.get("index_unit")
+        if u is not None and u not in UNIT_VOCAB:
+            print(f"BAD index_unit {u!r} on {module}.{e.get('name', '?')} — "
+                  f"vocabulary: {sorted(UNIT_VOCAB)}")
+            failed = True
     entries = {e["name"]: e for e in manifest[module]["fn"]}
     src = open(f"stdlib/{module}.almd").read()
     int_fns = []


### PR DESCRIPTION
First slice of #1244 (leverage order from the issue). The burn-down protocol immediately paid for itself: of the three gates probed, **two had real holes** — exactly what the UNVERIFIED class predicted ("the gate may be decorative and we would not know").

**check-abstain-classes.sh — REAL HOLE, fixed.** A forged class name (`HEAP_BOUNDARY` → `BOGUS_CLASS`) sailed through green: the class table had no vocabulary, and the near-horizon arithmetic reads `BRIDGEABLE` BY NAME, so a canonical-name drift would silently miscount coverage. Fixed with a pinned two-class vocabulary (+ duplicate/empty-table guards); both directions now demonstrated (bogus class → FAIL, unclassified entry → FAIL).

**check-semantics-manifest.sh — REAL HOLE, fixed.** A landed `default_index_unit = "bogus_unit"` forge stayed green: unit spellings were never validated, so a typo'd unit would silently declare nothing. Fixed with vocabularies MEASURED from the manifest (21 entry-unit spellings, 5 default-unit spellings, 4 required fields per entry); default-unit and entry-unit branches each demonstrated to fail.

**check-libm-determinism.sh — sound; my first probes were duds.** The initial forge used the wrong block/field names (`[[call]]`/`class` vs the real `[[site]]`/`verdict`) and "passed" vacuously — which briefly read as a hole in the #1197 recurrence gate. With LANDED forgeries (diff-verified), both directions fire correctly (UNCLASSIFIED, BAD VERDICT). **Protocol lesson, now recorded in the ledger row: a negative probe must verify the forge landed** — an un-landed forge wrongly convicts or wrongly acquits.

Ceiling 18 → 15. NEGATIVE_TESTED 6 → 9.