### PR TITLE
Retire the dead-from-source print_int prelude cluster, porting the certificate layer to print_str (#1208)

### DIFF
--- a/crates/almide-mir/examples/emit_cert.rs
+++ b/crates/almide-mir/examples/emit_cert.rs
@@ -65,34 +65,45 @@ fn scenario(which: &str) -> MirFunction {
             ],
             ..Default::default()
         },
-        // prints a scalar (reaches Stdout) AND declares Stdout → within bound,
-        // the capability checker must accept.
+        // prints a string (reaches Stdout via PrintStr — the print real lowering
+        // emits, #1208) AND declares Stdout → within bound, the capability
+        // checker must accept.
         "sandboxed" => MirFunction {
             name: "f".into(),
             ops: vec![
-                Op::Const { dst: a },
+                Op::Alloc {
+                    dst: a,
+                    repr: heap(),
+                    init: Init::Str("hi".into()),
+                },
                 Op::Call {
                     dst: None,
-                    func: RtFn::PrintInt,
-                    args: vec![CallArg::Scalar(a)],
+                    func: RtFn::PrintStr,
+                    args: vec![CallArg::Handle(a)],
                     result: None,
                 },
+                Op::Drop { v: a },
             ],
             declared_caps: vec![Capability::Stdout],
             ..Default::default()
         },
-        // prints a scalar (reaches Stdout) but declares NOTHING → an undeclared
+        // prints a string (reaches Stdout) but declares NOTHING → an undeclared
         // host effect, the capability checker must reject.
         "undeclared" => MirFunction {
             name: "f".into(),
             ops: vec![
-                Op::Const { dst: a },
+                Op::Alloc {
+                    dst: a,
+                    repr: heap(),
+                    init: Init::Str("hi".into()),
+                },
                 Op::Call {
                     dst: None,
-                    func: RtFn::PrintInt,
-                    args: vec![CallArg::Scalar(a)],
+                    func: RtFn::PrintStr,
+                    args: vec![CallArg::Handle(a)],
                     result: None,
                 },
+                Op::Drop { v: a },
             ],
             declared_caps: vec![], // declares no capability
             ..Default::default()

--- a/crates/almide-mir/src/certificate_p2.rs
+++ b/crates/almide-mir/src/certificate_p2.rs
@@ -20,11 +20,12 @@
     #[test]
     fn cap_witness_derives_used_from_runtime_calls() {
         // The 4th property: used capabilities come from the body's runtime calls
-        // (PrintInt reaches Stdout); pure heap ops reach none. The witness checks
+        // (PrintStr reaches Stdout); pure heap ops reach none. The witness checks
         // them against the declared bound.
         let print = func(vec![
-            Op::Const { dst: ValueId(0) },
-            Op::Call { dst: None, func: RtFn::PrintInt, args: vec![CallArg::Scalar(ValueId(0))] , result: None },
+            Op::Alloc { dst: ValueId(0), repr: heap(), init: Init::Str("hi".into()) },
+            Op::Call { dst: None, func: RtFn::PrintStr, args: vec![CallArg::Handle(ValueId(0))] , result: None },
+            Op::Drop { v: ValueId(0) },
         ]);
         assert_eq!(cap_witness(&print).used, vec![Capability::Stdout]);
 
@@ -33,9 +34,9 @@
             Op::Alloc { dst: ValueId(0), repr: heap(), init: Init::Opaque },
             Op::MakeUnique { v: ValueId(0) },
             Op::Call {
-                dst: Some(ValueId(0)),
-                func: RtFn::ListPush,
-                args: vec![CallArg::Handle(ValueId(0)), CallArg::Imm(1)],
+                dst: None,
+                func: RtFn::ListSet,
+                args: vec![CallArg::Handle(ValueId(0)), CallArg::Imm(0), CallArg::Imm(1)],
             result: None },
             Op::Drop { v: ValueId(0) },
         ]);
