### PR TITLE
Gate burn-down round 4: reachability ratchet verified; the environment-gated tail mapped (#1244)

### DIFF
--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -17,7 +17,7 @@
 #                     Honest debt: the gate may be decorative and we would
 #                     not know. Burn-down tracked by the ceiling.
 #
-# unverified_ceiling = "10"
+# unverified_ceiling = "9"
 
 [[gate]]
 path = "scripts/check-contracts.sh"
@@ -105,7 +105,8 @@ class = "UNVERIFIED"
 
 [[gate]]
 path = "proofs/check-wasm-reachability.sh"
-class = "UNVERIFIED"
+class = "NEGATIVE_TESTED"
+evidence = "#1244 round 4: a dropped baseline row (env.set) demonstrated to fail as WASM PARITY REGRESSION naming the fn; restored green (394 parity / 0 frontier)"
 
 [[gate]]
 path = "scripts/check-abstain-classes.sh"


### PR DESCRIPTION
Fourth slice of #1244. One gate verified, and the remaining tail's probe conditions are now precisely mapped on the issue.

**proofs/check-wasm-reachability.sh — verified.** A dropped baseline row (`env.set`) fails as `WASM PARITY REGRESSION` naming the exact fn; restored green (394 fns at parity, 0 frontier). Ceiling **10 → 9**.

**The remaining 9, by why they resist local probing** (recorded for whoever picks them up):
- `check-wasm-bytes.sh` / `check-wasm-exec.sh` — SKIP locally (no wat2wasm); the skip IS the documented honest-local behavior, CI enforces. Probeable on a wat2wasm host.
- `check-{host,browser}-determinism.sh` — wasm32 harness unbuildable here (memchr); fail-closed observed live in round 3.
- `build-checker.sh` / `receipt.sh` — Coq-dependent (no local coqc; the trust-spine CI leg owns them).
- `coverage.sh` / `check-perf-ratio.sh` — probeable but each probe costs a full measurement run (llvm-cov suite / bench suite).
- `diff-fuzz.sh` — its semantic fail direction (MISMATCH/RUNERR) requires a live miscompile to demonstrate; with zero open correctness findings there is nothing honest to feed it. Its stamp fail-closed is shared evidence (stamp.sh, demonstrated live this session).