### PR TITLE
Lift almide-mir to codopsy A by splitting the corpus classifier's three largest functions

### DIFF
--- a/crates/almide-mir/examples/classify_corpus.rs
+++ b/crates/almide-mir/examples/classify_corpus.rs
@@ -109,6 +109,28 @@ fn count_eq_calls_depth(
         return 1;
     }
     if let Ty::Applied(TC::List, es) = ty {
+        return count_eq_calls_list(es, registry, variant_layouts, depth);
+    }
+    if let Some(n) = count_eq_calls_map_set(ty) {
+        return n;
+    }
+    if let Some(n) = count_eq_calls_variant(ty, registry, variant_layouts, depth) {
+        return n;
+    }
+    count_eq_calls_compound(ty, registry, variant_layouts, depth)
+}
+
+/// The `List[…]` element tier of [`count_eq_calls_depth`] — extracted verbatim
+/// (codopsy A-maintenance split): the variant/record/Option-record loop-helper
+/// routes, then the single-CallFn element shapes.
+fn count_eq_calls_list(
+    es: &[almide_lang::types::Ty],
+    registry: &almide_mir::lower::RecordLayouts,
+    variant_layouts: &almide_mir::lower::VariantLayouts,
+    depth: u32,
+) -> usize {
+    use almide_lang::types::{constructor::TypeConstructorId as TC, Ty};
+    {
         // List[<custom variant>] — the synthesized loop-helper route (engine's
         // List-of-variant arm): the site's helper call + the generated bodies,
         // via the shared count (see synth_eq.rs; the site/list-body calls swap
@@ -149,7 +171,12 @@ fn count_eq_calls_depth(
                         && !variant_layouts.by_type.contains_key(n.as_str())
                         && registry.get(n.as_str()).is_some()
                     {
-                        return 3 + count_eq_calls_depth(&oa[0], registry, variant_layouts, depth + 1);
+                        return 3 + count_eq_calls_depth(
+                            &oa[0],
+                            registry,
+                            variant_layouts,
+                            depth + 1,
+                        );
                     }
                 }
             }
@@ -177,48 +204,75 @@ fn count_eq_calls_depth(
                     || res_scalar_elem),
         );
     }
