### PR TITLE
Geometric block capacity in the self-host map/set grow paths (#1219 wasm leg)

### DIFF
--- a/stdlib/map_core.almd
+++ b/stdlib/map_core.almd
@@ -53,10 +53,20 @@ fn __map_put(rh: Int, len: Int, idx: Int, k: Int, v: Int) -> Int = if idx < 0 th
   len
 }
 
+// GEOMETRIC capacity (#1219): grow the copy's slot count by doubling epochs instead of the
+// exact (len+1)*2. The $alloc free-list reuses only EXACT-size blocks, so an exact-size grow
+// loop (`m = map.set(m, k, v)`, the lowered form of `m[k] = v` / `map.insert`) frees a
+// never-reusable block every call — O(n^2) bytes and an O(n) dead-list walk per alloc. With a
+// stable epoch size the block freed by the PREVIOUS rebind is an exact head match: O(1) reuse,
+// O(n) total memory. Slack slots past 2*len are never read (len governs iteration/eq/repr —
+// filter/remove results already carry cap slack), so observable behavior is unchanged.
 fn map_set(m: Map[Int, Int], k: Int, v: Int) -> Map[Int, Int] = {
   let sh = prim.handle(m)
   let len = prim.load32(sh + 4)
-  let slots = (len + 1) * 2
+  let cap = prim.load32(sh + 8)
+  let need = (len + 1) * 2
+  let slots = if need > cap then (if cap * 2 > need then cap * 2 else need)
+  else cap
   let r = prim.alloc_map(slots)
   let rh = prim.handle(r)
   let _c = __map_copy(sh, rh, len, 0)
@@ -168,7 +178,7 @@ fn map_merge(a: Map[Int, Int], b: Map[Int, Int]) -> Map[Int, Int] = {
 
 // map.update — if k is present, replace its value with f(old); else the map is unchanged. f is a
 // one-arity closure (Int)->Int invoked via CallIndirect. update never changes the entry count.
-fn __map_update_at(rh: Int, idx: Int, f: fn(Int) -> Int) -> Int = if idx < 0 then 0
+fn __map_update_at(rh: Int, idx: Int, f: (Int) -> Int) -> Int = if idx < 0 then 0
 else {
   let old = prim.load64(rh + 12 + idx * 16 + 8)
   let nv = f(old)
@@ -176,7 +186,7 @@ else {
   0
 }
 
-fn map_update(m: Map[Int, Int], k: Int, f: fn(Int) -> Int) -> Map[Int, Int] = {
+fn map_update(m: Map[Int, Int], k: Int, f: (Int) -> Int) -> Map[Int, Int] = {
   let sh = prim.handle(m)
   let len = prim.load32(sh + 4)
   let slots = len * 2
@@ -192,7 +202,7 @@ fn map_update(m: Map[Int, Int], k: Int, f: fn(Int) -> Int) -> Map[Int, Int] = {
 // ── Higher-order Map[Int,Int] (closures machinery) ── the predicate f is a TWO-arity closure
 // f : (Key, Value) -> Bool invoked via CallIndirect $closure_fn2. A pure predicate byte-matches
 // v0 (single pass, insertion order). filter keeps a subset of entries (still unique keys).
-fn __map_filter_fill(sh: Int, len: Int, rh: Int, f: fn(Int, Int) -> Bool, i: Int, w: Int) -> Int = if i >= len then w
+fn __map_filter_fill(sh: Int, len: Int, rh: Int, f: (Int, Int) -> Bool, i: Int, w: Int) -> Int = if i >= len then w
 else {
   let k = prim.load64(sh + 12 + i * 16)
   let v = prim.load64(sh + 12 + i * 16 + 8)
@@ -206,7 +216,7 @@ else {
   }
 }
 
-fn map_filter(m: Map[Int, Int], f: fn(Int, Int) -> Bool) -> Map[Int, Int] = {
+fn map_filter(m: Map[Int, Int], f: (Int, Int) -> Bool) -> Map[Int, Int] = {
   let sh = prim.handle(m)
   let len = prim.load32(sh + 4)
   let slots = len * 2
@@ -218,7 +228,7 @@ fn map_filter(m: Map[Int, Int], f: fn(Int, Int) -> Bool) -> Map[Int, Int] = {
 }
 
 // Sum the predicate's 0/1 over all entries → the hit COUNT (a Bool is an i64 0/1).
-fn __map_count_hits(sh: Int, len: Int, f: fn(Int, Int) -> Bool, i: Int, acc: Int) -> Int = if i >= len then acc
+fn __map_count_hits(sh: Int, len: Int, f: (Int, Int) -> Bool, i: Int, acc: Int) -> Int = if i >= len then acc
 else {
   let k = prim.load64(sh + 12 + i * 16)
   let v = prim.load64(sh + 12 + i * 16 + 8)
@@ -227,21 +237,21 @@ else {
   else __map_count_hits(sh, len, f, i + 1, acc)
 }
 
-fn map_all(m: Map[Int, Int], f: fn(Int, Int) -> Bool) -> Bool = {
+fn map_all(m: Map[Int, Int], f: (Int, Int) -> Bool) -> Bool = {
   let sh = prim.handle(m)
   let len = prim.load32(sh + 4)
   let hits = __map_count_hits(sh, len, f, 0, 0)
   hits >= len
 }
 
-fn map_any(m: Map[Int, Int], f: fn(Int, Int) -> Bool) -> Bool = {
+fn map_any(m: Map[Int, Int], f: (Int, Int) -> Bool) -> Bool = {
   let sh = prim.handle(m)
   let len = prim.load32(sh + 4)
   let hits = __map_count_hits(sh, len, f, 0, 0)
   hits > 0
 }
 
-fn map_count(m: Map[Int, Int], f: fn(Int, Int) -> Bool) -> Int = {
+fn map_count(m: Map[Int, Int], f: (Int, Int) -> Bool) -> Int = {
   let sh = prim.handle(m)
   let len = prim.load32(sh + 4)
   __map_count_hits(sh, len, f, 0, 0)
@@ -250,7 +260,7 @@ fn map_count(m: Map[Int, Int], f: fn(Int, Int) -> Bool) -> Int = {
 // map.fold — left fold with a THREE-arity closure f : (Acc, Key, Value) -> Acc (v0's
 // fold(m, init, f), acc first). Int accumulator. The closure dispatches via $closure_fn3 (the
 // render generates one closure type per arity that appears — 3-arity needs no new machinery).
-fn __map_fold_loop(sh: Int, f: fn(Int, Int, Int) -> Int, len: Int, i: Int, acc: Int) -> Int = if i >= len then acc
+fn __map_fold_loop(sh: Int, f: (Int, Int, Int) -> Int, len: Int, i: Int, acc: Int) -> Int = if i >= len then acc
 else {
   let k = prim.load64(sh + 12 + i * 16)
   let v = prim.load64(sh + 12 + i * 16 + 8)
@@ -258,7 +268,7 @@ else {
   __map_fold_loop(sh, f, len, i + 1, nacc)
 }
 
-fn map_fold(m: Map[Int, Int], init: Int, f: fn(Int, Int, Int) -> Int) -> Int = {
+fn map_fold(m: Map[Int, Int], init: Int, f: (Int, Int, Int) -> Int) -> Int = {
   let sh = prim.handle(m)
   let len = prim.load32(sh + 4)
   __map_fold_loop(sh, f, len, 0, init)

--- a/stdlib/map_hobj.almd
+++ b/stdlib/map_hobj.almd
@@ -67,7 +67,13 @@ fn __hobj_set(m: Map[String, String], k: String, vh: Int) -> Map[String, String]
   let n = prim.load32(sh + 4)
   let idx = __hobj_find(sh, n, k, 0)
   let rn = if idx < 0 then n + 1 else n
-  let r = prim.alloc_map_kv(rn * 2)
+  // GEOMETRIC capacity (#1219, see map_core.map_set): epoch-stable alloc sizes let the $alloc
+  // exact-size free-list reuse the block freed by the previous set's rebind.
+  let need = rn * 2
+  let scap = prim.load32(sh + 8)
+  let slots = if need > scap then (if scap * 2 > need then scap * 2 else need)
+  else scap
+  let r = prim.alloc_map_kv(slots)
   let rh = prim.handle(r)
   let _c = __hobj_set_copy(sh, rh, n, rn, k, vh, 0)
   let _a = __hobj_set_append(rh, rn, idx, k, vh)

--- a/stdlib/map_hval.almd
+++ b/stdlib/map_hval.almd
@@ -65,7 +65,13 @@ fn map_set_hval(m: Map[String, List[Int]], k: String, v: List[Int]) -> Map[Strin
   let n = prim.load32(sh + 4)
   let idx = __hvl_find(sh, n, k, 0)
   let rn = if idx < 0 then n + 1 else n
-  let r = prim.alloc_map_kv(rn * 2)
+  // GEOMETRIC capacity (#1219, see map_core.map_set): epoch-stable alloc sizes let the $alloc
+  // exact-size free-list reuse the block freed by the previous `m = map.set(m, k, v)` rebind.
+  let need = rn * 2
+  let scap = prim.load32(sh + 8)
+  let slots = if need > scap then (if scap * 2 > need then scap * 2 else need)
+  else scap
+  let r = prim.alloc_map_kv(slots)
   let rh = prim.handle(r)
   let vh = prim.handle(v)
   let _c = __hvl_set_copy(sh, rh, n, rn, k, vh, 0)
@@ -252,7 +258,7 @@ fn __gby_add(m: Map[String, List[Int]], k: String, x: Int) -> Map[String, List[I
   map_set_hval(m, k, nl)
 }
 
-fn __gby_step(xs: List[Int], f: fn(Int) -> String, n: Int, i: Int, m: Map[String, List[Int]]) -> Map[String, List[Int]] = if i >= n then m
+fn __gby_step(xs: List[Int], f: (Int) -> String, n: Int, i: Int, m: Map[String, List[Int]]) -> Map[String, List[Int]] = if i >= n then m
 else {
   let x = prim.load64(prim.handle(xs) + 12 + i * 8)
   let k = f(x)
@@ -262,7 +268,7 @@ else {
   else __gby_step(xs, f, n, i + 1, __gby_add(m, k, x))
 }
 
-fn list_group_by(xs: List[Int], f: fn(Int) -> String) -> Map[String, List[Int]] = {
+fn list_group_by(xs: List[Int], f: (Int) -> String) -> Map[String, List[Int]] = {
   let n = prim.load32(prim.handle(xs) + 4)
   __gby_step(xs, f, n, 0, map_new_hval())
 }

--- a/stdlib/map_ivh.almd
+++ b/stdlib/map_ivh.almd
@@ -49,7 +49,13 @@ fn map_set_ivh(m: Map[Int, String], k: Int, v: String) -> Map[Int, String] = {
   let n = prim.load32(sh + 4)
   let idx = __ivh_find(sh, n, k, 0)
   let rn = if idx < 0 then n + 1 else n
-  let r = prim.alloc_map_kv(rn * 2)
+  // GEOMETRIC capacity (#1219, see map_core.map_set): epoch-stable alloc sizes let the $alloc
+  // exact-size free-list reuse the block freed by the previous `m = map.set(m, k, v)` rebind.
+  let need = rn * 2
+  let scap = prim.load32(sh + 8)
+  let slots = if need > scap then (if scap * 2 > need then scap * 2 else need)
+  else scap
+  let r = prim.alloc_map_kv(slots)
   let rh = prim.handle(r)
   let _c = __ivh_set_copy(sh, rh, n, rn, k, v, 0)
   let _a = __ivh_set_append(rh, rn, idx, k, v)

--- a/stdlib/map_mlo.almd
+++ b/stdlib/map_mlo.almd
@@ -66,7 +66,13 @@ fn map_set_mlo(m: Map[String, List[Int?]], k: String, v: List[Int?]) -> Map[Stri
   let n = prim.load32(sh + 4)
   let idx = __mlo_find(sh, n, k, 0)
   let rn = if idx < 0 then n + 1 else n
-  let r = prim.alloc_map_kv(rn * 2)
+  // GEOMETRIC capacity (#1219, see map_core.map_set): epoch-stable alloc sizes let the $alloc
+  // exact-size free-list reuse the block freed by the previous `m = map.set(m, k, v)` rebind.
+  let need = rn * 2
+  let scap = prim.load32(sh + 8)
+  let slots = if need > scap then (if scap * 2 > need then scap * 2 else need)
+  else scap
+  let r = prim.alloc_map_kv(slots)
   let rh = prim.handle(r)
   let vh = prim.handle(v)
   let _c = __mlo_set_copy(sh, rh, n, rn, k, vh, 0)

--- a/stdlib/map_msv.almd
+++ b/stdlib/map_msv.almd
@@ -67,7 +67,13 @@ fn map_set_msv(m: Map[String, Map[String, String]], k: String, v: Map[String, St
   let n = prim.load32(sh + 4)
   let idx = __msv_find(sh, n, k, 0)
   let rn = if idx < 0 then n + 1 else n
-  let r = prim.alloc_map_kv(rn * 2)
+  // GEOMETRIC capacity (#1219, see map_core.map_set): epoch-stable alloc sizes let the $alloc
+  // exact-size free-list reuse the block freed by the previous `m = map.set(m, k, v)` rebind.
+  let need = rn * 2
+  let scap = prim.load32(sh + 8)
+  let slots = if need > scap then (if scap * 2 > need then scap * 2 else need)
+  else scap
+  let r = prim.alloc_map_kv(slots)
   let rh = prim.handle(r)
   let vh = prim.handle(v)
   let _c = __msv_set_copy(sh, rh, n, rn, k, vh, 0)

--- a/stdlib/map_skv.almd
+++ b/stdlib/map_skv.almd
@@ -3,13 +3,14 @@
 //
 // PHYSICAL LAYOUT (distinct from map_str's interleaved all-String form): a single block with TWO
 // regions — `entries` String-handle KEY slots followed by `entries` i64 VALUE slots:
-//   [rc][len@4 = entries][cap@8 = 2*entries][k0@12, k1@20, ..., k(e-1), v0, v1, ..., v(e-1)]
+//   [rc][len@4 = entries][cap@8 >= 2*entries][k0@12, k1@20, ..., k(e-1), v0, v1, ..., v(e-1)]
 //   key   i @  h + 12 +            i  * 8
 //   value i @  h + 12 + (entries + i) * 8
 // The `len` header (at +4) is the KEY count `entries`, so a scope-end DropListStr frees EXACTLY the
 // `entries` key handles (the keys are owned Strings) and never touches the scalar value region (the
-// values own no heap). `cap` (at +8) is the FULL slot count `2*entries`, so the $alloc free-list
-// reuse — which recomputes a freed block's size from `cap` — sees the true allocation. INSERTION-
+// values own no heap). `cap` (at +8) is the FULL allocated slot count (>= 2*entries — map_set may
+// leave geometric slack, #1219), so the $alloc free-list reuse — which recomputes a freed block's
+// size from `cap` — sees the true allocation; both regions are addressed from `len`. INSERTION-
 // ORDERED (v0's AlmideMap). Keys compared by byte equality. Source borrowed; constructed maps owned.
 fn __skv_eq_bytes(pa: Int, pb: Int, n: Int, i: Int) -> Bool = if i >= n then true
 else {
@@ -110,7 +111,13 @@ fn map_set_skv(m: Map[String, Int], k: String, v: Int) -> Map[String, Int] = {
   let extra = if idx < 0 then 1 else 0
   let rentries = sentries + extra
   let rslots = rentries * 2
-  let r = prim.alloc_map_skv(rslots)
+  // GEOMETRIC capacity (#1219, see map_core.map_set): epoch-stable alloc sizes let the $alloc
+  // exact-size free-list reuse the block freed by the previous `m = map.set(m, k, v)` rebind.
+  // Slack past the len-derived regions is never read (filter's compacted results prove it).
+  let scap = prim.load32(sh + 8)
+  let slots = if rslots > scap then (if scap * 2 > rslots then scap * 2 else rslots)
+  else scap
+  let r = prim.alloc_map_skv(slots)
   let rh = prim.handle(r)
   let _c = __skv_set_copy(sh, rh, sentries, rentries, k, v, 0)
   let _a = __skv_set_append(rh, sentries, rentries, idx, k, v)

--- a/stdlib/map_str.almd
+++ b/stdlib/map_str.almd
@@ -118,7 +118,13 @@ fn map_set_str(m: Map[String, String], k: String, v: String) -> Map[String, Stri
   let extra = if idx < 0 then 1 else 0
   let rentries = entries + extra
   let rslots = rentries * 2
-  let r = prim.alloc_map_str(rslots)
+  // GEOMETRIC capacity (#1219, see map_core.map_set): epoch-stable alloc sizes let the $alloc
+  // exact-size free-list reuse the block freed by the previous `m = map.set(m, k, v)` rebind.
+  // Slack past `len` is never read (len governs iteration/eq/repr, as filter results show).
+  let scap = prim.load32(sh + 8)
+  let slots = if rslots > scap then (if scap * 2 > rslots then scap * 2 else rslots)
+  else scap
+  let r = prim.alloc_map_str(slots)
   let rh = prim.handle(r)
   let _c = __mset_copy(sh, rh, entries, k, v, 0)
   let _a = __mset_append(rh, entries, idx, k, v)
@@ -239,16 +245,16 @@ fn map_merge_str(a: Map[String, String], b: Map[String, String]) -> Map[String, 
 // map.update — if k is present, replace its value with f(old); else the map is unchanged. f is a
 // one-arity closure (String)->String. Entry count never changes. Deep-copy all keys + the unchanged
 // values; for the matching key store f(old) (created + consumed in __store_fv, no conditional consume).
-fn __store_fv(addr: Int, oldv: String, f: fn(String) -> String) -> Int = {
+fn __store_fv(addr: Int, oldv: String, f: (String) -> String) -> Int = {
   let nv = f(oldv)
   prim.store_str(addr, nv)
   0
 }
 
-fn __mupdate_val(eq: Bool, addr: Int, oldv: String, f: fn(String) -> String) -> Int = if eq then __store_fv(addr, oldv, f)
+fn __mupdate_val(eq: Bool, addr: Int, oldv: String, f: (String) -> String) -> Int = if eq then __store_fv(addr, oldv, f)
 else __store_copy(addr, oldv)
 
-fn __mupdate_copy(sh: Int, rh: Int, entries: Int, k: String, f: fn(String) -> String, i: Int) -> Int = if i >= entries then 0
+fn __mupdate_copy(sh: Int, rh: Int, entries: Int, k: String, f: (String) -> String, i: Int) -> Int = if i >= entries then 0
 else {
   let kk = prim.load_str(sh + 12 + i * 16)
   let _kc = __store_copy(rh + 12 + i * 16, kk)
@@ -258,7 +264,7 @@ else {
   __mupdate_copy(sh, rh, entries, k, f, i + 1)
 }
 
-fn map_update_str(m: Map[String, String], k: String, f: fn(String) -> String) -> Map[String, String] = {
+fn map_update_str(m: Map[String, String], k: String, f: (String) -> String) -> Map[String, String] = {
   let sh = prim.handle(m)
   let n = prim.load32(sh + 4)
   let entries = n / 2
@@ -272,7 +278,7 @@ fn map_update_str(m: Map[String, String], k: String, f: fn(String) -> String) ->
 // ── Higher-order Map[String,String] (closures machinery; the predicate f is a TWO-arity closure
 // f : (Key, Value) -> Bool with String args, heap-widened) ── filter keeps matching entries
 // (deep-copied); all/any/count read.
-fn __mfilter_fill(sh: Int, rh: Int, entries: Int, f: fn(String, String) -> Bool, i: Int, w: Int) -> Int = if i >= entries then w
+fn __mfilter_fill(sh: Int, rh: Int, entries: Int, f: (String, String) -> Bool, i: Int, w: Int) -> Int = if i >= entries then w
 else {
   let k = prim.load_str(sh + 12 + i * 16)
   let v = prim.load_str(sh + 12 + i * 16 + 8)
@@ -286,7 +292,7 @@ else {
   }
 }
 
-fn map_filter_str(m: Map[String, String], f: fn(String, String) -> Bool) -> Map[String, String] = {
+fn map_filter_str(m: Map[String, String], f: (String, String) -> Bool) -> Map[String, String] = {
   let sh = prim.handle(m)
   let n = prim.load32(sh + 4)
   let entries = n / 2
@@ -297,7 +303,7 @@ fn map_filter_str(m: Map[String, String], f: fn(String, String) -> Bool) -> Map[
   r
 }
 
-fn __mcount_hits(sh: Int, entries: Int, f: fn(String, String) -> Bool, i: Int, acc: Int) -> Int = if i >= entries then acc
+fn __mcount_hits(sh: Int, entries: Int, f: (String, String) -> Bool, i: Int, acc: Int) -> Int = if i >= entries then acc
 else {
   let k = prim.load_str(sh + 12 + i * 16)
   let v = prim.load_str(sh + 12 + i * 16 + 8)
@@ -306,7 +312,7 @@ else {
   else __mcount_hits(sh, entries, f, i + 1, acc)
 }
 
-fn map_all_str(m: Map[String, String], f: fn(String, String) -> Bool) -> Bool = {
+fn map_all_str(m: Map[String, String], f: (String, String) -> Bool) -> Bool = {
   let sh = prim.handle(m)
   let n = prim.load32(sh + 4)
   let entries = n / 2
@@ -314,7 +320,7 @@ fn map_all_str(m: Map[String, String], f: fn(String, String) -> Bool) -> Bool = 
   hits >= entries
 }
 
-fn map_any_str(m: Map[String, String], f: fn(String, String) -> Bool) -> Bool = {
+fn map_any_str(m: Map[String, String], f: (String, String) -> Bool) -> Bool = {
   let sh = prim.handle(m)
   let n = prim.load32(sh + 4)
   let entries = n / 2
@@ -322,7 +328,7 @@ fn map_any_str(m: Map[String, String], f: fn(String, String) -> Bool) -> Bool = 
   hits > 0
 }
 
-fn map_count_str(m: Map[String, String], f: fn(String, String) -> Bool) -> Int = {
+fn map_count_str(m: Map[String, String], f: (String, String) -> Bool) -> Int = {
   let sh = prim.handle(m)
   let n = prim.load32(sh + 4)
   let entries = n / 2
@@ -331,7 +337,7 @@ fn map_count_str(m: Map[String, String], f: fn(String, String) -> Bool) -> Int =
 
 // map.fold — left fold with a THREE-arity closure f : (Acc, Key, Value) -> Acc (Int accumulator;
 // the closure mixes a scalar Acc with two heap String args — the uniform i64 ABI widens the handles).
-fn __mfold_loop(sh: Int, f: fn(Int, String, String) -> Int, entries: Int, i: Int, acc: Int) -> Int = if i >= entries then acc
+fn __mfold_loop(sh: Int, f: (Int, String, String) -> Int, entries: Int, i: Int, acc: Int) -> Int = if i >= entries then acc
 else {
   let k = prim.load_str(sh + 12 + i * 16)
   let v = prim.load_str(sh + 12 + i * 16 + 8)
@@ -339,7 +345,7 @@ else {
   __mfold_loop(sh, f, entries, i + 1, nacc)
 }
 
-fn map_fold_str(m: Map[String, String], init: Int, f: fn(Int, String, String) -> Int) -> Int = {
+fn map_fold_str(m: Map[String, String], init: Int, f: (Int, String, String) -> Int) -> Int = {
   let sh = prim.handle(m)
   let n = prim.load32(sh + 4)
   let entries = n / 2

--- a/stdlib/set_core.almd
+++ b/stdlib/set_core.almd
@@ -191,10 +191,17 @@ fn __set_addone(rh: Int, slen: Int, x: Int) -> Int = {
   }
 }
 
+// GEOMETRIC capacity (#1219), same reasoning as map_core's map_set: a `s = set.insert(s, x)`
+// grow loop with exact-size allocs defeats the $alloc exact-size free-list (O(n^2) bytes, O(n)
+// dead-list walk per alloc); doubling epochs make the previously freed block an exact head
+// match. Slack past len is never read (len governs iteration/eq/repr).
 fn set_insert(s: Set[Int], x: Int) -> Set[Int] = {
   let sh = prim.handle(s)
   let slen = prim.load32(sh + 4)
-  let cap = slen + 1
+  let scap = prim.load32(sh + 8)
+  let need = slen + 1
+  let cap = if need > scap then (if scap * 2 > need then scap * 2 else need)
+  else scap
   let r = prim.alloc_set(cap)
   let rh = prim.handle(r)
   let _c = __set_copy(sh, rh, slen, 0)
@@ -256,7 +263,7 @@ fn set_symmetric_difference(a: Set[Int], b: Set[Int]) -> Set[Int] = {
 // ── Higher-order Set[Int] (closures machinery) ── the predicate f is invoked via CallIndirect.
 // A pure predicate byte-matches v0 (single pass, no short-circuit). filter keeps a subset of an
 // already-unique set, so the result stays unique (no re-dedup).
-fn __set_filter_fill(dh: Int, sh: Int, f: fn(Int) -> Bool, n: Int, i: Int, di: Int) -> Int = if i >= n then di
+fn __set_filter_fill(dh: Int, sh: Int, f: (Int) -> Bool, n: Int, i: Int, di: Int) -> Int = if i >= n then di
 else {
   let x = prim.load64(sh + 12 + i * 8)
   let keep = f(x)
@@ -268,7 +275,7 @@ else {
   }
 }
 
-fn set_filter(s: Set[Int], f: fn(Int) -> Bool) -> Set[Int] = {
+fn set_filter(s: Set[Int], f: (Int) -> Bool) -> Set[Int] = {
   let sh = prim.handle(s)
   let n = prim.load32(sh + 4)
   let r = prim.alloc_set(n)
@@ -279,7 +286,7 @@ fn set_filter(s: Set[Int], f: fn(Int) -> Bool) -> Set[Int] = {
 }
 
 // Sum the predicate's 0/1 over all elements (a Bool is an i64 0/1) → the hit COUNT.
-fn __set_count_hits(sh: Int, f: fn(Int) -> Bool, n: Int, i: Int, acc: Int) -> Int = if i >= n then acc
+fn __set_count_hits(sh: Int, f: (Int) -> Bool, n: Int, i: Int, acc: Int) -> Int = if i >= n then acc
 else {
   let x = prim.load64(sh + 12 + i * 8)
   let h = f(x)
@@ -287,14 +294,14 @@ else {
   else __set_count_hits(sh, f, n, i + 1, acc)
 }
 
-fn set_all(s: Set[Int], f: fn(Int) -> Bool) -> Bool = {
+fn set_all(s: Set[Int], f: (Int) -> Bool) -> Bool = {
   let sh = prim.handle(s)
   let n = prim.load32(sh + 4)
   let hits = __set_count_hits(sh, f, n, 0, 0)
   hits >= n
 }
 
-fn set_any(s: Set[Int], f: fn(Int) -> Bool) -> Bool = {
+fn set_any(s: Set[Int], f: (Int) -> Bool) -> Bool = {
   let sh = prim.handle(s)
   let n = prim.load32(sh + 4)
   let hits = __set_count_hits(sh, f, n, 0, 0)
@@ -304,7 +311,7 @@ fn set_any(s: Set[Int], f: fn(Int) -> Bool) -> Bool = {
 // set.map — apply f to each element, collecting UNIQUE results (f may collapse distinct inputs
 // to the same output, so the mapped values MUST be re-deduped, exactly v0's `.map(f).collect()`
 // into an AlmideSet). Append f(x) iff not already present; first-seen order. Int->Int.
-fn __set_map_fill(dh: Int, sh: Int, f: fn(Int) -> Int, n: Int, i: Int, w: Int) -> Int = if i >= n then w
+fn __set_map_fill(dh: Int, sh: Int, f: (Int) -> Int, n: Int, i: Int, w: Int) -> Int = if i >= n then w
 else {
   let x = prim.load64(sh + 12 + i * 8)
   let y = f(x)
@@ -316,7 +323,7 @@ else {
   }
 }
 
-fn set_map(s: Set[Int], f: fn(Int) -> Int) -> Set[Int] = {
+fn set_map(s: Set[Int], f: (Int) -> Int) -> Set[Int] = {
   let sh = prim.handle(s)
   let n = prim.load32(sh + 4)
   let r = prim.alloc_set(n)
@@ -328,14 +335,14 @@ fn set_map(s: Set[Int], f: fn(Int) -> Int) -> Set[Int] = {
 
 // set.fold — left fold with a TWO-arity closure f : (Acc, Int) -> Acc (acc first, element
 // second — v0's fold(s, init, f)). Int accumulator. The set walk order = insertion order.
-fn __set_fold_loop(sh: Int, f: fn(Int, Int) -> Int, n: Int, i: Int, acc: Int) -> Int = if i >= n then acc
+fn __set_fold_loop(sh: Int, f: (Int, Int) -> Int, n: Int, i: Int, acc: Int) -> Int = if i >= n then acc
 else {
   let x = prim.load64(sh + 12 + i * 8)
   let nacc = f(acc, x)
   __set_fold_loop(sh, f, n, i + 1, nacc)
 }
 
-fn set_fold(s: Set[Int], init: Int, f: fn(Int, Int) -> Int) -> Int = {
+fn set_fold(s: Set[Int], init: Int, f: (Int, Int) -> Int) -> Int = {
   let sh = prim.handle(s)
   let n = prim.load32(sh + 4)
   __set_fold_loop(sh, f, n, 0, init)

--- a/stdlib/set_str.almd
+++ b/stdlib/set_str.almd
@@ -216,10 +216,15 @@ fn __set_str_addone(rh: Int, slen: Int, x: String) -> Int = {
   }
 }
 
+// GEOMETRIC capacity (#1219, see map_core.map_set): epoch-stable alloc sizes let the $alloc
+// exact-size free-list reuse the block freed by the previous `s = set.insert(s, x)` rebind.
 fn set_insert_str(s: Set[String], x: String) -> Set[String] = {
   let sh = prim.handle(s)
   let slen = prim.load32(sh + 4)
-  let cap = slen + 1
+  let scap = prim.load32(sh + 8)
+  let need = slen + 1
+  let cap = if need > scap then (if scap * 2 > need then scap * 2 else need)
+  else scap
   let r = prim.alloc_set_str(cap)
   let rh = prim.handle(r)
   let _c = __set_str_copyn(sh, rh, slen, 0)
@@ -281,7 +286,7 @@ fn set_symmetric_difference_str(a: Set[String], b: Set[String]) -> Set[String] =
 
 // ── Higher-order Set[String] (closures machinery; the closure takes a String element by handle,
 // widened by the heap-arg closure ABI) ── filter keeps a deep-copied subset; all/any/fold read.
-fn __set_str_filter_fill(dh: Int, sh: Int, f: fn(String) -> Bool, n: Int, i: Int, di: Int) -> Int = if i >= n then di
+fn __set_str_filter_fill(dh: Int, sh: Int, f: (String) -> Bool, n: Int, i: Int, di: Int) -> Int = if i >= n then di
 else {
   let x = prim.load_str(sh + 12 + i * 8)
   let keep = f(x)
@@ -294,7 +299,7 @@ else {
   }
 }
 
-fn set_filter_str(s: Set[String], f: fn(String) -> Bool) -> Set[String] = {
+fn set_filter_str(s: Set[String], f: (String) -> Bool) -> Set[String] = {
   let sh = prim.handle(s)
   let n = prim.load32(sh + 4)
   let r = prim.alloc_set_str(n)
@@ -304,7 +309,7 @@ fn set_filter_str(s: Set[String], f: fn(String) -> Bool) -> Set[String] = {
   r
 }
 
-fn __set_str_count_hits(sh: Int, f: fn(String) -> Bool, n: Int, i: Int, acc: Int) -> Int = if i >= n then acc
+fn __set_str_count_hits(sh: Int, f: (String) -> Bool, n: Int, i: Int, acc: Int) -> Int = if i >= n then acc
 else {
   let x = prim.load_str(sh + 12 + i * 8)
   let h = f(x)
@@ -312,14 +317,14 @@ else {
   else __set_str_count_hits(sh, f, n, i + 1, acc)
 }
 
-fn set_all_str(s: Set[String], f: fn(String) -> Bool) -> Bool = {
+fn set_all_str(s: Set[String], f: (String) -> Bool) -> Bool = {
   let sh = prim.handle(s)
   let n = prim.load32(sh + 4)
   let hits = __set_str_count_hits(sh, f, n, 0, 0)
   hits >= n
 }
 
-fn set_any_str(s: Set[String], f: fn(String) -> Bool) -> Bool = {
+fn set_any_str(s: Set[String], f: (String) -> Bool) -> Bool = {
   let sh = prim.handle(s)
   let n = prim.load32(sh + 4)
   let hits = __set_str_count_hits(sh, f, n, 0, 0)
@@ -328,14 +333,14 @@ fn set_any_str(s: Set[String], f: fn(String) -> Bool) -> Bool = {
 
 // set.fold over Set[String] — f : (Acc, String) -> Acc (Int accumulator). 2-arity closure with a
 // String second arg (heap-widened). Insertion-order walk.
-fn __set_str_fold_loop(sh: Int, f: fn(Int, String) -> Int, n: Int, i: Int, acc: Int) -> Int = if i >= n then acc
+fn __set_str_fold_loop(sh: Int, f: (Int, String) -> Int, n: Int, i: Int, acc: Int) -> Int = if i >= n then acc
 else {
   let x = prim.load_str(sh + 12 + i * 8)
   let nacc = f(acc, x)
   __set_str_fold_loop(sh, f, n, i + 1, nacc)
 }
 
-fn set_fold_str(s: Set[String], init: Int, f: fn(Int, String) -> Int) -> Int = {
+fn set_fold_str(s: Set[String], init: Int, f: (Int, String) -> Int) -> Int = {
   let sh = prim.handle(s)
   let n = prim.load32(sh + 4)
   __set_str_fold_loop(sh, f, n, 0, init)


### PR DESCRIPTION
Wasm leg of #1219 (partial — the lookup index stays open, see below).

## What was wrong

On the wasm leg every `m[k] = v` / `map.insert(m, k, v)` lowers to the persistent rebind `m = map.set(m, k, v)`, and the self-host `map_set` allocated an **exact-size** `(len+1)*2`-slot block every call. The WAT `$alloc` free-list reuses only blocks of **exactly** the requested byte size, so a grow loop freed one never-reusable block per iteration: O(n²) total allocated bytes (linear-memory grow + page faults) and an O(n) dead-list walk inside *every* `$alloc` — on top of the O(n) copy and O(n) find. Measurement shows this allocator churn, not the copy or the find, was the dominant term of the issue's quadratic table.

## The change (stdlib-only, no layout/ABI change, no cert machinery touched)

Each growing producer now reads the source block's `cap@8` and allocates `cap` slots when the new entry still fits, else `max(need, cap*2)` — doubling epochs. Within an epoch the block freed by the *previous* rebind is an exact head match on the free-list: O(1) reuse, O(n) live memory. Applied by matrix to every growing producer in the self-host family, never point-wise:

`map_core.map_set`, `map_str.map_set_str`, `map_skv.map_set_skv` (upsert delegates), `map_ivh.map_set_ivh`, `map_hval.map_set_hval`, `map_msv.map_set_msv`, `map_mlo.map_set_mlo`, `map_hobj.__hobj_set`, `set_core.set_insert`, `set_str.set_insert_str`.

Soundness: slack past the len-derived regions is never read — `len` governs iteration/eq/repr/drop in every variant, and slack-capped blocks are already a normal shape today (`filter`/`remove`/`from_list` over-alloc and patch `len`; `map_filter_skv` even compacts its value region to the `len`-derived base). `cap` keeps meaning "true allocated slot count", which is exactly what the free-list sizing reads. The `map_skv` header comment is updated to say `cap >= 2*entries`.

## MEASURED (M4 Pro, wasmtime, best of 3, byte-identical stdout before/after and native⇄wasm)

Int bench (build n `Map[Int,Int]` entries via `m[k] = v`, n `map.get_or` reads, build n `Set[Int]` via `set.insert`, n `set.contains`):

| n | wasm before | wasm after | speedup | native (unchanged) |
|---|---:|---:|---:|---:|
| 5 000 | 0.62 s | 0.02 s | 31x | 0.01 s |
| 10 000 | 2.75 s | 0.11 s | 25x | 0.04 s |
| 20 000 | 11.45 s | 0.43 s | 27x | 0.14 s |

`Map[String,Int]` (skv shape; build n via `m["key_${i}"] = i` + n reads):

| n | wasm before | wasm after | speedup |
|---|---:|---:|---:|
| 5 000 | 0.66 s | 0.25 s | 2.6x |
| 10 000 | 3.46 s | 1.07 s | 3.2x |

(The skv win is smaller because its per-op cost is dominated by the per-entry key deep-copies, untouched here.)

The wasm/native gap at n=20 000 drops from ~80x to ~3x. Per-doubling growth is still ~4x (the copy and the linear find remain O(n) per op) — the curve is lower, not flattened; the remaining stages below are what flatten it.

## Verified

- `almide test`: 384 files, 367 via WASM, 0 failed (full suite re-run after the last edit)
- `cargo test -p almide-types -p almide-mir --release`: all green
- `scripts/check-semantics-manifest.sh`: 20 modules, 266 entries, coverage + regen-diff green (re-run on the final tree)
- `make verify-trust`: full chain including the kernel-checked PCC oracle, exit 0 (run with the workspace binary first on PATH; the shared `~/.local/bin` install was not touched)
- `cargo test --release --test traversal_totality_lint`: green
- `scripts/check-embedded-size.sh`: 837 176 bytes, within ceiling 901 600 — no baseline change needed
- No contract-ledger change: observable behavior (stdout/stderr/exit, C-013 insertion order, order-independent `==`) is unchanged; only time and allocation pattern move. OOM onset can shift marginally either way per allocation pattern, which C-197 contracts as a resource limit with a defined abort.

Note: `almide fmt --no-import-edit` also normalized legacy `fn(...)` closure-type annotations to `(...)` in the touched files (current formatter canonical form).

## Still open on #1219 (the deliberately-split trust-spine stages, per the issue's recorded plan)

1. **Stage 1** — in-place mutable insert routed through the MakeUnique guard (kills the remaining O(n) copy per insert; needs cert coverage + C-033 matrix extension).
2. **Stage 2** — bucket/fingerprint index for `get`/`contains` parity with native a712f2cba (block-layout change across the family + matrix gate; the issue's title item).
3. Set mirrors whatever map gets.
