### PR TITLE
ALS-S1 binding statements: fixture, contract C-241, coverage 57 to 54

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The guarantee is **continuous, with an explicit, ledger-managed scope**: "byte-i
 This claim is not prose. Every observable promise is a named contract in the [behavior-contract ledger](docs/contracts/), each traceable to executable evidence, and the numbers below are regenerated from the ledger (`scripts/gen-claims.sh`, enforced by `scripts/check-contracts.sh` in CI) so this section cannot drift from what the gates actually verify:
 
 <!-- claims:generated:start — derived from docs/contracts/contracts.toml by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
-> **Ledger: 240 contracts — 240 active, 0 flagged-for-revision.**
+> **Ledger: 241 contracts — 241 active, 0 flagged-for-revision.**
 >
 > **Divergences awaiting a fix: none.** Every contract in the ledger is
 > `active`, carrying executable evidence of class >= `fixture`. The one

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-240 contracts
+241 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -268,4 +268,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-238 | First-class range values iterate their true bounds on both targets | 0.57.1 | active | fixture | 1 |
 | C-239 | Collection literals, indexing, and the empty spellings behave identically on both targets | 0.57.1 | active | fixture | 1 |
 | C-240 | Map literals and empty-map reads behave identically on both targets | 0.57.1 | active | fixture | 1 |
+| C-241 | Binding statements: let shadowing, var reassignment, and their check-time guards are identical on both targets | 0.57.1 | active | fixture | 1 |
 

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,7 +11,7 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-75 normative sections; 399 distinct executable fixtures.
+75 normative sections; 400 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|
@@ -66,7 +66,7 @@
 | ALS-R4 | C-012 | `spec/wasm_cross/const_fold_nonfinite_float.almd` (byte-compare) |
 | ALS-R5 | C-096, C-112, C-118, C-133, C-189, C-214, C-215 | `spec/wasm_cross/process_args.almd` (byte-compare)<br>`spec/wasm_cross/random_int_entropy.almd` (byte-compare)<br>`spec/wasm_cross/env_args.almd` (byte-compare)<br>`spec/wasm_cross/env_get.almd` (byte-compare)<br>`spec/wasm_cross/env_platform_reporting.almd` (byte-compare)<br>`spec/stdlib/process_timeout_test.almd` (both-target test)<br>`spec/stdlib/fs_if_exists_test.almd` (both-target test) |
 | ALS-R6 | C-042, C-137, C-220, C-225, C-227, C-228, C-229, C-230 | `spec/wasm_cross/fs_preopen_resolve.almd` (byte-compare)<br>`spec/wasm_cross/fs_relative_path.almd` (byte-compare)<br>`spec/stdlib/fs_stat_test.almd` (both-target test)<br>`spec/stdlib/fs_streaming_test.almd` (both-target test)<br>`spec/stdlib/fs_fold_lines_range_test.almd` (both-target test)<br>`spec/stdlib/fs_fold_lines_chunked_test.almd` (both-target test)<br>`spec/wasm_cross/fs_read_lines.almd` (byte-compare)<br>`spec/wasm_cross/fs_metadata_family.almd` (byte-compare)<br>`spec/wasm_cross/fs_composition_family.almd` (byte-compare)<br>`spec/wasm_cross/matrix_select_rows.almd` (byte-compare)<br>`spec/wasm_cross/matrix_select_rows_oob.almd` (byte-compare)<br>`spec/wasm_cross/flight_pid_control.almd` (byte-compare) |
-| ALS-S1 | C-016, C-065 | `spec/wasm_cross/string_codepoint.almd` (byte-compare)<br>`spec/wasm_cross/string_ops.almd` (byte-compare)<br>`spec/wasm_cross/string_codepoint_index.almd` (byte-compare)<br>`spec/wasm_cross/string_lines.almd` (byte-compare) |
+| ALS-S1 | C-016, C-065, C-241 | `spec/wasm_cross/string_codepoint.almd` (byte-compare)<br>`spec/wasm_cross/string_ops.almd` (byte-compare)<br>`spec/wasm_cross/string_codepoint_index.almd` (byte-compare)<br>`spec/wasm_cross/string_lines.almd` (byte-compare)<br>`spec/wasm_cross/binding_stmts.almd` (byte-compare) |
 | ALS-S2 | C-017 | `spec/wasm_cross/string_empty_pattern.almd` (byte-compare) |
 | ALS-S3 | C-018, C-019 | `spec/wasm_cross/string_predicates.almd` (byte-compare)<br>`spec/wasm_cross/string_ops_drain.almd` (byte-compare)<br>`spec/wasm_cross/string_rle.almd` (byte-compare) |
 | ALS-S4 | C-022 | `spec/wasm_cross/string_from_bytes.almd` (byte-compare) |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -2988,3 +2988,14 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/collection_literals.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-241"
