### PR TITLE
Stage 5's named deliverable: the consolidated DO-330 gap analysis (proofs/DO330-GAP.md)

### DIFF
--- a/proofs/DO330-GAP.md
+++ b/proofs/DO330-GAP.md
@@ -1,0 +1,55 @@
+# DO-330 Gap Analysis — the consolidated Stage-5 document
+
+The single page the staged plan calls for: existing gates mapped to tool-
+qualification objectives, the three formalized artifacts, and the enumerated
+remaining gaps. This is an INDEX over instrument-backed sources — every claim
+here is gated elsewhere; every `source:` line below must resolve
+(`scripts/check-tor-refs.sh` scans this file too). Ferrocene (Rust's
+ISO 26262/DO-178C qualification) is the prior-example model throughout.
+
+## 1. The qualification argument (mapping)
+
+The DO-178C Table-A objective mapping and the DO-330 TQL argument live in
+the G-F5 design: the PCC asymmetry demotes the UNTRUSTED compiler to a
+TQL-5/Criteria-3 tool (its output independently re-verified every build)
+and leaves the small kernel-proven checker as the qualification object —
+qualified by formal proof (DO-330 + DO-333), not by test.
+source: docs/roadmap/active/flight-qualification.md
+
+Claim strength at a glance (measured, drift-gated):
+source: proofs/STAGE-STATUS.md
+
+## 2. The three formalized artifacts (goal-directed trio — all instrument-backed)
+
+| artifact | home | enforcement |
+|---|---|---|
+| Tool Operational Requirements | proofs/TOR.md (TOR-1..9) | check-tor-refs.sh: every requirement keeps its enforcing instrument |
+| Verification-tool verification | proofs/gate-verification.toml | check-gate-verification.sh: every gate classified by how it can FAIL; UNVERIFIED shrink-only |
+| Known-problems formalization | proofs/releases/ (per-release seals) | release-seal.sh: `known_problems` REQUIRED, derived fields re-measured against the tag forever |
+
+source: proofs/TOR.md
+source: proofs/gate-verification.toml
+source: scripts/release-seal.sh
+
+## 3. Remaining gaps (enumerated, owned)
+
+| gap | state | owner / ref |
+|---|---|---|
+| MC/DC & branch coverage | line coverage only (ratcheted) | flight-evidence-gaps F2 remainder |
+| C-WCET (counted-loop keystone あ) | PENDING in the receipt design | flight-reference-app Slice 2 |
+| C-FAITHFUL + Ferrocene leg (keystone い) | PENDING; no qualified native toolchain in the chain | flight-reference-app Slice 3, needs Ferrocene access |
+| wasmtime qualification pedigree | unqualified COTS, procedural TOR-9 | #865 |
+| ALS syntax-element authoring | 0/73 sectioned, shrink-only | proofs/als-element-coverage.toml (freeze precondition) |
+| Durability evidence | streak meter live, day 0 | research/benchmark/fuzz-green/ (90-day milestone) |
+| Process independence | ratchet-separation gate exists; human/organizational review split is org-level work | flight-evidence-gaps F5 close note |
+| PSAC / certification planning | no plan document yet | flight-qualification §G-F6 (dossier template) |
+| External assessment itself | a market/authority fact, not a ledger fact | out of repo scope by definition |
+
+source: docs/roadmap/active/flight-evidence-gaps.md
+source: proofs/als-element-coverage.toml
+
+## 4. What this page is not
+
+Not a claim of qualification, adoption, or completeness — it is the honest
+inventory an assessor starts from, regenerable numbers included by pointer
+rather than by copy so it cannot silently drift.

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -25,7 +25,8 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).
 >
 > **Stage 5 (auditability): 1 release seal(s); 32 verification gates classified
