### PR TITLE
Restore the lost corpus-counter credit for bind-position ranges (develop Trust Spine is red)

### DIFF
--- a/crates/almide-mir/examples/classify_corpus.rs
+++ b/crates/almide-mir/examples/classify_corpus.rs
@@ -289,6 +289,19 @@ fn count_ir_calls(
             {
                 self.n += 1;
             }
+            // A HEAP `Range` BIND initializer (`let r = 0..<n`) materializes ONE
+            // synthetic `list.range` CallFn (#1272 — the deferred-Opaque bind made a
+            // later `for i in r` iterate zero times, so the bind now emits the real
+            // list, mirroring the call-ARG credit below in visit_expr). Credit the
+            // statement so the synthetic call has a matching ir_call and
+            // `mir_calls <= ir_calls` holds BY CONSTRUCTION; a Range the bind cannot
+            // materialize WALLS (mir < ir only, honest taint). list.range is pure.
+            if matches!(&s.kind, almide_ir::IrStmtKind::Bind { value, .. }
+                if matches!(value.kind, almide_ir::IrExprKind::Range { .. })
+                    && almide_mir::lower::is_heap_ty(&value.ty))
+            {
+                self.n += 1;
+            }
             almide_ir::visit::walk_stmt(self, s);
         }
         fn visit_expr(&mut self, e: &almide_ir::IrExpr) {


### PR DESCRIPTION
**Develop's Trust Spine has been red since PR #1273 merged** — the counter-credit commit was pushed to the PR branch during its CI window but did not make it into the rebase-merge (the merge took the 3-commit head), so every subsequent develop run fails:

```
MIR>IR spec/wasm_cross/range_first_class.almd::main (mir 12 > ir 8)
WALL BREACH: 1 function(s) have MORE MIR call-ops than IR call-nodes
```

The #1273 lowering synthesizes one `list.range` CallFn per bind-position range (`let r = 0..<3`), and `count_ir_calls` only credited the call-ARG position. This cherry-picks the exact credit (visit_stmt: a Bind whose initializer is a heap-typed Range counts one ir_call, mirroring the arg-position precedent) — as narrow as the synthesis, so no over-credit can falsely de-taint.

Verified locally: `proofs/corpus-wall.sh` reaches WALL OK over 6337 corpus functions with zero MIR>IR breaches.

Process note recorded for the ledger: a push during a PR's check window must be re-verified against `git log origin/<branch>` before relying on auto-merge picking it up.