### PR TITLE
Add the strict workflow-file parse gate (a schedule-only workflow that cannot parse fails silently)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,6 +820,9 @@ jobs:
       - name: Forbidden impurities (no raw clocks/threads in the compile path)
         run: scripts/check-forbidden-impurities.sh
 
+      - name: Workflow files parse strictly (a schedule-only workflow that cannot parse fails silently, #1234)
+        run: bash scripts/check-workflows.sh
+
       - name: rt-oracle registry (RETIRED with v0, #782 — prints the tombstone; v1 is gated by spec/wasm_cross + the interp oracle)
         # The step name previously claimed "every compile_* registered +
         # verified tests exist" while the script short-circuits on the deleted

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -38,6 +38,12 @@ pre-commit:
       run: bash scripts/check-wat-prelude-audit.sh
     ratchet-separation:
       run: scripts/check-ratchet-separation.sh
+    workflow-parse:
+      # A schedule-only workflow that cannot parse fails SILENTLY at trigger
+      # time (#1234, the 0.57.0 fuzz-nightly dup-key incident) — strict-parse
+      # every workflow file whenever one changes.
+      glob: "{.github/workflows/*.yml,.github/workflows/*.yaml,scripts/check-workflows.sh}"
+      run: bash scripts/check-workflows.sh
     semantics-manifest:
       # Globbed by PATTERN, not by covered module: the hook named
       # stdlib/string.almd literally, so the next module onto the ratchet

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -24,7 +24,7 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).
 >
-> **Stage 5 (auditability): 1 release seal(s); 32 verification gates classified
+> **Stage 5 (auditability): 1 release seal(s); 33 verification gates classified
 > (9 UNVERIFIED under a shrink-only ceiling); TOR with 9 enforced rows;
 > gap analysis consolidated in proofs/DO330-GAP.md (reference-gated).**
 <!-- stages:generated:end -->

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -114,6 +114,11 @@ class = "NEGATIVE_TESTED"
 evidence = "#1244 burn-down PR: the first probe EXPOSED a real hole (a bogus class name sailed through green) — fixed with a pinned vocabulary, then both directions demonstrated (bogus class, unclassified entry)"
 
 [[gate]]
+path = "scripts/check-workflows.sh"
+class = "NEGATIVE_TESTED"
+evidence = "#1234 landing PR: forged a workflow with a duplicate `if:` key (the exact 0.57.0 fuzz-nightly incident shape) — the strict loader rejected it with the key named and exit 1; the empty-glob path also fails loud (no find-nothing-exit-0)"
+
+[[gate]]
 path = "scripts/check-browser-determinism.sh"
 class = "UNVERIFIED"
 

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Workflow-file parse gate (#1234): a schedule-only workflow that cannot parse
+# fails SILENTLY — Actions never validates workflow files until a trigger
+# fires, so a broken file ships through green CI and the scheduled instrument
+# goes dark (the 0.57.0 release-gate incident: a duplicate `if:` key killed
+# fuzz-nightly's parse; only a manual dispatch surfaced it, #1225).
+#
+# STRICT parse: `yaml.safe_load` alone accepts the exact duplicate-key case
+# that bit, so the loader here rejects duplicate mapping keys explicitly.
+# The 計器の計器 principle: every gate that only runs on a schedule needs a
+# parse/health check that runs on every PR.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+python3 - "$ROOT" <<'PYEOF'
+import glob
+import sys
+
+import yaml
+
+
+class StrictLoader(yaml.SafeLoader):
+    pass
+
+
+def no_duplicate_keys(loader, node, deep=False):
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise yaml.constructor.ConstructorError(
+                None,
+                None,
+                f"duplicate mapping key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+StrictLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, no_duplicate_keys
+)
+
+root = sys.argv[1]
+files = sorted(glob.glob(f"{root}/.github/workflows/*.yml")) + sorted(
+    glob.glob(f"{root}/.github/workflows/*.yaml")
+)
+if not files:
+    print("WORKFLOW PARSE FAIL — no workflow files found (the glob moved?)", file=sys.stderr)
+    sys.exit(1)
+
+fail = 0
+for f in files:
+    try:
+        with open(f) as fh:
+            doc = yaml.load(fh, Loader=StrictLoader)
+    except yaml.YAMLError as e:
+        print(f"  {f}: {e}", file=sys.stderr)
+        fail = 1
+        continue
+    # An Actions workflow must at least be a mapping with jobs; a file that
+    # parses to a scalar/list would also die at trigger time.
+    if not isinstance(doc, dict) or "jobs" not in doc:
+        print(f"  {f}: parses but has no `jobs` mapping — not a valid workflow", file=sys.stderr)
+        fail = 1
+
+if fail:
+    print("WORKFLOW PARSE FAIL — a broken workflow file is invisible until its trigger fires.", file=sys.stderr)
+    sys.exit(1)
+print(f"workflows OK: {len(files)} file(s) parse strictly (duplicate keys rejected)")
+PYEOF


### PR DESCRIPTION
Closes #1234 — the 0.57.0 release-gate incident class: a duplicate `if:` key killed fuzz-nightly's PARSE, Actions never validates workflow files until a trigger fires, and the scheduled instrument went dark behind green CI.

## The gate (計器の計器)

`scripts/check-workflows.sh` — strict-parses every `.github/workflows/*.yml`:
- **duplicate mapping keys rejected explicitly** (a custom SafeLoader constructor — plain `yaml.safe_load` ACCEPTS the exact shape that bit)
- a file that parses but has no `jobs` mapping fails (would also die at trigger time)
- an empty glob is a hard error (the find-nothing-exit-0 blindness class)

Wired three ways, one instrument: CI `checks` job step, lefthook pre-commit (armed by any workflow-file or script change), and the gate-verification ledger row.

## Verification

- **Forge probe run live**: a workflow with the incident's duplicate `if:` key → rejected with the key named, exit 1; removed → 7 files parse green.
- Ledger row class **NEGATIVE_TESTED** with that evidence; `check-gate-verification.sh` green at 33 gates (it caught the unclassified script before the row existed — the enumeration works).
- No new dependencies (PyYAML already on the runners; actionlint noted on #1234 as a possible future strengthening for expression-level lint).