-> (9 UNVERIFIED under a shrink-only ceiling); TOR with 9 enforced rows.**
+> (9 UNVERIFIED under a shrink-only ceiling); TOR with 9 enforced rows;
+> gap analysis consolidated in proofs/DO330-GAP.md (reference-gated).**
 <!-- stages:generated:end -->
 
 What the numbers do NOT claim: external adoption (a market fact, not a

--- a/scripts/check-tor-refs.sh
+++ b/scripts/check-tor-refs.sh
@@ -7,17 +7,23 @@
 set -euo pipefail
 export LC_ALL=C
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-TOR="$ROOT/proofs/TOR.md"
+# Both operational documents carry checkable pointers: TOR rows name their
+# enforcing instrument (`enforced-by:`), the DO-330 gap index names its
+# instrument-backed sources (`source:`). A row whose target vanished is a
+# requirement/claim with no enforcement — the stale-pointer class.
+FILES="$ROOT/proofs/TOR.md $ROOT/proofs/DO330-GAP.md"
 
 fail=0
 count=0
-while IFS= read -r ref; do
-  count=$((count + 1))
-  if [ ! -e "$ROOT/$ref" ]; then
-    echo "  TOR names enforced-by: $ref — which does not exist" >&2
-    fail=1
-  fi
-done < <(sed -n 's/^enforced-by: *//p' "$TOR")
+for f in $FILES; do
+  while IFS= read -r ref; do
+    count=$((count + 1))
+    if [ ! -e "$ROOT/$ref" ]; then
+      echo "  $(basename "$f") names: $ref — which does not exist" >&2
+      fail=1
+    fi
+  done < <(sed -n 's/^enforced-by: *//p; s/^source: *//p' "$f")
+done
 
 if [ "$count" -eq 0 ]; then
   echo "TOR REFS FAIL — no enforced-by rows found (the parse anchor moved?)" >&2

--- a/scripts/gen-claims.sh
+++ b/scripts/gen-claims.sh
@@ -172,7 +172,8 @@ stage_block() {
   printf '> the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).\n'
   printf '>\n'
   printf '> **Stage 5 (auditability): %s release seal(s); %s verification gates classified\n' "$seals" "$gates"
-  printf '> (%s UNVERIFIED under a shrink-only ceiling); TOR with %s enforced rows.**\n' "$unverified" "$torrows"
+  printf '> (%s UNVERIFIED under a shrink-only ceiling); TOR with %s enforced rows;\n' "$unverified" "$torrows"
+  printf '> gap analysis consolidated in proofs/DO330-GAP.md (reference-gated).**\n'
 }
 if grep -qxF "$SSTART" "$STAGES"; then
   sblockfile="$(mktemp)"


### PR DESCRIPTION
The Stage-5 pieces all exist and are instrument-backed — the G-F5 TQL mapping (flight-qualification.md), the artifact trio (TOR / gate-verification ledger / seal known-problems), the findings ledger — but no single document bound them, so an assessor (or tonight's automated evaluator, literally) reads the plan text and concludes "Stage 5 not yet undertaken".

**proofs/DO330-GAP.md** — the one page: (1) the qualification argument by pointer (the PCC asymmetry: untrusted compiler demoted to TQL-5/Criteria-3, the kernel-proven checker qualified by proof), (2) the formalized trio with their enforcement instruments, (3) the enumerated remaining gaps, each owned (MC/DC, keystones あ/い, wasmtime pedigree #865, ALS 0/73, streak day 0, process independence, PSAC, and external assessment itself — out of repo scope by definition), (4) an explicit "what this page is not".

**It cannot rot**: it is an INDEX, not a copy — numbers live in their gated sources, and every `source:` pointer is now scanned by `check-tor-refs.sh` (extended to both operational documents; a bogus pointer demonstrated to fail before first green — 15 references resolve). STAGE-STATUS's Stage 5 line now names it.

With this, every stage of the plan has both its instrument and its named deliverable; what remains is authoring (ALS 73 rows), engineering (keystones, MC/DC), and time (the streak).