### PR TITLE
Gate burn-down round 2: four more gates verified incl. the tombstone re-arm (#1244)

### DIFF
--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -17,7 +17,7 @@
 #                     Honest debt: the gate may be decorative and we would
 #                     not know. Burn-down tracked by the ceiling.
 #
-# unverified_ceiling = "15"
+# unverified_ceiling = "11"
 
 [[gate]]
 path = "scripts/check-contracts.sh"
@@ -92,7 +92,8 @@ class = "UNVERIFIED"
 
 [[gate]]
 path = "proofs/check-stdlib-purity-registry.sh"
-class = "UNVERIFIED"
+class = "NEGATIVE_TESTED"
+evidence = "#1244 round 2: effectful module 'fs' forged into PURE_MODULES demonstrated to fail with the accept-but-unsafe rationale; restored green"
 
 [[gate]]
 path = "proofs/check-wasm-bytes.sh"
@@ -117,11 +118,13 @@ class = "UNVERIFIED"
 
 [[gate]]
 path = "scripts/check-embedded-size.sh"
-class = "UNVERIFIED"
+class = "NEGATIVE_TESTED"
+evidence = "#1244 round 2: baseline forged DOWN (measured > ceiling) demonstrated to fail with the raise-in-same-change instruction; restored green"
 
 [[gate]]
 path = "scripts/check-forbidden-impurities.sh"
-class = "UNVERIFIED"
+class = "NEGATIVE_TESTED"
+evidence = "#1244 round 2: a std::time::Instant::now planted in almide-codegen demonstrated to fail naming the exact line; restored green"
 
 [[gate]]
 path = "scripts/check-frees-churn.sh"
@@ -142,7 +145,8 @@ class = "UNVERIFIED"
 
 [[gate]]
 path = "scripts/check-rt-oracle-registry.sh"
-class = "UNVERIFIED"
+class = "NEGATIVE_TESTED"
+evidence = "#1244 round 2: the tombstone RE-ARM demonstrated — a recreated emit_wasm/ with a compile_* fn fails on the missing registry; removal returns to the RETIRED tombstone"
 
 [[gate]]
 path = "scripts/check-semantics-manifest.sh"


### PR DESCRIPTION
Second slice of #1244, all probes diff-verified per round 1's protocol lesson. All four gates proved SOUND — each fail direction fired on the first landed forgery:

- **check-embedded-size.sh**: baseline forged down (measured > ceiling) → fails with the raise-in-the-same-change instruction.
- **check-forbidden-impurities.sh**: a `std::time::Instant::now()` planted in almide-codegen → fails naming the exact file:line (the playground-breaking class the gate exists for).
- **proofs/check-stdlib-purity-registry.sh**: effectful `fs` forged into `PURE_MODULES` → fails with the accept-but-unsafe rationale.
- **scripts/check-rt-oracle-registry.sh**: the RETIRED tombstone's re-arm demonstrated — recreating `emit_wasm/` with a `compile_*` fn fires the registry demand; removal returns to the tombstone. (A tombstone whose re-arm was never tested is a tombstone in name only.)

Ceiling **15 → 11**. NEGATIVE_TESTED 9 → 13. Cumulative round 1+2: 7 gates verified, 2 real holes closed, 0 decorative gates remaining among the probed set.