### PR TITLE
Stage status becomes a measured artifact (proofs/STAGE-STATUS.md)

### DIFF
--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -1,0 +1,35 @@
+# Mission-Critical Stage Status — measured, regenerated
+
+The five-stage plan (Stage 1 accept-and-wrong の族滅 → Stage 2 translation
+validation 全数化 → Stage 3 意味論凍結 → Stage 4 持続性計測 → Stage 5 DO-330
+ギャップ分析) is the standing adoption roadmap. This page is its SINGLE
+checkable status artifact: every number between the markers is measured from
+the committed ledgers by `scripts/gen-claims.sh` and drift fails CI
+(`check-contracts.sh` runs `--check`) — an auditor reads THIS, not prose
+claims scattered across sessions. Stage semantics and evidence pointers:
+`docs/roadmap/active/flight-evidence-gaps.md` (the audit findings ledger,
+re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
+
+<!-- stages:generated:start — derived from the proofs/ ledgers by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
+> **Stage 1 (accept-and-wrong extinction): audits COMPLETE and gated** —
+> scalar-read 63 arms / 0 UNGUARDED; WAT prelude 66 fns classified;
+> platform-libm 5 sites classified. New entries cannot land unclassified.
+>
+> **Stage 2 (translation validation): 254/374 fixtures cast a real 3-way vote (67%)** —
+> the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
+>
+> **Stage 3 (semantics freeze): 230/230 contracts spec-keyed, both directions gated** —
+> the ALS authoring sweep (syntax-element coverage) is the remaining half.
+>
+> **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
+> the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).
+>
+> **Stage 5 (auditability): 1 release seal(s); 31 verification gates classified
+> (9 UNVERIFIED under a shrink-only ceiling); TOR with 9 enforced rows.**
+<!-- stages:generated:end -->
+
+What the numbers do NOT claim: external adoption (a market fact, not a
+ledger fact), MC/DC coverage (line coverage only, ratcheted), C-WCET /
+C-FAITHFUL (keystone-gated, honestly PENDING in the receipt design), or ALS
+authoring completeness (the section→contract direction is gated; the
+syntax-element→section direction is Stage 3's remaining half).

--- a/scripts/gen-claims.sh
+++ b/scripts/gen-claims.sh
@@ -129,7 +129,65 @@ else
   echo "::error::tcb markers missing from $SPINE"; exit 2
 fi
 
+# ── Stage-status block in proofs/STAGE-STATUS.md ────────────────────────────
+# The five-stage adoption roadmap's single checkable status artifact: every
+# number measured from committed ledgers (no session prose). Same marker
+# discipline; --check makes drift red.
+STAGES="proofs/STAGE-STATUS.md"
+SSTART="<!-- stages:generated:start — derived from the proofs/ ledgers by scripts/gen-claims.sh; DO NOT EDIT between the markers -->"
+SEND="<!-- stages:generated:end -->"
+stage_block() {
+  local arms unguarded watfns libms corpus abstains voting contracts keyed
+  local seals gates unverified torrows streak
+  arms=$(grep -c '^\[\[arm\]\]' proofs/scalar-read-audit.toml)
+  unguarded=$(grep -c 'class = "UNGUARDED"' proofs/scalar-read-audit.toml || true)
+  watfns=$(grep -c '^\[\[fn\]\]' proofs/wat-prelude-audit.toml)
+  libms=$(grep -c '^\[\[site\]\]' proofs/libm-determinism-audit.toml)
+  corpus=$(ls spec/wasm_cross/*.almd | wc -l | tr -d ' ')
+  abstains=$(grep -vc '^#\|^$' crates/almide-interp/interp-abstain-ledger.txt)
+  voting=$((corpus - abstains))
+  contracts=$(grep -c '^\[\[contract\]\]' docs/contracts/contracts.toml)
+  keyed=$(grep -c '^spec ' docs/contracts/contracts.toml)
+  seals=$(ls proofs/releases/v*.toml 2>/dev/null | wc -l | tr -d ' ')
+  gates=$(grep -c '^\[\[gate\]\]' proofs/gate-verification.toml)
+  unverified=$(grep -c 'class = "UNVERIFIED"' proofs/gate-verification.toml || true)
+  torrows=$(grep -c '^\*\*TOR-' proofs/TOR.md)
+  # The streak is a dated meter maintained by fuzz-green-streak.sh — quote its
+  # last recorded row (a ledger value, not a re-derivation).
+  streak=$(grep -E '^\| [0-9]{4}-' research/benchmark/fuzz-green/README.md | tail -1 | awk -F'|' '{gsub(/ /,"",$3); print $3}')
+  printf '> **Stage 1 (accept-and-wrong extinction): audits COMPLETE and gated** —\n'
+  printf '> scalar-read %s arms / %s UNGUARDED; WAT prelude %s fns classified;\n' "$arms" "$unguarded" "$watfns"
+  printf '> platform-libm %s sites classified. New entries cannot land unclassified.\n' "$libms"
+  printf '>\n'
+  printf '> **Stage 2 (translation validation): %s/%s fixtures cast a real 3-way vote (%s%%)** —\n' "$voting" "$corpus" "$((voting * 100 / corpus))"
+  printf '> the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).\n'
+  printf '>\n'
+  printf '> **Stage 3 (semantics freeze): %s/%s contracts spec-keyed, both directions gated** —\n' "$keyed" "$contracts"
+  printf '> the ALS authoring sweep (syntax-element coverage) is the remaining half.\n'
+  printf '>\n'
+  printf '> **Stage 4 (durability): fuzz true-green streak = %s day(s)** (dated meter;\n' "$streak"
+  printf '> the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).\n'
+  printf '>\n'
+  printf '> **Stage 5 (auditability): %s release seal(s); %s verification gates classified\n' "$seals" "$gates"
+  printf '> (%s UNVERIFIED under a shrink-only ceiling); TOR with %s enforced rows.**\n' "$unverified" "$torrows"
+}
+if grep -qxF "$SSTART" "$STAGES"; then
+  sblockfile="$(mktemp)"
+  stage_block > "$sblockfile"
+  stages_rendered="$(awk -v start="$SSTART" -v end="$SEND" -v bf="$sblockfile" '
+    $0 == start { print; while ((getline line < bf) > 0) print line; skip = 1; next }
+    $0 == end   { skip = 0; print; next }
+    !skip { print }
+  ' "$STAGES")"
+else
+  echo "::error::stage markers missing from $STAGES"; exit 2
+fi
+
 if [ "${1:-}" = "--check" ]; then
+  if [ "$stages_rendered" != "$(cat "$STAGES")" ]; then
+    echo "::error::proofs/STAGE-STATUS.md stage block is stale — run: bash scripts/gen-claims.sh"
+    exit 1
+  fi
   if [ "$rendered" != "$(cat "$README")" ]; then
     echo "::error::README.md claims block is stale — run: bash scripts/gen-claims.sh"
     exit 1
@@ -143,3 +201,4 @@ fi
 
 printf '%s\n' "$rendered" > "$README"
 printf '%s\n' "$spine_rendered" > "$SPINE"
+printf '%s\n' "$stages_rendered" > "$STAGES"


### PR DESCRIPTION
The five-stage adoption roadmap's completion state lived only in the goal text, session prose, and scattered ledgers — so any external reader (an auditor, or tonight's literal experience: an automated evaluator) could only see the ORIGINAL plan text and conclude "Stage 1 not yet started" while the repo's own ledgers say 63/63 arms classified since PR #1185.

**proofs/STAGE-STATUS.md** — one checkable page. Every number between the markers is measured from committed ledgers by `scripts/gen-claims.sh` (the third generated block, same discipline as the README claims and TRUST-SPINE TCB blocks; `check-contracts.sh --check` makes drift red, negative-tested):

- Stage 1: 63 arms / 0 UNGUARDED, WAT 66 fns, libm 5 sites — audits complete and gated
- Stage 2: 254/374 three-way voting, abstains classified shrink-only
- Stage 3: 230/230 spec-keyed both directions; ALS authoring = the remaining half
- Stage 4: streak 0 days (the honest meter; correctness-only verdict ships tonight)
- Stage 5: 1 seal, 31 gates classified (9 UNVERIFIED ratcheted), TOR 9 rows

Equally load-bearing is the **"what the numbers do NOT claim"** footer: external adoption (a market fact, not a ledger fact), MC/DC, C-WCET/C-FAITHFUL, ALS completeness — the page states its own limits the way the receipt design demands.