+spec      = "ALS-S1"
+title     = "Binding statements: let shadowing, var reassignment, and their check-time guards are identical on both targets"
+statement = "ALS-S1 (the first statement-direction section): immutable `let` with SHADOWING (the new binding's initializer sees the old one — let x = 1 then let x = x + 10 gives 11), mutable `var` with sequential and in-loop reassignment (10, 6), and a conditional-expression initializer, byte-identical native <-> wasm. The negative half is check-time and pinned by tests/binding_diag_test.rs: assigning a `let` is E009 whose hint steers to `var`; reassigning a `var` at a different type is E001 (the declared type never silently widens)."
+since     = "0.57.1"
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/binding_stmts.almd", class = "fixture" },
+]

--- a/docs/specs/als/expressions.md
+++ b/docs/specs/als/expressions.md
@@ -201,3 +201,23 @@ JSON/他言語からの転記ミスは検査時に止まる)。
 挿入順は決定的に保存される(AlmideMap の規範; 反復順は挿入順)。
 
 テスト: `spec/wasm_cross/collection_literals.almd`(契約 C-239)。
+
+## ALS-S1 束縛文(`Stmt::Let` / `Stmt::Var` / `Stmt::Assign`)
+
+**受理形**: 不変束縛 `let x = e`(型注釈 `let x: T = e` 任意)、可変束縛
+`var x = e`、再代入 `x = e`(`var` のみ)。
+
+**シャドーイングの裁定**: `let` の同名再束縛は**受理** — 新しい束縛の
+初期化子は古い束縛を見る(`let x = 1` の後の `let x = x + 10` で `x` は
+11)。これはエラーでも警告でもない(段階的な値の精製が idiom)。
+
+**不変性の裁定**: `let` への代入は**検査時 E009** — ヒントは `var` 宣言へ
+誘導する。`var` の再代入は宣言時の型に固定され、別の型での代入は
+**E001**(黙った拡大なし)。負例は `tests/binding_diag_test.rs` が pin。
+
+**値の規範**: `var` への代入は制御フロー(ループ本体・分岐)を貫いて
+観測可能に反映される(fixture: 逐次 2 代入 → 10、ループ内累積 → 6)。
+`let` の初期化子には条件式も取れる(`let y = if … then … else …`)。
+
+テスト: `spec/wasm_cross/binding_stmts.almd`(契約 C-241)、
+`tests/binding_diag_test.rs`(負例)。

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,11 +15,11 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 66 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 262/382 fixtures cast a real 3-way vote (68%)** —
+> **Stage 2 (translation validation): 263/383 fixtures cast a real 3-way vote (68%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
-> **Stage 3 (semantics freeze): 240/240 contracts spec-keyed; syntax-element coverage
-> 16/73 sectioned (57 UNWRITTEN, shrink-only — the freeze precondition is 0).**
+> **Stage 3 (semantics freeze): 241/241 contracts spec-keyed; syntax-element coverage
+> 19/73 sectioned (54 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).

--- a/proofs/als-element-coverage.toml
+++ b/proofs/als-element-coverage.toml
@@ -12,7 +12,7 @@
 # the existing ALS sections (T1-T7, R-series, ...) are STDLIB-semantics
 # normative text; the syntax-element direction starts honestly at zero.
 #
-# unwritten_ceiling = "57"
+# unwritten_ceiling = "54"
 
 [[element]]
 name = "ExprKind::Int"
@@ -228,7 +228,7 @@ section = "UNWRITTEN"
 
 [[element]]
 name = "Stmt::Let"
-section = "UNWRITTEN"
+section = "ALS-S1"
 
 [[element]]
 name = "Stmt::LetDestructure"
@@ -236,11 +236,11 @@ section = "UNWRITTEN"
 
 [[element]]
 name = "Stmt::Var"
-section = "UNWRITTEN"
+section = "ALS-S1"
 
 [[element]]
 name = "Stmt::Assign"
-section = "UNWRITTEN"
+section = "ALS-S1"
 
 [[element]]
 name = "Stmt::IndexAssign"

--- a/spec/wasm_cross/binding_stmts.almd
+++ b/spec/wasm_cross/binding_stmts.almd
@@ -1,0 +1,23 @@
+// @contract: C-241
+// ALS-S1 (docs/specs/als/expressions.md): the binding statements — immutable
+// `let` with SHADOWING (a new binding whose initializer sees the old one),
+// mutable `var` with type-fixed reassignment, assignment through control
+// flow, and block-scoped shadowing. The negative half is check-time and
+// pinned by tests/binding_diag_test.rs: assigning a `let` is E009 (steering
+// to `var`), retyping a `var` is E001. Identical observables on both targets.
+effect fn main() -> Unit = {
+  let x = 1
+  let x = x + 10
+  println(int.to_string(x))
+  var c = 0
+  c = c + 5
+  c = c * 2
+  println(int.to_string(c))
+  var acc = 0
+  for i in 0..<4 {
+    acc = acc + i
+  }
+  println(int.to_string(acc))
+  let y = if x > 5 then "big" else "small"
+  println(y)
+}

--- a/tests/binding_diag_test.rs
+++ b/tests/binding_diag_test.rs
@@ -1,0 +1,55 @@
+//! The binding statements' negative half, cited by ALS-S1 (the accepted
+//! spellings are pinned by `spec/wasm_cross/binding_stmts.almd`, C-241):
+//!
+//! - assigning an immutable `let` binding is E009, and the hint must STEER
+//!   to `var` so the fix is mechanical;
+//! - reassigning a `var` at a different type is E001 — the type is fixed at
+//!   declaration, never silently widened.
+
+use std::process::Command;
+
+fn almide() -> &'static str {
+    env!("CARGO_BIN_EXE_almide")
+}
+
+fn check(dir: &std::path::Path, source: &str) -> String {
+    let file = dir.join("bind.almd");
+    std::fs::write(&file, source).expect("write fixture");
+    let out = Command::new(almide())
+        .arg("check")
+        .arg(&file)
+        .output()
+        .expect("run almide check");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+#[test]
+fn assigning_a_let_is_e009_steering_to_var() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = check(
+        dir.path(),
+        "effect fn main() -> Unit = {\n  let x = 1\n  x = 2\n  println(int.to_string(x))\n}\n",
+    );
+    assert!(out.contains("E009"), "assign-to-let must be E009, got:\n{out}");
+    assert!(
+        out.contains("var x"),
+        "the E009 hint must steer to `var`, got:\n{out}"
+    );
+}
+
+#[test]
+fn retyping_a_var_is_e001() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = check(
+        dir.path(),
+        "effect fn main() -> Unit = {\n  var x = 1\n  x = \"s\"\n  println(int.to_string(x))\n}\n",
+    );
+    assert!(
+        out.contains("E001") && out.contains("expected Int but got String"),
+        "var retype must be a typed E001, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Rows 17–19, and the first section of the STATEMENT direction (Stmt::Let / Stmt::Var / Stmt::Assign on one section — a binding and its mutation rules are one surface).

## ALS-S1 (C-241)

Measured cross-target (parity `11 10 6 big`):
- **let shadowing is accepted and normative** — `let x = 1` then `let x = x + 10` gives 11 (the new initializer sees the old binding); progressive value refinement is the idiom, not an error.
- `var` reassignment sequentially, through a loop body, and a conditional-expression initializer.

Negative half (`tests/binding_diag_test.rs`, the established pattern):
- assigning a `let` is **E009** and the hint steers to `var` (mechanical fix);
- retyping a `var` is **E001** `expected Int but got String` — the declared type never silently widens.

## Gates

- interp voting gate green; binding diag test 2/2; fixture fmt-clean
- contract ledger: 241 contracts / 383 fixtures, links symmetric
- als-element-coverage: **19 sectioned / 54 UNWRITTEN (ceiling 57 → 54)**