### PR TITLE
Gate burn-down round 3: frees-churn verified with a live divergence probe (#1244)

### DIFF
--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -17,7 +17,7 @@
 #                     Honest debt: the gate may be decorative and we would
 #                     not know. Burn-down tracked by the ceiling.
 #
-# unverified_ceiling = "11"
+# unverified_ceiling = "10"
 
 [[gate]]
 path = "scripts/check-contracts.sh"
@@ -128,7 +128,8 @@ evidence = "#1244 round 2: a std::time::Instant::now planted in almide-codegen d
 
 [[gate]]
 path = "scripts/check-frees-churn.sh"
-class = "UNVERIFIED"
+class = "NEGATIVE_TESTED"
+evidence = "#1244 round 3: corpus-floor direction (1 fixture => FAIL, the #976 vacuous-pass guard) and a REAL cross-leg divergence (an env-reading probe fixture: native sees the var, wasmtime passes no environ => output diverges => FAIL) both demonstrated; restored green"
 
 [[gate]]
 path = "scripts/check-host-determinism.sh"


### PR DESCRIPTION
Third slice of #1244. One gate fully verified, one honest non-result recorded.

**check-frees-churn.sh — verified.** Both directions demonstrated with landed probes: the corpus floor (1 fixture → FAIL, the #976 vacuous-pass guard doing its job) and — the interesting one — a **real cross-leg divergence**: a temporary churn fixture reading an env var diverges genuinely (native sees the shell's variable, wasmtime passes no environ) and the gate reports `FAIL (output diverges)`. No forged baseline needed; the probe splits the legs for real. Ceiling 11 → 10.

**check-host-determinism.sh — stays UNVERIFIED, with a recorded observation.** On this host the wasm32 harness does not build (`memchr` fails under wasm32-unknown-unknown), and the gate correctly HARD-FAILS ("wasm32 harness build failed") rather than passing vacuously — the fail-CLOSED direction observed live, per the #978 discipline. But the SEMANTIC fail direction (a real determinism divergence) cannot be probed from a host that cannot reach green, so the row honestly keeps UNVERIFIED rather than over-claiming. (CI runs this gate green on every PR; the semantic probe needs a CI-side or wasm32-capable environment.)