### PR TITLE
Correct the chunked fallback row to the measured cell (chunked x List[String] acc)

### DIFF
--- a/proofs/wasm-fallback-baseline.txt
+++ b/proofs/wasm-fallback-baseline.txt
@@ -23,7 +23,7 @@ spec/integration/modules/cross_module_cell_update_test.almd :: COMPILER_FRONTIER
 spec/integration/modules/cross_module_global_state_loop_test.almd :: COMPILER_FRONTIER :: test mode: MUTABLE module top-lets need the per-test region bridge
 spec/lang/result_zip_test.almd :: COMPILER_FRONTIER :: result.zip_x unlinked (typed self-host twin missing)
 spec/stdlib/stdlib-test.almd :: COMPILER_FRONTIER :: list.sort_by_str_key_x unlinked (typed self-host twin missing)
-spec/stdlib/fs_fold_lines_chunked_test.almd :: COMPILER_FRONTIER :: bare named-fn callback (count_step passed as a value) declines the HOF lift — the #1108 fn-value class (ladder-subject router bypass closed 2026-08-12; the _i cell is executable-gated by fs_fold_lines_int_acc_test on the wasm leg)
+spec/stdlib/fs_fold_lines_chunked_test.almd :: COMPILER_FRONTIER :: un-twinned cell chunked x List[String] acc (router sees fully refined types — measured; partials Result[List[List[String]]] needs its recursive drop route before the _ls twin can land; named-fn callbacks probed FINE, the earlier lift attribution was wrong)
 spec/stdlib/fs_streaming_test.almd :: COMPILER_FRONTIER :: non-msi accumulator twins + for_each_line (create_temp_dir now self-hosted)
 spec/stdlib/fs_if_exists_test.almd :: COMPILER_FRONTIER :: C-215 errno-carrying read prim not landed
 #


### PR DESCRIPTION
Ledger-accuracy fix from tonight's bounded recon (instrumented the fs router and read the ACTUAL types):

- Every consultation arrives **fully refined** — the earlier unrefined-`map.new()` hypothesis was wrong, and so was the "named-fn callback declines the lift" attribution (both int and msi named-fn callbacks probe GREEN on the wasm leg in main mode; the `[defunc] fold route declined` lines are incidental).
- The one walling call is the file's later tests' `fold_lines_chunked(p, w, [], (acc, line) => acc + [line])` — the **un-twinned cell: chunked × List[String] accumulator**. Its `_ls` twin is a straightforward walker transcription, BUT the partials' `Result[List[List[String]], String]` has no exact recursive drop route today (the res_msi/res_lmsi/ResultListStr family covers the neighboring shapes; the else-bucket's flat free would leak the inner lists) — that drop route is the real engineering, deferred to a fresh session rather than hour nine of this one.

The row now states exactly that. Probe branches carried no speculative code into the tree (the result-type router fallback drafted tonight was reverted once the measurement disproved its premise).