### PR TITLE
Sweep the accumulated rustc warnings down from 40+ to the annotated dead-code tail

### DIFF
--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -261,7 +261,7 @@ pub fn codegen_with(program: &mut IrProgram, target: Target, options: &CodegenOp
     // the correctness completeness roadmap.
     pass_concretize_types::assert_types_concretized(program);
 
-    let et = almide_base::profile::ProfileTimer::start(prof);
+    let _et = almide_base::profile::ProfileTimer::start(prof);
 
     // Layer 3: Target-specific emit
     match target {

--- a/crates/almide-codegen/src/pass.rs
+++ b/crates/almide-codegen/src/pass.rs
@@ -8,7 +8,7 @@
 //! - MLIR dialect conversion patterns
 //! - NLLB-200 Mixture of Experts (shared + language-specific)
 
-use almide_ir::{IrProgram, IrExprKind, IrPattern, IrVisitor};
+use almide_ir::IrProgram;
 use almide_lang::types::Ty;
 
 // ── Pass Result ──
@@ -121,7 +121,7 @@ pub enum Postcondition {
 
 /// Verify postconditions for a pass. Returns list of violations.
 pub fn verify_postconditions(pass_name: &str, program: &IrProgram, postconditions: &[Postcondition]) -> Vec<String> {
-    use almide_lang::types::Ty;
+    
     let mut violations = Vec::new();
 
     for pc in postconditions {
@@ -202,7 +202,7 @@ fn count_typevars_in_functions(program: &IrProgram) -> usize {
 }
 
 fn count_incomplete_types(program: &IrProgram) -> (usize, usize) {
-    use almide_lang::types::Ty;
+    
     let mut unknowns = 0;
     let mut typevars = 0;
     for func in &program.functions {

--- a/crates/almide-codegen/src/pass_builtin_lowering.rs
+++ b/crates/almide-codegen/src/pass_builtin_lowering.rs
@@ -56,7 +56,7 @@ fn collect_module_method_fns(program: &IrProgram) -> HashMap<String, String> {
     // origin is the versioned `codeclib_v0_inner` — so every call site that
     // rebuilt the name from its own guess disagreed with the definition
     // (#1094). Storing what the definition emits means no consumer has to guess.
-    let mut add = |map: &mut HashMap<String, String>, name: &str, origin: &str| {
+    let add = |map: &mut HashMap<String, String>, name: &str, origin: &str| {
         if !name.contains('.') {
             return;
         }

--- a/crates/almide-codegen/src/pass_clone.rs
+++ b/crates/almide-codegen/src/pass_clone.rs
@@ -184,7 +184,7 @@ fn split_clone_ids(
         // list/string accumulators O(n²) on native (wasm ran O(n)).
         if tco_owned_params.contains(&id) { continue; }
 
-        let name = almide_base::intern::resolve(info.name);
+        let _name = almide_base::intern::resolve(info.name);
         if top_let_vars.contains(&id) || matches!(&info.ty, Ty::Fn { .. } | Ty::TypeVar(_))
             || always_clone_marks.contains(&id)
             || info.module_origin.is_some()

--- a/crates/almide-codegen/src/pass_concretize_types.rs
+++ b/crates/almide-codegen/src/pass_concretize_types.rs
@@ -103,7 +103,7 @@ impl NanoPass for ConcretizeTypesPass {
 /// `mod type SafeHtml = String` → `aliases["SafeHtml"] = String`.
 /// Erase aliases throughout the IR (WASM target only — Rust codegen
 /// handles newtypes natively) so downstream codegen never sees them.
-fn erase_wasm_type_aliases(program: &mut IrProgram, target: Target) {
+fn erase_wasm_type_aliases(program: &mut IrProgram, _target: Target) {
     let mut aliases: HashMap<String, Ty> = HashMap::new();
     for td in program.type_decls.iter().chain(program.modules.iter().flat_map(|m| m.type_decls.iter())) {
         if let almide_ir::IrTypeDeclKind::Alias { target: alias_target } = &td.kind {

--- a/crates/almide-codegen/src/pass_lambda_type_resolve.rs
+++ b/crates/almide-codegen/src/pass_lambda_type_resolve.rs
@@ -922,7 +922,7 @@ fn resolve_via_tuple_index(expr: &IrExpr, params: &[(VarId, Ty)]) -> Option<Ty> 
 /// without a SymbolTable. Used by LTR to propagate concrete types
 /// into downstream Var bindings before ConcretizeTypes runs.
 fn compute_stdlib_call_ret(target: &CallTarget, args: &[IrExpr], vt: &VarTable) -> Option<Ty> {
-    use almide_lang::types::constructor::TypeConstructorId as TCI;
+    
     let (module, func): (&str, &str) = match target {
         CallTarget::Module { module, func, .. } => (module.as_str(), func.as_str()),
         CallTarget::Named { name } => {

--- a/crates/almide-codegen/src/pass_shared_cell_borrow.rs
+++ b/crates/almide-codegen/src/pass_shared_cell_borrow.rs
@@ -41,7 +41,7 @@
 
 use std::collections::HashSet;
 use almide_ir::*;
-use almide_ir::visit::{walk_expr, walk_stmt, IrVisitor};
+use almide_ir::visit::{walk_expr, IrVisitor};
 use almide_ir::visit_mut::{walk_expr_mut, walk_stmt_mut, IrMutVisitor};
 use almide_base::intern::sym;
 use super::pass::{NanoPass, PassResult, Target};

--- a/crates/almide-codegen/src/pass_tco.rs
+++ b/crates/almide-codegen/src/pass_tco.rs
@@ -141,7 +141,7 @@ fn is_self_call(expr: &IrExpr, fn_name: &str) -> bool {
 /// Rewrite binary recursion: f(n) = if n<=1 then n else f(n-1) + f(n-2)
 /// Into: f(n) = { var acc = 0; while n > 1 { acc += f(n-1); n -= step }; acc + base(n) }
 fn rewrite_binary_rec(func: &mut IrFunction, var_table: &mut VarTable) {
-    let fn_name = func.name.clone();
+    let _fn_name = func.name.clone();
     let param = func.params[0].clone();
     let ret_ty = func.ret_ty.clone();
 

--- a/crates/almide-codegen/src/pass_tco_loop_rewrite.rs
+++ b/crates/almide-codegen/src/pass_tco_loop_rewrite.rs
@@ -333,7 +333,7 @@ struct TailFrame<'a> {
 /// - Block: recurse into trailing expr
 /// - Anything else (base case): assign to result var, break
 fn rewrite_tail_expr(expr: IrExpr, f: &TailFrame<'_>) -> IrExpr {
-    let TailFrame { fn_name, params, temps, result_var, is_effect, dec_params, owned_params } = *f;
+    let TailFrame { fn_name, params: _, temps: _, result_var, is_effect, dec_params, owned_params } = *f;
     match expr.kind {
         // Self-recursive call in tail position -> reassign params and continue
         IrExprKind::Call { target: CallTarget::Named { name }, args, .. } if name == fn_name => {

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -143,18 +143,6 @@ impl<'a> RenderContext<'a> {
         escape_rust_ident(name.as_str(), self.templates)
     }
 
-    /// The thread_local static name for a global var, matching exactly what the
-    /// `render_program` top_let emission declares. Built from the RAW (un-escaped)
-    /// var name: `var_name(id)` raw-escapes Rust keywords (`box` → `r#box`), and
-    /// uppercasing that yields the invalid `R#BOX`, which mismatches the `BOX` the
-    /// declaration emits. Every read/write of a global must route through here.
-    pub(crate) fn global_static_name(&self, id: VarId) -> String {
-        let vi = self.var_table.get(id);
-        match &vi.module_origin {
-            Some(origin) => format!("ALMIDE_RT_{}_{}", origin.to_uppercase(), vi.name.to_uppercase()),
-            None => vi.name.to_uppercase(),
-        }
-    }
 }
 
 // ── Function rendering ──

--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -66,7 +66,6 @@ pub fn render_stmt(ctx: &RenderContext, stmt: &IrStmt) -> String {
 /// `ListSwap { target, a, b }` arm of [`render_stmt`].
 fn render_stmt_list_swap(ctx: &RenderContext, target: VarId, a: &IrExpr, b: &IrExpr) -> String {
     let t = ctx.var_name(target).to_string();
-    let upper = ctx.global_static_name(target);
     let a_s = render_expr(ctx, a);
     let b_s = render_expr(ctx, b);
     if let Some(info) = ctx.ann.global(target) {
@@ -86,7 +85,6 @@ fn render_stmt_list_swap(ctx: &RenderContext, target: VarId, a: &IrExpr, b: &IrE
 /// `ListReverse { target, end }` arm of [`render_stmt`].
 fn render_stmt_list_reverse(ctx: &RenderContext, target: VarId, end: &IrExpr) -> String {
     let t = ctx.var_name(target).to_string();
-    let upper = ctx.global_static_name(target);
     let e = render_expr(ctx, end);
     if let Some(info) = ctx.ann.global(target) {
         use almide_ir::top_let_storage::TopLetStorage as Tls;
@@ -105,7 +103,6 @@ fn render_stmt_list_reverse(ctx: &RenderContext, target: VarId, end: &IrExpr) ->
 /// `ListRotateLeft { target, end }` arm of [`render_stmt`].
 fn render_stmt_list_rotate_left(ctx: &RenderContext, target: VarId, end: &IrExpr) -> String {
     let t = ctx.var_name(target).to_string();
-    let upper = ctx.global_static_name(target);
     let e = render_expr(ctx, end);
     if let Some(info) = ctx.ann.global(target) {
         use almide_ir::top_let_storage::TopLetStorage as Tls;
@@ -125,7 +122,6 @@ fn render_stmt_list_rotate_left(ctx: &RenderContext, target: VarId, end: &IrExpr
 fn render_stmt_list_copy_slice(ctx: &RenderContext, dst: VarId, src: VarId, len: &IrExpr) -> String {
     let d = ctx.var_name(dst).to_string();
     let s = ctx.var_name(src).to_string();
-    let upper_d = ctx.global_static_name(dst);
     let n = render_expr(ctx, len);
     // §4 Stage 2: both the dst write AND the src re-read dispatch on
     // the attribute (the src probe was the 9th hand-rolled copy of
@@ -499,7 +495,6 @@ fn render_stmt_guard(ctx: &RenderContext, stmt: &IrStmt) -> String {
 fn render_stmt_index_assign(ctx: &RenderContext, stmt: &IrStmt) -> String {
     let IrStmtKind::IndexAssign { target, index, value } = &stmt.kind else { unreachable!() };
     let target_str = ctx.var_name(*target).to_string();
-    let upper = ctx.global_static_name(*target);
     let idx_str = render_expr(ctx, index);
     let val_str = render_expr(ctx, value);
     let var_ty = &ctx.var_table.get(*target).ty;
@@ -535,7 +530,6 @@ fn render_stmt_index_assign(ctx: &RenderContext, stmt: &IrStmt) -> String {
 fn render_stmt_map_insert(ctx: &RenderContext, stmt: &IrStmt) -> String {
     let IrStmtKind::MapInsert { target, key, value } = &stmt.kind else { unreachable!() };
     let target_str = ctx.var_name(*target).to_string();
-    let upper = ctx.global_static_name(*target);
     let key_str = render_expr(ctx, key);
     let val_str = render_expr(ctx, value);
     // Shared-mut non-Copy var (`SharedMut`, P6): insert through the cell.
@@ -562,7 +556,6 @@ fn render_stmt_map_insert(ctx: &RenderContext, stmt: &IrStmt) -> String {
 fn render_stmt_field_assign(ctx: &RenderContext, stmt: &IrStmt) -> String {
     let IrStmtKind::FieldAssign { target, field, value } = &stmt.kind else { unreachable!() };
     let target_str = ctx.var_name(*target).to_string();
-    let upper = ctx.global_static_name(*target);
     let val_str = render_expr(ctx, value);
     // Shared-mut non-Copy var (`SharedMut`, P6): assign the field through the cell.
     if ctx.ann.is_shared_mut(target) {

--- a/crates/almide-frontend/src/canonicalize/mod.rs
+++ b/crates/almide-frontend/src/canonicalize/mod.rs
@@ -60,7 +60,7 @@ pub fn canonicalize_program<'a>(
     }
 
     // 2. Register user modules (with prefix)
-    let mut collect_dep_roots = |env: &mut TypeEnv, prog: &ast::Program| {
+    let collect_dep_roots = |env: &mut TypeEnv, prog: &ast::Program| {
         for imp in &prog.imports {
             if let ast::Decl::Import { path, .. } = imp {
                 if let Some(root) = path.first() {

--- a/crates/almide-frontend/src/canonicalize/registration.rs
+++ b/crates/almide-frontend/src/canonicalize/registration.rs
@@ -364,7 +364,7 @@ pub fn register_derive_sigs(env: &mut TypeEnv, derives: &[Sym], type_name: &str,
     // the qualified key here instead would change the name LOWERING emits, and
     // the backend resolves a derived method by its bare name plus
     // `module_origin` (#1087).
-    let mut register = |env: &mut TypeEnv, method: &str, sig: FnSig| {
+    let register = |env: &mut TypeEnv, method: &str, sig: FnSig| {
         let key = format!("{}.{}", type_name, method);
         if !env.functions.contains_key(&sym(&key)) {
             env.functions.insert(sym(&key), sig);

--- a/crates/almide-frontend/src/check/calls_arg.rs
+++ b/crates/almide-frontend/src/check/calls_arg.rs
@@ -13,7 +13,7 @@ impl Checker {
         structural_bounds: &HashMap<Sym, Ty>,
         bindings: &mut HashMap<Sym, Ty>,
     ) -> bool {
-        let ArgSite { fn_name, param_name } = site;
+        let ArgSite { fn_name: _, param_name: _ } = site;
         if let Ty::TypeVar(tv) = param_ty {
             self.unify_call_arg_typevar(site, *tv, arg_ty, structural_bounds, bindings)
         } else {

--- a/crates/almide-frontend/src/check/infer_control_ops.rs
+++ b/crates/almide-frontend/src/check/infer_control_ops.rs
@@ -115,7 +115,7 @@ impl Checker {
 
             ExprKind::None => Ty::option(self.fresh_var()),
 
-            ExprKind::Ident { name, .. } => self.infer_expr_g2_ident(expr),
+            ExprKind::Ident { name: _, .. } => self.infer_expr_g2_ident(expr),
             _ => return None,
         })
     }
@@ -173,16 +173,16 @@ impl Checker {
                 for f in fields.iter_mut() { self.infer_expr(&mut f.value); }
                 base_ty
             }
-            ExprKind::IndexAccess { object, index, .. } => self.infer_expr_g2_index_access(expr),
-            ExprKind::Binary { op, left, right, .. } => self.infer_expr_g2_binary(expr),
+            ExprKind::IndexAccess { object: _, index: _, .. } => self.infer_expr_g2_index_access(expr),
+            ExprKind::Binary { op: _, left: _, right: _, .. } => self.infer_expr_g2_binary(expr),
 
-            ExprKind::Unary { op, operand, .. } => self.infer_expr_g2_unary(expr),
+            ExprKind::Unary { op: _, operand: _, .. } => self.infer_expr_g2_unary(expr),
 
-            ExprKind::If { cond, then, else_, .. } => self.infer_expr_g2_if(expr),
+            ExprKind::If { cond: _, then: _, else_: _, .. } => self.infer_expr_g2_if(expr),
 
-            ExprKind::IfLet { name, scrutinee, then, else_ } => self.infer_expr_g2_if_let(expr),
+            ExprKind::IfLet { name: _, scrutinee: _, then: _, else_: _ } => self.infer_expr_g2_if_let(expr),
 
-            ExprKind::Match { subject, arms, .. } => self.infer_expr_g2_match(expr),
+            ExprKind::Match { subject: _, arms: _, .. } => self.infer_expr_g2_match(expr),
             _ => return None,
         })
     }

--- a/crates/almide-frontend/src/check/module_inference.rs
+++ b/crates/almide-frontend/src/check/module_inference.rs
@@ -260,7 +260,7 @@ impl Checker {
         name: &str,
         ret_ty: &Ty,
         body_ty: &Ty,
-        body: &ast::Expr,
+        _body: &ast::Expr,
         is_effect: bool,
     ) {
         let rr = resolve_ty(ret_ty, &self.uf);

--- a/crates/almide-frontend/src/check/solving.rs
+++ b/crates/almide-frontend/src/check/solving.rs
@@ -406,7 +406,7 @@ fn if_arm_unit_leak(exp_str: &str, fix_hint: Option<&FixHint>) -> Option<String>
     // the Unit arm — turns the generic template into a rewrite that
     // names the real variable so the LLM can copy-paste the structure.
     if let Some(FixHint::IfArmAssign { arm, var_name }) = fix_hint {
-        let (unit_arm, good_arm) = match arm {
+        let (unit_arm, _good_arm) = match arm {
             IfArm::Then => ("then", "else"),
             IfArm::Else => ("else", "then"),
         };

--- a/crates/almide-frontend/src/lower/auto_try.rs
+++ b/crates/almide-frontend/src/lower/auto_try.rs
@@ -387,7 +387,7 @@ fn insert_try_control(kind: IrExprKind, ty: &Ty, ctx: &mut TryCtx) -> Result<IrE
             let r_try = matches!(right.kind, IrExprKind::Try { .. });
             if l_try || r_try {
                 let mut stmts = Vec::new();
-                let mut hoist = |e: IrExpr, name: &str, stmts: &mut Vec<IrStmt>, ctx: &mut TryCtx| -> IrExpr {
+                let hoist = |e: IrExpr, name: &str, stmts: &mut Vec<IrStmt>, ctx: &mut TryCtx| -> IrExpr {
                     let ty = e.ty.clone();
                     let span = e.span;
                     let var = ctx.var_table.alloc(sym(name), ty.clone(), Mutability::Let, span);

--- a/crates/almide-frontend/src/lower/expressions.rs
+++ b/crates/almide-frontend/src/lower/expressions.rs
@@ -64,8 +64,8 @@ fn lower_expr_literal(ctx: &mut LowerCtx, expr: &ast::Expr, ty: Ty, span: Option
         ast::ExprKind::Bool { value, .. } => ctx.mk(IrExprKind::LitBool { value: *value }, ty, span),
         ast::ExprKind::Unit => ctx.mk(IrExprKind::Unit, Ty::Unit, span),
         // ── Variables ──
-        ast::ExprKind::Ident { name, .. } => lower_expr_ident(ctx, expr, ty, span),
-        ast::ExprKind::TypeName { name, .. } => lower_expr_type_name(ctx, expr, ty, span),
+        ast::ExprKind::Ident { name: _, .. } => lower_expr_ident(ctx, expr, ty, span),
+        ast::ExprKind::TypeName { name: _, .. } => lower_expr_type_name(ctx, expr, ty, span),
         _ => return None,
     })
 }
@@ -106,7 +106,7 @@ fn lower_expr_collection(ctx: &mut LowerCtx, expr: &ast::Expr, ty: Ty, span: Opt
             ctx.mk(IrExprKind::Tuple { elements: elems }, resolved_ty, span)
         }
         // ── Records ──
-        ast::ExprKind::Record { name, fields, .. } => lower_expr_record(ctx, expr, ty, span),
+        ast::ExprKind::Record { name: _, fields: _, .. } => lower_expr_record(ctx, expr, ty, span),
         ast::ExprKind::SpreadRecord { base, fields, .. } => {
             let ir_base = lower_expr(ctx, base);
             let fs = fields.iter().map(|f| (f.name, lower_expr(ctx, &f.value))).collect();
@@ -126,8 +126,8 @@ fn lower_expr_collection(ctx: &mut LowerCtx, expr: &ast::Expr, ty: Ty, span: Opt
 fn lower_expr_operator(ctx: &mut LowerCtx, expr: &ast::Expr, ty: Ty, span: Option<ast::Span>) -> Option<IrExpr> {
     Some(match &expr.kind {
         // ── Operators ──
-        ast::ExprKind::Binary { op, left, right, .. } => lower_expr_binary(ctx, expr, ty, span),
-        ast::ExprKind::Unary { op, operand, .. } => lower_expr_unary(ctx, expr, ty, span),
+        ast::ExprKind::Binary { op: _, left: _, right: _, .. } => lower_expr_binary(ctx, expr, ty, span),
+        ast::ExprKind::Unary { op: _, operand: _, .. } => lower_expr_unary(ctx, expr, ty, span),
         _ => return None,
     })
 }
@@ -148,8 +148,8 @@ fn lower_expr_control(ctx: &mut LowerCtx, expr: &ast::Expr, ty: Ty, span: Option
             let e = lower_expr(ctx, else_);
             ctx.mk(IrExprKind::If { cond: Box::new(c), then: Box::new(t), else_: Box::new(e) }, ty, span)
         }
-        ast::ExprKind::Match { subject, arms, .. } => lower_expr_match_arm(ctx, expr, ty, span),
-        ast::ExprKind::IfLet { name, scrutinee, then, else_ } => lower_expr_if_let(ctx, expr, ty, span),
+        ast::ExprKind::Match { subject: _, arms: _, .. } => lower_expr_match_arm(ctx, expr, ty, span),
+        ast::ExprKind::IfLet { name: _, scrutinee: _, then: _, else_: _ } => lower_expr_if_let(ctx, expr, ty, span),
         ast::ExprKind::Block { stmts, expr, .. } => {
             ctx.push_scope();
             let body = lower_block_body(ctx, stmts, expr.as_deref(), &ty, span);
@@ -326,7 +326,7 @@ fn lower_expr_control(ctx: &mut LowerCtx, expr: &ast::Expr, ty: Ty, span: Option
             outline_ir_as_fn(ctx, full, "__almd_res", span)
         }
         // ── Loops ──
-        ast::ExprKind::ForIn { var, var_tuple, iterable, body, .. } => lower_expr_for_in(ctx, expr, ty, span),
+        ast::ExprKind::ForIn { var: _, var_tuple: _, iterable: _, body: _, .. } => lower_expr_for_in(ctx, expr, ty, span),
         ast::ExprKind::While { cond, body, .. } => {
             let ir_cond = lower_expr(ctx, cond);
             ctx.push_scope();

--- a/crates/almide-mir/src/certificate_b.rs
+++ b/crates/almide-mir/src/certificate_b.rs
@@ -773,7 +773,7 @@ pub fn ownership_certificate_with_poison(func: &MirFunction) -> (String, bool) {
     // own named functions. `CertScan::step` (protected, unchanged) and the rest of the
     // emission pipeline below are untouched.
     let (feeder_to_slot, slots, line_slots) = loop_carried_slots(func);
-    let mut depth: u32 = 0;
+    let depth: u32 = 0;
     let mut s = Streams::new();
 
     let released_merge_dsts = ownership_certificate_released_merge_dsts(func);

--- a/crates/almide-mir/src/lower/binds_p2_b.rs
+++ b/crates/almide-mir/src/lower/binds_p2_b.rs
@@ -661,14 +661,14 @@ impl LowerCtx {
             self.variant_drop_handles.insert(dst, "map_mlo".to_string());
             return;
         }
-        if let Some(rname) = (match ty {
+        if let Some(rname) = match ty {
             Ty::Applied(almide_lang::types::constructor::TypeConstructorId::List, a)
                 if a.len() == 1 =>
             {
                 self.record_or_anon_drop_type_name(&a[0])
             }
             _ => None,
-        }) {
+        }  {
             // A `List[<recursive-drop record>]` result (`list.unique` over a
             // String-field record via the `__krec_*` twins): route to the generated
             // `$__drop_list_<R>` (emitted for EVERY recursive-drop record) — the

--- a/crates/almide-mir/src/lower/calls_p3.rs
+++ b/crates/almide-mir/src/lower/calls_p3.rs
@@ -612,7 +612,7 @@ impl LowerCtx {
     }
 
     pub(crate) fn lower_scalar_field_access(&mut self, expr: &IrExpr) -> Option<ValueId> {
-        use crate::{IntOp, PrimKind};
+        
         // Scalar result only (the caller's contract; a heap field defers to the
         // container-grain extraction).
         if is_heap_ty(&expr.ty) {
@@ -665,7 +665,7 @@ impl LowerCtx {
         index: &IrExpr,
         elem_ty: &Ty,
     ) -> Option<ValueId> {
-        use crate::PrimKind;
+        
         // Scalar element only — a heap element (List[String]) needs a borrowing LoadHandle path,
         // handled by the heap-extraction lowering, not here.
         if is_heap_ty(elem_ty) {

--- a/crates/almide-mir/src/lower/calls_p4_c.rs
+++ b/crates/almide-mir/src/lower/calls_p4_c.rs
@@ -655,14 +655,14 @@ impl LowerCtx {
             self.variant_drop_handles.insert(dst, "map_mlo".to_string());
             return;
         }
-        if let Some(rname) = (match ty {
+        if let Some(rname) = match ty {
             Ty::Applied(almide_lang::types::constructor::TypeConstructorId::List, a)
                 if a.len() == 1 =>
             {
                 self.record_or_anon_drop_type_name(&a[0])
             }
             _ => None,
-        }) {
+        }  {
             // A `List[<recursive-drop record>]` arg temp — `$__drop_list_<R>` (the
             // bind-site route, mirrored; the flat fallback leaked each element's
             // String fields — the krec-unique residue).

--- a/crates/almide-mir/src/lower/control.rs
+++ b/crates/almide-mir/src/lower/control.rs
@@ -15,7 +15,7 @@ use almide_lang::types::Ty;
 /// auto-`Dup`s in `lower_heap_result_arm`; a consuming re-use `Dup`s in
 /// `lower_owned_heap_field` — so the borrow is never released at rc 0. A `Wildcard` arm is the
 /// unconditional catch-all.
-enum VariantArmKind {
+pub(in crate::lower) enum VariantArmKind {
     Ctor { tag: i64, binds: Vec<(usize, VarId, bool, Ty)> },
     Wildcard,
     /// A BINDER catch-all (`e => err(e)` — the regrouped compute fall-through): matches any

--- a/crates/almide-mir/src/lower/control_b.rs
+++ b/crates/almide-mir/src/lower/control_b.rs
@@ -610,7 +610,7 @@ fn detect_enum_map_fusion<'a>(
     params: &[(VarId, Ty)],
     body: &IrExpr,
 ) -> Option<(&'a IrExpr, VarId, VarId, Ty, IrExpr)> {
-    use almide_ir::{IrPattern, IrStmtKind};
+    
     // xs = list.enumerate(real)
     let real = match &xs.kind {
         IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, .. }

--- a/crates/almide-mir/src/lower/control_p2_c.rs
+++ b/crates/almide-mir/src/lower/control_p2_c.rs
@@ -366,7 +366,7 @@ impl LowerCtx {
         // roll its ops back.
         let ops_mark = self.ops.len();
         let lhh_mark = self.live_heap_handles.len();
-        let mut rollback = |s: &mut Self| {
+        let rollback = |s: &mut Self| {
             s.ops.truncate(ops_mark);
             s.live_heap_handles.truncate(lhh_mark);
         };

--- a/crates/almide-mir/src/lower/defunc_find.rs
+++ b/crates/almide-mir/src/lower/defunc_find.rs
@@ -51,7 +51,7 @@ impl LowerCtx {
         result_ty: &Ty,
     ) -> Option<ValueId> {
         use crate::PrimKind;
-        use almide_lang::types::constructor::TypeConstructorId;
+        
         let elem_ty = defunc_find_elem_ty(xs, params, result_ty)?;
         let elem_heap = is_heap_ty(&elem_ty);
         // Borrow the source list (evaluated once).

--- a/crates/almide-mir/src/lower/defunc_hof_inner.rs
+++ b/crates/almide-mir/src/lower/defunc_hof_inner.rs
@@ -461,7 +461,7 @@ impl LowerCtx {
         xs: &IrExpr,
         st: &DefuncLoopSt,
     ) {
-        use crate::PrimKind;
+        
         let elem_param = if func == "fold" { params[1].0 } else { params[0].0 };
         self.value_of.insert(elem_param, st.elem);
         self.bind_defunc_second_elem(st);

--- a/crates/almide-mir/src/lower/defunc_tuple_fold_b.rs
+++ b/crates/almide-mir/src/lower/defunc_tuple_fold_b.rs
@@ -110,8 +110,8 @@ impl LowerCtx {
     ) -> Option<ValueId> {
         let DefuncLambda { params, body } = lambda;
         use crate::{IntOp, PrimKind};
-        use almide_lang::types::constructor::TypeConstructorId;
-        use almide_ir::{BinOp, IrPattern, IrStmtKind};
+        
+        use almide_ir::{BinOp, IrPattern};
         let (p_var, found_var) = plan_opt_tuple_fold(params, body, init, result_ty)?;
         let acc_var = params[0].0;
         let IrExprKind::Tuple { elements: init_elems } = &init.kind else { return None };
@@ -398,7 +398,7 @@ impl LowerCtx {
         acc: OptFoldAcc,
         slots: OptFoldSlots,
     ) -> Option<()> {
-        let OptFoldAcc { acc: acc_var, found: found_var, found_tag: ft, found_val: fv } = acc;
+        let OptFoldAcc { acc: acc_var, found: found_var, found_tag: _ft, found_val: fv } = acc;
         let OptFoldSlots { scalar: s0, tag: tloc, val: vloc } = slots;
         use almide_ir::IrPattern;
         match &e.kind {

--- a/crates/almide-mir/src/lower/desugar_fan.rs
+++ b/crates/almide-mir/src/lower/desugar_fan.rs
@@ -9,7 +9,7 @@
 /// […]; fan.race(ts)`) has no inlinable bodies → left for the call-site purity wall.
 pub fn desugar_fan_race_any(body: &IrExpr, next_var: &mut u32) -> Option<IrExpr> {
     use almide_ir::visit_mut::{walk_expr_mut, IrMutVisitor};
-    use almide_ir::{CallTarget, IrMatchArm, IrPattern};
+    use almide_ir::{CallTarget, IrPattern};
     // A LET-BOUND, never-reassigned thunk-list literal (`let lam: List[() -> R] = [() => …];
     // fan.race(lam)` — the #599 var-bound form): resolve the Var back to its literal elements
     // so the SAME inliners run as for the inline form. Sound: VarIds are shadowing-free
@@ -341,7 +341,7 @@ pub fn desugar_fan_race_any(body: &IrExpr, next_var: &mut u32) -> Option<IrExpr>
             }
         }
         fn rewrite_settle_any(&mut self, e: &mut IrExpr) {
-            use almide_ir::{IrMatchArm, IrPattern};
+            
             // `fan.settle([…])` as a bind value / tail — the results list literal.
             // A PURE thunk's body is bare `T` while settle's checked type is
             // `List[Result[T, E]]` (FanLowering's phantom-Result convention) — wrap each

--- a/crates/almide-mir/src/lower/desugar_guard.rs
+++ b/crates/almide-mir/src/lower/desugar_guard.rs
@@ -394,7 +394,7 @@ pub fn hoist_block_call_args(program: &mut almide_ir::IrProgram) {
     // interp lowering then sees only plain operands. Sound when every EARLIER Expr
     // part is pure (a literal/Var); parts after the block already evaluate after it.
     fn hoist_in_stmts(stmts: &mut Vec<almide_ir::IrStmt>) {
-        use almide_ir::{IrExprKind, IrStmtKind, IrStringPart};
+        
         let mut i = 0;
         while i < stmts.len() {
             let hoisted = take_first_block_part(&mut stmts[i]);

--- a/crates/almide-mir/src/lower/desugar_nested_unwrap.rs
+++ b/crates/almide-mir/src/lower/desugar_nested_unwrap.rs
@@ -38,7 +38,7 @@ pub(crate) fn desugar_stmt_value_nested_unwrap(
 /// Depth-first search for a statement list containing a qualifying stmt;
 /// rewrites in place and returns true on the first hit.
 fn nested_unwrap_rewrite_expr(e: &mut IrExpr, next_var: &mut u32) -> bool {
-    use almide_ir::{IrExprKind, IrStmt, IrStmtKind};
+    use almide_ir::IrExprKind;
     match &mut e.kind {
         IrExprKind::Block { stmts, expr } => {
             if nested_unwrap_rewrite_stmts(stmts, next_var) {

--- a/crates/almide-mir/src/lower/desugar_unwrap.rs
+++ b/crates/almide-mir/src/lower/desugar_unwrap.rs
@@ -18,7 +18,7 @@ pub fn desugar_effect_unwrap(
     body: &IrExpr,
     unit_main: bool,
     ret_is_result: bool,
-    layouts: &crate::lower::VariantLayouts,
+    _layouts: &crate::lower::VariantLayouts,
 ) -> Option<IrExpr> {
     let mut next_var = max_var_id(body) + 1;
     desugar_effect_unwrap_inner(body, &mut next_var, unit_main, ret_is_result)
@@ -45,7 +45,7 @@ fn desugar_effect_unwrap_inner(
     unit_main: bool,
     ret_is_result: bool,
 ) -> Option<IrExpr> {
-    use almide_ir::{IrMatchArm, IrPattern};
+    
     use almide_lang::types::Ty;
     // A `!` in a FOR-IN ITERABLE HEAD (`for row in list.get(XS, 0)! { … }` — #1168):
     // hoist it FIRST into `let $t = <head>!; for row in $t { … }` (exactly the manual

--- a/crates/almide-mir/src/lower/drop_sources.rs
+++ b/crates/almide-mir/src/lower/drop_sources.rs
@@ -337,7 +337,7 @@ impl almide_ir::visit::IrVisitor for GenericVariantListInstantiationScan<'_> {
 /// `for` costs more cognitive complexity per level than a flat `.chain()`/
 /// `.flat_map()` pipeline, which this crate's Op-rendering code already prefers for
 /// exactly that reason). A plain iteration helper, no decision logic.
-fn for_each_program_expr(ir: &almide_ir::IrProgram, mut visit: impl FnMut(&almide_ir::IrExpr)) {
+fn for_each_program_expr(ir: &almide_ir::IrProgram, visit: impl FnMut(&almide_ir::IrExpr)) {
     let main = ir.functions.iter().map(|f| &f.body).chain(ir.top_lets.iter().map(|tl| &tl.value));
     let modules = ir.modules.iter().flat_map(|m| {
         m.functions.iter().map(|f| &f.body).chain(m.top_lets.iter().map(|tl| &tl.value))

--- a/crates/almide-mir/src/lower/list_literal_elements.rs
+++ b/crates/almide-mir/src/lower/list_literal_elements.rs
@@ -89,8 +89,8 @@ impl LowerCtx {
         elem_ty: &Ty,
         kind: ListElemDrop,
     ) -> Option<Option<ValueId>> {
-        use crate::{IntOp, PrimKind};
-        use almide_lang::types::constructor::TypeConstructorId;
+        
+        
         // When the element type is forced (a structural record LITERAL in a `List[Named]` context),
         // materialize the element AS the Named type so `try_lower_record_construct` lays it out by
         // the DECLARED field order (matching the `$__drop_list_<Named>` teardown). Field-by-name

--- a/crates/almide-mir/src/lower/mod_b.rs
+++ b/crates/almide-mir/src/lower/mod_b.rs
@@ -535,7 +535,7 @@ fn die_on(lit: IrExpr) -> IrExpr {
 /// `desugar_heap_branches`), so every driver counts and lowers the SAME tree.
 fn desugar_assert_calls(body: &IrExpr) -> Option<IrExpr> {
     use almide_ir::{walk_expr_mut, IrMutVisitor};
-    use almide_lang::intern::sym;
+    
     struct S {
         changed: bool,
         /// Fresh-VarId counter for the unwrap-operand hoist below (the

--- a/crates/almide-mir/src/lower/mod_p2.rs
+++ b/crates/almide-mir/src/lower/mod_p2.rs
@@ -528,7 +528,7 @@ pub fn rewrap_never_err_into_result_targets(
     use almide_lang::types::constructor::TypeConstructorId;
     // Pass 1: vars DECLARED with a Result type (Bind.ty).
     fn collect_result_vars(e: &IrExpr, out: &mut std::collections::HashSet<u32>) {
-        use almide_ir::visit::{walk_expr, IrVisitor};
+        use almide_ir::visit::IrVisitor;
         struct C<'a>(&'a mut std::collections::HashSet<u32>);
         impl IrVisitor for C<'_> {
             fn visit_stmt(&mut self, s: &IrStmt) {

--- a/crates/almide-mir/src/lower/mod_p4_e.rs
+++ b/crates/almide-mir/src/lower/mod_p4_e.rs
@@ -335,7 +335,7 @@ fn map_variant_heap_key(r: MapRoute<'_>) -> Option<MapName> {
 /// fall-through. Reached only with a heap key AND a heap value; the `(key_heap,
 /// val_heap)` match is kept so each arm reads exactly as it did in the one body.
 fn map_heap_val_construction_route(r: MapRoute<'_>) -> Option<MapName> {
-    use almide_lang::types::constructor::TypeConstructorId;
+    
     let MapRoute { func, result_ty, val_is_string, val_is_flat_list, val_is_fn, .. } = r;
     match (r.key_heap, r.val_heap) {
     // `Map[String, List[scalar]]` — the implemented subset of the heap-value
@@ -462,7 +462,7 @@ fn map_heap_val_nested_route(r: MapRoute<'_>) -> Option<MapName> {
 /// fall-through. Reached only with a heap key AND a heap value; the `(key_heap,
 /// val_heap)` match is kept so each arm reads exactly as it did in the one body.
 fn map_heap_val_named_and_typechange_route(r: MapRoute<'_>) -> Option<MapName> {
-    use almide_lang::types::constructor::TypeConstructorId;
+    
     let MapRoute { func, arg_tys, result_ty, key_is_string, key_scalar_rec: map_key_scalar_rec, .. } = r;
     match (r.key_heap, r.val_heap) {
     // `map.from_list` over a NAMED-value map (`["o": Point{..}]` / `["a":

--- a/crates/almide-mir/src/lower/repr_sources_c.rs
+++ b/crates/almide-mir/src/lower/repr_sources_c.rs
@@ -495,11 +495,11 @@ fn generate_anon_and_tuple_interp_reprs(
     out: &mut String,
     type_decls: &[almide_ir::IrTypeDecl],
     interp_anon_recs: &[Vec<(almide_lang::intern::Sym, Ty)>],
-    interp_containers: &InterpReprContainers,
+    _interp_containers: &InterpReprContainers,
     gates: &ReprGates,
 ) {
     use almide_ir::IrTypeDeclKind;
-    let ReprGates { names, emittable, .. } = gates;
+    let ReprGates { names, emittable: _, .. } = gates;
     let _ = (type_decls, names);
     // ── ANONYMOUS-record reprs (`__repr_anonrec_<hash>`) ──
     // v0 renders an anon record `{ apple: 2, mango: 3, zebra: 1 }` with fields SORTED BY

--- a/crates/almide-mir/src/lower/result_ctors.rs
+++ b/crates/almide-mir/src/lower/result_ctors.rs
@@ -84,7 +84,7 @@ impl LowerCtx {
         result_ty: &Ty,
     ) -> Option<ValueId> {
         use crate::{IntOp, PrimKind};
-        use almide_lang::types::constructor::TypeConstructorId;
+        
         let rec_ty = self.rec_int_ok_payload(result_ty)?;
         // A RECURSIVE-drop record routes through the generated `$__drop_tup_int_<R>`
         // wrapper; a FLAT (all-scalar-field) record's tuple frees exactly like the

--- a/crates/almide-mir/src/pipeline.rs
+++ b/crates/almide-mir/src/pipeline.rs
@@ -15,11 +15,9 @@ use crate::render_wasm::try_render_wasm_program;
 use crate::MirProgram;
 use almide_frontend::canonicalize;
 use almide_frontend::check::Checker;
-use almide_frontend::ir_link;
 use almide_frontend::lower::lower_program;
 use almide_lang::lexer::Lexer;
 use almide_lang::parser::Parser;
-use almide_optimize::{mono, optimize};
 use std::collections::HashMap;
 
 /// The mangled flat name a user-module function gets when resolved to a user `CallFn`

--- a/crates/almide-mir/src/pipeline_native_rungs.rs
+++ b/crates/almide-mir/src/pipeline_native_rungs.rs
@@ -233,7 +233,7 @@ fn build_native_sig_table(
 // `Repr::Ptr` as `&str` vs `&[i64]` per the declaration.
 let mut sigs: crate::render_native::NativeSigs = Default::default();
 {
-    use almide_lang::types::constructor::TypeConstructorId;
+    
     use almide_lang::types::Ty;
     use crate::render_native::NativeSigKind;
     for func in &ir.functions {

--- a/crates/almide-mir/src/render_native.rs
+++ b/crates/almide-mir/src/render_native.rs
@@ -22,7 +22,7 @@
 //! full scalar-or-String control flow (if-as-value, loops).
 
 use crate::lower::LowerError;
-use crate::{CallArg, Init, IntOp, MirFunction, MirProgram, Op, Repr, ValueId};
+use crate::{CallArg, IntOp, MirFunction, MirProgram, Op, Repr, ValueId};
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
@@ -117,12 +117,11 @@ pub(crate) fn as_f64_arg(code: &str, t: NTy) -> Result<String, LowerError> {
 /// addition needs a differential-corpus row in the same PR
 /// (tests/native_v1_differential_test.rs).
 use crate::render_native_op_families::{
-    render_native_float_op, render_native_meter_op, render_native_result_op,
+    render_native_meter_op, render_native_result_op,
     render_native_scalar_op, render_native_termination_op,
 };
 use crate::render_native_shims::{
-    shim, shim_rust_name, BUDGET_SHIM, CHARGE_DYN_SHIM, CHARGE_SHIM, COUNTER_SHIM, CUT_RET_MARKER,
-    FUEL_LT0_SHIM, TIMEOUT_SHIM,
+    shim, shim_rust_name, CHARGE_SHIM, COUNTER_SHIM, CUT_RET_MARKER,
 };
 
 /// The Perceus balance is machine-checked on the SAME ops this render erases

--- a/crates/almide-mir/src/render_wasm_b.rs
+++ b/crates/almide-mir/src/render_wasm_b.rs
@@ -334,7 +334,7 @@ fn render_op_range(
     // stateful reconstruction of the flat marker stream. A scalar `if` is an
     // expression `(local.set $dst (if (result i64) cond (then …val) (else …val)))`;
     // each arm leaves its value on the stack. Only the taken arm executes.
-    let arm_val = |v: &Option<ValueId>| {
+    let _arm_val = |v: &Option<ValueId>| {
         v.map(|v| format!("      (local.get {})\n", local(v))).unwrap_or_default()
     };
     let mut i = start;
@@ -778,16 +778,16 @@ fn wasm_ty(repr: Repr) -> &'static str {
     }
 }
 
-/// Every [`ValueId`] an op READS (operands only — never the defined dst),
-/// exhaustively and with multiplicity (`IntBinOp { a: v, b: v }` pushes `v`
-/// twice). The read half of the `op_values` split (#777 F3 item 2): together
-/// with [`defined_value`] and the `SetLocal` redefinition case it partitions
-/// every value an op touches, and `mir_wellformed::check_def_before_use`
-/// asserts that partition against `op_values` on every real op in every
-/// lowered function — corpus-wide, not on hand-built samples.
-///
-/// A `SetLocal`'s `local` is counted as a READ here: the op stores INTO an
-/// existing slot, and def-before-use demands the slot already exist. Its `src`
+// Every [`ValueId`] an op READS (operands only — never the defined dst),
+// exhaustively and with multiplicity (`IntBinOp { a: v, b: v }` pushes `v`
+// twice). The read half of the `op_values` split (#777 F3 item 2): together
+// with [`defined_value`] and the `SetLocal` redefinition case it partitions
+// every value an op touches, and `mir_wellformed::check_def_before_use`
+// asserts that partition against `op_values` on every real op in every
+// lowered function — corpus-wide, not on hand-built samples.
+//
+// A `SetLocal`'s `local` is counted as a READ here: the op stores INTO an
+// existing slot, and def-before-use demands the slot already exist. Its `src`
 
 include!("render_wasm_fuse.rs");
 

--- a/crates/almide-mir/src/render_wasm_c.rs
+++ b/crates/almide-mir/src/render_wasm_c.rs
@@ -86,7 +86,7 @@ fn fusable_float_prim(
     floats: &BTreeSet<ValueId>,
 ) -> Option<(ValueId, String, BTreeSet<ValueId>)> {
     let mut reads = BTreeSet::new();
-    let mut farg = |fuser: &mut Fuser, reads: &mut BTreeSet<ValueId>, i: usize| {
+    let farg = |fuser: &mut Fuser, reads: &mut BTreeSet<ValueId>, i: usize| {
         let raw = fuser.take(args[i], reads);
         if floats.contains(&args[i]) {
             raw

--- a/crates/almide-mir/src/render_wasm_calls.rs
+++ b/crates/almide-mir/src/render_wasm_calls.rs
@@ -156,7 +156,7 @@ match dst {
 }
 
 fn render_op_call_light(op: &Op, env: &WasmEnv<'_>, tail_call: bool) -> String {
-    let WasmEnv { label_off, param_counts, reprs, floats } = *env;
+    let WasmEnv { label_off, param_counts: _, reprs, floats } = *env;
     match op {
         // An alias SHARES the object and bumps its refcount (A1.3-render): dst and
         // src become two handles to the SAME block, rc += 1 — matching the cert's

--- a/crates/almide-mir/src/translation_validation.rs
+++ b/crates/almide-mir/src/translation_validation.rs
@@ -47,7 +47,7 @@ pub fn validate_safety(wat: &str, mir: &crate::MirFunction) -> bool {
 /// REALIZES the abstract op (the runtime memory model) are the refinements — the
 /// latter is the once-built WasmCert-Coq library (G1.2, the deferred heavy track).
 pub fn wasm_pattern(op: &crate::Op) -> Option<String> {
-    use crate::{Init, IntOp, Op, RtFn};
+    use crate::{Init, Op, RtFn};
     Some(match op {
         // Probe charge: the SITE-SPECIFIC trace update is the presence claim — a
         // renderer that drops THIS charge (not just any charge) fails the gate.

--- a/crates/almide-mir/src/wasm_op_tables.rs
+++ b/crates/almide-mir/src/wasm_op_tables.rs
@@ -7,7 +7,7 @@
 /// is an ordinary read. An `IfThen`'s `dst` is the definition, not a read; the
 /// `Else`/`EndIf` `val`s are reads (they feed the enclosing if-result).
 pub(crate) fn op_reads(op: &Op, out: &mut Vec<ValueId>) {
-    let args_vals = |args: &[CallArg], out: &mut Vec<ValueId>| {
+    let _args_vals = |args: &[CallArg], out: &mut Vec<ValueId>| {
         for a in args {
             match a {
                 CallArg::Handle(v) | CallArg::Scalar(v) => out.push(*v),
@@ -126,7 +126,7 @@ fn op_reads_flow(op: &Op, out: &mut Vec<ValueId>) {
 /// generic occurrence walk the render-level peepholes (#806 step 3b) use to
 /// prove a value is single-use before fusing its def into its use site.
 pub(crate) fn op_values(op: &Op, out: &mut Vec<ValueId>) {
-    let args_vals = |args: &[CallArg], out: &mut Vec<ValueId>| {
+    let _args_vals = |args: &[CallArg], out: &mut Vec<ValueId>| {
         for a in args {
             match a {
                 CallArg::Handle(v) | CallArg::Scalar(v) => out.push(*v),

--- a/crates/almide-optimize/src/mono/discovery.rs
+++ b/crates/almide-optimize/src/mono/discovery.rs
@@ -182,7 +182,7 @@ pub(super) fn discover_in_stmt(
     program_functions: &[IrFunction],
     instances: &mut HashMap<MonoKey, HashMap<String, Ty>>,
 ) {
-    use almide_ir::visit::walk_stmt;
+    
     let mut visitor = DiscoverVisitor { bound_fns, program_functions, instances: HashMap::new() };
     visitor.visit_stmt(stmt);
     instances.extend(visitor.instances);

--- a/crates/almide-optimize/src/optimize/mod.rs
+++ b/crates/almide-optimize/src/optimize/mod.rs
@@ -87,7 +87,7 @@ fn constant_fold(program: &mut IrProgram) {
     // cross-module top-let read goes through a synthesized ref in the
     // READER's own region resolved by NAME later, never by a raw foreign id,
     // so per-region scoping loses no legitimate #809 chain.
-    let mut fold_top_let = |tl: &mut IrTopLet,
+    let fold_top_let = |tl: &mut IrTopLet,
                             env: &mut std::collections::HashMap<VarId, IrExprKind>| {
         subst_const_vars(&mut tl.value, env);
         fold_expr(&mut tl.value);

--- a/crates/almide-syntax/src/parser/declarations.rs
+++ b/crates/almide-syntax/src/parser/declarations.rs
@@ -1,6 +1,5 @@
 use crate::lexer::TokenType;
 use crate::ast::*;
-use crate::ast::ExprKind;
 use crate::intern::{Sym, sym};
 use super::Parser;
 

--- a/crates/almide-syntax/src/parser/entry.rs
+++ b/crates/almide-syntax/src/parser/entry.rs
@@ -71,7 +71,6 @@ impl Parser {
         // Import declarations (with recovery)
         while self.check(TokenType::Import) {
             program.comment_map.push(std::mem::take(&mut pending));
-            gap_blanks = 0;
             match self.parse_import_decl() {
                 Ok(import) => program.imports.push(import),
                 Err(msg) => {
@@ -95,7 +94,6 @@ impl Parser {
             program.doc_map.push(doc);
             program.blank_lines_map.push(gap_blanks);
             program.comment_map.push(std::mem::take(&mut pending));
-            gap_blanks = 0;
 
             let pre_err_len = self.errors.len();
             match self.parse_top_decl() {

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -216,7 +216,7 @@ enum WasmTestOutcome {
 /// early-return order exactly.
 fn wasm_test_preflight_outcome(
     test_file: &str,
-    program: &almide_lang::ast::Program,
+    _program: &almide_lang::ast::Program,
     source_text: &str,
     parse_errors: &[crate::diagnostic::Diagnostic],
 ) -> Option<WasmTestOutcome> {

--- a/src/cli/lsp.rs
+++ b/src/cli/lsp.rs
@@ -464,6 +464,10 @@ fn lsp_server_capabilities() -> ServerCapabilities {
 
 /// `run_lsp`'s workspace-root derivation from `initialize`'s `root_uri`,
 /// falling back to CWD. Extracted verbatim.
+/// `root_uri` is deprecated upstream in favor of `workspace_folders`, but VS
+/// Code still sends it and the single-root fallback is exactly this field —
+/// keep reading it deliberately until multi-root support is a real need.
+#[allow(deprecated)]
 fn derive_workspace_root(init: &InitializeParams) -> Option<std::path::PathBuf> {
     init.root_uri.as_ref()
         .and_then(|u| u.path().to_string().strip_prefix('/').or(Some(u.path().as_str())).map(|s| std::path::PathBuf::from(s.to_string())))


### PR DESCRIPTION
#1228: the develop build had accumulated 40+ warnings — noise that buries real signals. This clears the mechanical classes and leaves an annotated tail.

## Fixed (verified: cargo check --all-targets clean, all 96 test harnesses green, almide test 383/383)

- **unused imports/variables** across 50+ files (cargo fix, then hand-reviewed — every removal checked against side effects; drop-guards like `ProfileTimer` correctly became `_et` bindings, not deletions)
- **dead pure lets deleted** (`let _upper = ctx.global_static_name(...)` — verified `&self`-pure, then the now-orphaned fn removed too)
- **two real dead stores** in the parser (`gap_blanks = 0` in parser/entry.rs, both always overwritten before any read)
- **visibility mismatch**: `VariantArmKind` now `pub(in crate::lower)` matching its reachable field
- **deprecated `root_uri`**: deliberate `#[allow(deprecated)]` with a comment (VS Code still sends it; single-root fallback is exactly this field)
- **orphaned doc comment** on an `include!` converted to a regular comment

## Deliberately left (20 warnings, all never-used dead-code class)

The never-used fns in `mono/discovery.rs`, `optimize/dce.rs` belong to the in-progress #1108 Phase 2b/3 machinery; the LSP/cli helpers and frontend `lower_test`/`resolve_type_expr_with_env` need an owner's judgment on whether they are future surface or deletable. Enumerated on #1228 rather than silently allowed — the count only shrinks from here.