### PR TITLE
Close #1270: nested-Option unwrap-or lowers via the option-match rewrite (gated to Option payloads)

### DIFF
--- a/crates/almide-mir/src/lower/binds_p2_heap.rs
+++ b/crates/almide-mir/src/lower/binds_p2_heap.rs
@@ -58,6 +58,29 @@ impl LowerCtx {
                 self.live_heap_handles.truncate(lhh_mark);
                 self.lifted.truncate(lifted_mark);
             }
+            // The OPTION-polarity mirror (#1270): a heap `??` whose operand is
+            // Option-typed and whose PAYLOAD is itself Option (`sn ?? none`
+            // over Option[Option[Int]] — the nested-Option elimination)
+            // declined the direct route above. Rewrite to `match expr {
+            // some(p) => p, none => fallback }` through the same speculative
+            // bind-position heap-match machinery; a decline ROLLS BACK to the
+            // honest wall below. GATED to Option payloads: an Option[record]
+            // subject through THIS synthesized route mis-reads the record's
+            // String fields on wasm (measured: "x" printed as blanks) even
+            // though a user-written match over the same source is correct —
+            // the record case stays on the wall until the bind-position
+            // synthesized-match route is fixed (#1270 follow-up).
+            if expr.ty.is_option() && ty.is_option() {
+                let ops_mark = self.ops.len();
+                let lhh_mark = self.live_heap_handles.len();
+                let rewritten = Self::unwrap_or_as_option_match(value, expr, fallback);
+                if self.lower_bind(var, ty, &rewritten).is_ok() {
+                    return Ok(true);
+                }
+                self.ops.truncate(ops_mark);
+                self.live_heap_handles.truncate(lhh_mark);
+                self.lifted.truncate(lifted_mark);
+            }
             // A HEAP-result `??` over an Option/Result operand that `try_lower_option_unwrap_or`
             // declined (e.g. `Option[record]` — no faithful record-payload unwrap-or yet) must
             // NOT fall to the `Alloc{Opaque}` below: that binds an EMPTY heap value the caller
