### PR TITLE
Cut normalize_fallible_user_hofs deep clones with a read-only AST visitor (#1231)

### DIFF
--- a/crates/almide-frontend/src/check/fallible_user_hof.rs
+++ b/crates/almide-frontend/src/check/fallible_user_hof.rs
@@ -32,8 +32,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use almide_base::intern::{sym, Sym};
-use almide_base::span::Span;
-use almide_lang::ast::{self, Decl, Expr, ExprId, ExprKind, GenericParam, Param, TypeExpr, Visibility};
+use almide_lang::ast::{self, Decl, Expr, ExprId, ExprKind, TypeExpr, Visibility};
 
 /// The twin's name for a user HOF. Double separator so a user fn named
 /// `fallible_x` can never collide with the twin of a fn named `x`.
@@ -41,17 +40,14 @@ fn twin_name(hof: Sym) -> Sym {
     sym(&format!("__fallible__{}", hof.as_str()))
 }
 
-/// A Cell-1-admissible HOF: the slot to retype plus everything twin synthesis
-/// needs, cloned up front so the later mutable passes hold no immutable borrow.
+/// A Cell-1-admissible HOF: the slot to retype plus WHERE its decl lives.
+/// Copy-only on purpose (#1231): the check/detect phases borrow the decl in
+/// place, and twin synthesis re-reads `program.decls[decl_idx]` so a body is
+/// cloned exactly once, and only for a HOF that turned out to be needed.
 struct HofCandidate {
     param_idx: usize,
     cb_name: Sym,
-    effect: Option<bool>,
-    generics: Option<Vec<GenericParam>>,
-    params: Vec<Param>,
-    return_type: TypeExpr,
-    body: Expr,
-    span: Option<Span>,
+    decl_idx: usize,
 }
 
 /// Returns the number of twin decls appended to `program.decls` (all at the
@@ -65,11 +61,11 @@ pub fn normalize_fallible_user_hofs(
         return 0;
     }
     // Detection: which candidate HOFs are called with a fallible callback in
-    // the bare slot (outside test blocks)?
+    // the bare slot (outside test blocks)? Pure observation — read-only walk.
     let mut needed: BTreeSet<Sym> = BTreeSet::new();
-    for decl in program.decls.iter_mut() {
+    for decl in program.decls.iter() {
         let Decl::Fn { body: Some(body), .. } = decl else { continue };
-        ast::visit_expr_mut(body, &mut |e| {
+        ast::visit_expr(body, &mut |e| {
             if let Some(name) = fallible_slot_call(e, &candidates, fallible_marker_fns) {
                 needed.insert(name);
             }
@@ -80,12 +76,18 @@ pub fn normalize_fallible_user_hofs(
     }
     // Synthesis: one twin per needed HOF, with fresh ExprIds above the
     // program's maximum — a cloned body sharing ids would alias the checker's
-    // ExprId-keyed type map between original and twin.
+    // ExprId-keyed type map between original and twin. This is the ONE place a
+    // HOF body is cloned (#1231), and only for the `needed` subset.
     let mut next_id = max_expr_id(program) + 1;
     let mut twins: Vec<Decl> = Vec::new();
     for hof in &needed {
         let c = &candidates[hof];
-        let mut twin_params = c.params.clone();
+        let Decl::Fn { effect, generics, params, return_type, body: Some(body), span, .. } =
+            &program.decls[c.decl_idx]
+        else {
+            continue;
+        };
+        let mut twin_params = params.clone();
         let TypeExpr::Fn { params: fp, ret, is_effect } = twin_params[c.param_idx].ty.clone() else {
             continue;
         };
@@ -94,21 +96,21 @@ pub fn normalize_fallible_user_hofs(
             ret: Box::new(TypeExpr::Generic { name: sym("!"), args: vec![*ret] }),
             is_effect,
         };
-        let mut twin_body = c.body.clone();
+        let mut twin_body = body.clone();
         renumber_expr_ids(&mut twin_body, &mut next_id);
         unwrap_direct_cb_calls(&mut twin_body, c.cb_name, &mut next_id);
         twins.push(Decl::Fn {
             name: twin_name(*hof),
-            effect: c.effect,
+            effect: *effect,
             visibility: Visibility::Local,
             extern_attrs: vec![],
             export_attrs: vec![],
             attrs: vec![],
-            generics: c.generics.clone(),
+            generics: generics.clone(),
             params: twin_params,
-            return_type: TypeExpr::Generic { name: sym("!"), args: vec![c.return_type.clone()] },
+            return_type: TypeExpr::Generic { name: sym("!"), args: vec![return_type.clone()] },
             body: Some(twin_body),
-            span: c.span.clone(),
+            span: span.clone(),
         });
     }
     // Rewrite: rename each fallible-callback call site to its twin (test
@@ -132,13 +134,13 @@ pub fn normalize_fallible_user_hofs(
     n
 }
 
-/// Every Cell-1-admissible HOF in the program, keyed by name.
+/// Every Cell-1-admissible HOF in the program, keyed by name. Admission is
+/// checked by borrowing the decl in place — nothing is cloned here (#1231).
 fn collect_candidates(program: &ast::Program) -> BTreeMap<Sym, HofCandidate> {
     let mut out = BTreeMap::new();
-    for decl in &program.decls {
-        let Decl::Fn {
-            name, effect, extern_attrs, generics, params, return_type, body: Some(body), span, ..
-        } = decl
+    for (decl_idx, decl) in program.decls.iter().enumerate() {
+        let Decl::Fn { name, effect, extern_attrs, params, return_type, body: Some(body), .. } =
+            decl
         else {
             continue;
         };
@@ -175,19 +177,7 @@ fn collect_candidates(program: &ast::Program) -> BTreeMap<Sym, HofCandidate> {
         if cb_called_inside_loop(body, cb_name) {
             continue;
         }
-        out.insert(
-            *name,
-            HofCandidate {
-                param_idx,
-                cb_name,
-                effect: *effect,
-                generics: generics.clone(),
-                params: params.clone(),
-                return_type: return_type.clone(),
-                body: body.clone(),
-                span: span.clone(),
-            },
-        );
+        out.insert(*name, HofCandidate { param_idx, cb_name, decl_idx });
     }
     out
 }
@@ -209,20 +199,26 @@ fn fallible_slot_call(
     arg_is_fallible(arg, fallible_marker_fns).then_some(*name)
 }
 
+/// Is `e` a direct call whose callee is the bare identifier `cb`?
+fn is_direct_cb_call(e: &Expr, cb: Sym) -> bool {
+    matches!(
+        &e.kind,
+        ExprKind::Call { callee, .. }
+            if matches!(&callee.kind, ExprKind::Ident { name } if *name == cb)
+    )
+}
+
 /// True when every occurrence of `cb` in the body is the callee of a direct
 /// call — the shape whose twin rewrite (`cb(..)` → `cb(..)!`) is total.
 fn cb_used_only_as_callee(body: &Expr, cb: Sym) -> bool {
     let mut ident_uses = 0usize;
     let mut callee_uses = 0usize;
-    let mut owned = body.clone();
-    ast::visit_expr_mut(&mut owned, &mut |e| {
+    ast::visit_expr(body, &mut |e| {
         if matches!(&e.kind, ExprKind::Ident { name } if *name == cb) {
             ident_uses += 1;
         }
-        if let ExprKind::Call { callee, .. } = &e.kind {
-            if matches!(&callee.kind, ExprKind::Ident { name } if *name == cb) {
-                callee_uses += 1;
-            }
+        if is_direct_cb_call(e, cb) {
+            callee_uses += 1;
         }
     });
     ident_uses == callee_uses
@@ -232,25 +228,22 @@ fn cb_used_only_as_callee(body: &Expr, cb: Sym) -> bool {
 /// the #1183 exclusion. Over-conservative on purpose: the walk covers the
 /// loop's whole subtree including the head (a head-position `!` is actually
 /// the proven #1168 hoist class), because conservatism here only keeps
-/// today's honest E005.
+/// today's honest E005. One borrowed walk; each loop node scans its own
+/// subtree in place (#1231 — no clone, no subtree accumulation).
 fn cb_called_inside_loop(body: &Expr, cb: Sym) -> bool {
     let mut found = false;
-    let mut owned = body.clone();
-    let mut in_loop_subtrees: Vec<Expr> = Vec::new();
-    ast::visit_expr_mut(&mut owned, &mut |e| {
-        if matches!(&e.kind, ExprKind::ForIn { .. } | ExprKind::While { .. }) {
-            in_loop_subtrees.push(e.clone());
+    ast::visit_expr(body, &mut |e| {
+        if found {
+            return;
         }
-    });
-    for mut lp in in_loop_subtrees {
-        ast::visit_expr_mut(&mut lp, &mut |c| {
-            if let ExprKind::Call { callee, .. } = &c.kind {
-                if matches!(&callee.kind, ExprKind::Ident { name } if *name == cb) {
+        if matches!(&e.kind, ExprKind::ForIn { .. } | ExprKind::While { .. }) {
+            ast::visit_expr(e, &mut |c| {
+                if is_direct_cb_call(c, cb) {
                     found = true;
                 }
-            }
-        });
-    }
+            });
+        }
+    });
     found
 }
 
@@ -261,8 +254,7 @@ fn arg_is_fallible(arg: &Expr, fallible_marker_fns: &HashSet<Sym>) -> bool {
     match &arg.kind {
         ExprKind::Lambda { body, .. } => {
             let mut found = false;
-            let mut owned = (**body).clone();
-            ast::visit_expr_mut(&mut owned, &mut |e| {
+            ast::visit_expr(body, &mut |e| {
                 if matches!(e.kind, ExprKind::Unwrap { .. }) {
                     found = true;
                 }
@@ -286,12 +278,7 @@ fn unwrap_direct_cb_calls(body: &mut Expr, cb: Sym, next_id: &mut u32) {
         if done.contains(&e.id) {
             return;
         }
-        let is_cb_call = matches!(
-            &e.kind,
-            ExprKind::Call { callee, .. }
-                if matches!(&callee.kind, ExprKind::Ident { name } if *name == cb)
-        );
-        if !is_cb_call {
+        if !is_direct_cb_call(e, cb) {
             return;
         }
         done.insert(e.id);
@@ -319,15 +306,15 @@ fn renumber_expr_ids(body: &mut Expr, next_id: &mut u32) {
 }
 
 /// The program's maximum ExprId, so twin ids allocate above every parsed id.
-fn max_expr_id(program: &mut ast::Program) -> u32 {
+fn max_expr_id(program: &ast::Program) -> u32 {
     let mut max = 0u32;
-    for decl in program.decls.iter_mut() {
+    for decl in program.decls.iter() {
         let (Decl::Fn { body: Some(b), .. } | Decl::Test { body: b, .. } | Decl::TopLet { value: b, .. }) =
             decl
         else {
             continue;
         };
-        ast::visit_expr_mut(b, &mut |e| {
+        ast::visit_expr(b, &mut |e| {
             if e.id.0 > max {
                 max = e.id.0;
             }

--- a/crates/almide-syntax/src/ast.rs
+++ b/crates/almide-syntax/src/ast.rs
@@ -659,3 +659,197 @@ fn visit_block_mut(
         visit_expr_mut(e, f);
     }
 }
+
+// ── Read-only AST visitor (#1231) ──
+//
+// Mirror of `visit_expr_mut` for callers that only OBSERVE the tree (counting
+// uses, scanning for a node kind) — before this existed, every such caller had
+// to clone the subtree just to run the mutable walker. Identical traversal
+// order and identical shallow-visit contracts; keep the two families in
+// lockstep. Exhaustive with no wildcard, so a new `ExprKind` fails to compile
+// here until its shape is declared.
+
+fn visit_stmt_exprs(stmt: &Stmt, f: &mut impl FnMut(&Expr)) {
+    match stmt {
+        Stmt::Let { value, .. } | Stmt::Var { value, .. } | Stmt::Assign { value, .. } => visit_expr(value, f),
+        Stmt::LetDestructure { pattern, value, .. } => {
+            visit_pattern_exprs(pattern, f);
+            visit_expr(value, f);
+        }
+        Stmt::IndexAssign { index, value, .. } => { visit_expr(index, f); visit_expr(value, f); }
+        Stmt::FieldAssign { value, .. } => visit_expr(value, f),
+        Stmt::Guard { cond, else_, .. } => { visit_expr(cond, f); visit_expr(else_, f); }
+        Stmt::GuardLet { scrutinee, else_, .. } => { visit_expr(scrutinee, f); visit_expr(else_, f); }
+        Stmt::Expr { expr, .. } => visit_expr(expr, f),
+        Stmt::Comment { .. } | Stmt::Error { .. } => {}
+    }
+}
+
+fn visit_pattern_exprs(pat: &Pattern, f: &mut impl FnMut(&Expr)) {
+    match pat {
+        Pattern::Literal { value } => visit_expr(value, f),
+        Pattern::Constructor { args, .. } => { for a in args.iter() { visit_pattern_exprs(a, f); } }
+        Pattern::RecordPattern { fields, .. } => {
+            for fp in fields.iter() { if let Some(ref p) = fp.pattern { visit_pattern_exprs(p, f); } }
+        }
+        Pattern::Tuple { elements } | Pattern::List { elements } => { for e in elements.iter() { visit_pattern_exprs(e, f); } }
+        Pattern::Some { inner } | Pattern::Ok { inner } | Pattern::Err { inner } => visit_pattern_exprs(inner, f),
+        Pattern::Wildcard | Pattern::Ident { .. } | Pattern::None => {}
+    }
+}
+
+/// Visits each element of an expression slice (List/Tuple/Fan payloads).
+fn visit_exprs_slice(exprs: &[Expr], f: &mut impl FnMut(&Expr)) {
+    for e in exprs.iter() { visit_expr(e, f); }
+}
+
+/// Visits each key/value pair of a map literal.
+fn visit_map_entries(entries: &[(Expr, Expr)], f: &mut impl FnMut(&Expr)) {
+    for (k, v) in entries.iter() { visit_expr(k, f); visit_expr(v, f); }
+}
+
+/// Visits each field value of a record literal (Record/SpreadRecord payloads).
+fn visit_field_inits(fields: &[FieldInit], f: &mut impl FnMut(&Expr)) {
+    for fi in fields.iter() { visit_expr(&fi.value, f); }
+}
+
+/// Visits pattern/guard/body of each match arm.
+fn visit_match_arms(arms: &[MatchArm], f: &mut impl FnMut(&Expr)) {
+    for arm in arms.iter() {
+        visit_pattern_exprs(&arm.pattern, f);
+        if let Some(ref g) = arm.guard { visit_expr(g, f); }
+        visit_expr(&arm.body, f);
+    }
+}
+
+/// Visits a statement list (Block/ForIn/While bodies).
+fn visit_stmts(stmts: &[Stmt], f: &mut impl FnMut(&Expr)) {
+    for s in stmts.iter() { visit_stmt_exprs(s, f); }
+}
+
+/// Visits the embedded expressions of an interpolated string.
+fn visit_string_parts(parts: &[StringPart], f: &mut impl FnMut(&Expr)) {
+    for part in parts.iter() {
+        if let StringPart::Expr { expr: e } = part { visit_expr(e, f); }
+    }
+}
+
+/// Apply `f` to `expr` and then to every child expression — the read-only
+/// mirror of `visit_expr_mut`, same order, same fan-family shallow contract.
+pub fn visit_expr(expr: &Expr, f: &mut impl FnMut(&Expr)) {
+    f(expr);
+    match &expr.kind {
+        // ── One child ──
+        ExprKind::Member { object: e, .. } | ExprKind::TupleIndex { object: e, .. }
+        | ExprKind::Unary { operand: e, .. } | ExprKind::Lambda { body: e, .. }
+        | ExprKind::Try { expr: e } | ExprKind::Unwrap { expr: e }
+        | ExprKind::ToOption { expr: e } | ExprKind::Paren { expr: e }
+        | ExprKind::Some { expr: e } | ExprKind::Ok { expr: e } | ExprKind::Err { expr: e }
+        | ExprKind::OptionalChain { expr: e, .. }
+        | ExprKind::TypeAscription { expr: e, .. } => visit_expr(e, f),
+
+        // ── Two children, left to right ──
+        ExprKind::Binary { left: a, right: b, .. } | ExprKind::Pipe { left: a, right: b }
+        | ExprKind::Compose { left: a, right: b }
+        | ExprKind::UnwrapOr { expr: a, fallback: b }
+        | ExprKind::IndexAccess { object: a, index: b }
+        | ExprKind::Range { start: a, end: b, .. } => {
+            visit_expr(a, f);
+            visit_expr(b, f);
+        }
+
+        // ── Three children ──
+        ExprKind::If { cond: a, then: b, else_: c }
+        | ExprKind::IfLet { scrutinee: a, then: b, else_: c, .. } => {
+            visit_expr(a, f);
+            visit_expr(b, f);
+            visit_expr(c, f);
+        }
+
+        // ── A flat sequence of children ──
+        ExprKind::List { elements: xs } | ExprKind::Tuple { elements: xs }
+        | ExprKind::Fan { exprs: xs } | ExprKind::FanSettle { arms: xs } => {
+            visit_exprs_slice(xs, f)
+        }
+
+        // ── Name-tagged children ──
+        ExprKind::MapLiteral { entries } => visit_map_entries(entries, f),
+        ExprKind::Record { fields, .. } => visit_field_inits(fields, f),
+        ExprKind::SpreadRecord { base, fields } => {
+            visit_expr(base, f);
+            visit_field_inits(fields, f);
+        }
+
+        // ── The fan family: `f` is applied SHALLOWLY to the budget and the
+        //    body/arms (no recursion into their subtrees) — the pre-existing
+        //    contract, kept verbatim.
+        ExprKind::FanBounded { budget, body } => {
+            f(budget);
+            f(body);
+        }
+        ExprKind::FanRace { budget, arms } => {
+            visit_opt_shallow(budget, f);
+            visit_exprs_slice(arms, f);
+        }
+        ExprKind::FanRaceMap { budget, list, mapper } => {
+            visit_opt_shallow(budget, f);
+            f(list);
+            f(mapper);
+        }
+        ExprKind::FanTimeout { deadline, body } => {
+            f(deadline);
+            f(body);
+        }
+
+        // ── Shapes with their own traversal order ──
+        ExprKind::Call { callee, args, named_args, .. } => {
+            visit_expr(callee, f);
+            visit_exprs_slice(args, f);
+            visit_named_args(named_args, f);
+        }
+        ExprKind::Match { subject, arms } => {
+            visit_expr(subject, f);
+            visit_match_arms(arms, f);
+        }
+        ExprKind::Block { stmts, expr: tail } => visit_block(stmts, tail, f),
+        ExprKind::ForIn { iterable: lead, body, .. }
+        | ExprKind::While { cond: lead, body } => {
+            visit_expr(lead, f);
+            visit_stmts(body, f);
+        }
+        ExprKind::InterpolatedString { parts } => visit_string_parts(parts, f),
+
+        // ── No children ──
+        ExprKind::Int { .. } | ExprKind::Float { .. } | ExprKind::String { .. } |
+        ExprKind::Bool { .. } | ExprKind::Ident { .. } | ExprKind::TypeName { .. } |
+        ExprKind::EmptyMap | ExprKind::Hole | ExprKind::Todo { .. } |
+        ExprKind::Break | ExprKind::Continue | ExprKind::Placeholder |
+        ExprKind::Unit | ExprKind::None | ExprKind::Error => {}
+    }
+}
+
+/// An optional child the fan family applies `f` to WITHOUT recursing.
+fn visit_opt_shallow(e: &Option<Box<Expr>>, f: &mut impl FnMut(&Expr)) {
+    if let Some(b) = e {
+        f(b);
+    }
+}
+
+/// A call's named arguments — the name plays no part in the walk.
+fn visit_named_args(args: &[(Sym, Expr)], f: &mut impl FnMut(&Expr)) {
+    for (_, a) in args.iter() {
+        visit_expr(a, f);
+    }
+}
+
+/// A block: every statement, then the tail expression if there is one.
+fn visit_block(
+    stmts: &[Stmt],
+    tail: &Option<Box<Expr>>,
+    f: &mut impl FnMut(&Expr),
+) {
+    visit_stmts(stmts, f);
+    if let Some(e) = tail {
+        visit_expr(e, f);
+    }
+}


### PR DESCRIPTION
Closes #1231.

`normalize_fallible_user_hofs` runs unconditionally at the Checker entry on every compile and paid whole-body deep clones in four places. All four are gone:

- **`collect_candidates`** — `HofCandidate` is now Copy-only (`param_idx`, `cb_name`, `decl_idx`); the body/params/generics/return_type clones are deleted. Twin synthesis re-reads `program.decls[decl_idx]` and clones a body exactly once, and only for a HOF that turned out to be `needed`.
- **`cb_used_only_as_callee`** — counts on a borrowed walk, no clone.
- **`cb_called_inside_loop`** — the `in_loop_subtrees` accumulation (which cloned the body once plus every loop subtree, rescanning nests d times) is now one borrowed walk; each loop node scans its own subtree in place. Zero allocation.
- **`arg_is_fallible`** — scans the lambda body borrowed, no clone (this one fired twice per call site: detect + rewrite).

The enabler is a read-only `visit_expr` family in `almide-syntax/src/ast.rs` — an exact mirror of `visit_expr_mut` (same traversal order, same fan-family shallow contract, exhaustive with no wildcard so a new `ExprKind` fails to compile in both until its shape is declared). The detection pass and `max_expr_id` also moved to the read-only walk.

## Measured

Bench: a generated 6,618-line file with 120 Cell-1-admissible HOFs (~500 expr nodes each), all called with total callbacks, 2 also called with fallible lambdas (so the full detect → synthesize → rewrite path runs). File attached shape in issue-style; script in scratchpad.

**Clone traffic** (expr nodes cloned per compile, counted via `--emit-ast` node census × per-phase multipliers read from the code):

| | before | after |
|---|---|---|
| collect_candidates | 60,480 | 0 |
| cb_used_only_as_callee | 60,480 | 0 |
| cb_called_inside_loop | 60,480 | 0 |
| twin synthesis (needed only) | 1,008 | 1,008 |
| **total** | **182,448** | **1,008** (−99.4%) |

**Wall clock**, `almide check bench_hof.almd`, interleaved A/B, n=12 after warmup (baseline = origin/develop 52200340 release build):

| | min | median | mean |
|---|---|---|---|
| baseline | 67.0 ms | 69.0 ms | 69.8 ms |
| this PR | 62.2 ms | 64.0 ms | 64.4 ms |

= 1.078× (−5.0 ms median) on the whole compile including process start, parse, and full inference.

**Byte-identity** (this is pure compile-time cost — behavior must not move):

- `--target rust` emit + stderr: byte-identical baseline vs new on the bench file (twins synthesized) and on `spec/lang/fallible_user_hof_test.almd`, identical exit codes.
- Full `PATH=/opt/homebrew/bin ./target/release/almide test`: **383/383 files pass**, identical 366-via-WASM / 17-via-native-fallback split as baseline. Full-suite wall time unchanged within noise (13–16 s both binaries — spec files are small, the pass cost concentrates in HOF-heavy files).
- `cargo test --release` (full workspace): all green. `almide-syntax` and `almide-frontend` compile with no new warnings.
