### PR TITLE
Keep 1-tuples real tuples in the v0 Rust walker (#1267)

### DIFF
--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -282,7 +282,9 @@ fn render_expr_range(ctx: &RenderContext, start: &IrExpr, end: &IrExpr, inclusiv
 
 /// `Tuple { elements }` case of `render_expr`.
 fn render_expr_tuple(ctx: &RenderContext, elements: &[IrExpr]) -> String {
-    let parts = elements.iter().map(|e| render_expr_owned(ctx, e)).collect::<Vec<_>>().join(", ");
+    let parts = super::helpers::tuple_elems_join(
+        &elements.iter().map(|e| render_expr_owned(ctx, e)).collect::<Vec<_>>(),
+    );
     ctx.templates.render_with("tuple_literal", None, &[], &[("elements", parts.as_str())])
         .unwrap_or_else(|| "tuple(...)".into())
 }

--- a/crates/almide-codegen/src/walker/expressions_calls_binops.rs
+++ b/crates/almide-codegen/src/walker/expressions_calls_binops.rs
@@ -579,7 +579,11 @@ pub(super) fn rc_cow_result_glue(expr_str: String, ty: &Ty) -> String {
                 .zip(&names)
                 .map(|(t, n)| rc_cow_result_glue(n.clone(), t))
                 .collect();
-            format!("{{ let ({}) = {expr_str}; ({}) }}", names.join(", "), parts.join(", "))
+            format!(
+                "{{ let ({}) = {expr_str}; ({}) }}",
+                super::helpers::tuple_elems_join(&names),
+                super::helpers::tuple_elems_join(&parts)
+            )
         }
         _ => expr_str,
     }
@@ -633,7 +637,11 @@ pub(super) fn rc_cow_unglue(expr_str: String, ty: &Ty) -> String {
                 .zip(&names)
                 .map(|(t, n)| rc_cow_unglue(n.clone(), t))
                 .collect();
-            format!("{{ let ({}) = {expr_str}; ({}) }}", names.join(", "), parts.join(", "))
+            format!(
+                "{{ let ({}) = {expr_str}; ({}) }}",
+                super::helpers::tuple_elems_join(&names),
+                super::helpers::tuple_elems_join(&parts)
+            )
         }
         _ => expr_str,
     }

--- a/crates/almide-codegen/src/walker/expressions_control.rs
+++ b/crates/almide-codegen/src/walker/expressions_control.rs
@@ -167,9 +167,9 @@ fn render_expr_for_in(ctx: &RenderContext, expr: &IrExpr) -> String {
     }
     let var_name = if let Some(tuple_vars) = var_tuple {
         let names: Vec<String> = tuple_vars.iter().map(|id| ctx.var_name(*id).to_string()).collect();
-        let vars_s = names.join(", ");
+        let vars_s = super::helpers::tuple_elems_join(&names);
         ctx.templates.render_with("for_tuple_destructure", None, &[], &[("vars", vars_s.as_str())])
-            .unwrap_or_else(|| format!("({})", names.join(", ")))
+            .unwrap_or_else(|| format!("({})", vars_s))
     } else {
         ctx.var_name(*var).to_string()
     };

--- a/crates/almide-codegen/src/walker/helpers.rs
+++ b/crates/almide-codegen/src/walker/helpers.rs
@@ -159,6 +159,18 @@ pub fn render_type_box_fn(ctx: &RenderContext, ty: &Ty, bounds: &str) -> String 
     }
 }
 
