### PR TITLE
Make the wasm string-accumulator TCO multi-concat amortized (#1229)

### DIFF
--- a/crates/almide-mir/src/concat_to_append.rs
+++ b/crates/almide-mir/src/concat_to_append.rs
@@ -48,6 +48,11 @@ use std::collections::BTreeMap;
 /// `Drop t` is searched separately (it may trail by straight-line ops).
 const WINDOW_HEAD: usize = 4;
 
+/// How many straight-line ops past a window a trailing `Drop` may lag (drops
+/// batch after e.g. the loop counter increment — see `match_window`'s doc).
+/// Shared by the scalar-list window and the string-chain window.
+const DROP_SCAN: usize = 8;
+
 /// `Some((e, d, x, drop_at))` when `ops[i..i+WINDOW_HEAD]` is exactly the
 /// self-append head described in the module doc and `ops[drop_at]` is the
 /// temp's trailing `Drop` in the same straight-line region. `occ` counts
@@ -97,7 +102,6 @@ fn match_window(
     // nothing in between references the temp, so DELETING the trailing drop
     // is position-independent; the scan stops at any control marker (the
     // drop must live in the same straight-line region as the window).
-    const DROP_SCAN: usize = 8;
     let mut drop_at = None;
     for (k, op) in ops.iter().enumerate().skip(i + WINDOW_HEAD).take(DROP_SCAN) {
         match op {
@@ -242,6 +246,150 @@ fn match_str_window(ops: &[Op], i: usize, occ: &BTreeMap<ValueId, usize>) -> boo
     occ.get(d).copied() == Some(2)
 }
 
+/// The CHAINED string self-append window (#1229): `x = x + s1 + s2 (+ …)` —
+/// the TCO'd multi-concat accumulator (`build(n, pos + 1, acc + c0 + c1)`,
+/// base64's `enc(.., acc + c0 + c1 + c2 + c3)`) lowers as a LEFT-SPINE chain
+/// of `__str_concat` calls through fresh intermediates:
+///
+/// ```text
+/// d1 ← __str_concat(x, t1)
+/// d2 ← __str_concat(d1, t2)      ; …up to dk
+/// Drop x
+/// SetLocal x ← dk
+/// …straight-line ops…
+/// Drop d1 … Drop d(k-1)          ; the intermediates' trailing drops
+/// ```
+///
+/// `match_str_window` never fires on it (the drop/rebind target `x` is not the
+/// LAST call's left operand), so every iteration whole-copied the accumulator
+/// once per `+`: O(n²) bytes for the loop — the 0.57.0 release-gate fuzz
+/// "hang" (run 31486558420: `build(65535, 0, "")` took 21.7 s on wasm, native
+/// instant; the exact-size free-list never reuses a monotonically growing
+/// block, so every step also bump-allocated fresh).
+///
+/// The rewrite renames every call in the chain to `__str_append1` and moves
+/// each consumed owner's `Drop` to DIRECTLY AFTER the call that consumed it:
+///
+/// ```text
+/// d1 ← __str_append1(x, t1)      ; rc(x)==1 → in-place, ret Dups (rc 2)
+/// Drop x                          ; rc 2 → 1: d1 is now the sole owner
+/// d2 ← __str_append1(d1, t2)     ; rc(d1)==1 → in-place again
+/// Drop d1                         ; …
+/// SetLocal x ← dk                 ; the loop-carried slot, rc 1
+/// ```
+///
+/// Moving the drops is what makes the chain amortized: without it the first
+/// append's value-semantics return leaves rc == 2, forcing every later link
+/// down the whole-copy slow path. Each moved `Drop` still sits AFTER its
+/// value's last use (the very call that consumed it), so def-before-use and
+/// the one-`rc_dec`-per-drop release accounting are unchanged — the op
+/// multiset is identical, only the order shifts. In-place mutation stays
+/// unobservable for the same dynamic reason as the single window: it fires
+/// only at `rc == 1`, when the about-to-be-dropped handle is the sole owner.
+/// Suffixes must be DISTINCT ValueIds from `x` and the intermediates
+/// (`match_str_chain_window` rejects `acc + acc + c`): an in-place first
+/// append would mutate the block a later suffix read still expects original
+/// bytes from. Aliases via `Dup` (a distinct ValueId over the same block) are
+/// safe dynamically — the extra owner holds rc > 1, which forces the copying
+/// slow path.
+struct StrChain {
+    /// `(dst, left, suffix)` of each `__str_concat` in chain order. The first
+    /// link's `left` is the loop-carried slot `x` (the `Drop`/`SetLocal`
+    /// target — the emitter clones the window's own rebind op, so it is not
+    /// carried separately).
+    calls: Vec<(ValueId, ValueId, ValueId)>,
+    /// Op index of each intermediate's trailing `Drop`, chain order (all past
+    /// the rebind).
+    inter_drop_at: Vec<usize>,
+}
+
+/// `Some((dst, left, suffix))` when `op` is `dst ← __str_concat(left, suffix)`.
+fn as_str_concat(op: &Op) -> Option<(ValueId, ValueId, ValueId)> {
+    let Op::CallFn { dst: Some(d), name, args, .. } = op else {
+        return None;
+    };
+    if name != "__str_concat" {
+        return None;
+    }
+    let [CallArg::Handle(l), CallArg::Handle(t)] = args.as_slice() else {
+        return None;
+    };
+    Some((*d, *l, *t))
+}
+
+/// Match the chained window at `ops[i..]` (k >= 2 calls; k == 1 is
+/// `match_str_window`'s). See [`StrChain`] for the shape and the safety
+/// argument each check enforces.
+fn match_str_chain_window(
+    ops: &[Op],
+    i: usize,
+    occ: &BTreeMap<ValueId, usize>,
+) -> Option<StrChain> {
+    let (d1, x, t1) = as_str_concat(&ops[i])?;
+    let mut calls = vec![(d1, x, t1)];
+    while let Some((d, l, t)) = ops.get(i + calls.len()).and_then(as_str_concat) {
+        if l != calls.last().expect("chain is non-empty").0 {
+            break;
+        }
+        calls.push((d, l, t));
+    }
+    let k = calls.len();
+    if k < 2 {
+        return None;
+    }
+    let Some(Op::Drop { v: x2 }) = ops.get(i + k) else {
+        return None;
+    };
+    let Some(Op::SetLocal { local: x3, src: dk }) = ops.get(i + k + 1) else {
+        return None;
+    };
+    if *x2 != x || *x3 != x || *dk != calls[k - 1].0 {
+        return None;
+    }
+    // Mention counts: the final result is used only by the rebind (dst +
+    // SetLocal src = 2); each intermediate only by its def, the next link's
+    // left arg, and its trailing drop (3). Any extra reference (including an
+    // intermediate reused as a later SUFFIX) means the shape is not the pure
+    // chain and the copying concat must stay.
+    if occ.get(&calls[k - 1].0).copied() != Some(2) {
+        return None;
+    }
+    if calls[..k - 1].iter().any(|(d, _, _)| occ.get(d).copied() != Some(3)) {
+        return None;
+    }
+    // Alias guard: a suffix that IS `x` (or an intermediate) would read the
+    // accumulator's block AFTER an in-place append mutated it. Distinct
+    // ValueIds only — Dup-aliases are dynamically safe (rc > 1 → slow path).
+    if calls.iter().any(|(_, _, t)| *t == x || calls.iter().any(|(d, _, _)| d == t)) {
+        return None;
+    }
+    if calls.iter().any(|(d, _, _)| *d == x) {
+        return None;
+    }
+    // Each intermediate's trailing Drop must live in the same straight-line
+    // region after the rebind (same scan discipline as `match_window`).
+    let mut inter_drop_at = Vec::with_capacity(k - 1);
+    'inters: for (d, _, _) in &calls[..k - 1] {
+        for (m, op) in ops.iter().enumerate().skip(i + k + 2).take(DROP_SCAN) {
+            match op {
+                Op::Drop { v } if v == d => {
+                    inter_drop_at.push(m);
+                    continue 'inters;
+                }
+                Op::IfThen { .. }
+                | Op::Else { .. }
+                | Op::EndIf { .. }
+                | Op::LoopStart
+                | Op::LoopBreakUnless { .. }
+                | Op::LoopEnd => return None,
+                _ => {}
+            }
+        }
+        return None;
+    }
+    Some(StrChain { calls, inter_drop_at })
+}
+
 /// Rewrite every self-append concat window in `functions` to the amortized
 /// O(1) append form: the scalar `__list_concat` window is REPLACED (temp
 /// eliminated — see `match_window`) and the heap-element `__list_concat_rc`
@@ -298,6 +446,10 @@ fn rewrite_ops(
             i = next;
             continue;
         }
+        if let Some(next) = push_str_chain_window(ops, i, occ, &mut out) {
+            i = next;
+            continue;
+        }
         if let Some(next) = push_renamed_window(ops, i, occ, def_at, &mut out) {
             i = next;
             continue;
@@ -306,6 +458,45 @@ fn rewrite_ops(
         i += 1;
     }
     out
+}
+
+/// The chained string window: every link renamed to `__str_append1` with the
+/// consumed owner's `Drop` moved to directly after the call that consumed it
+/// (see [`StrChain`] for why the move is what unlocks the rc == 1 fast path),
+/// then the rebind, then the straight-line ops up to the last intermediate
+/// drop verbatim — minus those drops, which were emitted early. Same op
+/// multiset, new order. Returns the next index when it fired.
+fn push_str_chain_window(
+    ops: &[Op],
+    i: usize,
+    occ: &BTreeMap<ValueId, usize>,
+    out: &mut Vec<Op>,
+) -> Option<usize> {
+    let ch = match_str_chain_window(ops, i, occ)?;
+    let k = ch.calls.len();
+    for (j, (d, l, t)) in ch.calls.iter().enumerate() {
+        let Op::CallFn { result, .. } = &ops[i + j] else {
+            unreachable!("a matched chain link is always a CallFn")
+        };
+        out.push(Op::CallFn {
+            dst: Some(*d),
+            name: "__str_append1".to_string(),
+            args: vec![CallArg::Handle(*l), CallArg::Handle(*t)],
+            result: result.clone(),
+        });
+        // The consumed owner's drop: `Drop x` (the window's own, op i+k) for
+        // the first link, the intermediate's trailing drop for the rest.
+        out.push(Op::Drop { v: *l });
+    }
+    out.push(ops[i + k + 1].clone()); // SetLocal x ← dk
+    let last = *ch.inter_drop_at.iter().max().expect("k >= 2 has intermediates");
+    for m in i + k + 2..=last {
+        if ch.inter_drop_at.contains(&m) {
+            continue;
+        }
+        out.push(ops[m].clone());
+    }
+    Some(last + 1)
 }
 
 /// The 4-op list-concat window: emit `__list_append1`, free the old list, rebind

--- a/crates/almide-mir/src/pipeline_c.rs
+++ b/crates/almide-mir/src/pipeline_c.rs
@@ -410,6 +410,32 @@ fn main() -> Unit = {
             "a string self-append loop must call the amortized append"
         );
 
+        // #1229: the TCO'd MULTI-concat accumulator (`acc + c0 + c1` — a
+        // left-spine chain through a fresh intermediate) must ALSO reach the
+        // amortized append. `match_str_window` alone never fired on it (the
+        // drop/rebind target is the chain HEAD's left operand, not the last
+        // call's), so both links stayed whole-copy `__str_concat`s: O(n²)
+        // bytes, which the 0.57.0 release-gate fuzz read as a hang at
+        // n = 65535 (21.7 s wasm vs instant native, run 31486558420). Two
+        // appends per iteration means TWO `$__str_append1` call sites in the
+        // loop body — pinned structurally, like the rest of this family.
+        let multi_concat_tco = r#"
+local fn build(n: Int, pos: Int, acc: String) -> String = if pos >= n then acc
+else {
+  let c0 = "a"
+  let c1 = "b"
+  build(n, pos + 1, acc + c0 + c1)
+}
+fn main() -> Unit = println(build(3, 0, ""))
+"#;
+        let wat = try_render_wasm_source(multi_concat_tco, &[], false)
+            .expect("the TCO multi-concat accumulator renders");
+        assert!(
+            wat.matches("(call $__str_append1").count() >= 2,
+            "a TCO'd multi-concat string accumulator must chain through the \
+             amortized append (both links), not the whole-copy concat:\n{wat}"
+        );
+
         let parser_loop = r#"
 import json
 fn main() -> Unit = {

--- a/spec/lang/string_concat_chain_test.almd
+++ b/spec/lang/string_concat_chain_test.almd
@@ -1,0 +1,69 @@
+// Regression tests for the CHAINED string self-append rewrite (#1229):
+// `x = x + s1 + s2 (+ …)` lowers as a left-spine `__str_concat` chain through
+// fresh intermediates, and concat_to_append.rs rewrites the whole chain to the
+// amortized in-place `__str_append1` (drops repositioned to keep rc == 1 at
+// every link). These pin the BYTES of every shape the matcher admits or
+// declines — an unsound future widening (e.g. dropping the aliased-suffix
+// guard) shows up here as a wrong string, not just a slow loop.
+local fn build2(n: Int, pos: Int, acc: String) -> String = if pos >= n then acc
+else {
+  let c0 = "a"
+  let c1 = "b"
+  build2(n, pos + 1, acc + c0 + c1)
+}
+
+local fn build3(n: Int, pos: Int, acc: String) -> String = if pos >= n then acc
+else {
+  let c0 = "x"
+  let c1 = "y"
+  let c2 = "z"
+  build3(n, pos + 1, acc + c0 + c1 + c2)
+}
+
+// The suffix IS the accumulator (`acc + acc + c`): the chain rewrite must
+// DECLINE (an in-place first append would mutate the block the second read
+// still expects original bytes from) — the copying concat stays and the
+// bytes stay right.
+local fn doubler(n: Int, pos: Int, acc: String) -> String = if pos >= n then acc
+else {
+  let c = "."
+  doubler(n, pos + 1, acc + acc + c)
+}
+
+test "TCO multi-concat accumulator: two appends per iteration" {
+  assert_eq(build2(3, 0, ""), "ababab")
+  assert_eq(string.len(build2(600, 0, "")), 1200)
+}
+
+test "TCO multi-concat accumulator: three appends per iteration" {
+  assert_eq(build3(2, 0, "-"), "-xyzxyz")
+  assert_eq(string.len(build3(500, 0, "")), 1500)
+}
+
+test "self-referencing suffix declines the chain: acc + acc + c" {
+  // 1 → "ss." → "ss.ss.." → "ss.ss..ss.ss..." (len 2n+1 per step)
+  assert_eq(doubler(3, 0, "s"), "ss.ss..ss.ss...")
+}
+
+test "var reassign chain in a while loop" {
+  var acc = ""
+  var i = 0
+  while i < 400 {
+    let a = "<"
+    let b = ">"
+    acc = acc + a + b
+    i = i + 1
+  }
+  assert_eq(string.len(acc), 800)
+  assert(string.starts_with(acc, "<><>"))
+  assert(string.ends_with(acc, "<><>"))
+}
+
+test "dup-aliased suffix stays value-semantic: t bound before the append" {
+  var acc = "AB"
+  let t = acc
+  let c = "-"
+  acc = acc + c + t
+  assert_eq(acc, "AB-AB")
+  assert_eq(t, "AB")
+}

--- a/spec/wasm_cross/tco_multi_concat.almd
+++ b/spec/wasm_cross/tco_multi_concat.almd
@@ -2,7 +2,9 @@
 // A tail-recursive String accumulator grown by a MULTI-concat `acc + c0 + c1` (base64 encode_chunks:
 // `enc(.., acc + c0 + c1 + c2 + c3)`). The TCO's self-append detector recurses the ConcatStr left
 // spine to the leftmost leaf (`acc`), admitting the nested concat; the loop-body general-reassign
-// path materializes it (try_lower_concat_str) with the loop-carried i(id)m drop-old/alloc-new. v0==v1.
+// path materializes it (try_lower_concat_str) as a left-spine __str_concat chain, which
+// concat_to_append.rs's chain window (#1229) rewrites to amortized in-place __str_append1 links —
+// the whole-copy chain was O(n²) and the release-gate fuzz read build(65535,…) as a hang. v0==v1.
 local fn build(n: Int, pos: Int, acc: String) -> String = if pos >= n then acc
 else {
   let c0 = "a"


### PR DESCRIPTION
## What

The 0.57.0 release-gate fuzz "hang" (run 31486558420) was the TCO'd string-accumulator MULTI-concat (`build(n, pos+1, acc + c0 + c1)`) going quadratic on wasm: the loop body lowers as a left-spine `__str_concat` chain through fresh intermediates, `match_str_window` never fires on it (the drop/rebind target is the chain HEAD's left operand, not the last call's), so every iteration whole-copied the accumulator once per `+` — O(n²) bytes — and every step bump-allocated fresh because the exact-size free-list never fits a monotonically growing block.

Fix is the issue's preferred direction 1 (amortized capacity for the loop-carried slot), implemented where that machinery already lives: `concat_to_append.rs` gains a CHAIN window that renames every link to the self-hosted `__str_append1` (rc==1 in-place append, geometric growth on overflow) and moves each consumed owner's `Drop` to directly after the call that consumed it — the move is what keeps rc==1 at every link; without it the first append's value-semantics return leaves rc==2 and every later link takes the whole-copy slow path. Same op multiset, new order; each moved `Drop` still sits after its value's last use. Aliased suffixes (`acc + acc + c`) are declined by ValueId (Dup-aliases are dynamically safe: rc>1 forces the copying path). The WAT prelude, `$alloc`/FreeList.v contract, and the wat-prelude audit ledger are untouched.

## Measured

String-accumulator TCO bench (`build(n, 0, "")` appending 2 chars/iter, `almide run --target wasm`, wall clock incl. compile ~0.08 s):

| n | wasm before | wasm after |
|---|---|---|
| 8192 | 0.286 s | 0.097 s |
| 16384 | 1.075 s (4.0x for 2x n — quadratic) | 0.088 s |
| 65535 | 24.06 s | 0.081 s (~300x; flat = compile+startup dominated) |

The exact fuzzed mutation (`spec/wasm_cross/tco_multi_concat.almd` with `build(65535, 0, "")`, classified Hang at 21.7 s in the triage): now **0.076 s** on wasm, stdout byte-identical to native (cmp: IDENTICAL, 131071 bytes). The unmutated C-104 fixture is also byte-identical native ⇄ wasm.

Loop-body WAT before/after (n=65535 shape): two `$__str_concat` + drop-old/alloc-new per iteration → two `$__str_append1` each immediately followed by its owner's `rc_dec`.

## Both-target verification

- `cargo test -p almide-mir --release` — 618 passed, 0 failed (includes a new structural pin: the TCO multi-concat program must render ≥2 `$__str_append1` call sites)
- `PATH=/opt/homebrew/bin:$PATH ./target/release/almide test` — **384/384 files pass** (367 via WASM, 17 native fallback; +1 file = new `spec/lang/string_concat_chain_test.almd`, runs via WASM: pins bytes of 2-link/3-link chains, the declined `acc + acc + c` shape, a while-loop reassign chain, and a Dup-aliased suffix)
- `ALMIDE_BIN=$PWD/target/release/almide bash proofs/check-wasm-fallback.sh` — WASM COVERAGE RATCHET OK (17 fallback files, all enumerated)
- `bash proofs/corpus-wall.sh` — WALL OK (total over 6350 corpus fns), WALLED-REAL RATCHET OK, no WALL BREACH / MIR>IR; only the known-local coqc-missing tail step fails
- `bash scripts/check-wat-prelude-audit.sh` — WAT PRELUDE AUDIT OK (prelude not touched)
- `bash scripts/check-contracts.sh` — 249 contracts OK, 388/388 fixtures bidirectional (fixture header comment refreshed, `@contract: C-104` retained)

No observable cross-target behavior change (stdout/stderr/exit identical; perf only), so no contract ledger change.

Closes #1229
