### PR TITLE
Stage 3's remaining half becomes an instrument: ALS element coverage, 73/73 honestly UNWRITTEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -839,6 +839,9 @@ jobs:
       - name: TOR references (every operational requirement keeps its enforcing instrument)
         run: bash scripts/check-tor-refs.sh
 
+      - name: ALS element coverage (every syntax element rowed; UNWRITTEN shrink-only — the freeze precondition)
+        run: bash scripts/check-als-element-coverage.sh
+
       - name: Scalar-read audit (every raw-load arm classified, zero unguarded — the #1183 class stays extinct)
         run: scripts/check-scalar-read-audit.sh
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,6 +21,9 @@ pre-commit:
     tor-refs:
       glob: "{proofs/TOR.md,scripts/check-tor-refs.sh}"
       run: bash scripts/check-tor-refs.sh
+    als-element-coverage:
+      glob: "{proofs/als-element-coverage.toml,scripts/check-als-element-coverage.sh,scripts/lib/als-element-enumerate.py,crates/almide-syntax/src/ast.rs,docs/specs/als/*.md}"
+      run: bash scripts/check-als-element-coverage.sh
     libm-determinism:
       glob: "{runtime/rs/src/*.rs,crates/almide-kernel/src/*.rs,proofs/libm-determinism-audit.toml,scripts/check-libm-determinism.sh,scripts/lib/libm-call-enumerate.py}"
       run: bash scripts/check-libm-determinism.sh

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -18,13 +18,13 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > **Stage 2 (translation validation): 254/374 fixtures cast a real 3-way vote (67%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
-> **Stage 3 (semantics freeze): 230/230 contracts spec-keyed, both directions gated** —
-> the ALS authoring sweep (syntax-element coverage) is the remaining half.
+> **Stage 3 (semantics freeze): 230/230 contracts spec-keyed; syntax-element coverage
+> 0/73 sectioned (73 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).
 >
-> **Stage 5 (auditability): 1 release seal(s); 31 verification gates classified
+> **Stage 5 (auditability): 1 release seal(s); 32 verification gates classified
 > (9 UNVERIFIED under a shrink-only ceiling); TOR with 9 enforced rows.**
 <!-- stages:generated:end -->
 

--- a/proofs/als-element-coverage.toml
+++ b/proofs/als-element-coverage.toml
@@ -1,0 +1,307 @@
+# ALS SYNTAX-ELEMENT COVERAGE LEDGER — Stage 3's element→section direction.
+#
+# Every surface-AST syntax element (ExprKind / Stmt / Decl variants,
+# enumerated by scripts/lib/als-element-enumerate.py — the ledger and the
+# gate share that enumerator) carries a row naming the ALS normative section
+# that specifies it, or the honest UNWRITTEN. The freeze precondition
+# (Stage 3) is UNWRITTEN = 0: a 1.0 cannot freeze semantics nobody wrote
+# down. Gate: scripts/check-als-element-coverage.sh — every enumerated
+# element rowed, stale rows fail, a `section` must resolve to a real
+# `ALS-<id>` header in docs/specs/als/, and the UNWRITTEN count may only
+# SHRINK (ceiling below). First measurement 2026-08-12: 73/73 UNWRITTEN —
+# the existing ALS sections (T1-T7, R-series, ...) are STDLIB-semantics
+# normative text; the syntax-element direction starts honestly at zero.
+#
+# unwritten_ceiling = "73"
+
+[[element]]
+name = "ExprKind::Int"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Float"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::String"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::InterpolatedString"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Bool"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Ident"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::TypeName"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::List"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::MapLiteral"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::EmptyMap"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Record"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::SpreadRecord"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Call"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Member"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::TupleIndex"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::IndexAccess"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Pipe"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Compose"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::If"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::IfLet"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Match"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Block"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Fan"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::FanBounded"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::FanRace"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::FanRaceMap"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::FanTimeout"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::FanSettle"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::ForIn"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::While"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Lambda"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Hole"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Todo"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Try"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Unwrap"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::UnwrapOr"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::ToOption"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::OptionalChain"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Binary"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Unary"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Paren"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Tuple"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Range"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Break"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Continue"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Placeholder"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Unit"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::None"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Some"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Ok"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Err"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::TypeAscription"
+section = "UNWRITTEN"
+
+[[element]]
+name = "ExprKind::Error"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Stmt::Let"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Stmt::LetDestructure"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Stmt::Var"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Stmt::Assign"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Stmt::IndexAssign"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Stmt::FieldAssign"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Stmt::Guard"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Stmt::GuardLet"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Stmt::Expr"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Stmt::Comment"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Stmt::Error"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Decl::Module"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Decl::Import"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Decl::Type"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Decl::Fn"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Decl::TopLet"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Decl::Protocol"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Decl::Strict"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Decl::Test"
+section = "UNWRITTEN"
+
+[[element]]
+name = "Decl::TestWhereDef"
+section = "UNWRITTEN"

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -164,3 +164,8 @@ evidence = "bootstrap run (PR that landed this ledger): a mis-pathed row failed 
 path = "scripts/check-tor-refs.sh"
 class = "NEGATIVE_TESTED"
 evidence = "landing PR: a TOR row retargeted to a nonexistent instrument demonstrated to FAIL before first green"
+
+[[gate]]
+path = "scripts/check-als-element-coverage.sh"
+class = "NEGATIVE_TESTED"
+evidence = "landing PR: an unresolvable section (ALS-Z999) and a dropped row (UNCLASSIFIED) each demonstrated to FAIL before first green, with the below-ceiling ratchet demand firing in both"

--- a/scripts/check-als-element-coverage.sh
+++ b/scripts/check-als-element-coverage.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# ALS SYNTAX-ELEMENT COVERAGE GATE (Stage 3, the element→section direction).
+# See proofs/als-element-coverage.toml's header for the model. The freeze
+# precondition is UNWRITTEN = 0; until then the ceiling is shrink-only.
+set -uo pipefail
+export LC_ALL=C
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LEDGER="$ROOT/proofs/als-element-coverage.toml"
+
+python3 - "$ROOT" "$LEDGER" <<'EOF'
+import glob
+import importlib.util
+import re
+import sys
+
+root, ledger_path = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location(
+    "enum", f"{root}/scripts/lib/als-element-enumerate.py")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+elements = set(mod.enumerate_elements(root))
+
+# The resolvable ALS section ids: any `ALS-<id>` token in a heading line of
+# the normative docs (the same resolution the contract spec-keying uses).
+sections = set()
+for p in glob.glob(f"{root}/docs/specs/als/*.md"):
+    for line in open(p, encoding="utf-8"):
+        if line.startswith("#"):
+            sections.update(re.findall(r"ALS-[A-Z]*\d+[a-z]?", line))
+
+ceiling = None
+rows, cur = [], None
+for raw in open(ledger_path, encoding="utf-8"):
+    line = raw.strip()
+    m = re.match(r'#\s*unwritten_ceiling\s*=\s*"(\d+)"', line)
+    if m:
+        ceiling = int(m.group(1))
+    if line == "[[element]]":
+        if cur:
+            rows.append(cur)
+        cur = {}
+        continue
+    m = re.match(r'(\w+)\s*=\s*"(.*)"$', line)
+    if m and cur is not None:
+        cur[m.group(1)] = m.group(2)
+if cur:
+    rows.append(cur)
+
+errs = []
+if ceiling is None:
+    errs.append("ledger header is missing `# unwritten_ceiling = \"N\"`")
+seen = set()
+unwritten = 0
+for r in rows:
+    n = r.get("name")
+    if not n:
+        errs.append(f"row without a name: {r}")
+        continue
+    if n in seen:
+        errs.append(f"{n}: duplicate row")
+    seen.add(n)
+    if n not in elements:
+        errs.append(f"{n}: STALE row — no such variant in the surface AST any more")
+    s = r.get("section", "")
+    if s == "UNWRITTEN":
+        unwritten += 1
+    elif s not in sections:
+        errs.append(f"{n}: section {s!r} does not resolve to any ALS heading in docs/specs/als/")
+
+for n in sorted(elements - seen):
+    errs.append(f"{n}: UNCLASSIFIED — a syntax element with no coverage row. A new "
+                f"element lands with its ALS row (UNWRITTEN is honest) in the same PR.")
+
+if ceiling is not None:
+    if unwritten > ceiling:
+        errs.append(f"UNWRITTEN count {unwritten} exceeds the ceiling {ceiling}")
+    elif unwritten < ceiling:
+        errs.append(f"UNWRITTEN count {unwritten} is BELOW the ceiling {ceiling} — ratchet it down")
+
+if errs:
+    print("ALS ELEMENT COVERAGE FAIL —", file=sys.stderr)
+    for e in errs:
+        print(f"  {e}", file=sys.stderr)
+    sys.exit(1)
+written = len(rows) - unwritten
+print(f"als-element-coverage OK: {len(rows)} element(s) — {written} sectioned, "
+      f"{unwritten} UNWRITTEN (ceiling {ceiling}; freeze precondition: 0)")
+EOF

--- a/scripts/gen-claims.sh
+++ b/scripts/gen-claims.sh
@@ -162,8 +162,11 @@ stage_block() {
   printf '> **Stage 2 (translation validation): %s/%s fixtures cast a real 3-way vote (%s%%)** —\n' "$voting" "$corpus" "$((voting * 100 / corpus))"
   printf '> the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).\n'
   printf '>\n'
-  printf '> **Stage 3 (semantics freeze): %s/%s contracts spec-keyed, both directions gated** —\n' "$keyed" "$contracts"
-  printf '> the ALS authoring sweep (syntax-element coverage) is the remaining half.\n'
+  local els unwritten_els
+  els=$(grep -c '^\[\[element\]\]' proofs/als-element-coverage.toml)
+  unwritten_els=$(grep -c 'section = "UNWRITTEN"' proofs/als-element-coverage.toml || true)
+  printf '> **Stage 3 (semantics freeze): %s/%s contracts spec-keyed; syntax-element coverage\n' "$keyed" "$contracts"
+  printf '> %s/%s sectioned (%s UNWRITTEN, shrink-only — the freeze precondition is 0).**\n' "$((els - unwritten_els))" "$els" "$unwritten_els"
   printf '>\n'
   printf '> **Stage 4 (durability): fuzz true-green streak = %s day(s)** (dated meter;\n' "$streak"
   printf '> the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).\n'

--- a/scripts/lib/als-element-enumerate.py
+++ b/scripts/lib/als-element-enumerate.py
@@ -1,0 +1,22 @@
+# Shared enumerator for the ALS syntax-element coverage gate (Stage 3's
+# element→section direction). The syntax-element universe is the surface AST:
+# every variant of ExprKind / Stmt / Decl in crates/almide-syntax/src/ast.rs.
+# Enumerating from the AST (not from prose) is what makes the deficit
+# unarguable — a new syntax element lands as a new variant here and the gate
+# demands its ledger row in the same PR (the #1176 one-instrument rule: the
+# ledger and the gate share THIS file).
+import re
+
+
+def enumerate_elements(root):
+    src = open(f"{root}/crates/almide-syntax/src/ast.rs", encoding="utf-8").read()
+    out = []
+    for enum_name in ("ExprKind", "Stmt", "Decl"):
+        m = re.search(rf"pub enum {enum_name}\b.*?\{{(.*?)\n\}}", src, re.S)
+        if not m:
+            continue
+        for line in m.group(1).splitlines():
+            mm = re.match(r"\s{4}([A-Z][A-Za-z0-9]*)\s*[\{(,]", line)
+            if mm:
+                out.append(f"{enum_name}::{mm.group(1)}")
+    return out


### PR DESCRIPTION
The stage-status artifact (PR #1257) says Stage 3's remainder is "the ALS authoring sweep" — but that deficit had no denominator: nobody could say WHICH syntax elements lack normative text, so the sweep could neither be scoped nor tracked. This gives it the same treatment every other stage got: enumerate + classify + ratchet.

**The universe**: every surface-AST variant — `ExprKind` (53) + `Stmt` + `Decl` = **73 syntax elements**, enumerated from `crates/almide-syntax/src/ast.rs` by a shared enumerator (`scripts/lib/als-element-enumerate.py`, the #1176 one-instrument rule) — a new syntax element cannot land without its coverage row.

**The first measurement is honestly zero**: all 73 rows are `UNWRITTEN` under a shrink-only ceiling. The existing ALS sections (T1–T7, the R-series) are STDLIB-semantics normative text; the syntax-element direction genuinely starts unwritten, and the ledger header says so. The freeze precondition (Stage 3 / 1.0) is UNWRITTEN = 0: a 1.0 cannot freeze semantics nobody wrote down.

**The gate** (`scripts/check-als-element-coverage.sh`, CI + lefthook): enumerated↔ledger sync both ways, a `section` must resolve to a real `ALS-<id>` heading in `docs/specs/als/`, ceiling breach and below-ceiling both fail. Negative-tested before first green (unresolvable `ALS-Z999`, dropped row — with the ratchet demand firing in both). Classified in the gate-verification ledger (32 gates).

STAGE-STATUS's Stage 3 line now carries the number: `230/230 contracts spec-keyed; syntax-element coverage 0/73 sectioned`. The authoring sweep finally has a denominator, a burn-down direction, and a CI-enforced definition of done.