@@ -99,6 +122,42 @@ impl LowerCtx {
                     },
                     IrMatchArm {
                         pattern: IrPattern::Err { inner: Box::new(IrPattern::Wildcard) },
+                        guard: None,
+                        body: fallback.clone(),
+                    },
+                ],
+            },
+            ty: value.ty.clone(),
+            span: value.span.clone(),
+            def_id: value.def_id,
+        }
+    }
+
+    /// The Option-polarity mirror of [`Self::unwrap_or_as_result_match`] (#1270):
+    /// `e ?? d` → `match e { some(p) => p, none => d }`, same speculative
+    /// discipline (the caller gates on `is_option` and rolls back on decline).
+    fn unwrap_or_as_option_match(value: &IrExpr, expr: &IrExpr, fallback: &IrExpr) -> IrExpr {
+        use almide_ir::{IrMatchArm, IrPattern};
+        let payload_ty = value.ty.clone();
+        let p = VarId(crate::lower::max_var_id(value) + 1);
+        let bind = IrPattern::Bind { var: p, ty: payload_ty.clone() };
+        let payload = IrExpr {
+            kind: IrExprKind::Var { id: p },
+            ty: payload_ty,
+            span: value.span.clone(),
+            def_id: None,
+        };
+        IrExpr {
+            kind: IrExprKind::Match {
+                subject: Box::new(expr.clone()),
+                arms: vec![
+                    IrMatchArm {
+                        pattern: IrPattern::Some { inner: Box::new(bind) },
+                        guard: None,
+                        body: payload,
+                    },
+                    IrMatchArm {
+                        pattern: IrPattern::None,
                         guard: None,
                         body: fallback.clone(),
                     },

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -2949,7 +2949,7 @@ evidence  = [
 id        = "C-237"
 spec      = "ALS-E9"
 title     = "Option/Result constructor literals build and eliminate identically on both targets"
-statement = "ALS-E9: `some(e)` / bare `none` / `ok(e)` / `err(e)` under a Result-typed expectation construct the same values on both targets, and `??` eliminates them identically (ok(3) ?? 0 -> 3, err ?? -9 -> -9, some(5) ?? 0 -> 5, none ?? -1 -> -1 — byte-identical native <-> wasm). The negative half is check-time and pinned by tests/ctor_diag_test.rs: `none()` is E001 (none is a value, not a function), and an un-annotated `let o = ok(3)` in an effect fn is the ADR-0008 explicit-propagation rejection. Nested `some(none)` elimination is deliberately outside this contract while #1270 (v1 wall on ?? with an Option-typed default, loud) stands."
+statement = "ALS-E9: `some(e)` / bare `none` / `ok(e)` / `err(e)` under a Result-typed expectation construct the same values on both targets, and `??` eliminates them identically (ok(3) ?? 0 -> 3, err ?? -9 -> -9, some(5) ?? 0 -> 5, none ?? -1 -> -1 — byte-identical native <-> wasm). The negative half is check-time and pinned by tests/ctor_diag_test.rs: `none()` is E001 (none is a value, not a function), and an un-annotated `let o = ok(3)` in an effect fn is the ADR-0008 explicit-propagation rejection. Nested elimination is IN contract since #1270 closed: some(none) ?? none -> inner none -> 9, some(some(5)) ?? none -> some(5) -> 5, byte-identical (the bind rewrites to `match e { some(p) => p, none => d }`, the Option-polarity mirror of the Result rewrite)."
 since     = "0.57.1"
 status    = "active"
 evidence  = [

--- a/docs/specs/als/expressions.md
+++ b/docs/specs/als/expressions.md
@@ -148,9 +148,10 @@ E001)、`ok(e)`、`err(e)`。すべて小文字綴り。
 (`ok(3) ?? 0` → `3`、`err("boom") ?? -9` → `-9`、両ターゲット実測)。
 伝搬・分岐の全規範は R 系列(エラー面)を参照。
 
-**既知の制限(loud、誤値なし)**: 入れ子 `some(none)` は検査を通り native
-で正しく動くが、Option 型のデフォルトを持つ `??` は v1 renderer が wall
-する(#1270)。
+**入れ子の規範**: `some(none)` / `some(some(v))` は通常の Option 値であり、
+Option 型のデフォルトを持つ `??` で一段ずつ剥がせる(`sn ?? none` →
+内側 Option、実測: none 側 → 9、some 側 → 5、両ターゲット同一 —
+#1270 で v1 の wall を閉鎖)。
 
 テスト: `spec/wasm_cross/option_result_ctors.almd`(契約 C-237)、
 `tests/ctor_diag_test.rs`(負例)。

--- a/spec/wasm_cross/option_result_ctors.almd
+++ b/spec/wasm_cross/option_result_ctors.almd
@@ -3,9 +3,10 @@
 // literals — `some(e)` and the BARE value `none` (calling `none()` is a
 // check-time E001), `ok(e)` / `err(e)` under a Result-typed expectation
 // (an un-annotated binding is E041, ADR-0008 — pinned by
-// tests/ctor_diag_test.rs), and `??` elimination. Identical
-// observables on both targets. Nested `some(none)` is deliberately absent:
-// `??` with an Option-typed default walls in the v1 renderer (#1270, loud).
+// tests/ctor_diag_test.rs), `??` elimination, and the
+// NESTED case: `some(none)` / `some(some(5))` eliminated through an
+// Option-typed default (#1270 — the v1 renderer now rewrites the bind to
+// `match e { some(p) => p, none => d }`). Identical on both targets.
 effect fn main() -> Unit = {
   let s = some(5)
   let n: Int? = none
@@ -15,4 +16,10 @@ effect fn main() -> Unit = {
   let e: Result[Int, String] = err("boom")
   println(int.to_string(o ?? 0))
   println(int.to_string(e ?? -9))
+  let sn = some(none)
+  let inner: Int? = sn ?? none
+  println(int.to_string(inner ?? 9))
+  let sv = some(some(5))
+  let iv: Int? = sv ?? none
+  println(int.to_string(iv ?? 9))
 }


### PR DESCRIPTION
Closes #1270 — `sn ?? none` over `Option[Option[Int]]` walled in the v1 renderer; it now lowers through the Option-polarity mirror of the existing Result-polarity rewrite: `match e { some(p) => p, none => d }`, synthesized speculatively at bind position with full rollback on decline.

## The gate that matters

The rewrite is **gated to Option payloads** (`expr.ty.is_option() && ty.is_option()`). The first, ungated version was caught by the existing regression test `heap_option_record_unwrap_or_walls_not_miscompiles` — and end-to-end measurement confirmed the test was right: an `Option[record]` subject through the SYNTHESIZED route mis-reads the record's String fields on wasm (`"x"` printed as blanks; the Int fields survive), even though a user-written match over the same source is correct on both targets. That latent divergence in the bind-position synthesized-match path is now **#1287** (unreachable behind the wall + gate — no wrong bytes can ship). The record case stays on its honest wall.

## Evidence

- C-237 fixture extended with both nested paths: `some(none) ?? none → ?? 9 → 9` and `some(some(5)) ?? none → ?? 9 → 5`, parity `[5 -1 3 -9 9 5]` byte-identical; ALS-E9's known-limitation note replaced by the nested norm
- almide-mir: 618 tests green including the wall regression test; corpus WALL OK over 6342 functions, no MIR>IR breach
- `almide test` 383/383; wasm-fallback ratchet 17 (no STALE/new); interp voting gate green