+/// Join tuple element texts for Rust emission — literals, types, and
+/// patterns alike. A 1-tuple MUST keep a trailing comma: `(x)` is a
+/// parenthesized scalar in Rust, not a tuple, so emitting `let t: (i64) =
+/// (5i64);` silently scalarized `t` and the subsequent `t.0` was rustc
+/// E0610 (#1267).
+pub(crate) fn tuple_elems_join<S: AsRef<str>>(parts: &[S]) -> String {
+    match parts {
+        [single] => format!("{},", single.as_ref()),
+        _ => parts.iter().map(|s| s.as_ref()).collect::<Vec<_>>().join(", "),
+    }
+}
+
 /// True if `ty` mentions a function type anywhere (directly or nested).
 pub(super) fn ty_mentions_fn(ty: &Ty) -> bool {
     match ty {
@@ -193,7 +205,7 @@ pub fn render_type_field_fn(ctx: &RenderContext, ty: &Ty) -> String {
                 format!("std::rc::Rc<dyn Fn({}) -> {}>", params_str, ret_str))
         }
         Ty::Tuple(elems) => {
-            let parts = elems.iter().map(&rf).collect::<Vec<_>>().join(", ");
+            let parts = tuple_elems_join(&elems.iter().map(&rf).collect::<Vec<_>>());
             tmpl("type_tuple", &[("elements", parts.as_str())], format!("({})", parts))
         }
         Ty::Applied(TCI::List, args) if args.len() == 1 => {

--- a/crates/almide-codegen/src/walker/statements_box_patterns.rs
+++ b/crates/almide-codegen/src/walker/statements_box_patterns.rs
@@ -85,7 +85,7 @@ fn guard_shape(ctx: &RenderContext, pat: &IrPattern, counter: &mut usize, subs: 
         IrPattern::Tuple { elements } => {
             let shapes: Vec<String> =
                 elements.iter().map(|p| guard_shape(ctx, p, counter, subs)).collect();
-            format!("({})", shapes.join(", "))
+            format!("({})", super::helpers::tuple_elems_join(&shapes))
         }
         IrPattern::Constructor { name, args } => {
             let qualified = qualify_ctor(ctx, name.as_str(), None);
@@ -407,7 +407,9 @@ pub fn render_pattern_hinted(ctx: &RenderContext, pat: &IrPattern, enum_hint: Op
         }
         IrPattern::Constructor { name, args } => render_pattern_constructor(ctx, name, args, enum_hint),
         IrPattern::Tuple { elements } => {
-            let elems = elements.iter().map(|e| render_pattern(ctx, e)).collect::<Vec<_>>().join(", ");
+            let elems = super::helpers::tuple_elems_join(
+                &elements.iter().map(|e| render_pattern(ctx, e)).collect::<Vec<_>>(),
+            );
             ctx.templates.render_with("tuple_literal", None, &[], &[("elements", elems.as_str())])
                 .unwrap_or_else(|| "tuple(...)".into())
         }

--- a/crates/almide-codegen/src/walker/types.rs
+++ b/crates/almide-codegen/src/walker/types.rs
@@ -196,7 +196,9 @@ pub fn render_type(ctx: &RenderContext, ty: &Ty) -> String {
         // renders every (possibly nested) Fn as `Rc<dyn Fn>`.
         Ty::Fn { .. } => super::helpers::render_type_field_fn(ctx, ty),
         Ty::Tuple(elems) => {
-            let parts = elems.iter().map(|t| render_type(ctx, t)).collect::<Vec<_>>().join(", ");
+            let parts = super::helpers::tuple_elems_join(
+                &elems.iter().map(|t| render_type(ctx, t)).collect::<Vec<_>>(),
+            );
             ctx.templates.render_with("type_tuple", None, &[], &[("elements", parts.as_str())])
                 .unwrap_or_else(|| "tuple".into())
         }

--- a/tests/singleton_tuple_native_test.rs
+++ b/tests/singleton_tuple_native_test.rs
@@ -1,0 +1,99 @@
+//! A 1-tuple must stay a real tuple in emitted Rust — `(x)` is a
+//! parenthesized scalar, not a tuple (#1267).
+//!
+//! The v0 walker joined tuple elements with `", "` and wrapped them in
+//! parens, so a 1-tuple rendered as `let t: (i64) = (5i64);` — Rust reads
+//! both as bare `i64` and the subsequent `t.0` is rustc E0610. The bug only
+//! surfaced when something routed the build to the v0 codegen: `almide run`
+//! tries the v1 MIR native render first, and a string interpolation of a
+//! Bool (`"${true}"` → `bool.to_string`, outside the native runtime floor)
+//! walls it, falling back to v0. Hence the confusing shape in the issue:
+//! interpolation anywhere in the fn "scalarized" an unrelated 1-tuple.
+//!
+//! Pinned as a cargo gate rather than a spec test because the assertion is
+//! about the NATIVE v0 leg specifically (the wasm leg always ran this
+//! correctly), plus a textual pin on the v0 Rust emission so the coverage
+//! survives even if the v1 wall that routes to v0 disappears.
+
+use std::process::Command;
+
+fn almide() -> &'static str {
+    env!("CARGO_BIN_EXE_almide")
+}
+
+/// The issue #1267 repro: interpolation forces the v0 fallback, the 1-tuple
+/// plus `.0` must still compile and run.
+const INTERP_PLUS_SINGLETON_TUPLE: &str = r#"
+effect fn main() -> Unit = {
+  println("${true}")
+  let t = (5,)
+  println(int.to_string(t.0))
+}
+"#;
+
+/// The no-interpolation control from the issue: same 1-tuple shape, no
+/// forced v0 routing. Must keep working.
+const SINGLETON_TUPLE_CONTROL: &str = r#"
+effect fn main() -> Unit = {
+  let t = (5,)
+  println(int.to_string(t.0))
+}
+"#;
+
+fn run_native(name: &str, src_text: &str) -> (bool, String, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join(name);
+    std::fs::write(&src, src_text).expect("write fixture");
+    let out = Command::new(almide())
+        .args(["run", src.to_str().unwrap()])
+        .output()
+        .expect("run almide");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn interpolation_plus_singleton_tuple_runs_native() {
+    let (ok, stdout, stderr) = run_native("interp_1tuple.almd", INTERP_PLUS_SINGLETON_TUPLE);
+    assert!(ok, "native run failed (1-tuple scalarized to bare i64 again? E0610):\n{stderr}");
+    assert_eq!(stdout, "true\n5\n", "wrong output (wasm leg prints exactly this)");
+}
+
+#[test]
+fn singleton_tuple_control_still_runs_native() {
+    let (ok, stdout, stderr) = run_native("control_1tuple.almd", SINGLETON_TUPLE_CONTROL);
+    assert!(ok, "native control run failed:\n{stderr}");
+    assert_eq!(stdout, "5\n");
+}
+
+/// Pin the v0 emission itself: the `--target rust` emit path is always v0
+/// (no v1 routing), so this asserts the 1-tuple repr directly and keeps
+/// covering the walker even if the v1 native wall that routes the repro to
+/// v0 is later lifted.
+#[test]
+fn v0_emission_keeps_singleton_tuple_repr() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("emit_1tuple.almd");
+    std::fs::write(&src, INTERP_PLUS_SINGLETON_TUPLE).expect("write fixture");
+    let out = Command::new(almide())
+        .args([src.to_str().unwrap(), "--target", "rust"])
+        .output()
+        .expect("emit rust");
+    assert!(out.status.success(), "emit failed:\n{}", String::from_utf8_lossy(&out.stderr));
+    let code = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        code.contains("(5i64,)"),
+        "1-tuple literal lost its trailing comma (scalarizes to i64 in Rust)"
+    );
+    assert!(
+        code.contains("(i64,)"),
+        "1-tuple type annotation lost its trailing comma (scalarizes to i64 in Rust)"
+    );
+    assert!(
+        !code.contains("let t: (i64) ="),
+        "the exact #1267 broken shape is back: `let t: (i64) = ...`"
+    );
+}


### PR DESCRIPTION
Closes #1267.

## Root cause (measured, not the shape the issue guessed)

No optimizer pass scalarizes the tuple. The v0 Rust walker joined tuple elements with `", "` inside plain parens at every emission site, so a 1-tuple rendered as `let t: (i64) = (5i64);` — Rust reads both as a parenthesized scalar, and the subsequent `t.0` is rustc E0610.

The interpolation's role is routing, not representation: `almide run` tries the v1 MIR native render first, and `"${true}"` lowers to `bool.to_string`, which walls it (measured with `ALMIDE_WALL_REASON=1`: "call to `bool.to_string` — not a lowered user fn and not in the native runtime floor"), falling back to the v0 walker. Without the interpolation the v1 renderer handles the program and the broken v0 text is never used — the v0 emission (`almide file.almd --target rust`) of the CONTROL was equally broken before this fix (verified: it fails rustc with the same E0610).

## Fix

One helper, `tuple_elems_join` (walker/helpers.rs): a 1-element tuple keeps its trailing comma. Applied at every tuple text-emission site in the v0 walker: tuple literal exprs, `type_tuple` in both type renderers, tuple patterns (`render_pattern_hinted` + `guard_shape`), for-in tuple destructures, and both RcCow tuple glue sites (`let (__t0,) = …; (…,)`). Templates unchanged.

## Measurements (repro from the issue, both targets, before → after)

| program | leg | before | after |
|---|---|---|---|
| interp + `(5,)` + `t.0` | native `almide run` | refusal: "codegen produced invalid Rust" (rustc E0610) | `true\n5` |
| interp + `(5,)` + `t.0` | wasm `almide run --target wasm` | `true\n5` | `true\n5` (unchanged, byte-identical to native) |
| control (no interp) | native | `5` | `5` |
| control (no interp) | wasm | `5` | `5` |
| interp repro | v0 emission `--target rust` | `let t: (i64) = (5i64);` (parenthesized scalar) | `let t: (i64,) = (5i64,);` (real 1-tuple) |

A 1-tuple in a `match` pattern (`(x,) =>`) is rejected by the parser on BOTH targets identically (pre-existing, #1266 territory) — the pattern-side change is defensive only, verified inert.

## Verification

- New `tests/singleton_tuple_native_test.rs` (pattern of `tuple_capture_clone_test.rs`; the task's referenced `tupleindex_diag_test.rs` does not exist): end-to-end `almide run` of the issue repro + the no-interp control, plus a textual pin on the v0 `--target rust` emission so coverage survives even if the v1 `bool.to_string` wall is later lifted. All 3 pass; the exact commands were measured failing on the pre-fix build (A/B).
- `cargo test --release --test codegen_snapshot_test --test codegen_v3_compare --test codegen_v3_real`: 20 passed.
- `cargo test -p almide-codegen --release`: pass (crate has no unit tests).
- Full spec suite `almide test`: **383/383 files pass** (366 via WASM, 17 native fallback).
- No almide-mir changes — wasm renderer untouched; the wasm leg's behavior is bit-identical before/after.

Note for the contract ledger owner (not edited here): `spec/wasm_cross/tuple_single.almd` (C-234) deliberately excludes string interpolation because of this bug — its comment and constraint can now be lifted.