@@ -99,13 +100,14 @@
         // its Stdout (no accept-but-unsafe) — the fold follows the same edge cap_witness
         // dropped the taint for, so a printing lambda's effect always reaches the caller.
         let mut printing_lambda = func(vec![
-            Op::Const { dst: ValueId(0) },
+            Op::Alloc { dst: ValueId(0), repr: heap(), init: Init::Str("hi".into()) },
             Op::Call {
                 dst: None,
-                func: RtFn::PrintInt,
-                args: vec![CallArg::Scalar(ValueId(0))],
+                func: RtFn::PrintStr,
+                args: vec![CallArg::Handle(ValueId(0))],
                 result: None,
             },
+            Op::Drop { v: ValueId(0) },
         ]);
         printing_lambda.name = "printing_lambda".into();
         let mut main = func(vec![
@@ -137,13 +139,14 @@
         // deferred/operand call path or passed elsewhere, so accounting at CREATION means
         // incremental lambda-lifting cannot lose a closure's effect however the call lowers.
         let mut printing = func(vec![
-            Op::Const { dst: ValueId(0) },
+            Op::Alloc { dst: ValueId(0), repr: heap(), init: Init::Str("hi".into()) },
             Op::Call {
                 dst: None,
-                func: RtFn::PrintInt,
-                args: vec![CallArg::Scalar(ValueId(0))],
+                func: RtFn::PrintStr,
+                args: vec![CallArg::Handle(ValueId(0))],
                 result: None,
             },
+            Op::Drop { v: ValueId(0) },
         ]);
         printing.name = "printing".into();
         // main only CREATES the closure (FuncRef) — it does NOT CallIndirect it.
@@ -164,8 +167,9 @@
     fn cap_witness_string_matches_the_coq_parser_format() {
         // declares Stdout, prints → `0|0`  (allowed ⊇ used → checker accepts).
         let mut declared = func(vec![
-            Op::Const { dst: ValueId(0) },
-            Op::Call { dst: None, func: RtFn::PrintInt, args: vec![CallArg::Scalar(ValueId(0))] , result: None },
+            Op::Alloc { dst: ValueId(0), repr: heap(), init: Init::Str("hi".into()) },
+            Op::Call { dst: None, func: RtFn::PrintStr, args: vec![CallArg::Handle(ValueId(0))] , result: None },
+            Op::Drop { v: ValueId(0) },
         ]);
         declared.declared_caps = vec![Capability::Stdout];
         assert_eq!(cap_witness_string(&declared), "0|0");
@@ -183,8 +187,9 @@
         // helper prints (Stdout=0); main calls helper; both declare Stdout. Sorted by name:
         // 0=helper, 1=main, 2=UNIVERSE. helper `0|0|`, main `0||0` (callee 0), UNIVERSE sentinel.
         let mut helper = func(vec![
-            Op::Const { dst: ValueId(0) },
-            Op::Call { dst: None, func: RtFn::PrintInt, args: vec![CallArg::Scalar(ValueId(0))], result: None },
+            Op::Alloc { dst: ValueId(0), repr: heap(), init: Init::Str("hi".into()) },
+            Op::Call { dst: None, func: RtFn::PrintStr, args: vec![CallArg::Handle(ValueId(0))], result: None },
+            Op::Drop { v: ValueId(0) },
         ]);
         helper.name = "helper".into();
         helper.declared_caps = vec![Capability::Stdout];
@@ -211,8 +216,9 @@
         use std::collections::{BTreeMap, BTreeSet};
         // main → beep (prints, reaches Stdout). main has NO direct effect.
         let mut beep = func(vec![
-            Op::Const { dst: ValueId(0) },
-            Op::Call { dst: None, func: RtFn::PrintInt, args: vec![CallArg::Scalar(ValueId(0))] , result: None },
+            Op::Alloc { dst: ValueId(0), repr: heap(), init: Init::Str("hi".into()) },
+            Op::Call { dst: None, func: RtFn::PrintStr, args: vec![CallArg::Handle(ValueId(0))] , result: None },
+            Op::Drop { v: ValueId(0) },
         ]);
         beep.name = "beep".into();
         let mut main = func(vec![Op::CallFn { dst: None, name: "beep".into(), args: vec![] , result: None }]);
@@ -313,11 +319,12 @@
     #[test]
     fn transitive_capability_through_callfn_is_caught() {
         use std::collections::{BTreeMap, BTreeSet};
-        // main → beep; beep prints (PrintInt → Stdout). main has NO direct cap but
+        // main → beep; beep prints (PrintStr → Stdout). main has NO direct cap but
         // reaches one transitively — the fold MUST flag it (the direct witness wouldn't).
         let mut beep = func(vec![
-            Op::Const { dst: ValueId(0) },
-            Op::Call { dst: None, func: RtFn::PrintInt, args: vec![CallArg::Scalar(ValueId(0))], result: None },
+            Op::Alloc { dst: ValueId(0), repr: heap(), init: Init::Str("hi".into()) },
+            Op::Call { dst: None, func: RtFn::PrintStr, args: vec![CallArg::Handle(ValueId(0))], result: None },
+            Op::Drop { v: ValueId(0) },
         ]);
         beep.name = "beep".into();
         let mut main = func(vec![Op::CallFn { dst: None, name: "beep".into(), args: vec![], result: None }]);
@@ -398,8 +405,9 @@
         let not_elided = |_: &str| false;
         // main → beep (prints Stdout): reachable = {Stdout}, FULLY known.
         let mut beep = func(vec![
-            Op::Const { dst: ValueId(0) },
-            Op::Call { dst: None, func: RtFn::PrintInt, args: vec![CallArg::Scalar(ValueId(0))], result: None },
+            Op::Alloc { dst: ValueId(0), repr: heap(), init: Init::Str("hi".into()) },
+            Op::Call { dst: None, func: RtFn::PrintStr, args: vec![CallArg::Handle(ValueId(0))], result: None },
+            Op::Drop { v: ValueId(0) },
         ]);
         beep.name = "beep".into();
         let mut main = func(vec![Op::CallFn { dst: None, name: "beep".into(), args: vec![], result: None }]);
@@ -439,13 +447,14 @@
         // ADVERSARIAL: the lifted lambda prints. main = `FuncRef(printing_lambda)` only —
         // no CallIndirect — so coverage-free folding (at creation) must still surface Stdout.
         let mut printing_lambda = func(vec![
-            Op::Const { dst: ValueId(0) },
+            Op::Alloc { dst: ValueId(0), repr: heap(), init: Init::Str("hi".into()) },
             Op::Call {
                 dst: None,
-                func: RtFn::PrintInt,
-                args: vec![CallArg::Scalar(ValueId(0))],
+                func: RtFn::PrintStr,
+                args: vec![CallArg::Handle(ValueId(0))],
                 result: None,
             },
+            Op::Drop { v: ValueId(0) },
         ]);
         printing_lambda.name = "printing_lambda".into();
         let mut main = func(vec![Op::FuncRef { dst: ValueId(0), name: "printing_lambda".into() }]);

--- a/crates/almide-mir/src/lib_b.rs
+++ b/crates/almide-mir/src/lib_b.rs
@@ -461,34 +461,26 @@ pub enum IntOp {
 pub enum RtFn {
     /// `list[index] = value` in place (after a [`Op::MakeUnique`]).
     ListSet,
-    /// push a value onto a list in place (after a [`Op::MakeUnique`]); the
-    /// result is rebound to `dst` (the buffer may move).
-    ListPush,
-    /// `println` a list as `label=e0,e1,…`.
-    PrintList,
-    /// `println` a scalar integer.
-    PrintInt,
-    /// `println` a heap string (the value-semantics subset's string print). A
-    /// WITNESS-LEVEL primitive today: it carries the ownership (borrows the
-    /// string handle) and capability ([`Capability::Stdout`]) facts the proven
-    /// checker re-verifies, but the renderers do NOT lower it yet — strings are
-    /// `Init::Opaque` skeletons in this subset (no content bytes), so a faithful
-    /// `print_str` render awaits the string-content lowering brick. Until then a
-    /// renderer asked to emit it refuses LOUDLY (the catch-all panic), never
-    /// silently — the flight-grade totality rule.
+    /// `println` a heap string — the ONE print primitive: `println(s)` lowers to
+    /// it, and every other print (`int.to_string`, list formatting) reaches
+    /// stdout THROUGH it via the self-hosted stdlib. It borrows the string
+    /// handle (no ownership event) and carries [`Capability::Stdout`] — the
+    /// facts the proven checker re-verifies. (`PrintInt`/`PrintList`/`ListPush`
+    /// were retired in #1208: no frontend lowering constructed them, so their
+    /// hand-written wasm bodies were dead-from-source — DO-178C dead code.)
     PrintStr,
 }
 
 impl RtFn {
     /// The host [`Capability`] this runtime function reaches, if any. Pure heap
-    /// ops touch no host effect; the print ops reach [`Capability::Stdout`]. This
+    /// ops touch no host effect; the print op reaches [`Capability::Stdout`]. This
     /// is the SINGLE mapping the capability witness derives "used capabilities"
     /// from — exhaustive, so a new effectful runtime fn cannot silently escape
     /// the sandbox accounting.
     pub const fn capability(self) -> Option<Capability> {
         match self {
-            RtFn::ListSet | RtFn::ListPush => None,
-            RtFn::PrintList | RtFn::PrintInt | RtFn::PrintStr => Some(Capability::Stdout),
+            RtFn::ListSet => None,
+            RtFn::PrintStr => Some(Capability::Stdout),
         }
     }
 }
@@ -503,7 +495,7 @@ impl RtFn {
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, PartialOrd, Ord)]
 pub enum Capability {
     /// Writing to standard output (the only host effect the current MIR subset
-    /// reaches, via [`RtFn::PrintInt`] / [`RtFn::PrintList`]).
+    /// reaches, via [`RtFn::PrintStr`] / [`PrimKind::FdWrite`]).
     Stdout,
     /// Reading host ENTROPY — the WASI `random_get` floor ([`PrimKind::RandomGet`]),
     /// reached by the self-hosted `random.int`. The second sandbox exit. A pure `fn`

--- a/crates/almide-mir/src/render_native_b.rs
+++ b/crates/almide-mir/src/render_native_b.rs
@@ -534,13 +534,6 @@ fn render_call_witness(
             used_shims.push(shim("print_str").expect("\"print_str\" is a literal shim() match arm, always Some").2);
             line!("rt_print_str({});", as_str_arg(&code, t));
         }
-        (RtFn::PrintInt, [a]) => {
-            let (code, t) = call_arg(a, tys)?;
-            if t != NTy::I64 {
-                return Err(wall("native: print_int of a non-Int"));
-            }
-            line!("println!(\"{{}}\", {code});");
-        }
         other => {
             return Err(wall(format!(
                 "native: runtime call {other:?} — outside the rung subset"

--- a/crates/almide-mir/src/render_wasm.rs
+++ b/crates/almide-mir/src/render_wasm.rs
@@ -25,14 +25,14 @@
 //! `eager_copy_refines_safety` safety regime is fully preserved.
 //!
 //! ⚠ BOOTSTRAP SHORTCUT — DO NOT GROW (see §4.1 of the architecture doc). The
-//! hand-written WAT runtime below (`$list_copy`/`$itoa_append`/`$print_list`)
-//! and the computation baked into the `Push`/`IndexSet`/`Print` MIR ops are the
-//! EXACT trap that made v0's wasm emitter a nightmare (a large hand-written wasm
-//! surface dual-maintained with native). They exist only to prove the
-//! dual-renderer path RUNS. The ideal form shrinks the hand-written wasm to a
-//! tiny, total, decision-free, spec-provable MIR-PRIMITIVE mapping, and moves
-//! all of list/string/format/RC into Almide compiled through this same path
-//! (`Push`/`IndexSet`/`Print` become `Call`s to self-hosted runtime functions).
+//! hand-written WAT runtime below (`$list_copy` and kin) is the EXACT trap that
+//! made v0's wasm emitter a nightmare (a large hand-written wasm surface
+//! dual-maintained with native). It exists only to prove the dual-renderer path
+//! RUNS — the `$print_int`/`$print_list`/`$list_push`/`$itoa_append`/`$list_len`
+//! bootstrap cluster was deleted once real programs printed through the
+//! self-hosted runtime instead (#1208). The ideal form shrinks the hand-written
+//! wasm to a tiny, total, decision-free, spec-provable MIR-PRIMITIVE mapping,
+//! with all of list/string/format in Almide compiled through this same path.
 //! Convergence rule: never add another hand-written WAT runtime routine — with
 //! ONE principled exception, the proven MEMORY-MODEL primitives (`RC_PRIMITIVE_FNS`,
 //! the realization of `RuntimeModel.v`'s `rt_inc`/`rt_dec`). They are a CLOSED set
@@ -49,11 +49,8 @@ use std::collections::{BTreeMap, BTreeSet};
 // Fixed low-memory addresses (named — no raw literals in the emitted WAT logic).
 const NWRITTEN_ADDR: u32 = 0; // i32 scratch for fd_write's bytes-written out-param
 const IOVEC_ADDR: u32 = 8; // [buf: i32][len: i32]
-const ITOA_TMP_ADDR: u32 = 32; // reversed-digit scratch (≤ 20 bytes)
-                               // The fs.read_text path_open error message — a CONST byte run in the data section
-                               // (the `$read_text_file` Err arm copies it into a canonical String). Reserved BELOW the
-                               // dynamic print labels so the per-function label writer (which starts at `LABELS_ADDR`)
-                               // never overlaps it.
+                           // The fs.read_text path_open error message — a CONST byte run in the data section
+                           // (the `$read_text_file` Err arm copies it into a canonical String).
 const RTF_NOTFOUND_ADDR: u32 = 64; // "file not found" message bytes
 const RTF_NOTFOUND_LEN: u32 = 14; // len of "file not found"
 const RDIR_ERR_ADDR: u32 = 80; // "directory not found" message bytes (fs.list_dir Err)
@@ -72,11 +69,9 @@ const MAIN_ERR_NL_ADDR: u32 = DIVZERO_MSG_ADDR + 23; // the div-zero line's "\n"
 const OVERFLOW_MSG_ADDR: u32 = 176; // "Error: integer overflow\n" — 176..200 (__div_trap)
 const BOUNDS_MSG_ADDR: u32 = 208; // "Error: index out of bounds\n" — 208..235 (__div_trap)
 const OOM_MSG_ADDR: u32 = 376; // "Error: out of memory\n" — 376..397 ($oom, C-197)
-const LABELS_ADDR: u32 = 400; // print labels (the data section) — after ALL fixed messages (incl. fs errno + oom)
-                              // fs errno → native std::io Display strings (240..376, FIXED — placed BEFORE the
-                              // variable-length labels region so labels can never overwrite them): path_open errors
-                              // map to the EXACT message native std::fs emits, so `err(e)` observes byte-identical
-                              // text (C-042 kin).
+                               // fs errno → native std::io Display strings (240..376, FIXED): path_open errors
+                               // map to the EXACT message native std::fs emits, so `err(e)` observes byte-identical
+                               // text (C-042 kin).
 const FS_ERR_NOENT_ADDR: u32 = 240; // "No such file or directory (os error 2)" — WASI NOENT(44)
 const FS_ERR_NOENT_LEN: u32 = 38;
 const FS_ERR_ACCES_ADDR: u32 = 280; // "Permission denied (os error 13)" — WASI ACCES(2)
@@ -85,11 +80,10 @@ const FS_ERR_NOTDIR_ADDR: u32 = 312; // "Not a directory (os error 20)" — WASI
 const FS_ERR_NOTDIR_LEN: u32 = 29;
 const FS_ERR_ISDIR_ADDR: u32 = 344; // "Is a directory (os error 21)" — WASI ISDIR(31)
 const FS_ERR_ISDIR_LEN: u32 = 28;
-const SCRATCH_ADDR: u32 = 768; // the line build buffer
-                               // The bump allocator's DEFAULT start — also the mutable-global slot region's base
-                               // (`crate::MG_SLOT_BASE`, one authoritative value): a program with N mutable
-                               // module-level `var`s shifts its allocator base to `HEAP_BASE + 8*N` so the slots
-                               // are never allocated over (N = 0 keeps every existing module byte-identical).
+// The bump allocator's DEFAULT start — also the mutable-global slot region's base
+// (`crate::MG_SLOT_BASE`, one authoritative value): a program with N mutable
+// module-level `var`s shifts its allocator base to `HEAP_BASE + 8*N` so the slots
+// are never allocated over (N = 0 keeps every existing module byte-identical).
 const HEAP_BASE: u32 = crate::MG_SLOT_BASE;
 // The Ok/Err tag of a cap-as-tag `Result[String, String]` lives in the HIGH 32 bits of
 // the 1-slot block's element (@16) — the `materialize_result_str` layout `$read_text_file`
@@ -110,33 +104,14 @@ const RC_INITIAL: i32 = 1;
 const PUSH_HEADROOM: u32 = 8; // spare cap so demo pushes never realloc
 const IOVEC_LEN_OFFSET: u32 = I32_SIZE; // iovec = [buf:i32 @0][len:i32 @4]
 
-// WASI fd_write parameters / numeric base.
-const STDOUT_FD: u32 = 1;
-const IOVS_COUNT: u32 = 1; // one iovec per write
-const DECIMAL_BASE: i64 = 10;
-
-/// ASCII bytes the formatter writes.
-const ASCII_ZERO: u32 = 48;
-const ASCII_EQUALS: u32 = 61;
-const ASCII_COMMA: u32 = 44;
-const ASCII_NEWLINE: u32 = 10;
+/// ASCII bytes the fs path logic writes. (The itoa/print-list formatter bytes
+/// — zero/equals/comma/newline/minus, the digit scratch, and the line-buffer
+/// bound — went out with the #1208 prelude deletion: printing is self-hosted.)
 const ASCII_SLASH: u32 = 47; // '/' — stripped from an absolute fs.read_text path
-const ASCII_MINUS: u32 = 45; // '-' — the itoa sign byte
-
-/// The line buffer for printing lives in `[SCRATCH_ADDR, HEAP_BASE)`; one element
-/// appends at most a separator comma plus the digits of a u64 (≤ 20). The print
-/// loop traps if appending the next element would cross `HEAP_BASE` (the buffer
-/// end), so a very long list cannot overflow the line buffer into the heap.
-const MAX_I64_DIGITS: u32 = 20; // a u64 is at most 20 decimal digits
-const MAX_ELEM_PRINT_BYTES: u32 = 1 + MAX_I64_DIGITS; // comma + digits
 
 /// Render a MIR function to a runnable WAT module string.
 pub fn render_wasm(func: &MirFunction) -> String {
     let heap_locals = heap_handle_locals(&func.ops);
-    let mut label_off: BTreeMap<String, (u32, u32)> = BTreeMap::new();
-    let mut data = String::new();
-    collect_label_data(&func.ops, LABELS_ADDR, &mut label_off, &mut data);
-
     let locals_decl = heap_locals
         .iter()
         .map(|v| format!("(local {} i32)", local(*v)))
@@ -159,7 +134,6 @@ pub fn render_wasm(func: &MirFunction) -> String {
         body.push_str(&render_op(
             op,
             crate::render_wasm::OpTables {
-                label_off: &label_off,
                 func_slots: &no_slots,
                 param_counts: &no_param_counts,
                 masks: &func.heap_slot_masks,
@@ -172,9 +146,8 @@ pub fn render_wasm(func: &MirFunction) -> String {
     }
 
     format!(
-        "{preamble}{data}  (func $main {locals}\n{body}  )\n  (func (export \"_start\") (call $main))\n)\n",
+        "{preamble}  (func $main {locals}\n{body}  )\n  (func (export \"_start\") (call $main))\n)\n",
         preamble = preamble(),
-        data = data,
         locals = locals_decl,
         body = body,
     )
@@ -417,29 +390,8 @@ pub fn render_wasm_program(prog: &MirProgram) -> String {
         "render_wasm_program fed an unlinked call (use try_render_wasm_program to wall it): {:?}",
         unlinked_call_names(prog)
     );
-    // Labels (the data section) are module-level — collect across all functions.
-    let mut label_off: BTreeMap<String, (u32, u32)> = BTreeMap::new();
-    let mut data = String::new();
-    let mut cursor = LABELS_ADDR;
-    for func in &prog.functions {
-        for op in &func.ops {
-            let Op::Call { args, .. } = op else {
-                continue;
-            };
-            for a in args {
-                let CallArg::Label(label) = a else {
-                    continue;
-                };
-                if label_off.contains_key(label) {
-                    continue;
-                }
-                let len = label.len() as u32;
-                label_off.insert(label.clone(), (cursor, len));
-                data.push_str(&format!("  (data (i32.const {cursor}) {:?})\n", label));
-                cursor += len;
-            }
-        }
-    }
+    // (The module-level print-label data section died with `RtFn::PrintList`,
+    // #1208 — no op carries a `CallArg::Label` any more.)
     // Function-table slots by NAME (position in the module) — a FuncRef resolves its
     // referenced function to this index, the same index the `(elem)` table uses.
     let func_slots: BTreeMap<String, u32> = prog
@@ -469,12 +421,8 @@ pub fn render_wasm_program(prog: &MirProgram) -> String {
         .functions
         .iter()
         .map(|f| {
-            let body = fold_const_wrap_roundtrips(&render_wasm_fn(
-                f,
-                &label_off,
-                &func_slots,
-                &param_counts,
-            ));
+            let body =
+                fold_const_wrap_roundtrips(&render_wasm_fn(f, &func_slots, &param_counts));
             strip_region_clone_rc_incs(&f.name, body)
         })
         .collect::<String>();
@@ -694,7 +642,7 @@ pub fn render_wasm_program(prog: &MirProgram) -> String {
     // in this program's own rendered code — or a kept helper's own body —
     // transitively reaches. `println`-only programs no longer link
     // `path_open`/`fd_readdir`/`clock_time_get`/etc.
-    let used_text = format!("{data}{closure_table}{funcs}{mg_helpers}{start}{pub_exports}");
+    let used_text = format!("{closure_table}{funcs}{mg_helpers}{start}{pub_exports}");
     let preamble = filter_unreachable_preamble(&preamble, &used_text);
     format!(
         "{preamble}{used_text})

--- a/crates/almide-mir/src/render_wasm/tests_part1.rs
+++ b/crates/almide-mir/src/render_wasm/tests_part1.rs
@@ -5,6 +5,63 @@
         Repr::Ptr { layout: PLACEHOLDER_LAYOUT }
     }
 
+    /// The observation channel for hand-built-MIR execution tests: `put_digit(n)`
+    /// writes "<digit>\n" (n in 0..=9) to stdout through the PRIM FLOOR
+    /// (store8 + fd_write) — the same path source-lowered programs print
+    /// through. #1208 deleted the bootstrap `$print_int`/`RtFn::PrintInt`
+    /// (dead-from-source wasm), so MIR-level tests observe results the way real
+    /// programs do instead of through a prelude fn nothing real could reach.
+    /// Append it LAST in `MirProgram::functions` so tests that pin table slots
+    /// by position keep their indices.
+    fn put_digit_fn() -> MirFunction {
+        let scalar = Repr::Scalar { width: ScalarWidth::Double };
+        let n = ValueId(0);
+        let (c48, byte) = (ValueId(1), ValueId(2));
+        let (buf, nl, buf1) = (ValueId(3), ValueId(4), ValueId(5));
+        let (iov, iovlen_addr, two) = (ValueId(6), ValueId(7), ValueId(8));
+        let (fd, one, zero, errno) = (ValueId(9), ValueId(10), ValueId(11), ValueId(12));
+        MirFunction {
+            name: "put_digit".into(),
+            params: vec![MirParam { value: n, repr: scalar }],
+            ops: vec![
+                Op::ConstInt { dst: c48, value: 48 },
+                Op::IntBinOp { dst: byte, op: IntOp::Add, a: n, b: c48 },
+                // buf[512] = '0' + n; buf[513] = '\n'
+                Op::ConstInt { dst: buf, value: 512 },
+                Op::Prim { kind: PrimKind::Store { width: 1 }, dst: None, args: vec![buf, byte] },
+                Op::ConstInt { dst: buf1, value: 513 },
+                Op::ConstInt { dst: nl, value: 10 },
+                Op::Prim { kind: PrimKind::Store { width: 1 }, dst: None, args: vec![buf1, nl] },
+                // iovec @8 = [buf: 512][len: 2]; fd_write(1, 8, 1, 0)
+                Op::ConstInt { dst: iov, value: 8 },
+                Op::Prim { kind: PrimKind::Store { width: 4 }, dst: None, args: vec![iov, buf] },
+                Op::ConstInt { dst: iovlen_addr, value: 12 },
+                Op::ConstInt { dst: two, value: 2 },
+                Op::Prim {
+                    kind: PrimKind::Store { width: 4 },
+                    dst: None,
+                    args: vec![iovlen_addr, two],
+                },
+                Op::ConstInt { dst: fd, value: 1 },
+                Op::ConstInt { dst: one, value: 1 },
+                Op::ConstInt { dst: zero, value: 0 },
+                Op::Prim { kind: PrimKind::FdWrite, dst: Some(errno), args: vec![fd, iov, one, zero] },
+            ],
+            ret: None,
+            ..Default::default()
+        }
+    }
+
+    /// `put_digit(v)` as an op — the one-liner the ported tests print with.
+    fn call_put_digit(v: ValueId) -> Op {
+        Op::CallFn {
+            dst: None,
+            name: "put_digit".into(),
+            args: vec![CallArg::Scalar(v)],
+            result: None,
+        }
+    }
+
     /// Same program as the Rust-side test: `fn add(a,b)=a+b` + a `main` calling
     /// it. Both targets must print the same `5` — the dual-renderer thesis for
     /// USER FUNCTIONS (the mechanism that lets the runtime be self-hosted).
@@ -34,12 +91,12 @@
                     name: "add".into(),
                     args: vec![CallArg::Imm(2), CallArg::Imm(3)],
                 result: None },
-                Op::Call { dst: None, func: RtFn::PrintInt, args: vec![CallArg::Scalar(ValueId(0))] , result: None },
+                call_put_digit(ValueId(0)),
             ],
             ret: None,
             ..Default::default()
         };
-        MirProgram { functions: vec![add, main], exports: vec![], mutable_global_count: 0 }
+        MirProgram { functions: vec![add, main, put_digit_fn()], exports: vec![], mutable_global_count: 0 }
     }
 
     #[test]
@@ -68,12 +125,7 @@
                     args: vec![CallArg::Imm(5)],
                     result: Some(scalar),
                 },
-                Op::Call {
-                    dst: None,
-                    func: RtFn::PrintInt,
-                    args: vec![CallArg::Scalar(ValueId(1))],
-                    result: None,
-                },
+                call_put_digit(ValueId(1)),
             ],
             ret: None,
             ..Default::default()
@@ -88,8 +140,9 @@
             ret: Some(ValueId(2)),
             ..Default::default()
         };
-        // main at slot 0, add1 at slot 1 — FuncRef("add1") must resolve to 1.
-        let prog = MirProgram { functions: vec![main, add1], exports: vec![], mutable_global_count: 0 };
+        // main at slot 0, add1 at slot 1 — FuncRef("add1") must resolve to 1
+        // (put_digit appended LAST so those slots stay put).
+        let prog = MirProgram { functions: vec![main, add1, put_digit_fn()], exports: vec![], mutable_global_count: 0 };
         if let Some(out) = build_and_run("func_ref", &render_wasm_program(&prog)) {
             assert_eq!(out, "6");
         }
@@ -123,17 +176,13 @@
                     args: vec![CallArg::Imm(5)],
                     result: Some(scalar),
                 },
-                Op::Call {
-                    dst: None,
-                    func: RtFn::PrintInt,
-                    args: vec![CallArg::Scalar(ValueId(1))],
-                    result: None,
-                },
+                call_put_digit(ValueId(1)),
             ],
             ret: None,
             ..Default::default()
         };
-        let prog = MirProgram { functions: vec![add1, main], exports: vec![], mutable_global_count: 0 };
+        // add1 stays table index 0 — put_digit appended LAST.
+        let prog = MirProgram { functions: vec![add1, main, put_digit_fn()], exports: vec![], mutable_global_count: 0 };
         if let Some(out) = build_and_run("call_indirect", &render_wasm_program(&prog)) {
             assert_eq!(out, "6");
         }

--- a/crates/almide-mir/src/render_wasm/tests_part3.rs
+++ b/crates/almide-mir/src/render_wasm/tests_part3.rs
@@ -727,76 +727,11 @@
         }
     }
 
-    /// The five MIR_ONLY prelude fns EXECUTED with pinned stdout (#1208, the
-    /// Stage 1c ledger's evidence upgrade). `$print_int`, `$print_list`,
-    /// `$list_push`, and through them `$itoa_append` + `$list_len` are
-    /// hand-written wasm reachable only from hand-built MIR — no .almd program
-    /// can reach them, so no corpus fixture pins their BODIES; the
-    /// translation-validation mutation test checks only their EMISSION. This
-    /// runs the bytes: negative int through the itoa sign path, a push that
-    /// rebinds the handle, and the labeled list print walking len + per-element
-    /// itoa. The expected bytes were MEASURED on wasmtime, not reasoned.
-    #[test]
-    fn mir_only_prelude_fns_execute_with_pinned_stdout() {
-        use crate::{CallArg, Init, MirFunction, Op, Repr, RtFn, ValueId, PLACEHOLDER_LAYOUT};
-        let (xs, n, m) = (ValueId(0), ValueId(1), ValueId(2));
-        let mir = MirFunction {
-            name: "main".into(),
-            ops: vec![
-                Op::Alloc {
-                    dst: xs,
-                    repr: Repr::Ptr { layout: PLACEHOLDER_LAYOUT },
-                    init: Init::IntList(vec![1, 2, 3]),
-                },
-                Op::ConstInt { dst: n, value: -42 },
-                Op::Call {
-                    dst: None,
-                    func: RtFn::PrintInt,
-                    args: vec![CallArg::Scalar(n)],
-                    result: None,
-                },
-                // i64::MIN — the sign path's wrap-negation edge (2^63 has no
-                // positive i64 twin; the magnitude must still print exactly).
-                Op::ConstInt { dst: m, value: i64::MIN },
-                Op::Call {
-                    dst: None,
-                    func: RtFn::PrintInt,
-                    args: vec![CallArg::Scalar(m)],
-                    result: None,
-                },
-                // push may move the buffer — dst rebinds the SAME handle local.
-                Op::Call {
-                    dst: Some(xs),
-                    func: RtFn::ListPush,
-                    args: vec![CallArg::Handle(xs), CallArg::Imm(9)],
-                    result: None,
-                },
-                Op::Call {
-                    dst: None,
-                    func: RtFn::PrintList,
-                    args: vec![CallArg::Handle(xs), CallArg::Label("xs".into())],
-                    result: None,
-                },
-                Op::Drop { v: xs },
-            ],
-            ..Default::default()
-        };
-        let prog = crate::MirProgram { functions: vec![mir], ..Default::default() };
-        let wat = render_wasm_program(&prog);
-        for f in ["$print_int", "$print_list", "$list_push", "$itoa_append", "$list_len"] {
-            assert!(
-                wat.contains(&format!("(func {f} ")),
-                "{f} must be rendered for this MIR (the ledger's MIR_ONLY claim)"
-            );
-        }
-        if let Some(out) = build_and_run("mir_only_prelude", &wat) {
-            assert_eq!(
-                out,
-                "-42\n-9223372036854775808\nxs=1,2,3,9",
-                "the five bodies' observable bytes"
-            );
-        }
-    }
+    // (`mir_only_prelude_fns_execute_with_pinned_stdout` was deleted with its
+    // subjects in #1208's endgame: `$print_int`/`$print_list`/`$list_push`/
+    // `$itoa_append`/`$list_len` and the `RtFn::PrintInt`/`PrintList`/`ListPush`
+    // vocabulary are gone — no frontend lowering ever constructed them, so the
+    // bodies were dead-from-source wasm the pin alone kept alive.)
 
     include!("tests_part3_b.rs");
     include!("tests_part3_c.rs");

--- a/crates/almide-mir/src/render_wasm/tests_part3_c.rs
+++ b/crates/almide-mir/src/render_wasm/tests_part3_c.rs
@@ -41,6 +41,21 @@
         }
     }
 
+    /// A TEST-LOCAL single-digit printer for the raw-WAT fixtures below: writes
+    /// "<digit>\n" via `$fd_write`, byte-identical to what the deleted bootstrap
+    /// `$print_int` produced for 0..=9. #1208 removed `$print_int` from the
+    /// production prelude (dead-from-source), so the raw-WAT tests that observe
+    /// single-digit facts (freelist reuse, rc cell values) carry their own
+    /// observation channel instead of keeping unreachable wasm alive for it.
+    fn put_digit_wat() -> &'static str {
+        "  (func $put_digit (param $v i64)\n\
+         \u{20}   (i32.store8 (i32.const 512) (i32.add (i32.const 48) (i32.wrap_i64 (local.get $v))))\n\
+         \u{20}   (i32.store8 (i32.const 513) (i32.const 10))\n\
+         \u{20}   (i32.store (i32.const 8) (i32.const 512))\n\
+         \u{20}   (i32.store (i32.const 12) (i32.const 2))\n\
+         \u{20}   (drop (call $fd_write (i32.const 1) (i32.const 8) (i32.const 1) (i32.const 0))))\n"
+    }
+
     #[test]
     fn freelist_reuses_a_freed_block() {
         // A1.2-render: alloc p1, free p1 (-> the free-list), then alloc p2 of the
@@ -50,8 +65,9 @@
         // Prints `1` (p1 == p2, reuse happened) then `2` (p2[1] read back) — if the
         // reused block were corrupted the read-back would be wrong.
         let wat = format!(
-            "{}{}",
+            "{}{}{}",
             preamble(),
+            put_digit_wat(),
             "  (func $main (local $p1 i32) (local $p2 i32)\n\
              \u{20}   (local.set $p1 (call $list_new (i32.const 3) (i32.const 3)))\n\
              \u{20}   (call $rc_dec (local.get $p1))\n\
@@ -59,8 +75,8 @@
              \u{20}   (call $list_set (local.get $p2) (i32.const 0) (i64.const 1))\n\
              \u{20}   (call $list_set (local.get $p2) (i32.const 1) (i64.const 2))\n\
              \u{20}   (call $list_set (local.get $p2) (i32.const 2) (i64.const 3))\n\
-             \u{20}   (call $print_int (i64.extend_i32_s (i32.eq (local.get $p1) (local.get $p2))))\n\
-             \u{20}   (call $print_int (call $list_get (local.get $p2) (i32.const 1))))\n\
+             \u{20}   (call $put_digit (i64.extend_i32_s (i32.eq (local.get $p1) (local.get $p2))))\n\
+             \u{20}   (call $put_digit (call $list_get (local.get $p2) (i32.const 1))))\n\
              \u{20} (func (export \"_start\") (call $main))\n)\n"
         );
         if let Some(out) = build_and_run("reuse", &wat) {
@@ -78,24 +94,26 @@
         // matches the wasm spec" to "wasmtime matches the spec" (a trusted engine, the
         // same trust level as the wat2wasm byte grounding). `$list_new` inits rc to 1.
         let inc = format!(
-            "{}{}",
+            "{}{}{}",
             preamble(),
+            put_digit_wat(),
             "  (func $main (local $b i32)\n\
              \u{20}   (local.set $b (call $list_new (i32.const 0) (i32.const 1)))\n\
              \u{20}   (call $rc_inc (local.get $b))\n\
-             \u{20}   (call $print_int (i64.extend_i32_s (i32.load (local.get $b)))))\n\
+             \u{20}   (call $put_digit (i64.extend_i32_s (i32.load (local.get $b)))))\n\
              \u{20} (func (export \"_start\") (call $main))\n)\n"
         );
         if let Some(out) = build_and_run("rcinc_cell", &inc) {
             assert_eq!(out, "2", "rc_inc: cell 1→2 (rt_inc) — wasmtime must match run_g");
         }
         let dec = format!(
-            "{}{}",
+            "{}{}{}",
             preamble(),
+            put_digit_wat(),
             "  (func $main (local $b i32)\n\
              \u{20}   (local.set $b (call $list_new (i32.const 0) (i32.const 1)))\n\
              \u{20}   (call $rc_dec (local.get $b))\n\
-             \u{20}   (call $print_int (i64.extend_i32_s (i32.load (local.get $b)))))\n\
+             \u{20}   (call $put_digit (i64.extend_i32_s (i32.load (local.get $b)))))\n\
              \u{20} (func (export \"_start\") (call $main))\n)\n"
         );
         if let Some(out) = build_and_run("rcdec_cell", &dec) {
@@ -135,8 +153,14 @@
     }
 
     fn value_semantics_mir() -> MirFunction {
-        // var a = [1,2,3]; var b = a; a[0] = 9; print a; print b
+        // var a = [1,2,3]; var b = a; a[0] = 9; print a[0..2]; print b[0..2].
+        // Observation is element-wise through `put_digit` (the prim-floor digit
+        // printer) — #1208 deleted the bootstrap `RtFn::PrintList`/`$print_list`,
+        // so the cow claim is read back per element: a = 9,2,3 and b = 1,2,3.
         let (a, b) = (ValueId(0), ValueId(1));
+        let (i0, i1, i2) = (ValueId(2), ValueId(3), ValueId(4));
+        let (a0, a1, a2) = (ValueId(5), ValueId(6), ValueId(7));
+        let (b0, b1, b2) = (ValueId(8), ValueId(9), ValueId(10));
         MirFunction {
             name: "main".into(),
             ops: vec![
@@ -148,8 +172,21 @@
                     func: RtFn::ListSet,
                     args: vec![CallArg::Handle(a), CallArg::Imm(0), CallArg::Imm(9)],
                 result: None },
-                Op::Call { dst: None, func: RtFn::PrintList, args: vec![CallArg::Handle(a), CallArg::Label("a".into())] , result: None },
-                Op::Call { dst: None, func: RtFn::PrintList, args: vec![CallArg::Handle(b), CallArg::Label("b".into())] , result: None },
+                Op::ConstInt { dst: i0, value: 0 },
+                Op::ConstInt { dst: i1, value: 1 },
+                Op::ConstInt { dst: i2, value: 2 },
+                Op::ListGetScalar { dst: a0, list: a, idx: i0 },
+                call_put_digit(a0),
+                Op::ListGetScalar { dst: a1, list: a, idx: i1 },
+                call_put_digit(a1),
+                Op::ListGetScalar { dst: a2, list: a, idx: i2 },
+                call_put_digit(a2),
+                Op::ListGetScalar { dst: b0, list: b, idx: i0 },
+                call_put_digit(b0),
+                Op::ListGetScalar { dst: b1, list: b, idx: i1 },
+                call_put_digit(b1),
+                Op::ListGetScalar { dst: b2, list: b, idx: i2 },
+                call_put_digit(b2),
                 Op::Drop { v: b },
                 Op::Drop { v: a },
             ],
@@ -190,8 +227,12 @@
     fn wasm_runs_value_semantics_matching_rust() {
         let mir = value_semantics_mir();
         assert_eq!(verify_ownership(&mir), Ok(()));
-        if let Some(out) = build_and_run("valuesem", &render_wasm(&mir)) {
-            assert_eq!(out, "a=9,2,3\nb=1,2,3");
+        let prog = MirProgram {
+            functions: vec![mir, put_digit_fn()],
+            ..Default::default()
+        };
+        if let Some(out) = build_and_run("valuesem", &render_wasm_program(&prog)) {
+            assert_eq!(out, "9\n2\n3\n1\n2\n3");
             // (The rung-1 sketch renderer this test used to poke for a dual-render
             // sanity line was retired in #930. The dual-renderer thesis is carried
             // by the REAL evidence now: the cross-target byte gate runs whole
@@ -201,33 +242,12 @@
         }
     }
 
-    #[test]
-    fn wasm_push_through_alias_keeps_sibling_independent() {
-        // var a = [1]; var b = a; a.push(2); print a; print b → a=[1,2], b=[1]
-        let (a, b) = (ValueId(0), ValueId(1));
-        let mir = MirFunction {
-            name: "main".into(),
-            ops: vec![
-                Op::Alloc { dst: a, repr: heap(), init: Init::IntList(vec![1]) },
-                Op::Dup { dst: b, src: a },
-                Op::MakeUnique { v: a },
-                Op::Call {
-                    dst: Some(a),
-                    func: RtFn::ListPush,
-                    args: vec![CallArg::Handle(a), CallArg::Imm(2)],
-                result: None },
-                Op::Call { dst: None, func: RtFn::PrintList, args: vec![CallArg::Handle(a), CallArg::Label("a".into())] , result: None },
-                Op::Call { dst: None, func: RtFn::PrintList, args: vec![CallArg::Handle(b), CallArg::Label("b".into())] , result: None },
-                Op::Drop { v: b },
-                Op::Drop { v: a },
-            ],
-            ..Default::default()
-        };
-        assert_eq!(verify_ownership(&mir), Ok(()));
-        if let Some(out) = build_and_run("push", &render_wasm(&mir)) {
-            assert_eq!(out, "a=1,2\nb=1");
-        }
-    }
+    // (`wasm_push_through_alias_keeps_sibling_independent` was deleted in #1208's
+    // endgame with `RtFn::ListPush`/`$list_push`: no frontend lowering ever
+    // constructed the op — real pushes go through the self-hosted `list.push`,
+    // and push-through-alias independence is corpus-pinned by the cross-target
+    // byte gate (spec/wasm_cross/alias_cow.almd, list_comprehensive.almd,
+    // bytes_push_inplace.almd).)
 
     #[test]
     fn self_hosted_string_from_codepoint_encodes_utf8() {

--- a/crates/almide-mir/src/render_wasm_b.rs
+++ b/crates/almide-mir/src/render_wasm_b.rs
@@ -194,7 +194,6 @@ fn drop_scratch_locals(func: &MirFunction) -> Vec<String> {
 
 pub fn render_wasm_fn(
     func: &MirFunction,
-    label_off: &BTreeMap<String, (u32, u32)>,
     func_slots: &BTreeMap<String, u32>,
     param_counts: &BTreeMap<String, usize>,
 ) -> String {
@@ -256,7 +255,6 @@ pub fn render_wasm_fn(
     let ctx = RenderFnCtx {
         func,
         tail_calls: &tail_calls,
-        label_off,
         func_slots,
         param_counts,
         reprs: &reprs,
@@ -289,7 +287,6 @@ pub fn render_wasm_fn(
 struct RenderFnCtx<'a> {
     func: &'a MirFunction,
     tail_calls: &'a BTreeSet<usize>,
-    label_off: &'a BTreeMap<String, (u32, u32)>,
     func_slots: &'a BTreeMap<String, u32>,
     param_counts: &'a BTreeMap<String, usize>,
     reprs: &'a BTreeMap<ValueId, Repr>,
@@ -614,7 +611,6 @@ fn render_fused_or_plain_op(
                     return true;
                 }
                 body.push_str(&render_op(op, crate::render_wasm::OpTables {
-                    label_off: ctx.label_off,
                     func_slots: ctx.func_slots,
                     param_counts: ctx.param_counts,
                     masks: &ctx.func.heap_slot_masks,
@@ -634,7 +630,6 @@ fn render_fused_or_plain_op(
                     body.push_str(&render_list_access_unchecked(op, ctx.floats));
                 } else {
                     body.push_str(&render_op(op, crate::render_wasm::OpTables {
-                    label_off: ctx.label_off,
                     func_slots: ctx.func_slots,
                     param_counts: ctx.param_counts,
                     masks: &ctx.func.heap_slot_masks,

--- a/crates/almide-mir/src/render_wasm_c.rs
+++ b/crates/almide-mir/src/render_wasm_c.rs
@@ -685,46 +685,16 @@ fn imm_import_arg(n: i64, ty: crate::WasmAbi) -> String {
     }
 }
 
-fn render_call(
-    dst: Option<ValueId>,
-    func: &RtFn,
-    args: &[CallArg],
-    label_off: &BTreeMap<String, (u32, u32)>,
-    floats: &BTreeSet<ValueId>,
-) -> String {
+fn render_call(dst: Option<ValueId>, func: &RtFn, args: &[CallArg]) -> String {
+    // `dst` died with `RtFn::ListPush` (the rebind-on-realloc arm, #1208); it
+    // stays in the signature so a future dst-carrying runtime fn cannot land
+    // without deciding what its rebind means — but today it must be absent.
+    assert!(dst.is_none(), "runtime call {func:?} with a dst — no RtFn returns a value");
     match (func, args) {
         (RtFn::ListSet, [CallArg::Handle(t), CallArg::Imm(idx), CallArg::Imm(val)]) => format!(
             "    (call $list_set (local.get {t}) (i32.const {idx}) (i64.const {val}))\n",
             t = local(*t)
         ),
-        (RtFn::ListPush, [CallArg::Handle(t), CallArg::Imm(val)]) => {
-            // push may move the buffer → rebind the handle local (dst == target).
-            let target = dst.unwrap_or(*t);
-            format!(
-                "    (local.set {d} (call $list_push (local.get {t}) (i64.const {val})))\n",
-                d = local(target),
-                t = local(*t)
-            )
-        }
-        (RtFn::PrintList, [CallArg::Handle(v), CallArg::Label(label)]) => {
-            let (off, len) = label_off[label];
-            format!(
-                "    (call $print_list (local.get {v}) (i32.const {off}) (i32.const {len}))\n",
-                v = local(*v)
-            )
-        }
-        (RtFn::PrintInt, [CallArg::Scalar(v)]) => {
-            // An f64-classified value never legally reaches print_int, but the
-            // flexible-scalar-arg rule still owes the i64 BITS at the boundary.
-            if floats.contains(v) {
-                format!(
-                    "    (call $print_int (i64.reinterpret_f64 (local.get {})))\n",
-                    local(*v)
-                )
-            } else {
-                format!("    (call $print_int (local.get {}))\n", local(*v))
-            }
-        }
         (RtFn::PrintStr, [CallArg::Handle(v)]) => {
             format!("    (call $print_str (local.get {}))\n", local(*v))
         }

--- a/crates/almide-mir/src/render_wasm_calls.rs
+++ b/crates/almide-mir/src/render_wasm_calls.rs
@@ -1,8 +1,7 @@
-/// The per-function naming environment the call renderers read — the label
-/// offsets, callee param counts and value repr/float classes travel as one
-/// value (a caller could otherwise pair maps from different functions).
+/// The per-function naming environment the call renderers read — the callee
+/// param counts and value repr/float classes travel as one value (a caller
+/// could otherwise pair maps from different functions).
 pub(crate) struct WasmEnv<'a> {
-    pub label_off: &'a BTreeMap<String, (u32, u32)>,
     pub param_counts: &'a BTreeMap<String, usize>,
     pub reprs: &'a BTreeMap<ValueId, Repr>,
     pub floats: &'a BTreeSet<ValueId>,
@@ -156,7 +155,7 @@ match dst {
 }
 
 fn render_op_call_light(op: &Op, env: &WasmEnv<'_>, tail_call: bool) -> String {
-    let WasmEnv { label_off, param_counts: _, reprs, floats } = *env;
+    let WasmEnv { param_counts: _, reprs, floats } = *env;
     match op {
         // An alias SHARES the object and bumps its refcount (A1.3-render): dst and
         // src become two handles to the SAME block, rc += 1 — matching the cert's
@@ -168,7 +167,7 @@ fn render_op_call_light(op: &Op, env: &WasmEnv<'_>, tail_call: bool) -> String {
             s = local(*src)
         ),
         // A runtime call → a wasm `call` of the (bootstrap) runtime function.
-        Op::Call { dst, func, args, .. } => render_call(*dst, func, args, label_off, floats),
+        Op::Call { dst, func, args, .. } => render_call(*dst, func, args),
         // An indirect (closure) call: push the args, then the table index, and dispatch
         // through the module function table with the closure signature OF THIS ARITY
         // (`$closure_fnN`, N = arg count). The table + every `(type $closure_fnN)` are

--- a/crates/almide-mir/src/render_wasm_dce.rs
+++ b/crates/almide-mir/src/render_wasm_dce.rs
@@ -295,22 +295,6 @@ pub(crate) fn filter_unreachable_preamble(pre: &str, used_text: &str) -> String 
 /// a fixpoint (a dead function referenced only by another dead function
 /// prunes in a later round).
 pub(crate) fn prune_unreachable_functions(prog: &MirProgram) -> MirProgram {
-    let mut label_off: BTreeMap<String, (u32, u32)> = BTreeMap::new();
-    let mut cursor = LABELS_ADDR;
-    for func in &prog.functions {
-        for op in &func.ops {
-            let Op::Call { args, .. } = op else { continue };
-            for a in args {
-                let CallArg::Label(label) = a else { continue };
-                if label_off.contains_key(label) {
-                    continue;
-                }
-                let len = label.len() as u32;
-                label_off.insert(label.clone(), (cursor, len));
-                cursor += len;
-            }
-        }
-    }
     let func_slots: BTreeMap<String, u32> =
         prog.functions.iter().enumerate().map(|(i, f)| (f.name.clone(), i as u32)).collect();
     let param_counts: BTreeMap<String, usize> =
@@ -318,7 +302,7 @@ pub(crate) fn prune_unreachable_functions(prog: &MirProgram) -> MirProgram {
     let bodies: BTreeMap<String, String> = prog
         .functions
         .iter()
-        .map(|f| (f.name.clone(), render_wasm_fn(f, &label_off, &func_slots, &param_counts)))
+        .map(|f| (f.name.clone(), render_wasm_fn(f, &func_slots, &param_counts)))
         .collect();
     // `Op::FuncRef { name, .. }` — "the function-table slot of the lifted
     // function `name`" — renders to a bare `(i64.const {slot})`, NOT a `$name`

--- a/crates/almide-mir/src/render_wasm_module_parts.rs
+++ b/crates/almide-mir/src/render_wasm_module_parts.rs
@@ -20,31 +20,6 @@ fn heap_handle_locals(ops: &[Op]) -> Vec<ValueId> {
     heap_locals
 }
 
-/// Assign each distinct string label a data-section offset starting at `base`,
-/// emitting one `(data …)` line per label. Deduplicated, so a label used twice
-/// is stored once.
-fn collect_label_data(
-    ops: &[Op],
-    base: u32,
-    label_off: &mut BTreeMap<String, (u32, u32)>,
-    data: &mut String,
-) {
-    let mut cursor = base;
-    for op in ops {
-        let Op::Call { args, .. } = op else { continue };
-        for a in args {
-            let CallArg::Label(label) = a else { continue };
-            if label_off.contains_key(label) {
-                continue;
-            }
-            let len = label.len() as u32;
-            label_off.insert(label.clone(), (cursor, len));
-            data.push_str(&format!("  (data (i32.const {cursor}) {:?})\n", label));
-            cursor += len;
-        }
-    }
-}
-
 /// Rewrite every unresolvable-as-spelled call / drop target that HAS an alias to that
 /// alias, in place. Extracted verbatim from [`try_render_wasm_program`] (codopsy
 /// round-3 sweep, #852).

--- a/crates/almide-mir/src/render_wasm_p2.rs
+++ b/crates/almide-mir/src/render_wasm_p2.rs
@@ -1,11 +1,10 @@
 /// The read-only tables one wasm op is rendered against.
 ///
-/// Three are `BTreeMap<String, _>` and were adjacent parameters, so the label,
-/// slot and arity tables could be transposed silently — and a wrong slot table
-/// emits a call to the wrong function index, which the module still validates.
+/// Two are `BTreeMap<String, _>` and were adjacent parameters, so the slot and
+/// arity tables could be transposed silently — and a wrong slot table emits a
+/// call to the wrong function index, which the module still validates.
 #[derive(Copy, Clone)]
 pub(crate) struct OpTables<'a> {
-    pub label_off: &'a BTreeMap<String, (u32, u32)>,
     pub func_slots: &'a BTreeMap<String, u32>,
     pub param_counts: &'a BTreeMap<String, usize>,
     pub masks: &'a BTreeMap<ValueId, Vec<usize>>,
@@ -19,7 +18,7 @@ pub(crate) struct OpTables<'a> {
 }
 
 fn render_op(op: &Op, t: OpTables<'_>, fuser: &mut Fuser) -> String {
-    let OpTables { label_off, func_slots, param_counts, masks, reprs, floats, tail_call } = t;
+    let OpTables { func_slots, param_counts, masks, reprs, floats, tail_call } = t;
     // Router split out for codopsy cognitive-complexity (pure text-move, no behavior
     // change): the original single ~1100-line exhaustive match over every `Op` variant
     // is now 4 group helpers by variant family (alloc/list-literal, call/binop, the
@@ -39,7 +38,7 @@ fn render_op(op: &Op, t: OpTables<'_>, fuser: &mut Fuser) -> String {
         | Op::CallIndirect { .. }
         | Op::CallFn { .. }
         | Op::CallImport { .. } => {
-            render_op_call(op, &WasmEnv { label_off, param_counts, reprs, floats }, tail_call, fuser)
+            render_op_call(op, &WasmEnv { param_counts, reprs, floats }, tail_call, fuser)
         }
         Op::Drop { .. }
         | Op::DropListStr { .. }

--- a/crates/almide-mir/src/render_wasm_p3.rs
+++ b/crates/almide-mir/src/render_wasm_p3.rs
@@ -329,9 +329,6 @@ pub(crate) fn preamble_with_bump_base(bump_base: u32) -> String {
   (func $list_get (param $list i32) (param $idx i32) (result i64)
     (i64.load (call $elem_addr (local.get $list) (local.get $idx))))
 
-  (func $list_len (param $list i32) (result i32)
-    (i32.load (i32.add (local.get $list) (i32.const {LIST_LEN_OFFSET}))))
-
   ;; MakeUnique's clone: a RAW byte copy of the whole data region (cap*ELEM_SIZE
   ;; bytes). Both COW'able layouts store cap@8 in ELEM_SIZE units — a DynList's
   ;; data is len*8 <= cap*8, a DynStr/Bytes block's is len BYTES <= cap*8 — so the
@@ -353,99 +350,11 @@ pub(crate) fn preamble_with_bump_base(bump_base: u32) -> String {
       (br $loop)))
     (local.get $dst))
 
-  (func $list_push (param $list i32) (param $val i64) (result i32)
-    (local $len i32)
-    (local.set $len (i32.load (i32.add (local.get $list) (i32.const {LIST_LEN_OFFSET}))))
-    (call $list_set (local.get $list) (local.get $len) (local.get $val))
-    (i32.store (i32.add (local.get $list) (i32.const {LIST_LEN_OFFSET}))
-               (i32.add (local.get $len) (i32.const 1)))
-    (local.get $list))
-
-  ;; append the decimal digits of a non-negative i64 at $cur; return new cursor
-  (func $itoa_append (param $cur i32) (param $v i64) (result i32)
-    (local $n i32)
-    (if (i64.eqz (local.get $v))
-      (then
-        (i32.store8 (local.get $cur) (i32.const {ASCII_ZERO}))
-        (return (i32.add (local.get $cur) (i32.const 1)))))
-    ;; SIGN (#1208's execution pin found this missing: -42 printed as the u64
-    ;; 18446744073709551574): emit '-' and continue on the wrapped negation —
-    ;; for i64::MIN the wrap IS the correct 2^63 magnitude read unsigned, so
-    ;; the u64 digit loop below is exact for every negative including MIN.
-    (if (i64.lt_s (local.get $v) (i64.const 0))
-      (then
-        (i32.store8 (local.get $cur) (i32.const {ASCII_MINUS}))
-        (local.set $cur (i32.add (local.get $cur) (i32.const 1)))
-        (local.set $v (i64.sub (i64.const 0) (local.get $v)))))
-    (local.set $n (i32.const 0))
-    (block $ddone (loop $dloop
-      (br_if $ddone (i64.eqz (local.get $v)))
-      (i32.store8 (i32.add (i32.const {ITOA_TMP_ADDR}) (local.get $n))
-                  (i32.add (i32.const {ASCII_ZERO})
-                           (i32.wrap_i64 (i64.rem_u (local.get $v) (i64.const {DECIMAL_BASE})))))
-      (local.set $n (i32.add (local.get $n) (i32.const 1)))
-      (local.set $v (i64.div_u (local.get $v) (i64.const {DECIMAL_BASE})))
-      (br $dloop)))
-    (block $cdone (loop $cloop
-      (br_if $cdone (i32.eqz (local.get $n)))
-      (local.set $n (i32.sub (local.get $n) (i32.const 1)))
-      (i32.store8 (local.get $cur)
-                  (i32.load8_u (i32.add (i32.const {ITOA_TMP_ADDR}) (local.get $n))))
-      (local.set $cur (i32.add (local.get $cur) (i32.const 1)))
-      (br $cloop)))
-    (local.get $cur))
-
-  ;; print "<label>=<e0>,<e1>,...\n" to stdout
-  (func $print_list (param $list i32) (param $lblptr i32) (param $lbllen i32)
-    (local $cur i32) (local $i i32) (local $len i32)
-    (local.set $cur (i32.const {SCRATCH_ADDR}))
-    (local.set $i (i32.const 0))
-    (block $lbldone (loop $lblloop
-      (br_if $lbldone (i32.ge_s (local.get $i) (local.get $lbllen)))
-      (i32.store8 (local.get $cur)
-                  (i32.load8_u (i32.add (local.get $lblptr) (local.get $i))))
-      (local.set $cur (i32.add (local.get $cur) (i32.const 1)))
-      (local.set $i (i32.add (local.get $i) (i32.const 1)))
-      (br $lblloop)))
-    (i32.store8 (local.get $cur) (i32.const {ASCII_EQUALS}))
-    (local.set $cur (i32.add (local.get $cur) (i32.const 1)))
-    (local.set $len (call $list_len (local.get $list)))
-    (local.set $i (i32.const 0))
-    (block $eldone (loop $elloop
-      (br_if $eldone (i32.ge_s (local.get $i) (local.get $len)))
-      ;; SAFETY WALL: appending an element writes up to a comma + 20 digits; if
-      ;; that would cross HEAP_BASE (the line buffer's end), trap rather than
-      ;; overflow the buffer into the heap (the print-buffer-overflow gate).
-      (if (i32.gt_u (i32.add (local.get $cur) (i32.const {MAX_ELEM_PRINT_BYTES}))
-                    (i32.const {HEAP_BASE}))
-        (then (unreachable)))
-      (if (i32.gt_s (local.get $i) (i32.const 0))
-        (then
-          (i32.store8 (local.get $cur) (i32.const {ASCII_COMMA}))
-          (local.set $cur (i32.add (local.get $cur) (i32.const 1)))))
-      (local.set $cur (call $itoa_append (local.get $cur)
-                                         (call $list_get (local.get $list) (local.get $i))))
-      (local.set $i (i32.add (local.get $i) (i32.const 1)))
-      (br $elloop)))
-    (i32.store8 (local.get $cur) (i32.const {ASCII_NEWLINE}))
-    (local.set $cur (i32.add (local.get $cur) (i32.const 1)))
-    (i32.store (i32.const {IOVEC_ADDR}) (i32.const {SCRATCH_ADDR}))
-    (i32.store (i32.add (i32.const {IOVEC_ADDR}) (i32.const {IOVEC_LEN_OFFSET}))
-               (i32.sub (local.get $cur) (i32.const {SCRATCH_ADDR})))
-    (drop (call $fd_write (i32.const {STDOUT_FD}) (i32.const {IOVEC_ADDR})
-                          (i32.const {IOVS_COUNT}) (i32.const {NWRITTEN_ADDR}))))
-
-  ;; print a scalar integer followed by a newline
-  (func $print_int (param $v i64)
-    (local $cur i32)
-    (local.set $cur (call $itoa_append (i32.const {SCRATCH_ADDR}) (local.get $v)))
-    (i32.store8 (local.get $cur) (i32.const {ASCII_NEWLINE}))
-    (local.set $cur (i32.add (local.get $cur) (i32.const 1)))
-    (i32.store (i32.const {IOVEC_ADDR}) (i32.const {SCRATCH_ADDR}))
-    (i32.store (i32.add (i32.const {IOVEC_ADDR}) (i32.const {IOVEC_LEN_OFFSET}))
-               (i32.sub (local.get $cur) (i32.const {SCRATCH_ADDR})))
-    (drop (call $fd_write (i32.const {STDOUT_FD}) (i32.const {IOVEC_ADDR})
-                          (i32.const {IOVS_COUNT}) (i32.const {NWRITTEN_ADDR}))))
+  ;; ($list_len / $list_push / $itoa_append / $print_list / $print_int were
+  ;; deleted in #1208's endgame: their only constructors were hand-built MIR in
+  ;; the certificate layer — no frontend lowering reached them, so the bodies
+  ;; were dead-from-source wasm. Real programs print through the self-hosted
+  ;; `print_str` / `int.to_string` over the prim floor.)
 
   ;; env.args() — build a fresh OWNED `List[String]` of the program arguments
   ;; argv[1..] (SKIP argv[0] = program path, mirroring native `env.args`). The

--- a/crates/almide-mir/src/translation_validation.rs
+++ b/crates/almide-mir/src/translation_validation.rs
@@ -60,10 +60,11 @@ pub fn wasm_pattern(op: &crate::Op) -> Option<String> {
         Op::ListLit { .. } => "call $alloc".into(),
         Op::ListGetScalar { .. } | Op::ListSetScalar { .. } => "call $elem_addr_chk".into(),
         Op::Dup { .. } => "call $rc_inc".into(),
-        Op::Call { func: RtFn::PrintInt, .. } => "call $print_int".into(),
-        Op::Call { func: RtFn::PrintList, .. } => "call $print_list".into(),
+        // The ONE print op (#1208 retired the PrintInt/PrintList bootstrap): a
+        // `println(s)` lowers to PrintStr and must realize as a call of the
+        // auto-linked self-hosted `$print_str`.
+        Op::Call { func: RtFn::PrintStr, .. } => "call $print_str".into(),
         Op::Call { func: RtFn::ListSet, .. } => "call $list_set".into(),
-        Op::Call { func: RtFn::ListPush, .. } => "call $list_push".into(),
         Op::CallFn { name, .. } => format!("call ${name}"),
         // A host wasm IMPORT renders to `(call $<import>)`; the import name is the
         // mangled `__import_<module>_<name>` the render declares (see `import_symbol`).
@@ -108,8 +109,7 @@ pub fn wasm_pattern(op: &crate::Op) -> Option<String> {
         // per-op pattern claim here (like the if-markers), and no lowering emits it yet.
         // FuncRef (a closure's table-slot value) is likewise structural, no token claim.
         | Op::CallIndirect { .. }
-        | Op::FuncRef { .. }
-        | Op::Call { func: RtFn::PrintStr, .. } => return None,
+        | Op::FuncRef { .. } => return None,
     })
 }
 
@@ -284,8 +284,10 @@ mod tests {
     #[test]
     fn translation_validation_requires_each_op_realized() {
         use crate::{CallArg, RtFn};
-        // A real value-semantics program: build a list, print an int, drop.
-        let (a, n) = (ValueId(0), ValueId(1));
+        // A real value-semantics program: build a list, print a string (#1208
+        // ported this test from the retired PrintInt to the print_str-based
+        // expectation — the print real programs actually lower to), drop both.
+        let (a, s) = (ValueId(0), ValueId(1));
         let mir = MirFunction {
             name: "main".into(),
             ops: vec![
@@ -294,28 +296,33 @@ mod tests {
                     repr: heap(),
                     init: Init::IntList(vec![1, 2, 3]),
                 },
-                Op::Const { dst: n },
+                Op::Alloc {
+                    dst: s,
+                    repr: heap(),
+                    init: Init::Str("hi".into()),
+                },
                 Op::Call {
                     dst: None,
-                    func: RtFn::PrintInt,
-                    args: vec![CallArg::Scalar(n)],
+                    func: RtFn::PrintStr,
+                    args: vec![CallArg::Handle(s)],
                     result: None,
                 },
+                Op::Drop { v: s },
                 Op::Drop { v: a },
             ],
             ..Default::default()
         };
         let wat = render_wasm(&mir);
-        // Each op's table pattern is present (incl. `call $rc_dec` for the drop).
+        // Each op's table pattern is present (incl. `call $rc_dec` for the drops).
         assert!(validate_translation(&wat, &mir));
-        assert!(wat.contains("call $list_new") && wat.contains("call $print_int"));
+        assert!(wat.contains("call $list_new") && wat.contains("call $print_str"));
         assert!(
             wat.contains("call $rc_dec"),
             "the drop is realized as a release"
         );
         // Non-vacuous: a renderer that DROPPED the print fails V (the table catches
         // an unrealized op).
-        let stripped = wat.replace("call $print_int", "nop");
+        let stripped = wat.replace("call $print_str", "nop");
         assert!(
             !validate_translation(&stripped, &mir),
             "an unrealized op must fail V"

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -12,7 +12,7 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 
 <!-- stages:generated:start — derived from the proofs/ ledgers by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
 > **Stage 1 (accept-and-wrong extinction): audits COMPLETE and gated** —
-> scalar-read 63 arms / 0 UNGUARDED; WAT prelude 66 fns classified;
+> scalar-read 63 arms / 0 UNGUARDED; WAT prelude 61 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
 > **Stage 2 (translation validation): 268/388 fixtures cast a real 3-way vote (69%)** —

--- a/proofs/wat-prelude-audit.toml
+++ b/proofs/wat-prelude-audit.toml
@@ -45,7 +45,11 @@
 # Counts at the first measurement (2026-08-11, 63 functions):
 #   PROVEN 5 / CORPUS 41 / FALLBACK_ONLY 6 / PROBE_ONLY 2 / TEST_PINNED 5 / TEMPLATE 4
 #   (MIR_ONLY 5 at first measurement — upgraded to TEST_PINNED when the
-#   execution pin landed and immediately caught the itoa sign defect)
+#   execution pin landed and immediately caught the itoa sign defect; then
+#   DELETED in #1208's endgame: $print_int/$print_list/$list_push/$itoa_append/
+#   $list_len went out with the RtFn::PrintInt/PrintList/ListPush vocabulary —
+#   the certificate layer now speaks print_str, and the surface SHRANK to 0
+#   TEST_PINNED rows. Shrink is the only direction this note may move.)
 
 [[fn]]
 name = "__die"
@@ -63,14 +67,14 @@ via = "alias_combinator_rc.almd"
 
 [[fn]]
 name = "__export_"
-site = "crates/almide-mir/src/render_wasm.rs:669"
+site = "crates/almide-mir/src/render_wasm.rs:617"
 digest = "d1959ff9df04"
 class = "TEMPLATE"
 why = "`(func $__export_{internal}…)` — the export-wrapper TEMPLATE; each instance carries a user function's name."
 
 [[fn]]
 name = "__import_"
-site = "crates/almide-mir/src/render_wasm.rs:539"
+site = "crates/almide-mir/src/render_wasm.rs:487"
 digest = "e7030093815d"
 class = "TEMPLATE"
 why = "`(import … (func $__import_{sym}…))` — the extern-import TEMPLATE, one instance per declared import."
@@ -84,7 +88,7 @@ via = "args_surface.almd"
 
 [[fn]]
 name = "__mg_take"
-site = "crates/almide-mir/src/render_wasm.rs:686"
+site = "crates/almide-mir/src/render_wasm.rs:634"
 digest = "4185da3f48a0"
 class = "CORPUS"
 via = "mg_rebuild_two_phase.almd"
@@ -142,7 +146,7 @@ via = "args_surface.almd"
 
 [[fn]]
 name = "args_get_list"
-site = "crates/almide-mir/src/render_wasm_p3.rs:461"
+site = "crates/almide-mir/src/render_wasm_p3.rs:370"
 digest = "32c1abadb7b6"
 class = "CORPUS"
 via = "args_surface.almd"
@@ -177,7 +181,7 @@ via = "call_closure_lambda_param.almd"
 
 [[fn]]
 name = "env_get"
-site = "crates/almide-mir/src/render_wasm_p3.rs:519"
+site = "crates/almide-mir/src/render_wasm_p3.rs:428"
 digest = "6d99767442b6"
 class = "CORPUS"
 via = "env_get.almd"
@@ -239,16 +243,8 @@ class = "CORPUS"
 via = "fs_relative_path.almd"
 
 [[fn]]
-name = "itoa_append"
-site = "crates/almide-mir/src/render_wasm_p3.rs:365"
-digest = "3d4ad99f57b0"
-class = "TEST_PINNED"
-test = "render_wasm::tests::mir_only_prelude_fns_execute_with_pinned_stdout"
-why = "reachable only from hand-built MIR (certificate layer, #1208) — the named cargo test RUNS the body on wasmtime and pins its stdout, incl. the negative/i64::MIN itoa path the first execution immediately found broken."
-
-[[fn]]
 name = "list_copy"
-site = "crates/almide-mir/src/render_wasm_p3.rs:341"
+site = "crates/almide-mir/src/render_wasm_p3.rs:338"
 digest = "dd4b194ca2f0"
 class = "CORPUS"
 via = "alias_cow.almd"
@@ -262,27 +258,11 @@ via = "fs.list_dir"
 why = "reached through dirent list build; every fixture that would exercise it is in proofs/wasm-fallback-baseline.txt, so it runs on the NATIVE leg and the byte oracle never renders it. Shrinks with that ratchet."
 
 [[fn]]
-name = "list_len"
-site = "crates/almide-mir/src/render_wasm_p3.rs:332"
-digest = "a594d53bf87c"
-class = "TEST_PINNED"
-test = "render_wasm::tests::mir_only_prelude_fns_execute_with_pinned_stdout"
-why = "reachable only from hand-built MIR (certificate layer, #1208) — the named cargo test RUNS the body on wasmtime and pins its stdout, incl. the negative/i64::MIN itoa path the first execution immediately found broken."
-
-[[fn]]
 name = "list_new"
 site = "crates/almide-mir/src/render_wasm_p3.rs:260"
 digest = "67c00ad80bac"
 class = "CORPUS"
 via = "alias_combinator_rc.almd"
-
-[[fn]]
-name = "list_push"
-site = "crates/almide-mir/src/render_wasm_p3.rs:356"
-digest = "376724cbb191"
-class = "TEST_PINNED"
-test = "render_wasm::tests::mir_only_prelude_fns_execute_with_pinned_stdout"
-why = "reachable only from hand-built MIR (certificate layer, #1208) — the named cargo test RUNS the body on wasmtime and pins its stdout, incl. the negative/i64::MIN itoa path the first execution immediately found broken."
 
 [[fn]]
 name = "list_set"
@@ -307,7 +287,7 @@ via = "fs_relative_path.almd"
 
 [[fn]]
 name = "name"
-site = "crates/almide-mir/src/render_wasm.rs:192"
+site = "crates/almide-mir/src/render_wasm.rs:165"
 digest = "fa03a4a87d6a"
 class = "TEMPLATE"
 why = "`(func ${}` — the MirFunction rendering template (render_wasm_b.rs); every program function is an instance."
@@ -376,22 +356,6 @@ site = "crates/almide-mir/src/render_wasm_p3.rs:87"
 digest = "2fe62b017aff"
 class = "CORPUS"
 via = "fs_relative_path.almd"
-
-[[fn]]
-name = "print_int"
-site = "crates/almide-mir/src/render_wasm_p3.rs:439"
-digest = "5f544cd9d766"
-class = "TEST_PINNED"
-test = "render_wasm::tests::mir_only_prelude_fns_execute_with_pinned_stdout"
-why = "reachable only from hand-built MIR (certificate layer, #1208) — the named cargo test RUNS the body on wasmtime and pins its stdout, incl. the negative/i64::MIN itoa path the first execution immediately found broken."
-
-[[fn]]
-name = "print_list"
-site = "crates/almide-mir/src/render_wasm_p3.rs:399"
-digest = "c3b1a1fbb217"
-class = "TEST_PINNED"
-test = "render_wasm::tests::mir_only_prelude_fns_execute_with_pinned_stdout"
-why = "reachable only from hand-built MIR (certificate layer, #1208) — the named cargo test RUNS the body on wasmtime and pins its stdout, incl. the negative/i64::MIN itoa path the first execution immediately found broken."
 
 [[fn]]
 name = "proc_exit"


### PR DESCRIPTION
## #1208 endgame: delete the five dead-from-source prelude fns and their Op vocabulary

The issue's comment scoped the remaining work precisely: *"retiring `RtFn::PrintInt`/`PrintList`/`ListPush` from the Op vocabulary and deleting the five prelude fns"* (option 1 — the interim TEST_PINNED execution pin landed in #1222). This PR is that surgery.

### Deleted
- **Prelude WAT** (`render_wasm_p3.rs`): `$print_int`, `$print_list`, `$list_push`, `$itoa_append`, `$list_len` — a closed cluster; measured zero remaining `call $…` references in non-test renderer sources after removal.
- **Op vocabulary** (`lib_b.rs`): `RtFn::PrintInt` / `PrintList` / `ListPush` + their wasm/native renderer arms. `RtFn` is now `{ListSet, PrintStr}`; `render_call` asserts `dst: None` (the rebind-on-realloc semantics died with `ListPush`).
- **Fallout the compiler flagged**: the print-label data-section plumbing (`CallArg::Label` collection, `label_off` threading through `WasmEnv`/`OpTables`/`RenderFnCtx`/`render_wasm_fn`/dce) and the itoa/formatter consts — all had exactly one consumer, the deleted cluster. `almide-mir` builds with zero new warnings.

### Certificate layer ported to `print_str` (as the issue prescribes)
- `wasm_pattern` table: the three retired rows are gone; `Op::Call{PrintStr}` is now BOUND to `call $print_str` (it was `None`), and the mutation test strips `call $print_str` — the print real programs actually lower to.
- `certificate_p2.rs` / `emit_cert.rs`: every Stdout-reaching fixture is now `Alloc(Init::Str)` → `PrintStr(Handle)` → `Drop` (the real lowered shape of `println("…")`); the pure-heap fixture uses `ListSet`. Witness strings are unchanged (`0|0` / `|0`), so the Coq checker contract is untouched — **measured**: `proofs/gate.sh` runs the ported `sandboxed`/`undeclared` scenarios through the kernel-proven checker and agrees.
- MIR-level execution tests observe through the prim floor now (`put_digit`: store8 + fd_write — the same bytes-path real programs print through) instead of a prelude fn nothing real could reach. `wasm_push_through_alias` deleted with its op (push-through-alias is corpus-pinned: `alias_cow.almd`, `list_comprehensive.almd`, `bytes_push_inplace.almd`).

### Ledger (shrink direction)
`proofs/wat-prelude-audit.toml`: 66 → **61** rows, TEST_PINNED 5 → **0**; 7 `site` fields re-measured via the shared enumerate script (all digests unchanged — evidence carries over); `STAGE-STATUS.md` regenerated by `gen-claims.sh` (the gate demanded it for the count change).

### Measured (not reasoned)
- `scripts/check-wat-prelude-audit.sh` with `ALMIDE_WAT_PRELUDE_REACH=1`: **OK, 61 fns — every CORPUS/PROVEN `via` re-rendered and confirmed**.
- `make verify-trust` (full chain incl. the kernel-proven PCC checker, coqc local): **exit 0**.
- `almide test`: **384/384 files pass, 367 via WASM, 0 failed** — the five fns were unreachable from source, so zero observable behavior change (no contract ledger delta; `check-contracts.sh` OK, 249 contracts, 388/388 fixtures linked).
- `cargo test --release -p almide-mir`: **616 lib + all integration tests pass**; the six ported wasmtime-executing tests re-run directly on their emitted WAT: `valuesem → 9 2 3 1 2 3`, `fncall → 5`, `func_ref → 6`, `call_indirect → 6`, `reuse → 1 2`, `rcinc → 2` (exact expected bytes).
- `traversal_totality_lint`: pass.

Closes #1208
