### PR TITLE
Land all 9 constant-factor quick wins from the #1232 debt ledger

### DIFF
--- a/crates/almide-codegen/src/pass_auto_parallel.rs
+++ b/crates/almide-codegen/src/pass_auto_parallel.rs
@@ -67,20 +67,22 @@ impl NanoPass for AutoParallelPass {
         // Collect mutable variable IDs from var_table
         let mutable_vars = collect_mutable_var_ids(&program);
 
+        // `mem::take` (the pass_clone idiom) — `rewrite_expr` takes the body
+        // by value, so cloning it first cost a whole-AST copy per function.
         for func in &mut program.functions {
-            func.body = rewrite_expr(func.body.clone(), &effect_fns, &mutable_vars);
+            func.body = rewrite_expr(std::mem::take(&mut func.body), &effect_fns, &mutable_vars);
         }
         for tl in &mut program.top_lets {
-            tl.value = rewrite_expr(tl.value.clone(), &effect_fns, &mutable_vars);
+            tl.value = rewrite_expr(std::mem::take(&mut tl.value), &effect_fns, &mutable_vars);
         }
         // Post-unification every VarId lives in `program.var_table`;
         // `mutable_vars` already covers module-local bindings too.
         for module in &mut program.modules {
             for func in &mut module.functions {
-                func.body = rewrite_expr(func.body.clone(), &effect_fns, &mutable_vars);
+                func.body = rewrite_expr(std::mem::take(&mut func.body), &effect_fns, &mutable_vars);
             }
             for tl in &mut module.top_lets {
-                tl.value = rewrite_expr(tl.value.clone(), &effect_fns, &mutable_vars);
+                tl.value = rewrite_expr(std::mem::take(&mut tl.value), &effect_fns, &mutable_vars);
             }
         }
         PassResult { program, changed: true }

--- a/crates/almide-codegen/src/pass_borrow_inference.rs
+++ b/crates/almide-codegen/src/pass_borrow_inference.rs
@@ -18,28 +18,59 @@ use almide_base::intern::{sym, Sym};
 /// borrows the param at position `pos` (`&{name}`, `&*{name}`,
 /// `&mut {name}`, or `&mut *{name}`). Consumed ("owned") params have
 /// no sigil and render via `{name}` alone.
+///
+/// The per-position table is computed once per `(module, func)` and
+/// cached — the bundled source is process-constant, and the old
+/// per-query decl scan + 4×`format!` ran for every arg of every
+/// bundled call during inference.
 fn bundled_borrow_at(module: &str, func: &str, pos: usize) -> bool {
+    thread_local! {
+        static BORROW_TABLE: RefCell<HashMap<(Sym, Sym), std::rc::Rc<Vec<bool>>>> =
+            RefCell::new(HashMap::new());
+    }
+    let key = (sym(module), sym(func));
+    let flags = BORROW_TABLE.with(|c| {
+        if let Some(v) = c.borrow().get(&key) {
+            return v.clone();
+        }
+        let v = std::rc::Rc::new(bundled_borrow_table(module, func));
+        c.borrow_mut().insert(key, v.clone());
+        v
+    });
+    flags.get(pos).copied().unwrap_or(false)
+}
+
+/// Per-position borrow flags for a bundled `module.func`'s
+/// `@inline_rust` template — the single decl scan behind the
+/// `bundled_borrow_at` cache. Empty when the module is not bundled,
+/// the fn is absent, or it carries no `@inline_rust` template (all of
+/// which answered `false` for every position before).
+fn bundled_borrow_table(module: &str, func: &str) -> Vec<bool> {
     use almide_lang::ast::{AttrValue, Decl};
     let Some(source) = almide_lang::stdlib_info::bundled_source(module) else {
-        return false;
+        return Vec::new();
     };
-    let Some(program) = almide_lang::parse_cached(source) else { return false; };
+    let Some(program) = almide_lang::parse_cached(source) else { return Vec::new(); };
     for decl in &program.decls {
         let Decl::Fn { name, attrs, params, .. } = decl else { continue };
         if name.as_str() != func { continue; }
-        let Some(pname) = params.get(pos).map(|p| p.name) else { return false; };
         let Some(attr) = attrs.iter().find(|a| a.name.as_str() == "inline_rust") else {
-            return false;
+            return Vec::new();
         };
-        let Some(first) = attr.args.first() else { return false; };
-        let AttrValue::String { value } = &first.value else { return false; };
-        let p = pname.as_str();
-        return value.contains(&format!("&{{{}}}", p))
-            || value.contains(&format!("&*{{{}}}", p))
-            || value.contains(&format!("&mut {{{}}}", p))
-            || value.contains(&format!("&mut *{{{}}}", p));
+        let Some(first) = attr.args.first() else { return Vec::new(); };
+        let AttrValue::String { value } = &first.value else { return Vec::new(); };
+        return params
+            .iter()
+            .map(|param| {
+                let p = param.name.as_str();
+                value.contains(&format!("&{{{}}}", p))
+                    || value.contains(&format!("&*{{{}}}", p))
+                    || value.contains(&format!("&mut {{{}}}", p))
+                    || value.contains(&format!("&mut *{{{}}}", p))
+            })
+            .collect();
     }
-    false
+    Vec::new()
 }
 
 // Thread-local snapshot of currently-known borrow signatures, used during

--- a/crates/almide-codegen/src/pass_borrow_inference_ownership.rs
+++ b/crates/almide-codegen/src/pass_borrow_inference_ownership.rs
@@ -297,8 +297,10 @@ fn check_needs_ownership_call_bundled_module(target: &CallTarget, args: &[IrExpr
     let CallTarget::Module { module, func, .. } = target else { return false; };
     if !almide_lang::stdlib_info::is_bundled_module(module.as_str()) { return false; }
     for (i, arg) in args.iter().enumerate() {
-        let borrowed = bundled_borrow_at(module.as_str(), func.as_str(), i)
-            && matches!(arg.ty, Ty::Bytes);
+        // Free type test first — the parsed-decl table lookup only runs
+        // for Bytes args (the only type this branch can borrow).
+        let borrowed = matches!(arg.ty, Ty::Bytes)
+            && bundled_borrow_at(module.as_str(), func.as_str(), i);
         if !borrowed && is_var(arg, var) {
             *needs = true;
             return true;

--- a/crates/almide-frontend/src/bundled_sigs.rs
+++ b/crates/almide-frontend/src/bundled_sigs.rs
@@ -80,10 +80,17 @@ pub fn module_fn_names(module: &str) -> Vec<&'static str> {
 }
 
 /// Lazily populate the per-module cache and apply a read-only
-/// projection.
+/// projection. On a cache hit the projection runs under the read
+/// guard — the old path cloned the module's whole `HashMap<Sym,
+/// FnSig>` per lookup to shorten the critical section, which cost a
+/// full map deep-copy on every stdlib signature query during
+/// checking. `f` never re-enters this cache, so holding the read
+/// lock across it is deadlock-free.
 fn with_module<T>(module: &str, f: impl FnOnce(&HashMap<Sym, FnSig>) -> T) -> Option<T> {
-    if let Some(map) = cached_module(module) {
-        return Some(f(&map));
+    if let Ok(guard) = cache().read() {
+        if let Some(map) = guard.get(module) {
+            return Some(f(map));
+        }
     }
     let sigs = build_module_sigs(module)?;
     let result = f(&sigs);
@@ -106,13 +113,6 @@ fn intern_static(s: &str) -> &'static str {
     let leaked: &'static str = Box::leak(s.to_string().into_boxed_str());
     guard.insert(leaked);
     leaked
-}
-
-/// Read-locked cache hit. Returned map is cloned to keep the read
-/// lock critical section short.
-fn cached_module(module: &str) -> Option<HashMap<Sym, FnSig>> {
-    let guard = cache().read().ok()?;
-    guard.get(module).cloned()
 }
 
 fn store_module(module: &str, sigs: HashMap<Sym, FnSig>) {

--- a/crates/almide-frontend/src/check/infer_control_ops.rs
+++ b/crates/almide-frontend/src/check/infer_control_ops.rs
@@ -876,8 +876,11 @@ impl Checker {
     fn infer_expr_g2_ident(&mut self, expr: &mut ast::Expr) -> Ty {
         let ExprKind::Ident { name, .. } = &mut expr.kind else { unreachable!("infer_expr_g2_ident called on the wrong ExprKind") };
                 self.env.used_vars.insert(sym(name));
-                if let Some(ty) = self.env.lookup_var(name).cloned() { self.instantiate_ty(&ty) }
-                else if let Some(ty) = self.env.top_lets.get(&sym(name)).cloned() { self.instantiate_ty(&ty) }
+                // NOTE: no let-polymorphism here — the old `instantiate_ty`
+                // never freshened anything (its mapping was never written), so
+                // it was an identity deep copy of the already-cloned type.
+                if let Some(ty) = self.env.lookup_var(name).cloned() { ty }
+                else if let Some(ty) = self.env.top_lets.get(&sym(name)).cloned() { ty }
                 // Const param: `N: Int` in generic params resolves to its underlying type
                 else if let Some(Ty::ConstParam { ty, .. }) = self.env.types.get(&sym(name)).cloned() {
                     *ty

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -34,7 +34,7 @@ use almide_base::diagnostic::Diagnostic;
 use crate::import_table::{ImportTable, build_import_table};
 use almide_base::intern::{Sym, sym};
 use crate::types::{Ty, TypeEnv};
-use types::{TyVarId, Constraint, FixHint, UnionFind, resolve_ty};
+use types::{Constraint, FixHint, UnionFind, resolve_ty};
 
 /// Print a compiler trace line when the named debug channel is switched on.
 ///
@@ -576,23 +576,6 @@ impl Checker {
     pub(crate) fn fresh_var(&mut self) -> Ty {
         let id = self.uf.fresh();
         Ty::TypeVar(sym(&format!("?{}", id)))
-    }
-
-    /// Let-polymorphism: instantiate で TypeVar("?N") を fresh var に置換
-    /// 同じ let binding を2回参照する時、各参照で独立した型変数を使う
-    pub(crate) fn instantiate_ty(&mut self, ty: &Ty) -> Ty {
-        let mut mapping: std::collections::HashMap<u32, TyVarId> = std::collections::HashMap::new();
-        self.instantiate_inner(ty, &mut mapping)
-    }
-
-    fn instantiate_inner(&mut self, ty: &Ty, mapping: &mut std::collections::HashMap<u32, TyVarId>) -> Ty {
-        // Inference variables (?N) must NOT be freshened — they need to stay
-        // linked to the original constraint.
-        if matches!(ty, Ty::TypeVar(name) if name.starts_with('?')) {
-            return ty.clone();
-        }
-        // Recursively instantiate all children
-        ty.map_children_mut(&mut |child| self.instantiate_inner(child, mapping))
     }
 
     pub(crate) fn constrain(&mut self, expected: Ty, actual: Ty, context: impl Into<String>) {

--- a/crates/almide-frontend/src/lower/calls_target.rs
+++ b/crates/almide-frontend/src/lower/calls_target.rs
@@ -334,13 +334,17 @@ fn lower_call_target_cross_module_ufcs(ctx: &mut LowerCtx, object: &ast::Expr, f
         // the suffix scan only matched historical bare names).
         let defining_module = match type_name.as_str().rsplit_once('.') {
             Some((m, _)) => Some(m.to_string()),
-            None => ctx.env.types.keys()
-                .find(|k| {
-                    let s = k.as_str();
-                    s.ends_with(&format!(".{}", type_name.as_str()))
-                        && s.len() > type_name.as_str().len() + 1
-                })
-                .map(|k| k.as_str()[..k.as_str().len() - type_name.as_str().len() - 1].to_string()),
+            None => {
+                // Hoisted out of the `find` closure — the old code rebuilt
+                // the `.<type>` needle for every key in `env.types`.
+                let needle = format!(".{}", type_name.as_str());
+                ctx.env.types.keys()
+                    .find(|k| {
+                        let s = k.as_str();
+                        s.ends_with(&needle) && s.len() > type_name.as_str().len() + 1
+                    })
+                    .map(|k| k.as_str()[..k.as_str().len() - type_name.as_str().len() - 1].to_string())
+            }
         };
         if let Some(module) = defining_module {
             let key = format!("{}.{}", module, field);

--- a/crates/almide-interp/src/dispatch.rs
+++ b/crates/almide-interp/src/dispatch.rs
@@ -817,25 +817,12 @@ pub(crate) enum CtorKind {
 }
 
 impl<'a> Interpreter<'a> {
-    /// Look up a variant constructor by name in the program's type decls.
-    /// Returns `(type_name, ctor_kind)`.
+    /// Look up a variant constructor by name. Returns `(type_name,
+    /// ctor_kind)`. Backed by the `variant_ctors` registry built once in
+    /// `Interpreter::new` — this is on the hot path of every Named call,
+    /// where it used to linearly rescan all type decls.
     pub(crate) fn variant_ctor(&self, name: Sym) -> Option<(Sym, CtorKind)> {
-        use almide_ir::{IrTypeDeclKind, IrVariantKind};
-        for td in &self.program.type_decls {
-            if let IrTypeDeclKind::Variant { cases, .. } = &td.kind {
-                for case in cases {
-                    if case.name == name {
-                        let kind = match case.kind {
-                            IrVariantKind::Unit => CtorKind::Unit,
-                            IrVariantKind::Tuple { .. } => CtorKind::Tuple,
-                            IrVariantKind::Record { .. } => CtorKind::Record,
-                        };
-                        return Some((td.name, kind));
-                    }
-                }
-            }
-        }
-        None
+        self.variant_ctors.get(&name).copied()
     }
 }
 

--- a/crates/almide-interp/src/lib.rs
+++ b/crates/almide-interp/src/lib.rs
@@ -121,6 +121,12 @@ pub struct Interpreter<'a> {
     /// ambiguous and intentionally NOT indexed (the structural type is then
     /// treated as a true anonymous record).
     pub(crate) named_records: HashMap<Vec<Sym>, (Sym, Vec<Sym>)>,
+    /// Variant constructor registry: case name → `(type name, ctor kind)`,
+    /// built once from `program.type_decls`. The old per-call linear scan of
+    /// every type decl ran for EVERY Named call (user fn calls included)
+    /// before the fn-table lookup. First declaration wins on a shared case
+    /// name, exactly like the scan it replaces.
+    pub(crate) variant_ctors: HashMap<Sym, (Sym, dispatch::CtorKind)>,
     /// The global scope holding evaluated top-level lets. Every top-level fn
     /// call and `FnRef` closure parents off this so globals are visible from
     /// nested calls (not just from `main`'s body). Seeded once, lazily.
@@ -265,6 +271,27 @@ fn index_named_records(program: &IrProgram) -> HashMap<Vec<Sym>, (Sym, Vec<Sym>)
     named_records
 }
 
+/// Variant constructor registry: case name → `(type name, ctor kind)`.
+/// Mirrors the linear scan `variant_ctor` used to run per Named call:
+/// `program.type_decls` only (module decls were never scanned), in decl
+/// order, first declaration of a shared case name wins (`or_insert`).
+fn index_variant_ctors(program: &IrProgram) -> HashMap<Sym, (Sym, dispatch::CtorKind)> {
+    use almide_ir::{IrTypeDeclKind, IrVariantKind};
+    let mut out: HashMap<Sym, (Sym, dispatch::CtorKind)> = HashMap::new();
+    for td in &program.type_decls {
+        let IrTypeDeclKind::Variant { cases, .. } = &td.kind else { continue };
+        for case in cases {
+            let kind = match case.kind {
+                IrVariantKind::Unit => dispatch::CtorKind::Unit,
+                IrVariantKind::Tuple { .. } => dispatch::CtorKind::Tuple,
+                IrVariantKind::Record { .. } => dispatch::CtorKind::Record,
+            };
+            out.entry(case.name).or_insert((td.name, kind));
+        }
+    }
+    out
+}
+
 impl<'a> Interpreter<'a> {
     pub fn new(program: &'a IrProgram) -> Self {
         let mut fns = HashMap::new();
@@ -320,6 +347,7 @@ impl<'a> Interpreter<'a> {
             }
         }
         let named_records = index_named_records(program);
+        let variant_ctors = index_variant_ctors(program);
 
         Interpreter {
             program,
@@ -328,6 +356,7 @@ impl<'a> Interpreter<'a> {
             fns,
             module_fns,
             named_records,
+            variant_ctors,
             globals: env::Scope::root(),
             globals_ready: Cell::new(false),
             stdout: String::new(),

--- a/crates/almide-mir/src/pipeline.rs
+++ b/crates/almide-mir/src/pipeline.rs
@@ -752,12 +752,12 @@ fn build_ir_with_drops(
     let repr_type_decls = all_type_decls.clone();
     all_type_decls.extend(generic_variant_synthetic_decls);
     let uses_result_opt_str = crate::lower::program_uses_result_option_str(&ir);
+    // Bound once: also consulted by the `list_str_drop` gate below — each
+    // `program_uses_*` call is a full-program walk.
+    let uses_closures = crate::lower::program_uses_closures(&ir);
     // First-class function values need the UNIFORM closure-block release
     // (`$__drop_closure` — self-describing recursive drop, DropVariant "closure").
-    let closure_drop = gated(
-        crate::lower::program_uses_closures(&ir),
-        crate::lower::CLOSURE_DROP_SRC,
-    );
+    let closure_drop = gated(uses_closures, crate::lower::CLOSURE_DROP_SRC);
     // A `List[<Fn>]` LITERAL (`[(x)=>x+1, (x)=>x*2]`) routes its scope-end drop to the
     // generated `$__drop_list_closure` (per-element `$__drop_closure` — required, not a
     // blind rc_dec, since a captured heap slot would otherwise leak). Needs
@@ -806,7 +806,7 @@ fn build_ir_with_drops(
     let list_str_drop = gated(
         crate::lower::program_uses_list_str_drop_field(&all_type_decls)
             || crate::lower::program_uses_anon_list_str_record(&ir, &all_type_decls)
-            || crate::lower::program_uses_closures(&ir),
+            || uses_closures,
         crate::lower::LIST_STR_DROP_SRC,
     );
     // `Result[List[Int], List[String]]` (result.collect) routes its drop to the
@@ -819,14 +819,11 @@ fn build_ir_with_drops(
     // (the fs.fold_lines msi twins) route their drops to the TAG-AWARE
     // `$__drop_res_msi` / `$__drop_res_lmsi` (Ok → the skv key sweep; Err → the
     // message). One gate injects both — `res_lmsi` shares `res_msi`'s key loop.
-    let res_msi_drop = gated(
-        crate::lower::program_uses_res_map_si(&ir),
-        crate::lower::RES_MSI_DROP_SRC,
-    );
-    let res_lmsi_drop = gated(
-        crate::lower::program_uses_res_map_si(&ir),
-        crate::lower::RES_LMSI_DROP_SRC,
-    );
+    // Bound once for the msi twins — the walk answered the same question
+    // twice back-to-back.
+    let uses_res_map_si = crate::lower::program_uses_res_map_si(&ir);
+    let res_msi_drop = gated(uses_res_map_si, crate::lower::RES_MSI_DROP_SRC);
+    let res_lmsi_drop = gated(uses_res_map_si, crate::lower::RES_LMSI_DROP_SRC);
     // An `Option[(String, <scalar>)]` (map.find's result, or a plain `some((s, n))` ctor)
     // routes its drop to the TAG-AWARE `$__drop_opt_str_int` (Some → recursive String-slot
     // free; None → nothing) — a blind flat `rc_dec` of the Option's payload slot would only

--- a/crates/almide-optimize/src/mono/mod.rs
+++ b/crates/almide-optimize/src/mono/mod.rs
@@ -269,12 +269,25 @@ fn collect_module_generics(program: &IrProgram) -> Vec<ModuleGeneric> {
         .collect()
 }
 
+/// The interned flatten spelling (`almide_rt_<module>_<fn>`) per generic,
+/// computed once per round and shared by `Discover` / `Rewriter`.
+fn flatten_spellings(generics: &[ModuleGeneric], module_names: &[String]) -> Vec<Sym> {
+    generics
+        .iter()
+        .map(|g| sym(&format!("almide_rt_{}_{}", module_names[g.mi], g.name)))
+        .collect()
+}
+
 /// One discovery round's call-site scan: every `(module, generic)` call whose
 /// arg types pin the type variables concretely.
 struct Discover<'a> {
     generics: &'a [ModuleGeneric],
     param_types: Vec<Vec<Ty>>,
     module_names: &'a [String],
+    /// Per-generic interned flatten spelling (`almide_rt_<module>_<fn>`),
+    /// precomputed once — the old per-call `format!` ran for every Named
+    /// call × every generic × every discovery round.
+    flat_names: &'a [Sym],
     /// (mi, fi, bindings, suffix)
     out: Vec<(usize, usize, HashMap<String, Ty>, String)>,
 }
@@ -284,7 +297,7 @@ impl almide_ir::visit_mut::IrMutVisitor for Discover<'_> {
         use almide_ir::{CallTarget, IrExprKind};
         almide_ir::visit_mut::walk_expr_mut(self, expr);
         if let IrExprKind::Call { target: CallTarget::Named { name }, args, .. } = &expr.kind {
-            self.record_flattened_call(name.as_str(), args);
+            self.record_flattened_call(*name, args);
         }
         if let IrExprKind::Call { target: CallTarget::Module { module, func, .. }, args, .. } =
             &expr.kind
@@ -300,10 +313,9 @@ impl Discover<'_> {
     /// cell): match the exact flatten spelling per generic (module list + fn name
     /// — no string parsing), so the call site instantiates exactly like a
     /// `Module { m, f }` one.
-    fn record_flattened_call(&mut self, name: &str, args: &[almide_ir::IrExpr]) {
-        for (gi, g) in self.generics.iter().enumerate() {
-            let flat = format!("almide_rt_{}_{}", self.module_names[g.mi], g.name);
-            if name != flat {
+    fn record_flattened_call(&mut self, name: Sym, args: &[almide_ir::IrExpr]) {
+        for gi in 0..self.generics.len() {
+            if name != self.flat_names[gi] {
                 continue;
             }
             self.record(gi, args, None);
@@ -361,6 +373,8 @@ struct Rewriter<'a> {
     param_types: &'a [Vec<Ty>],
     rename: &'a HashMap<(String, String, String), String>,
     module_names: &'a [String],
+    /// Per-generic interned flatten spelling — same table as `Discover`.
+    flat_names: &'a [Sym],
 }
 
 impl almide_ir::visit_mut::IrMutVisitor for Rewriter<'_> {
@@ -397,13 +411,12 @@ impl Rewriter<'_> {
     /// flatten spelling (`almide_rt_m_stash__Int`) — the SAME name the module-fn
     /// flattening gives the pushed instance.
     fn rewrite_flattened_call(&self, name: &mut Sym, args: &[almide_ir::IrExpr]) {
-        let n = name.as_str().to_string();
         for (gi, g) in self.generics.iter().enumerate() {
-            let m = self.module_names[g.mi].clone();
-            if n != format!("almide_rt_{}_{}", m, g.name) {
+            if *name != self.flat_names[gi] {
                 continue;
             }
-            if let Some(new_name) = self.specialized_name(gi, &m, args) {
+            let m = &self.module_names[g.mi];
+            if let Some(new_name) = self.specialized_name(gi, m, args) {
                 *name = sym(&format!("almide_rt_{}_{}", m, new_name));
             }
             break;
@@ -411,9 +424,9 @@ impl Rewriter<'_> {
     }
 
     fn rewrite_module_call(&self, m: &str, func: &mut Sym, args: &[almide_ir::IrExpr]) {
-        let f = func.as_str().to_string();
+        let f = *func;
         for (gi, g) in self.generics.iter().enumerate() {
-            if g.name != f || self.module_names[g.mi] != m {
+            if g.name != f.as_str() || self.module_names[g.mi] != m {
                 continue;
             }
             if let Some(new_name) = self.specialized_name(gi, m, args) {
@@ -509,10 +522,12 @@ fn monomorphize_module_fns(program: &mut IrProgram) {
     loop {
         let module_names: Vec<String> =
             program.modules.iter().map(|m| m.name.to_string()).collect();
+        let flat_names = flatten_spellings(&generics, &module_names);
         let mut d = Discover {
             generics: &generics,
             param_types: generic_param_types(program, &generics),
             module_names: &module_names,
+            flat_names: &flat_names,
             out: Vec::new(),
         };
         walk_program_exprs(program, &mut d);
@@ -533,11 +548,13 @@ fn monomorphize_module_fns(program: &mut IrProgram) {
         let param_types = generic_param_types(program, &generics);
         let module_names: Vec<String> =
             program.modules.iter().map(|m| m.name.to_string()).collect();
+        let flat_names = flatten_spellings(&generics, &module_names);
         let mut rw = Rewriter {
             generics: &generics,
             param_types: &param_types,
             rename: &rename,
             module_names: &module_names,
+            flat_names: &flat_names,
         };
         walk_program_exprs(program, &mut rw);
     }

--- a/crates/almide-optimize/src/mono/varid_remap.rs
+++ b/crates/almide-optimize/src/mono/varid_remap.rs
@@ -7,8 +7,11 @@ use almide_ir::*;
 
 // ── VarId collection ────────────────────────────────────────────
 
+/// Duplicates are fine here: the only consumer (`specialize_function`
+/// Phase 2) already skips repeats via `remap.contains_key`, and the old
+/// `out.contains` linear scan made collection O(n²) per specialized fn.
 pub(super) fn collect_var_id(id: VarId, out: &mut Vec<VarId>) {
-    if !out.contains(&id) { out.push(id); }
+    out.push(id);
 }
 
 pub(super) fn collect_varids_in_expr(expr: &IrExpr, out: &mut Vec<VarId>) {


### PR DESCRIPTION
All 9 quick wins from the #1232 constant-factor debt ledger, one commit per win. Behavior is byte-identical everywhere it is observable (measured, see below). The new-code small fixes and the medium backlog sections of #1232 are NOT taken here — the issue stays open.

## Measured A/B protocol

Baseline binary (origin/develop) and patched binary built from the same worktree; workloads alternated (baseline → patched → baseline → patched) so both sides run warm; medians of 5 for the single-file workloads. Corpus:

- **W1** `almide check` on a synthetic 1200-fn file (stdlib-call heavy)
- **W2** emit Rust for the same file
- **W3** emit Rust for all 220 `spec/lang/*.almd`
- **W4** `almide build --target wasm` for the first 40 `spec/wasm_cross/*.almd`
- **W-interp** interp-only bench (temporary uncommitted example): 300k user-fn calls through variant ctors, 5 runs, patched vs baseline `almide-interp` lib from the same worktree

## Win → measurement

| # | Ledger row | Fix | Measurement (before → after) |
|---|---|---|---|
| 1 | `bundled_borrow_at` runs the parsed-decl scan before the free type test; rescans decls + 4×`format!` per query | Bytes test first; borrow-position table cached per `(module, fn)` | rides W3/W4 (below); emitted Rust byte-identical |
| 2 | `bundled_sigs::cached_module` clones the module's whole `HashMap<Sym, FnSig>` per cache hit | apply the projection under the read guard | **W1: 0.232s → 0.123s (−47%)**. Attribution build with ONLY this win kept in the frontend: 0.124s — this row is the W1 driver |
| 3 | `instantiate_ty` is an identity deep copy (mapping never written) — double deep copy per identifier reference | deleted; call sites return the cloned type | no additional W1 delta on top of win 2 at this corpus scale (0.124s → 0.123s, within noise); the second deep copy per ident is gone by construction |
| 4 | `collect_var_id` `out.contains` is O(n²) and redundant (Phase 2 dedups via `remap.contains_key`) | dropped | rides W3 |
| 5 | `pass_auto_parallel` `func.body.clone()` ×4 | `std::mem::take` (the pass_clone idiom) | rides W2/W3: **W2 0.497s → 0.377s (−24%)** |
| 6 | `record_flattened_call` builds `format!("almide_rt_{}_{}")` per Named call × generic × round | interned flatten spellings precomputed once per round; Rewriter twin (`rewrite_flattened_call`, same per-call format! + `to_string`s) fixed with the same table | rides W2/W3 |
| 7 | UFCS fallback rebuilds the `.{type}` needle inside the `env.types.keys().find` closure | hoisted | rides W1/W3 |
| 8 | interp `variant_ctor` linearly scans all type_decls per Named call | `HashMap<Sym, (Sym, CtorKind)>` built once in `Interpreter::new` (first-decl-wins preserved via `or_insert`) | **W-interp, 27 type decls: 0.329s → 0.280s (−15%)**; 3 decls: 0.290s → 0.281s (parity — the win scales with decl count, never regresses) |
| 9 | `pipeline.rs` calls `program_uses_res_map_si` twice back-to-back and `program_uses_closures` twice | bound once each (the `\|\|` hoist strictly reduces walk count) | rides W4: **3.69s → 2.92s (−21%)**; all 40 `.wasm` binaries byte-identical |

Aggregate (all 9 wins in the patched binary):

| Workload | baseline | patched | delta |
|---|---|---|---|
| W1 check 1200-fn file (median of 5) | 0.232s | 0.123s | −47% |
| W2 emit Rust 1200-fn file (median of 5) | 0.497s | 0.377s | −24% |
| W3 emit Rust × 220 spec/lang | 14.86s | 13.97s | −6% |
| W4 wasm build × 40 spec/wasm_cross | 3.69s | 2.92s | −21% |

## Byte-equivalence (measured, not reasoned)

- Emitted Rust for all 220 `spec/lang` files: `diff -r` identical
- Emitted Rust for the 1200-fn file: identical
- All 40 `spec/wasm_cross` `.wasm` binaries: identical
- Interp bench fixture: same `(exit, stdout)` on both sides

## Verification

- `cargo test -p almide-codegen -p almide-frontend -p almide-optimize -p almide-interp -p almide-mir --release` — all green (618-test interp battery included)
- `almide test` — 384 files, 0 failed (367 wasm, 17 native fallback)
- `make verify-trust` — full chain incl. kernel-checked PCC: PROOF SPINE OK, exit 0
- `cargo test --release --test traversal_totality_lint` — green

## Not taken (still open in #1232)

- The four "new-code small fixes" (#1183 desugar trigger gating, `continuation_lift` empty-chain early-continue, interp trampoline `cur.ty.clone()` per `!` hop, `fs.rs` per-line `buf.clone()`) — separate section of the ledger, each wants its own targeted measurement.
- The whole medium backlog (solving.rs 3× unification, exhaustiveness caches, pass_clone program-wide maps, worklist-less fixpoints, mod_c/binds Rc'ing, `strip_dead_const_sets`, fused `program_uses_*` flag-struct, shared-cell bottom-up summaries, interp Lambda memo, reverse type indexes).
- #1230 / #1231 rows were already fixed before this PR and were skipped here.