-    // Map/Set `==` — the implemented repr variants lower to ONE synthetic eq CallFn
-    // (`map.eq_ivh`/`map.eq_hval`/`map.eq_skv`/`set.eq_str`), all pure deep reads.
-    // Mirror EXACTLY the operand shapes calls_p4's eq dispatch admits.
+}
+
+/// The Map/Set tier of [`count_eq_calls_depth`], verbatim: the implemented repr
+/// variants lower to ONE synthetic eq CallFn (`map.eq_ivh`/`map.eq_hval`/
+/// `map.eq_skv`/`set.eq_str`), all pure deep reads. Mirror EXACTLY the operand
+/// shapes calls_p4's eq dispatch admits. `None` = not a Map/Set shape.
+fn count_eq_calls_map_set(ty: &almide_lang::types::Ty) -> Option<usize> {
+    use almide_lang::types::{constructor::TypeConstructorId as TC, Ty};
     if almide_mir::lower::is_map_ivh_ty(ty) || almide_mir::lower::is_map_hval_ty(ty) {
-        return 1;
+        return Some(1);
     }
     if let Ty::Applied(TC::Map, kv) = ty {
         if kv.len() == 2 && matches!(kv[0], Ty::String) && !almide_mir::lower::is_heap_ty(&kv[1]) {
-            return 1;
+            return Some(1);
         }
     }
     if let Ty::Applied(TC::Set, es) = ty {
         if es.len() == 1 && matches!(es[0], Ty::String) {
-            return 1;
+            return Some(1);
         }
     }
-    // A custom VARIANT `==` — the tag-dispatched chain statically emits every fielded
-    // case's per-field eq calls (only ONE case runs, but the caps witness is static).
-    // Mirror `custom_variant_type_name`'s three type spellings.
+    None
+}
+
+/// The custom-variant tier of [`count_eq_calls_depth`], verbatim: the
+/// tag-dispatched chain statically emits every fielded case's per-field eq calls
+/// (only ONE case runs, but the caps witness is static). Mirror
+/// `custom_variant_type_name`'s three type spellings. `None` = not a variant.
+fn count_eq_calls_variant(
+    ty: &almide_lang::types::Ty,
+    registry: &almide_mir::lower::RecordLayouts,
+    variant_layouts: &almide_mir::lower::VariantLayouts,
+    depth: u32,
+) -> Option<usize> {
+    use almide_lang::types::{constructor::TypeConstructorId as TC, Ty};
     let variant_name: Option<String> = match ty {
         Ty::Named(n, _) => Some(n.as_str().to_string()),
         Ty::Variant { name, .. } => Some(name.as_str().to_string()),
         Ty::Applied(TC::UserDefined(n), _) => Some(n.clone()),
         _ => None,
     };
-    if let Some(name) = variant_name {
-        if let Some(layout) = variant_layouts.by_type.get(&name) {
-            // A RECURSIVE variant routes through the synthesized helper family:
-            // ONE site call + every generated helper body's static calls — the
-            // SAME predicate + count the engine uses (synth_eq.rs), so mir == ir
-            // holds by construction.
-            if almide_mir::lower::variant_layout_recursive(variant_layouts, &name) {
-                return almide_mir::lower::eq_helper_call_count(variant_layouts, ty);
-            }
-            return layout
-                .cases
-                .iter()
-                .flat_map(|c| c.fields.iter())
-                .map(|(_, t)| count_eq_calls_depth(t, registry, variant_layouts, depth + 1))
-                .sum();
-        }
+    let name = variant_name?;
+    let layout = variant_layouts.by_type.get(&name)?;
+    // A RECURSIVE variant routes through the synthesized helper family:
+    // ONE site call + every generated helper body's static calls — the
+    // SAME predicate + count the engine uses (synth_eq.rs), so mir == ir
+    // holds by construction.
+    if almide_mir::lower::variant_layout_recursive(variant_layouts, &name) {
+        return Some(almide_mir::lower::eq_helper_call_count(variant_layouts, ty));
     }
+    Some(
+        layout
+            .cases
+            .iter()
+            .flat_map(|c| c.fields.iter())
+            .map(|(_, t)| count_eq_calls_depth(t, registry, variant_layouts, depth + 1))
+            .sum(),
+    )
+}
+
+/// The compound tail of [`count_eq_calls_depth`], verbatim: tuple/record/named
+/// field sums and the Option/Result payload recursions.
+fn count_eq_calls_compound(
+    ty: &almide_lang::types::Ty,
+    registry: &almide_mir::lower::RecordLayouts,
+    variant_layouts: &almide_mir::lower::VariantLayouts,
+    depth: u32,
+) -> usize {
+    use almide_lang::types::{constructor::TypeConstructorId as TC, Ty};
     match ty {
         Ty::Tuple(elems) => elems
             .iter()
@@ -254,6 +308,261 @@ fn count_eq_calls_depth(
         }
         _ => 0,
     }
+}
+
+/// The operator-node ir_call credits of [`count_ir_calls`]'s `visit_expr`,
+/// extracted verbatim (codopsy A-maintenance split): each block credits an
+/// operator NODE for exactly the shapes the lowering synthesizes a CallFn for,
+/// so `mir_calls <= ir_calls` holds BY CONSTRUCTION (each comment carries its
+/// own soundness argument, unchanged).
+fn operator_credit(
+    e: &almide_ir::IrExpr,
+    registry: &almide_mir::lower::RecordLayouts,
+    variant_layouts: &almide_mir::lower::VariantLayouts,
+) -> usize {
+    let mut n = 0;
+    // A string concat `a + b` (BinOp::ConcatStr) lowers to ONE synthetic `__str_concat`
+    // CallFn (a mir_call). Count the operator NODE as one ir_call so that synthetic call
+    // has a matching ir_call and `mir_calls <= ir_calls` holds BY CONSTRUCTION — a concat
+    // not yet lowered in some position just leaves mir < ir (honest caps taint), never the
+    // mir > ir over-count that would falsely caps-verify a fn. __str_concat is pure (the
+    // transitive fold sees no Stdout), so the synthetic call adds no real capability.
+    if matches!(
+        &e.kind,
+        almide_ir::IrExprKind::BinOp {
+            op: almide_ir::BinOp::ConcatStr,
+            ..
+        }
+    ) {
+        n += 1;
+    }
+    // A STRING equality `a == b` / `a != b` (BinOp::Eq/Neq over String operands) lowers
+    // to ONE synthetic `string.eq` CallFn (the `!=` negate is a prim, not a call). Count
+    // the operator NODE as one ir_call so the synthetic call has a matching ir_call and
+    // `mir_calls <= ir_calls` holds BY CONSTRUCTION. Gated on a String LEFT operand — an
+    // Int/Bool/Float `==` lowers to a prim compare (no call), so it is NOT counted.
+    // `string.eq` is pure (byte compare, no Stdout), adding no real capability.
+    // ALSO a Value `==`/`!=` (→ `value.eq`) and a List[Int|String|Value] `==`/`!=`
+    // (→ `list.eq_int`/`list.eq_str`/`list.eq_value`) lower to ONE synthetic CallFn — count
+    // the operator NODE for EXACTLY the operand shapes calls_p4 lowers to a call, so each has
+    // a matching ir_call and `mir_calls <= ir_calls` holds BY CONSTRUCTION. All three eq
+    // helpers are pure (deep reads, no Stdout), adding no real capability.
+    if let almide_ir::IrExprKind::BinOp {
+        op: almide_ir::BinOp::Eq | almide_ir::BinOp::Neq,
+        left,
+        ..
+    } = &e.kind
+    {
+        // String/Value/List → 1 call; a tuple/record/variant → the SUM of its
+        // fields' eq calls (recursing); Result general → ok+err; a scalar → 0.
+        // Matches `typed_slot_eq`'s static per-field call emission exactly.
+        n += count_eq_calls(&left.ty, registry, variant_layouts);
+    }
+    // A String ordering `< <= > >=` lowers to ONE `string.cmp` CallFn (then an Int compare
+    // with 0, a prim). Credit the operator node so `mir_calls <= ir_calls` holds. string.cmp
+    // is pure (byte compare, no Stdout).
+    if let almide_ir::IrExprKind::BinOp {
+        op:
+            almide_ir::BinOp::Lt | almide_ir::BinOp::Lte | almide_ir::BinOp::Gt | almide_ir::BinOp::Gte,
+        left,
+        ..
+    } = &e.kind
+    {
+        if matches!(left.ty, almide_lang::types::Ty::String) {
+            n += 1;
+        }
+    }
+    // A STRING-subject `match s { "a" => .., "b" => .., _ => .. }` desugars to a nested
+    // `if string.eq(s, "a") then .. else if string.eq(s, "b") then ..` — ONE synthetic
+    // `string.eq` CallFn PER STRING-LITERAL arm (the catch-all/binder arm emits no call).
+    // Count those arms here so the synthetic calls have matching ir_calls and
+    // `mir_calls <= ir_calls` holds BY CONSTRUCTION. `string.eq` is pure (no Stdout).
+    if let almide_ir::IrExprKind::Match { subject, arms } = &e.kind {
+        if matches!(subject.ty, almide_lang::types::Ty::String) {
+            let lit_arms = arms
+                .iter()
+                .filter(|a| matches!(a.pattern, almide_ir::IrPattern::Literal { .. }))
+                .count();
+            n += lit_arms;
+        }
+    }
+    // A list concat `a + b` (BinOp::ConcatList) lowers to ONE synthetic CallFn — `__list_concat`
+    // (SCALAR-element, byte-copy) or `__list_concat_rc` (HEAP-element String/Value, rc-incrementing
+    // copy). Count the operator NODE as one ir_call for EXACTLY the element shapes the lowering
+    // emits a call for (scalar, or String/Value heap-element); a heap-FIELD aggregate element
+    // (tuple/record) still DEFERS (no MIR call, no count). `mir_calls <= ir_calls` holds BY
+    // CONSTRUCTION. Both concat runtimes are pure (prim memory ops, no Stdout).
+    if let almide_ir::IrExprKind::BinOp {
+        op: almide_ir::BinOp::ConcatList,
+        ..
+    } = &e.kind
+    {
+        // `try_lower_concat_list` emits AT MOST ONE synthetic `__list_concat`/`__list_concat_rc`
+        // per ConcatList node (its operands materialize without their own concat call), and a
+        // ConcatList it cannot lower WALLS the enclosing function (so that function is not
+        // caps-checked). Therefore counting EVERY ConcatList node as one ir_call keeps
+        // `mir_calls <= ir_calls` BY CONSTRUCTION for EVERY admitted element shape — scalar,
+        // String/Value, the (String,String)/(Int,String)/(String,Value) tuples, List[List[String]],
+        // a flat OR rich custom-variant element, and a recursive-drop RECORD element (the wasm
+        // `acc + [{record}]` / `acc + [instr_r.val]` section-parser appends). A non-lowering
+        // ConcatList just leaves mir < ir (honest caps taint), never the mir > ir over-count
+        // that would falsely caps-verify a fn. Both concat runtimes are pure (no Stdout).
+        n += 1;
+    }
+    // The `**` OPERATOR (BinOp::PowFloat / PowInt) lowers to ONE synthetic CallFn —
+    // `math.fpow` (the bit-exact libm pow) for Float, `math.pow` (int squaring) for Int.
+    // Count the operator NODE as one ir_call so that synthetic call has a matching ir_call
+    // and `mir_calls <= ir_calls` holds BY CONSTRUCTION (a `**` not yet lowered in some
+    // position just leaves mir < ir — honest caps taint, never the mir > ir over-count that
+    // would falsely caps-verify a fn). Both callees are PURE (math/math_fpow modules reach
+    // no Stdout), so the synthetic call adds no real capability.
+    if matches!(
+        &e.kind,
+        almide_ir::IrExprKind::BinOp {
+            op: almide_ir::BinOp::PowFloat | almide_ir::BinOp::PowInt,
+            ..
+        }
+    ) {
+        n += 1;
+    }
+    // A HEAP `Range` in a call-ARGUMENT position (`f(0..n)`) lowers to ONE synthetic
+    // `list.range` CallFn (the materialized real list). Count the Range ARG node as one
+    // ir_call so `mir_calls <= ir_calls` holds by construction; a Range the lowering
+    // cannot materialize WALLS the function (never mir > ir). A `for i in 0..n` iterable
+    // is NOT a call argument (no count — the loop lowers inline, no CallFn). list.range
+    // is pure (no Stdout).
+    if let almide_ir::IrExprKind::Call { args, .. } = &e.kind {
+        n += args
+            .iter()
+            .filter(|a| {
+                matches!(&a.kind, almide_ir::IrExprKind::Range { .. })
+                    && almide_mir::lower::is_heap_ty(&a.ty)
+            })
+            .count();
+    }
+    n
+}
+
+/// The `??` (UnwrapOr) ir_call credits of [`count_ir_calls`]'s `visit_expr`,
+/// extracted verbatim: the heap-String route and the Value/List-payload routes,
+/// each credited exactly when the lowering emits its synthetic unwrap_or call.
+fn unwrap_or_credit(e: &almide_ir::IrExpr) -> usize {
+    let mut n = 0;
+    // A heap-String `??` (`Option[String] ?? default`) lowers to ONE synthetic
+    // `option.unwrap_or_str` CallFn (a mir_call) — but ONLY when its operand can be
+    // materialized as a self-host Option: a Var (possibly a materialized Option, which
+    // lowers) or a direct self-host OPTION call (string.first / list.get / json.as_string
+    // …). Count the operator node EXACTLY in those cases, so `mir_calls <= ir_calls` holds
+    // by construction without over-tainting a `??` over a NON-Option operand (a `Result`
+    // call like `value.as_string(x) ?? "?"`, or a not-yet-self-hosted `json.get_string`),
+    // which does NOT lower to a call (mir+0). A scalar `??` (non-String fallback) is also
+    // excluded (it lowers inline, no call). option.unwrap_or_str is pure (prim +
+    // string.repeat, no Stdout), so the synthetic call adds no real capability.
+    if let almide_ir::IrExprKind::UnwrapOr { expr, fallback } = &e.kind {
+        // The operand must be an OPTION (not a Result — `value.as_string(x) ?? "?"` is a
+        // Result `??`, expr.ty = Result, which the lowering does NOT route to
+        // option.unwrap_or_str, so counting it would falsely taint mir<ir).
+        let operand_is_option = matches!(
+            &expr.ty,
+            almide_lang::types::Ty::Applied(
+                almide_lang::types::constructor::TypeConstructorId::Option,
+                _
+            )
+        );
+        let operand_lowers = match &expr.kind {
+            almide_ir::IrExprKind::Var { .. } => true,
+            almide_ir::IrExprKind::Call {
+                target: almide_ir::CallTarget::Module { module, func, .. },
+                ..
+            } => {
+                almide_mir::lower::is_self_host_option_module_fn(module.as_str(), func.as_str())
+                            // The NEW operand-materialization path (`process.env(k) ?? "/tmp"` — an
+                            // IMPURE intrinsic `Option[String]`): it lowers to ONE synthetic
+                            // `option.unwrap_or_str` CallFn, so credit the node +1.
+                            || almide_mir::lower::unwrap_or_operand_admitted(expr)
+            }
+            // A USER function returning `Option[String]` (`fn first_char(s) ->
+            // Option[String]`, `first_char("hi") ?? "<none>"`): the lowering admits it
+            // through the `is_named_variant_call` operand route and then emits ONE
+            // `option.unwrap_or_str` — the SAME synthetic call a self-host operand gets.
+            // Credit it by the SAME shared predicate the lowering uses (#1079: uncredited,
+            // this was `mir 3 > ir 2`, a caps wall breach on correct output).
+            almide_ir::IrExprKind::Call {
+                target: almide_ir::CallTarget::Named { .. },
+                ..
+            } => almide_mir::lower::unwrap_or_named_variant_operand(expr),
+            _ => false,
+        };
+        if matches!(fallback.ty, almide_lang::types::Ty::String)
+            && operand_is_option
+            && operand_lowers
+        {
+            n += 1;
+        }
+        // A Value / List[Value] -payload Result `??` (`value.get(o,k) ?? value.null()`,
+        // `value.as_array(v) ?? []`) — the lowering routes it to ONE synthetic
+        // result.value_unwrap_or / result.list_value_unwrap_or CALL (a pure value_core
+        // helper, no Stdout). Count +1 so mir == ir, mirroring the String case.
+        let operand_is_value_result = almide_mir::lower::is_value_result_ty(&expr.ty)
+                    || almide_mir::lower::is_result_listval_ty(&expr.ty)
+                    || almide_mir::lower::is_result_str_str_ty(&expr.ty)
+                    || almide_mir::lower::is_option_value_ty(&expr.ty)
+                    // An Option[List[Value]] / Option[List[String]] `??` (`json.get_array(v,k) ?? []`,
+                    // `list.first_liststr(xs) ?? []`) routes to ONE synthetic option.listvalue_unwrap_or /
+                    // option.liststr_unwrap_or CALL (pure value_core helpers, no Stdout) — count +1 so
+                    // mir == ir, mirroring the Option[Value] case.
+                    || almide_mir::lower::is_option_listvalue_ty(&expr.ty)
+                    || almide_mir::lower::is_option_liststr_ty(&expr.ty)
+                    // An Option[List[<scalar>]] `??` (`map.get(groups, k) ?? []` — B19's
+                    // group_by class) routes to ONE synthetic option.listint_unwrap_or CALL —
+                    // count +1 so mir == ir (the missing credit was the B19-ship breach the
+                    // corpus gate caught: mir 2 > ir 1 on every listint `??` site).
+                    || almide_mir::lower::is_option_listscalar_ty(&expr.ty);
+        // value/list-Ok Result + Option[Value] Vars route (the handle Var-case admits
+        // them) — INCLUDING a str-str Var, which now routes to `result.str_unwrap_or`
+        // (the materialized_results_str Var-gate admission). An Option[Value] operand
+        // is a self-host option CALL (list.get) or a Var.
+        let value_operand_lowers = match &expr.kind {
+            almide_ir::IrExprKind::Var { .. } => true,
+            almide_ir::IrExprKind::Call {
+                target: almide_ir::CallTarget::Module { module, func, .. },
+                ..
+            } => {
+                almide_mir::lower::is_self_host_result_str_module_fn(
+                            module.as_str(),
+                            func.as_str(),
+                        ) || ((almide_mir::lower::is_option_value_ty(&expr.ty)
+                            || almide_mir::lower::is_option_listvalue_ty(&expr.ty)
+                            || almide_mir::lower::is_option_liststr_ty(&expr.ty)
+                            || almide_mir::lower::is_option_listscalar_ty(&expr.ty))
+                            && almide_mir::lower::is_self_host_option_module_fn(
+                                module.as_str(),
+                                func.as_str(),
+                            ))
+                            // The NEW operand-materialization path (`json.parse(s) ?? json.array([])`
+                            // — a PURE heap-`Result[Value, String]` module call): it lowers to ONE
+                            // synthetic `result.value_unwrap_or` CallFn, so credit the node +1.
+                            || almide_mir::lower::unwrap_or_operand_admitted(expr)
+            }
+            // A USER function returning a heap-payload variant (`fn lookup(k) ->
+            // Result[Value, String]`): admitted by the SAME `is_named_variant_call`
+            // operand route, then routed to ONE `result.value_unwrap_or` /
+            // `option.value_unwrap_or` helper — credit it, mirroring the String case
+            // above (#1079).
+            almide_ir::IrExprKind::Call {
+                target: almide_ir::CallTarget::Named { .. },
+                ..
+            } => almide_mir::lower::unwrap_or_named_variant_operand(expr),
+            _ => false,
+        };
+        if operand_is_value_result
+            && almide_mir::lower::is_heap_ty(&fallback.ty)
+            && value_operand_lowers
+        {
+            n += 1;
+        }
+    }
+    n
 }
 
 fn count_ir_calls(
@@ -326,243 +635,8 @@ fn count_ir_calls(
             {
                 self.n += 1;
             }
-            // A string concat `a + b` (BinOp::ConcatStr) lowers to ONE synthetic `__str_concat`
-            // CallFn (a mir_call). Count the operator NODE as one ir_call so that synthetic call
-            // has a matching ir_call and `mir_calls <= ir_calls` holds BY CONSTRUCTION — a concat
-            // not yet lowered in some position just leaves mir < ir (honest caps taint), never the
-            // mir > ir over-count that would falsely caps-verify a fn. __str_concat is pure (the
-            // transitive fold sees no Stdout), so the synthetic call adds no real capability.
-            if matches!(
-                &e.kind,
-                almide_ir::IrExprKind::BinOp {
-                    op: almide_ir::BinOp::ConcatStr,
-                    ..
-                }
-            ) {
-                self.n += 1;
-            }
-            // A STRING equality `a == b` / `a != b` (BinOp::Eq/Neq over String operands) lowers
-            // to ONE synthetic `string.eq` CallFn (the `!=` negate is a prim, not a call). Count
-            // the operator NODE as one ir_call so the synthetic call has a matching ir_call and
-            // `mir_calls <= ir_calls` holds BY CONSTRUCTION. Gated on a String LEFT operand — an
-            // Int/Bool/Float `==` lowers to a prim compare (no call), so it is NOT counted.
-            // `string.eq` is pure (byte compare, no Stdout), adding no real capability.
-            // ALSO a Value `==`/`!=` (→ `value.eq`) and a List[Int|String|Value] `==`/`!=`
-            // (→ `list.eq_int`/`list.eq_str`/`list.eq_value`) lower to ONE synthetic CallFn — count
-            // the operator NODE for EXACTLY the operand shapes calls_p4 lowers to a call, so each has
-            // a matching ir_call and `mir_calls <= ir_calls` holds BY CONSTRUCTION. All three eq
-            // helpers are pure (deep reads, no Stdout), adding no real capability.
-            if let almide_ir::IrExprKind::BinOp {
-                op: almide_ir::BinOp::Eq | almide_ir::BinOp::Neq,
-                left,
-                ..
-            } = &e.kind
-            {
-                // String/Value/List → 1 call; a tuple/record/variant → the SUM of its
-                // fields' eq calls (recursing); Result general → ok+err; a scalar → 0.
-                // Matches `typed_slot_eq`'s static per-field call emission exactly.
-                self.n += count_eq_calls(&left.ty, self.registry, self.variant_layouts);
-            }
-            // A String ordering `< <= > >=` lowers to ONE `string.cmp` CallFn (then an Int compare
-            // with 0, a prim). Credit the operator node so `mir_calls <= ir_calls` holds. string.cmp
-            // is pure (byte compare, no Stdout).
-            if let almide_ir::IrExprKind::BinOp {
-                op:
-                    almide_ir::BinOp::Lt
-                    | almide_ir::BinOp::Lte
-                    | almide_ir::BinOp::Gt
-                    | almide_ir::BinOp::Gte,
-                left,
-                ..
-            } = &e.kind
-            {
-                if matches!(left.ty, almide_lang::types::Ty::String) {
-                    self.n += 1;
-                }
-            }
-            // A STRING-subject `match s { "a" => .., "b" => .., _ => .. }` desugars to a nested
-            // `if string.eq(s, "a") then .. else if string.eq(s, "b") then ..` — ONE synthetic
-            // `string.eq` CallFn PER STRING-LITERAL arm (the catch-all/binder arm emits no call).
-            // Count those arms here so the synthetic calls have matching ir_calls and
-            // `mir_calls <= ir_calls` holds BY CONSTRUCTION. `string.eq` is pure (no Stdout).
-            if let almide_ir::IrExprKind::Match { subject, arms } = &e.kind {
-                if matches!(subject.ty, almide_lang::types::Ty::String) {
-                    let lit_arms = arms
-                        .iter()
-                        .filter(|a| matches!(a.pattern, almide_ir::IrPattern::Literal { .. }))
-                        .count();
-                    self.n += lit_arms;
-                }
-            }
-            // A list concat `a + b` (BinOp::ConcatList) lowers to ONE synthetic CallFn — `__list_concat`
-            // (SCALAR-element, byte-copy) or `__list_concat_rc` (HEAP-element String/Value, rc-incrementing
-            // copy). Count the operator NODE as one ir_call for EXACTLY the element shapes the lowering
-            // emits a call for (scalar, or String/Value heap-element); a heap-FIELD aggregate element
-            // (tuple/record) still DEFERS (no MIR call, no count). `mir_calls <= ir_calls` holds BY
-            // CONSTRUCTION. Both concat runtimes are pure (prim memory ops, no Stdout).
-            if let almide_ir::IrExprKind::BinOp {
-                op: almide_ir::BinOp::ConcatList,
-                ..
-            } = &e.kind
-            {
-                // `try_lower_concat_list` emits AT MOST ONE synthetic `__list_concat`/`__list_concat_rc`
-                // per ConcatList node (its operands materialize without their own concat call), and a
-                // ConcatList it cannot lower WALLS the enclosing function (so that function is not
-                // caps-checked). Therefore counting EVERY ConcatList node as one ir_call keeps
-                // `mir_calls <= ir_calls` BY CONSTRUCTION for EVERY admitted element shape — scalar,
-                // String/Value, the (String,String)/(Int,String)/(String,Value) tuples, List[List[String]],
-                // a flat OR rich custom-variant element, and a recursive-drop RECORD element (the wasm
-                // `acc + [{record}]` / `acc + [instr_r.val]` section-parser appends). A non-lowering
-                // ConcatList just leaves mir < ir (honest caps taint), never the mir > ir over-count
-                // that would falsely caps-verify a fn. Both concat runtimes are pure (no Stdout).
-                let _ = (&self.registry, &self.variant_layouts);
-                self.n += 1;
-            }
-            // The `**` OPERATOR (BinOp::PowFloat / PowInt) lowers to ONE synthetic CallFn —
-            // `math.fpow` (the bit-exact libm pow) for Float, `math.pow` (int squaring) for Int.
-            // Count the operator NODE as one ir_call so that synthetic call has a matching ir_call
-            // and `mir_calls <= ir_calls` holds BY CONSTRUCTION (a `**` not yet lowered in some
-            // position just leaves mir < ir — honest caps taint, never the mir > ir over-count that
-            // would falsely caps-verify a fn). Both callees are PURE (math/math_fpow modules reach
-            // no Stdout), so the synthetic call adds no real capability.
-            if matches!(
-                &e.kind,
-                almide_ir::IrExprKind::BinOp {
-                    op: almide_ir::BinOp::PowFloat | almide_ir::BinOp::PowInt,
-                    ..
-                }
-            ) {
-                self.n += 1;
-            }
-            // A HEAP `Range` in a call-ARGUMENT position (`f(0..n)`) lowers to ONE synthetic
-            // `list.range` CallFn (the materialized real list). Count the Range ARG node as one
-            // ir_call so `mir_calls <= ir_calls` holds by construction; a Range the lowering
-            // cannot materialize WALLS the function (never mir > ir). A `for i in 0..n` iterable
-            // is NOT a call argument (no count — the loop lowers inline, no CallFn). list.range
-            // is pure (no Stdout).
-            if let almide_ir::IrExprKind::Call { args, .. } = &e.kind {
-                self.n += args
-                    .iter()
-                    .filter(|a| {
-                        matches!(&a.kind, almide_ir::IrExprKind::Range { .. })
-                            && almide_mir::lower::is_heap_ty(&a.ty)
-                    })
-                    .count();
-            }
-            // A heap-String `??` (`Option[String] ?? default`) lowers to ONE synthetic
-            // `option.unwrap_or_str` CallFn (a mir_call) — but ONLY when its operand can be
-            // materialized as a self-host Option: a Var (possibly a materialized Option, which
-            // lowers) or a direct self-host OPTION call (string.first / list.get / json.as_string
-            // …). Count the operator node EXACTLY in those cases, so `mir_calls <= ir_calls` holds
-            // by construction without over-tainting a `??` over a NON-Option operand (a `Result`
-            // call like `value.as_string(x) ?? "?"`, or a not-yet-self-hosted `json.get_string`),
-            // which does NOT lower to a call (mir+0). A scalar `??` (non-String fallback) is also
-            // excluded (it lowers inline, no call). option.unwrap_or_str is pure (prim +
-            // string.repeat, no Stdout), so the synthetic call adds no real capability.
-            if let almide_ir::IrExprKind::UnwrapOr { expr, fallback } = &e.kind {
-                // The operand must be an OPTION (not a Result — `value.as_string(x) ?? "?"` is a
-                // Result `??`, expr.ty = Result, which the lowering does NOT route to
-                // option.unwrap_or_str, so counting it would falsely taint mir<ir).
-                let operand_is_option = matches!(
-                    &expr.ty,
-                    almide_lang::types::Ty::Applied(
-                        almide_lang::types::constructor::TypeConstructorId::Option,
-                        _
-                    )
-                );
-                let operand_lowers = match &expr.kind {
-                    almide_ir::IrExprKind::Var { .. } => true,
-                    almide_ir::IrExprKind::Call {
-                        target: almide_ir::CallTarget::Module { module, func, .. },
-                        ..
-                    } => {
-                        almide_mir::lower::is_self_host_option_module_fn(module.as_str(), func.as_str())
-                            // The NEW operand-materialization path (`process.env(k) ?? "/tmp"` — an
-                            // IMPURE intrinsic `Option[String]`): it lowers to ONE synthetic
-                            // `option.unwrap_or_str` CallFn, so credit the node +1.
-                            || almide_mir::lower::unwrap_or_operand_admitted(expr)
-                    }
-                    // A USER function returning `Option[String]` (`fn first_char(s) ->
-                    // Option[String]`, `first_char("hi") ?? "<none>"`): the lowering admits it
-                    // through the `is_named_variant_call` operand route and then emits ONE
-                    // `option.unwrap_or_str` — the SAME synthetic call a self-host operand gets.
-                    // Credit it by the SAME shared predicate the lowering uses (#1079: uncredited,
-                    // this was `mir 3 > ir 2`, a caps wall breach on correct output).
-                    almide_ir::IrExprKind::Call {
-                        target: almide_ir::CallTarget::Named { .. },
-                        ..
-                    } => almide_mir::lower::unwrap_or_named_variant_operand(expr),
-                    _ => false,
-                };
-                if matches!(fallback.ty, almide_lang::types::Ty::String)
-                    && operand_is_option
-                    && operand_lowers
-                {
-                    self.n += 1;
-                }
-                // A Value / List[Value] -payload Result `??` (`value.get(o,k) ?? value.null()`,
-                // `value.as_array(v) ?? []`) — the lowering routes it to ONE synthetic
-                // result.value_unwrap_or / result.list_value_unwrap_or CALL (a pure value_core
-                // helper, no Stdout). Count +1 so mir == ir, mirroring the String case.
-                let operand_is_value_result = almide_mir::lower::is_value_result_ty(&expr.ty)
-                    || almide_mir::lower::is_result_listval_ty(&expr.ty)
-                    || almide_mir::lower::is_result_str_str_ty(&expr.ty)
-                    || almide_mir::lower::is_option_value_ty(&expr.ty)
-                    // An Option[List[Value]] / Option[List[String]] `??` (`json.get_array(v,k) ?? []`,
-                    // `list.first_liststr(xs) ?? []`) routes to ONE synthetic option.listvalue_unwrap_or /
-                    // option.liststr_unwrap_or CALL (pure value_core helpers, no Stdout) — count +1 so
-                    // mir == ir, mirroring the Option[Value] case.
-                    || almide_mir::lower::is_option_listvalue_ty(&expr.ty)
-                    || almide_mir::lower::is_option_liststr_ty(&expr.ty)
-                    // An Option[List[<scalar>]] `??` (`map.get(groups, k) ?? []` — B19's
-                    // group_by class) routes to ONE synthetic option.listint_unwrap_or CALL —
-                    // count +1 so mir == ir (the missing credit was the B19-ship breach the
-                    // corpus gate caught: mir 2 > ir 1 on every listint `??` site).
-                    || almide_mir::lower::is_option_listscalar_ty(&expr.ty);
-                // value/list-Ok Result + Option[Value] Vars route (the handle Var-case admits
-                // them) — INCLUDING a str-str Var, which now routes to `result.str_unwrap_or`
-                // (the materialized_results_str Var-gate admission). An Option[Value] operand
-                // is a self-host option CALL (list.get) or a Var.
-                let value_operand_lowers = match &expr.kind {
-                    almide_ir::IrExprKind::Var { .. } => true,
-                    almide_ir::IrExprKind::Call {
-                        target: almide_ir::CallTarget::Module { module, func, .. },
-                        ..
-                    } => {
-                        almide_mir::lower::is_self_host_result_str_module_fn(
-                            module.as_str(),
-                            func.as_str(),
-                        ) || ((almide_mir::lower::is_option_value_ty(&expr.ty)
-                            || almide_mir::lower::is_option_listvalue_ty(&expr.ty)
-                            || almide_mir::lower::is_option_liststr_ty(&expr.ty)
-                            || almide_mir::lower::is_option_listscalar_ty(&expr.ty))
-                            && almide_mir::lower::is_self_host_option_module_fn(
-                                module.as_str(),
-                                func.as_str(),
-                            ))
-                            // The NEW operand-materialization path (`json.parse(s) ?? json.array([])`
-                            // — a PURE heap-`Result[Value, String]` module call): it lowers to ONE
-                            // synthetic `result.value_unwrap_or` CallFn, so credit the node +1.
-                            || almide_mir::lower::unwrap_or_operand_admitted(expr)
-                    }
-                    // A USER function returning a heap-payload variant (`fn lookup(k) ->
-                    // Result[Value, String]`): admitted by the SAME `is_named_variant_call`
-                    // operand route, then routed to ONE `result.value_unwrap_or` /
-                    // `option.value_unwrap_or` helper — credit it, mirroring the String case
-                    // above (#1079).
-                    almide_ir::IrExprKind::Call {
-                        target: almide_ir::CallTarget::Named { .. },
-                        ..
-                    } => almide_mir::lower::unwrap_or_named_variant_operand(expr),
-                    _ => false,
-                };
-                if operand_is_value_result
-                    && almide_mir::lower::is_heap_ty(&fallback.ty)
-                    && value_operand_lowers
-                {
-                    self.n += 1;
-                }
-            }
+            self.n += operator_credit(e, self.registry, self.variant_layouts);
+            self.n += unwrap_or_credit(e);
             // A STRING INTERPOLATION `"…${e}…"` desugars (the SHARED
             // `almide_mir::lower::desugar_string_interp`) to a synthetic `__str_concat`
             // chain (one per part, +1 empty-seed leaf ⇒ K concats) plus one

--- a/crates/almide-mir/examples/classify_corpus_parts/classify_corpus_c.rs
+++ b/crates/almide-mir/examples/classify_corpus_parts/classify_corpus_c.rs
@@ -1,4 +1,3 @@
-
 /// The Pass-1 per-(inlined-)function lowering-and-witness-emission body of
 /// [`classify_file`]'s main loop — verbatim move (`ctx.*` substituted for the
 /// free variables it used to close over as a nested loop body). `t`/`s` are
@@ -31,7 +30,11 @@ fn classify_check_unlinkable_call(ctx: &FileCtx, t: &mut Tally, mir: &MirFunctio
     // sound here: the name is not file-defined, so adding sibling
     // functions could not make it resolve (only the registry could,
     // which `ctx.auto_linkable` already ruled out).
-    let probe = MirProgram { functions: vec![mir.clone()], exports: vec![], mutable_global_count: 0 };
+    let probe = MirProgram {
+        functions: vec![mir.clone()],
+        exports: vec![],
+        mutable_global_count: 0,
+    };
     if !almide_mir::render_wasm::unlinked_call_names(&probe).contains(name) {
         t.forbidden_unwalled.push(format!(
             "{}::{} -> {name} (escaped the render wall)",
@@ -39,6 +42,217 @@ fn classify_check_unlinkable_call(ctx: &FileCtx, t: &mut Tally, mir: &MirFunctio
             mir.name
         ));
     }
+}
+
+/// The LOWERED arm of [`classify_lower_one_fn`], verbatim (codopsy
+/// A-maintenance split): witness emission, interp/link coverage, and the
+/// two-sided call-count gate for a function the lowering accepted.
+fn classify_lowered_fn(
+    ctx: &FileCtx,
+    func: &almide_ir::IrFunction,
+    mirs: Vec<MirFunction>,
+    t: &mut Tally,
+    s: &mut CertStreams,
+    file_mirs: &mut Vec<(String, MirFunction)>,
+    elided_call_fns: &mut HashSet<String>,
+) {
+    // `mirs[0]` is the source function; `mirs[1..]` are lambda-lifted
+    // auxiliaries (the closures machinery lifts `let f = (x) => …` bodies
+    // into fresh functions). Every one is a real MIR function the proven
+    // checker re-verifies, so backing / ownership / names witnesses are
+    // emitted for ALL of them and the program assembler tables them by the
+    // same position. With no lifting wired the vector is just `[main]` and
+    // this is byte-identical to the prior single-function pass.
+    t.in_profile += mirs.len();
+    // The EFFECTIVE body the lowering actually saw: a let-bound heap-result
+    // `if`/`match` is tail-duplicated PURELY in the IR before lowering, so the
+    // caps `count_ir_calls` 1:1 gate and the interp-coverage count must read the
+    // SAME rewritten tree (the duplicated continuation's calls / interps appear
+    // once per arm in BOTH MIR and this counted IR — `mir == ir` by construction).
+    // desugar-before-both: the SAME ANF-lift (call-arg heap-if → let) then
+    // tail-duplication the lowering applies, so the duplicated calls are counted
+    // 1:1 (mir == ir) and the caps gate stays exact.
+    // desugar-before-both: read the SAME fully-desugared tree the lowering emits
+    // its MIR from (the full guard → beta → tuple-unwrap → effect-unwrap →
+    // heap-branches fixpoint), so a tail-duplicating rewrite duplicates a call in
+    // BOTH the MIR and this counted IR — `mir == ir` by construction. A subset
+    // (only guard + heap-branches) missed `desugar_tuple_unwrap_or`, so a
+    // `let r = opt.unwrap_or((tuple)); f(r.0)` mir>ir-breached.
+    // BOTH ABI root retypes FIRST — the same root-ty adjustments
+    // `lower_function_all_impl` makes before ITS desugar ladder, via the same
+    // helper (single source of truth). `desugar_loop_unwrap`'s root gate keys on
+    // the Result carrier ty; counting the bare-sugar-typed body instead declined
+    // the loop-`!` flag rewrite the lowering applied, so its injected owned-copy
+    // concat was a MIR op with no counted IR node (#1176). The unit-tail ok-wrap
+    // half is registry-INDEPENDENT for a CAN-ERR declared-Unit effect fn — a
+    // post-registry `effect_cont_synth_*` continuation lowers through it, so the
+    // AUTO_WRAP retype alone re-opened the same false breach (fs_streaming).
+    let abi_body = almide_mir::lower::abi_effective_body(func);
+    let eff_body = almide_mir::lower::desugar_all(
+        abi_body.as_ref().unwrap_or(&func.body),
+        func.name.as_str() == "main",
+        ctx.variant_layouts,
+        ctx.record_layouts,
+        &func.params,
+    );
+    // INTERP COVERAGE (a): this function LOWERED, so its FULLY-LINKABLE
+    // interps (Lit/String/Int/Bool parts) fold to a registered __str_concat /
+    // int.to_string / bool.to_string chain (proven byte-match v0 by the
+    // render_wasm detectors); a non-desugarable interp stays the sound Opaque
+    // fallback, and a desugarable-but-UNLINKED one (Float/compound) walls at
+    // render — both are (b) cleanly walled (no invalid wasm). The per-CallFn
+    // loop below ADDS the unlinked-occurrence count to (b); this counts the
+    // interp SITE once, as proven or walled, with no proven mis-bucket.
+    let (proven, walled) = count_interp_sites(&eff_body, &ctx.auto_linkable, ctx.record_layouts);
+    t.interp_lowered += proven;
+    t.interp_walled += walled;
+    // LINK COVERAGE: a LOWERED function emitting a dotted `Op::CallFn` whose
+    // name the v1 linker cannot resolve (not in the self-host registry) would,
+    // if rendered, emit a dangling `(call $name)` — invalid wasm. The render-
+    // side `try_render_wasm_program` now WALLS the WHOLE program in that case
+    // (a clean `LowerError::Unsupported`, never an `Ok` invalid module). So each
+    // such site is a bucket-(b) cleanly-walled, NOT a (c) forbidden hole. We
+    // MEASURE the distinct unlinkable callees (the visible self-host gap) and
+    // fold each occurrence into (b). The wall's COMPLETENESS — that no such site
+    // escapes to `Ok` — is what keeps (c) == 0 (asserted below).
+    for mir in &mirs {
+        for op in &mir.ops {
+            if let Op::CallFn { name, .. } = op {
+                classify_check_unlinkable_call(ctx, t, mir, name);
+            }
+        }
+    }
+    for mir in &mirs {
+        // The borrow-by-default soundness gate: every `+1` event must
+        // be backed by a real runtime op (no synthetic param `+1`).
+        if !plus_one_events_backed(mir) {
+            t.cert_backing_breaches
+                .push(format!("{}::{}", ctx.file.display(), mir.name));
+        }
+        // Ownership is one heap object per line; names are one line per
+        // function. Both are LOCAL properties — no transitivity.
+        let (cert, poisoned) = almide_mir::certificate::ownership_certificate_with_poison(mir);
+        // A POISONED certificate (a nested-region arm flushed as the
+        // always-rejecting `{i|}`) is kernel-UNREPRESENTABLE by its own
+        // declaration — shipping it in the witness would fail the gate
+        // by design, not by finding a bug (#1146: the C-220 test fns
+        // were the first in-profile poisoned certs; every earlier
+        // poisoned fn sat outside the witness). EXCLUDE it, COUNTED —
+        // the render is still covered by the executable verifier.
+        if poisoned {
+            t.cert_poisoned_excluded += 1;
+            s.names.push_str(&name_witness_string(mir));
+            s.names.push('\n');
+            continue;
+        }
+        // Parallel name index (ownership.names): one `<file>::<fn>` line per
+        // cert line, so a checker REJECT bisects straight to its function
+        // (the anonymous 20k-line cert made a reject a needle hunt).
+        for _ in cert.lines() {
+            s.ownership_names
+                .push_str(&format!("{}::{}\n", ctx.file.display(), mir.name));
+        }
+        s.ownership.push_str(&cert);
+        s.names.push_str(&name_witness_string(mir));
+        s.names.push('\n');
+    }
+    // CAPS SOUNDNESS: count the source's call nodes. A call ELIDED by
+    // Opaque lowering (a list element, ctor payload, BinOp operand, …) is
+    // absent from the MIR ops, so the transitive caps fold over CallFn /
+    // FuncRef edges cannot see its effects — if it reached Stdout the
+    // function would be falsely caps-verified. The IR call count covers the
+    // WHOLE source body (including any lambda later lifted out), so the MIR
+    // call count is summed across the main AND its lifted auxiliaries — a
+    // lifted lambda carries its body's calls, and a `CallIndirect` (a
+    // lowered closure invocation) is a genuine call counted here too. If the
+    // cluster has MORE IR calls than MIR call-ops some call was elided
+    // SOMEWHERE within it, so EVERY function of the cluster is conservatively
+    // TAINTED below (we cannot tell which member hid it).
+    let ir_calls = count_ir_calls(&eff_body, ctx.record_layouts, ctx.variant_layouts);
+    let mir_calls = mirs
+        .iter()
+        .flat_map(|m| m.ops.iter())
+        .filter(|o| {
+            matches!(
+                o,
+                Op::Call { .. } | Op::CallFn { .. } | Op::CallIndirect { .. }
+            )
+        })
+        // `$__mg_take` is a COMPILER-INJECTED slot accessor (a raw i32.load,
+        // Stdout-free — the trusted-prim class), not a lowering of any IR
+        // call node: a mutable-global heap assign injects one with no IR
+        // counterpart, so counting it would false-breach `mir <= ir`.
+        .filter(|o| !matches!(o, Op::CallFn { name, .. } if name == "__mg_take"))
+        .count();
+    if std::env::var_os("ALMIDE_DEBUG_CALL_OPS").is_some() {
+        for mir in &mirs {
+            for o in &mir.ops {
+                match o {
+                    Op::Call { func, .. } => eprintln!("[call-op] {}: Call {func:?}", mir.name),
+                    Op::CallFn { name, .. } => eprintln!("[call-op] {}: CallFn {name}", mir.name),
+                    Op::CallIndirect { .. } => eprintln!("[call-op] {}: CallIndirect", mir.name),
+                    _ => {}
+                }
+            }
+        }
+        eprintln!("[call-count] ir={ir_calls}");
+    }
+    if ir_calls > mir_calls {
+        for mir in &mirs {
+            elided_call_fns.insert(mir.name.clone());
+        }
+    }
+    // SOUNDNESS BACKSTOP for the elided-call effect markers: a marker
+    // (`record_elided_calls`) may only surface a genuinely ELIDED
+    // call, so the MIR call count can rise at most TO the IR's. If it
+    // EXCEEDS, a marker double-counted a lowered call — which could
+    // mask another elision and falsely de-taint. A wall breach.
+    if mir_calls > ir_calls {
+        t.call_count_breaches.push(format!(
+            "{}::{} (mir {mir_calls} > ir {ir_calls})",
+            ctx.file.display(),
+            func.name.as_str()
+        ));
+    }
+    for mir in mirs {
+        file_mirs.push((mir.name.clone(), mir));
+    }
+}
+
+/// The WALLED arm of [`classify_lower_one_fn`], verbatim: categorize the wall
+/// (native-FFI vs REAL), tally the reason, and fold its interp sites into (b).
+fn classify_walled_fn(
+    ctx: &FileCtx,
+    func: &almide_ir::IrFunction,
+    wall_err: &almide_mir::lower::LowerError,
+    t: &mut Tally,
+) {
+    let reason = wall_err.reason().to_string();
+    let reason = &reason;
+    // Categorize the wall: NATIVE-FFI (structural, excluded) iff this function is
+    // in the transitive native-FFI closure; else REAL (a lowering gap to close).
+    // A name absent from the node map (an inline_mutual_tail_recursion-synthesized
+    // aux) defaults REAL (conservative — never over-excludes a real gap).
+    let is_native = ctx.native_ffi_set.contains(func.name.as_str());
+    if is_native {
+        t.walled_native_ffi += 1;
+    } else {
+        t.walled_real += 1;
+    }
+    if std::env::var("WALL_NAMES").is_ok() {
+        let tag = if is_native { "NATIVE-FFI" } else { "REAL" };
+        eprintln!(
+            "WALLED {tag} {} :: {} :: {}",
+            ctx.file.display(),
+            func.name.as_str(),
+            reason
+        );
+    }
+    *t.unsupported.entry(reason_key(&reason)).or_insert(0) += 1;
+    // INTERP COVERAGE (b): every interp site inside a WALLED function is
+    // cleanly walled too (its function emits no wasm) — never a miscompile.
+    let (proven, walled) = count_interp_sites(&func.body, &ctx.auto_linkable, ctx.record_layouts);
+    t.interp_walled += proven + walled;
 }
 
 fn classify_lower_one_fn(
@@ -60,198 +274,8 @@ fn classify_lower_one_fn(
         )
     }));
     match lowered {
-        Ok(Ok(mirs)) => {
-            // `mirs[0]` is the source function; `mirs[1..]` are lambda-lifted
-            // auxiliaries (the closures machinery lifts `let f = (x) => …` bodies
-            // into fresh functions). Every one is a real MIR function the proven
-            // checker re-verifies, so backing / ownership / names witnesses are
-            // emitted for ALL of them and the program assembler tables them by the
-            // same position. With no lifting wired the vector is just `[main]` and
-            // this is byte-identical to the prior single-function pass.
-            t.in_profile += mirs.len();
-            // The EFFECTIVE body the lowering actually saw: a let-bound heap-result
-            // `if`/`match` is tail-duplicated PURELY in the IR before lowering, so the
-            // caps `count_ir_calls` 1:1 gate and the interp-coverage count must read the
-            // SAME rewritten tree (the duplicated continuation's calls / interps appear
-            // once per arm in BOTH MIR and this counted IR — `mir == ir` by construction).
-            // desugar-before-both: the SAME ANF-lift (call-arg heap-if → let) then
-            // tail-duplication the lowering applies, so the duplicated calls are counted
-            // 1:1 (mir == ir) and the caps gate stays exact.
-            // desugar-before-both: read the SAME fully-desugared tree the lowering emits
-            // its MIR from (the full guard → beta → tuple-unwrap → effect-unwrap →
-            // heap-branches fixpoint), so a tail-duplicating rewrite duplicates a call in
-            // BOTH the MIR and this counted IR — `mir == ir` by construction. A subset
-            // (only guard + heap-branches) missed `desugar_tuple_unwrap_or`, so a
-            // `let r = opt.unwrap_or((tuple)); f(r.0)` mir>ir-breached.
-            // BOTH ABI root retypes FIRST — the same root-ty adjustments
-            // `lower_function_all_impl` makes before ITS desugar ladder, via the same
-            // helper (single source of truth). `desugar_loop_unwrap`'s root gate keys on
-            // the Result carrier ty; counting the bare-sugar-typed body instead declined
-            // the loop-`!` flag rewrite the lowering applied, so its injected owned-copy
-            // concat was a MIR op with no counted IR node (#1176). The unit-tail ok-wrap
-            // half is registry-INDEPENDENT for a CAN-ERR declared-Unit effect fn — a
-            // post-registry `effect_cont_synth_*` continuation lowers through it, so the
-            // AUTO_WRAP retype alone re-opened the same false breach (fs_streaming).
-            let abi_body = almide_mir::lower::abi_effective_body(func);
-            let eff_body = almide_mir::lower::desugar_all(
-                abi_body.as_ref().unwrap_or(&func.body),
-                func.name.as_str() == "main",
-                ctx.variant_layouts,
-                ctx.record_layouts,
-                &func.params,
-            );
-            // INTERP COVERAGE (a): this function LOWERED, so its FULLY-LINKABLE
-            // interps (Lit/String/Int/Bool parts) fold to a registered __str_concat /
-            // int.to_string / bool.to_string chain (proven byte-match v0 by the
-            // render_wasm detectors); a non-desugarable interp stays the sound Opaque
-            // fallback, and a desugarable-but-UNLINKED one (Float/compound) walls at
-            // render — both are (b) cleanly walled (no invalid wasm). The per-CallFn
-            // loop below ADDS the unlinked-occurrence count to (b); this counts the
-            // interp SITE once, as proven or walled, with no proven mis-bucket.
-            let (proven, walled) = count_interp_sites(&eff_body, &ctx.auto_linkable, ctx.record_layouts);
-            t.interp_lowered += proven;
-            t.interp_walled += walled;
-            // LINK COVERAGE: a LOWERED function emitting a dotted `Op::CallFn` whose
-            // name the v1 linker cannot resolve (not in the self-host registry) would,
-            // if rendered, emit a dangling `(call $name)` — invalid wasm. The render-
-            // side `try_render_wasm_program` now WALLS the WHOLE program in that case
-            // (a clean `LowerError::Unsupported`, never an `Ok` invalid module). So each
-            // such site is a bucket-(b) cleanly-walled, NOT a (c) forbidden hole. We
-            // MEASURE the distinct unlinkable callees (the visible self-host gap) and
-            // fold each occurrence into (b). The wall's COMPLETENESS — that no such site
-            // escapes to `Ok` — is what keeps (c) == 0 (asserted below).
-            for mir in &mirs {
-                for op in &mir.ops {
-                    if let Op::CallFn { name, .. } = op {
-                        classify_check_unlinkable_call(ctx, t, mir, name);
-                    }
-                }
-            }
-            for mir in &mirs {
-                // The borrow-by-default soundness gate: every `+1` event must
-                // be backed by a real runtime op (no synthetic param `+1`).
-                if !plus_one_events_backed(mir) {
-                    t.cert_backing_breaches
-                        .push(format!("{}::{}", ctx.file.display(), mir.name));
-                }
-                // Ownership is one heap object per line; names are one line per
-                // function. Both are LOCAL properties — no transitivity.
-                let (cert, poisoned) =
-                    almide_mir::certificate::ownership_certificate_with_poison(mir);
-                // A POISONED certificate (a nested-region arm flushed as the
-                // always-rejecting `{i|}`) is kernel-UNREPRESENTABLE by its own
-                // declaration — shipping it in the witness would fail the gate
-                // by design, not by finding a bug (#1146: the C-220 test fns
-                // were the first in-profile poisoned certs; every earlier
-                // poisoned fn sat outside the witness). EXCLUDE it, COUNTED —
-                // the render is still covered by the executable verifier.
-                if poisoned {
-                    t.cert_poisoned_excluded += 1;
-                    s.names.push_str(&name_witness_string(mir));
-                    s.names.push('\n');
-                    continue;
-                }
-                // Parallel name index (ownership.names): one `<file>::<fn>` line per
-                // cert line, so a checker REJECT bisects straight to its function
-                // (the anonymous 20k-line cert made a reject a needle hunt).
-                for _ in cert.lines() {
-                    s.ownership_names
-                        .push_str(&format!("{}::{}\n", ctx.file.display(), mir.name));
-                }
-                s.ownership.push_str(&cert);
-                s.names.push_str(&name_witness_string(mir));
-                s.names.push('\n');
-            }
-            // CAPS SOUNDNESS: count the source's call nodes. A call ELIDED by
-            // Opaque lowering (a list element, ctor payload, BinOp operand, …) is
-            // absent from the MIR ops, so the transitive caps fold over CallFn /
-            // FuncRef edges cannot see its effects — if it reached Stdout the
-            // function would be falsely caps-verified. The IR call count covers the
-            // WHOLE source body (including any lambda later lifted out), so the MIR
-            // call count is summed across the main AND its lifted auxiliaries — a
-            // lifted lambda carries its body's calls, and a `CallIndirect` (a
-            // lowered closure invocation) is a genuine call counted here too. If the
-            // cluster has MORE IR calls than MIR call-ops some call was elided
-            // SOMEWHERE within it, so EVERY function of the cluster is conservatively
-            // TAINTED below (we cannot tell which member hid it).
-            let ir_calls = count_ir_calls(&eff_body, ctx.record_layouts, ctx.variant_layouts);
-            let mir_calls = mirs
-                .iter()
-                .flat_map(|m| m.ops.iter())
-                .filter(|o| {
-                    matches!(
-                        o,
-                        Op::Call { .. } | Op::CallFn { .. } | Op::CallIndirect { .. }
-                    )
-                })
-                // `$__mg_take` is a COMPILER-INJECTED slot accessor (a raw i32.load,
-                // Stdout-free — the trusted-prim class), not a lowering of any IR
-                // call node: a mutable-global heap assign injects one with no IR
-                // counterpart, so counting it would false-breach `mir <= ir`.
-                .filter(|o| !matches!(o, Op::CallFn { name, .. } if name == "__mg_take"))
-                .count();
-            if std::env::var_os("ALMIDE_DEBUG_CALL_OPS").is_some() {
-                for mir in &mirs {
-                    for o in &mir.ops {
-                        match o {
-                            Op::Call { func, .. } => eprintln!("[call-op] {}: Call {func:?}", mir.name),
-                            Op::CallFn { name, .. } => eprintln!("[call-op] {}: CallFn {name}", mir.name),
-                            Op::CallIndirect { .. } => eprintln!("[call-op] {}: CallIndirect", mir.name),
-                            _ => {}
-                        }
-                    }
-                }
-                eprintln!("[call-count] ir={ir_calls}");
-            }
-            if ir_calls > mir_calls {
-                for mir in &mirs {
-                    elided_call_fns.insert(mir.name.clone());
-                }
-            }
-            // SOUNDNESS BACKSTOP for the elided-call effect markers: a marker
-            // (`record_elided_calls`) may only surface a genuinely ELIDED
-            // call, so the MIR call count can rise at most TO the IR's. If it
-            // EXCEEDS, a marker double-counted a lowered call — which could
-            // mask another elision and falsely de-taint. A wall breach.
-            if mir_calls > ir_calls {
-                t.call_count_breaches.push(format!(
-                    "{}::{} (mir {mir_calls} > ir {ir_calls})",
-                    ctx.file.display(),
-                    func.name.as_str()
-                ));
-            }
-            for mir in mirs {
-                file_mirs.push((mir.name.clone(), mir));
-            }
-        }
-        Ok(Err(wall_err)) => {
-            let reason = wall_err.reason().to_string();
-            let reason = &reason;
-            // Categorize the wall: NATIVE-FFI (structural, excluded) iff this function is
-            // in the transitive native-FFI closure; else REAL (a lowering gap to close).
-            // A name absent from the node map (an inline_mutual_tail_recursion-synthesized
-            // aux) defaults REAL (conservative — never over-excludes a real gap).
-            let is_native = ctx.native_ffi_set.contains(func.name.as_str());
-            if is_native {
-                t.walled_native_ffi += 1;
-            } else {
-                t.walled_real += 1;
-            }
-            if std::env::var("WALL_NAMES").is_ok() {
-                let tag = if is_native { "NATIVE-FFI" } else { "REAL" };
-                eprintln!(
-                    "WALLED {tag} {} :: {} :: {}",
-                    ctx.file.display(),
-                    func.name.as_str(),
-                    reason
-                );
-            }
-            *t.unsupported.entry(reason_key(&reason)).or_insert(0) += 1;
-            // INTERP COVERAGE (b): every interp site inside a WALLED function is
-            // cleanly walled too (its function emits no wasm) — never a miscompile.
-            let (proven, walled) = count_interp_sites(&func.body, &ctx.auto_linkable, ctx.record_layouts);
-            t.interp_walled += proven + walled;
-        }
+        Ok(Ok(mirs)) => classify_lowered_fn(ctx, func, mirs, t, s, file_mirs, elided_call_fns),
+        Ok(Err(wall_err)) => classify_walled_fn(ctx, func, &wall_err, t),
         Err(_) => {
             // THE wall breach: lowering must be total. Record file::func.
             t.lower_panics
@@ -284,10 +308,18 @@ fn classify_fold_caps_one_fn(
     file_graph_clean: &mut bool,
 ) {
     let mut visited = BTreeSet::new();
-    match reachable_caps_or_tainted(name, ctx.in_profile_map, ctx.is_known_free, ctx.is_elided, &mut visited)
-    {
+    match reachable_caps_or_tainted(
+        name,
+        ctx.in_profile_map,
+        ctx.is_known_free,
+        ctx.is_elided,
+        &mut visited,
+    ) {
         // Unanalyzable (an unknown/cross-file or elided callee hides effects).
-        None => { t.caps_unverified += 1; *file_graph_clean = false; }
+        None => {
+            t.caps_unverified += 1;
+            *file_graph_clean = false;
+        }
         // Fully-known reachable set. Caps-VERIFIED iff it is within the
         // DECLARED bound (`reachable ⊆ declared`): then emit the
         // `<declared>|<reachable>` witness for the proven `check_caps_cert` to
@@ -355,9 +387,10 @@ fn classify_file(
         .type_decls
         .iter()
         .flat_map(|td| match &td.kind {
-            IrTypeDeclKind::Variant { cases, .. } => {
-                cases.iter().map(|c| c.name.as_str().to_string()).collect::<Vec<_>>()
-            }
+            IrTypeDeclKind::Variant { cases, .. } => cases
+                .iter()
+                .map(|c| c.name.as_str().to_string())
+                .collect::<Vec<_>>(),
             _ => Vec::new(),
         })
         .collect();
@@ -389,7 +422,12 @@ fn classify_file(
     // init_order shapes), the cross-module NAME bridge OVERRIDES a colliding module-raw
     // key (the byvalue shapes), and main's own top-lets (re-inserted last) win where the
     // name bridge would misfire — composition order: module union → bridge → main.
-    almide_mir::lower::bridge_cross_module_toplets(&ir, &mut globals, &mut global_inits, &mut std::collections::HashMap::new());
+    almide_mir::lower::bridge_cross_module_toplets(
+        &ir,
+        &mut globals,
+        &mut global_inits,
+        &mut std::collections::HashMap::new(),
+    );
     for tl in &ir.top_lets {
         globals.insert(tl.var, tl.ty.clone());
         global_inits.insert(tl.var, tl.value.clone());
@@ -417,8 +455,11 @@ fn classify_file(
     // — it resolves to ITSELF / a sibling method, NOT a stdlib call. The unlinkable-
     // stdlib detector must exclude these (a dotted name is unlinkable only if it is also
     // NOT a function defined here), else a self-recursive method call falsely flags.
-    let file_fn_names: HashSet<String> =
-        ir.functions.iter().map(|f| f.name.as_str().to_string()).collect();
+    let file_fn_names: HashSet<String> = ir
+        .functions
+        .iter()
+        .map(|f| f.name.as_str().to_string())
+        .collect();
     // The record-layout registry (type name → fields) for the VALUE MODEL, so the
     // corpus-wall exercises (and the proven checker re-verifies) record/`r.x`
     // materialization over the whole v0 corpus, not just the structurally-typed forms.
@@ -433,7 +474,9 @@ fn classify_file(
         let m_vl = almide_mir::lower::build_variant_layouts(&m.type_decls);
         variant_layouts.by_type.extend(m_vl.by_type);
         variant_layouts.ctor_to_type.extend(m_vl.ctor_to_type);
-        variant_layouts.ctor_field_defaults.extend(m_vl.ctor_field_defaults);
+        variant_layouts
+            .ctor_field_defaults
+            .extend(m_vl.ctor_field_defaults);
     }
     // PROGRAM pre-pass: inline mutual-recursive tail siblings → direct self-recursion (exposed to
     // the append-accumulator TCO). Guarded: only where it makes a walled fn lower (no regression).
@@ -463,12 +506,15 @@ fn classify_file(
     // is Stdout-free only if it is a pure stdlib `Module` call (a dotted name,
     // purity-gated at lowering), a variant constructor, or a known Stdout-free
     // builtin. Everything else (walled / cross-file user fns) is tainted.
-    let is_known_free = |n: &str| {
-        n.contains('.') || ctors.contains(n) || KNOWN_STDOUT_FREE_BUILTINS.contains(&n)
-    };
+    let is_known_free =
+        |n: &str| n.contains('.') || ctors.contains(n) || KNOWN_STDOUT_FREE_BUILTINS.contains(&n);
     let is_elided = |n: &str| elided_call_fns.contains(n);
-    let cap_ids =
-        |c: &[Capability]| c.iter().map(|x| x.id().to_string()).collect::<Vec<_>>().join(" ");
+    let cap_ids = |c: &[Capability]| {
+        c.iter()
+            .map(|x| x.id().to_string())
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
     // Track whether the WHOLE file is analyzable + within-bound: only then is the
     // call-graph witness meaningful (any unanalyzable/over-bound function would route to
     // the UNIVERSE sentinel and reject — but unanalyzable is honest scope, not a failure).
@@ -486,8 +532,11 @@ fn classify_file(
     // for the proven `check_prog_cert` (caps-transitive), which re-derives the transitive
     // reach itself. (UNIVERSE is unreferenced here — every callee is in-file or known-free.)
     if file_graph_clean {
-        s.caps_graph
-            .push_str(&program_cap_graph_witness(&in_profile_map, &is_known_free, &is_elided));
+        s.caps_graph.push_str(&program_cap_graph_witness(
+            &in_profile_map,
+            &is_known_free,
+            &is_elided,
+        ));
         s.caps_graph.push('\n');
     }
 }
@@ -534,11 +583,11 @@ fn main() {
     // One witness stream per proven property. ownership = one heap object per
     // line; names/caps = one `<superset>|<subset>` line per in-profile function.
     let mut streams = CertStreams::default();
-                // One line per FULLY-ANALYZABLE+within-bound file: the call-graph witness for the proven
+    // One line per FULLY-ANALYZABLE+within-bound file: the call-graph witness for the proven
     // `check_prog_cert` (caps-transitive), which COMPUTES the transitive reach itself — the
     // fold moves out of this untrusted classifier into the proof. Partially-analyzable files
     // stay on the per-function `caps.cert` (honest scope), not emitted here.
-    
+
     // The render-resolvable name oracle for the interp-coverage (c) detector: a DOTTED
     // `CallFn` name (a stdlib `module.func`) renders to `(call $name)` and resolves ONLY
     // if the v1 linker auto-includes it (it is in the self-host registry). A dotted name


### PR DESCRIPTION
Quality-gate work under the standing codopsy-A mandate: almide-mir sat at **B (89/100)** — one point under — with both C-graded files in the corpus-classifier example.

## Splits (all verbatim moves, house recipe — no closure wrapping, no behavior change)

- `count_eq_calls_depth` (cc 50 / cog 60) → four tier helpers: `count_eq_calls_list` / `count_eq_calls_map_set` / `count_eq_calls_variant` / `count_eq_calls_compound` — each tier keeps its own soundness comment.
- `visit_expr` (cc 42) → `operator_credit` + `unwrap_or_credit` free fns; the visitor is now call-node counting + credit sums + descent.
- `classify_lower_one_fn` (cc 25 / cog 53) → `classify_lowered_fn` + `classify_walled_fn` arm extraction.

## Measured

- codopsy almide-mir: **89/B → 90/A** (files: classify_corpus.rs 65→81+, classify_corpus_c.rs 72→A-range; distribution now A-dominated)
- almide-tools re-measured **A (96)** after today's fmt fix — no regression
- Verification the instrument is unchanged: `proofs/corpus-wall.sh` — WALL OK over 6341 corpus functions, walled-real ratchet 0, no MIR>IR breach; `cargo test -p almide-mir` all 8 harnesses green

Remaining mir offenders (all sub-B files, logged for the next pass): `calls.rs` 866 lines + `is_admitted_effectful_fs` cc34 flat match (const-slice conversion candidate), `container_slot_eq` cog61, `kind_name_leaf`/`int_binop_instr` flat dispatch tables.