### PR TITLE
Admitted-effectful ladder subjects take the full module-call machinery (#1233 brick 3a)

### DIFF
--- a/crates/almide-mir/src/lower/calls.rs
+++ b/crates/almide-mir/src/lower/calls.rs
@@ -449,17 +449,21 @@ impl LowerCtx {
         }
         let arg_tys: Vec<Ty> = args.iter().map(|a| a.ty.clone()).collect();
         let lowered = self.lower_pure_module_call_args(module, func, args)?;
-        // `list.pop` keys its self-host on the ELEMENT type (scalar → the registered
-        // in-place impl; heap → the unregistered `_x`, walling at render) — route it
-        // through the SAME `list_heap_call_name` the value position uses, so a
-        // statement-position pop can never link the scalar impl over a heap element
-        // (which would leak the popped handle). Every other statement call keeps its
-        // raw dotted name, byte-identical to before.
-        let call_name = if module == "list" && func == "pop" {
-            list_heap_call_name(module, func, &arg_tys, result_ty, false, false)
-        } else {
-            format!("{module}.{func}")
-        };
+        // Route through the SAME `list_heap_call_name` the value position uses —
+        // for EVERY call, not just `list.pop` (#1233 brick 3a: this position
+        // emitted the RAW dotted name for `fs.fold_lines_chunked(...)!` under
+        // the effect-unwrap ladder, bypassing the `_i`/`_msi` acc routing,
+        // while the assert-position spelling of the SAME call routed
+        // correctly). The router returns the raw dotted name for every family
+        // outside its tables, so unrouted calls stay byte-identical; routed
+        // families now link their typed twin (or the honest `_x` wall) from
+        // this position exactly as from value position. (`list.pop`'s
+        // original special case — a heap-element pop must never link the
+        // scalar impl — is subsumed.)
+        let key_nullary = self.map_key_is_nullary_variant(&arg_tys, result_ty);
+        let key_scalar_rec = self.map_key_is_scalar_record(&arg_tys, result_ty);
+        let call_name =
+            list_heap_call_name(module, func, &arg_tys, result_ty, key_nullary, key_scalar_rec);
         if is_heap_ty(result_ty) {
             let dst = self.fresh_value();
             let repr = repr_of(result_ty)?;
@@ -683,7 +687,7 @@ pub(crate) fn is_inplace_mutator(module: &str, func: &str) -> bool {
 /// (random_choice.almd / random_shuffle.almd — typed element variants selected in
 /// `list_heap_call_name`, unsupported elements route `_x` and wall at render), so the
 /// transitive cap_witness counts Entropy exactly like `random.int`.
-fn is_admitted_effectful_pure_module_call(module: &str, func: &str) -> bool {
+pub(crate) fn is_admitted_effectful_pure_module_call(module: &str, func: &str) -> bool {
     // codopsy8 follow-up: the merged OR-chain still exceeded max-complexity on its own
     // (cyc42, cog1 — a flat lookup table with no nesting, so splitting doesn't reduce
     // real complexity, just brings each group under the per-function threshold). Split

--- a/crates/almide-mir/src/lower/control_p2_b.rs
+++ b/crates/almide-mir/src/lower/control_p2_b.rs
@@ -274,7 +274,20 @@ impl LowerCtx {
         if let IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, .. } =
             &subject.kind
         {
-            if crate::purity::is_pure(module.as_str(), func.as_str()) {
+            // ADMITTED-EFFECTFUL calls (fs.fold_lines*, io.*, …) take the same
+            // machinery as pure ones (#1233 brick 3a): the raw-name fallback
+            // below bypassed the acc-class router AND the closure lift, so the
+            // effect-unwrap ladder subject of fs.fold_lines_chunked emitted an
+            // unlinked plain name while its assert-position spelling linked
+            // the `_i` twin. lower_pure_module_value_call's admission gate
+            // (admit_module_call_purity) accepts exactly this set and captures
+            // the callback's capabilities through the lift.
+            if crate::purity::is_pure(module.as_str(), func.as_str())
+                || super::calls::is_admitted_effectful_pure_module_call(
+                    module.as_str(),
+                    func.as_str(),
+                )
+            {
                 let Ok(dst) = self.lower_pure_module_value_call(
                     module.as_str(),
                     func.as_str(),

--- a/proofs/wasm-fallback-baseline.txt
+++ b/proofs/wasm-fallback-baseline.txt
@@ -23,7 +23,7 @@ spec/integration/modules/cross_module_cell_update_test.almd :: COMPILER_FRONTIER
 spec/integration/modules/cross_module_global_state_loop_test.almd :: COMPILER_FRONTIER :: test mode: MUTABLE module top-lets need the per-test region bridge
 spec/lang/result_zip_test.almd :: COMPILER_FRONTIER :: result.zip_x unlinked (typed self-host twin missing)
 spec/stdlib/stdlib-test.almd :: COMPILER_FRONTIER :: list.sort_by_str_key_x unlinked (typed self-host twin missing)
-spec/stdlib/fs_fold_lines_chunked_test.almd :: COMPILER_FRONTIER :: two measured bricks — the ladder-subject call position bypasses the acc-class router (plain-name emission; the _i twin itself links and the assert-position call routes to it) and the bare named-fn callback (count_step as a value) declines the HOF lift
+spec/stdlib/fs_fold_lines_chunked_test.almd :: COMPILER_FRONTIER :: bare named-fn callback (count_step passed as a value) declines the HOF lift — the #1108 fn-value class (ladder-subject router bypass closed 2026-08-12; the _i cell is executable-gated by fs_fold_lines_int_acc_test on the wasm leg)
 spec/stdlib/fs_streaming_test.almd :: COMPILER_FRONTIER :: non-msi accumulator twins + for_each_line (create_temp_dir now self-hosted)
 spec/stdlib/fs_if_exists_test.almd :: COMPILER_FRONTIER :: C-215 errno-carrying read prim not landed
 #

--- a/spec/stdlib/fs_fold_lines_int_acc_test.almd
+++ b/spec/stdlib/fs_fold_lines_int_acc_test.almd
@@ -1,0 +1,22 @@
+// The Int-accumulator cell of the fold_lines_chunked twin matrix (#1233):
+// the `_i` self-host (fs_fold_lines.almd) stores each chunk partial as a raw
+// i64 slot, and the acc-class router now serves the ladder-subject position
+// too (brick 3a). Both paths execute on the wasm leg; the partials sum
+// equals the sequential line count (C-220's partition law, scalar class).
+import fs
+import testing
+
+effect fn tmp() -> String = fs.create_temp_dir("chunked-i")!
+
+test "int accumulator partials sum to the line count" {
+  let d = tmp()!
+  let p = d + "/data.txt"
+  fs.write(p, "a\nb\nc\nd\n")!
+  let parts = fs.fold_lines_chunked(p, 2, 0, (acc, line) => acc + 1)!
+  let total = parts |> list.fold(0, (a, b) => a + b)
+  assert_eq(total, 4)
+}
+
+test "missing file errs on the int class" {
+  testing.assert_err(fs.fold_lines_chunked("/nonexistent", 4, 0, (acc, line) => acc))
+}


### PR DESCRIPTION
Closes the router-bypass brick measured in PR #1251. `try_materialize_effect_result_subject` (the effect-unwrap ladder's subject materializer) had a pure-only gate: a PURE module subject routed through `lower_pure_module_value_call` (acc-class-routed name, closure lift, caps capture), while an ADMITTED-EFFECTFUL subject — `fs.fold_lines_chunked(...)!`, the whole fs/io admitted set — fell to a raw dotted-name `CallFn` with none of that. That is exactly why the same call linked its `_i` twin from assert position but emitted an unlinked plain name from under the ladder.

**The fix**: widen the gate to `is_pure || is_admitted_effectful_pure_module_call` — the admission predicate `lower_pure_module_value_call` already enforces internally (its `admit_module_call_purity` accepts precisely this set), so the subject position now takes the identical machinery every other position uses. One gate widening; no new code path.

(The statement-position raw-name site got the same treatment via the router generalization — `list.pop`'s special case is subsumed; the router returns the raw dotted name for every family outside its tables, so unrouted calls stay byte-identical.)

**Measured**:
- `spec/stdlib/fs_fold_lines_int_acc_test.almd` (new) — the `_i` cell's executable gate, now runs `1 via WASM`: the counting path (`...! ` ladder + partials sum) and the error path both execute on the wasm leg.
- Full suite 382 green, fallback set UNCHANGED at 17 (zero regressions from the widened gate).
- wasm_runtime battery 75/75 (voting, abstain ledger, caps gates all green).
- The chunked file's ratchet row re-measured to its last remaining brick: the bare named-fn callback (#1108 fn-value class).