### PR TITLE
Close #1296: unwrap native Bytes-result calls before applying the RcCow glue

### DIFF
--- a/crates/almide-codegen/src/walker/expressions_control.rs
+++ b/crates/almide-codegen/src/walker/expressions_control.rs
@@ -485,6 +485,31 @@ fn render_expr_unwrap(ctx: &RenderContext, expr: &IrExpr) -> String {
         };
         return render_expr(ctx, inner_expr);
     }
+    // #1296: a NATIVE-runtime call returning `Result[Bytes/Matrix, String]`
+    // unwrapped in place (`bytes.len(zlib.compress_level(d, 9)!)`): the #617
+    // glue wraps the Ok side BEFORE `?` (`(call.map(|__e| RcCow::from(__e)))?`),
+    // so in call-ARGUMENT position rustc back-infers `?`'s source from the
+    // consuming `&Vec<u8>` parameter and E0308s on the RcCow. Emit the RAW
+    // call, unwrap FIRST, then glue the Ok value — `RcCow::from((raw)?)` is
+    // concretely typed end to end, and the arg-position `&` deref-coerces.
+    // Narrow by construction: String-err only (the template's map_err
+    // variants keep their path), non-test (tests use .unwrap()).
+    if !ctx.is_test {
+        if let IrExprKind::RuntimeCall { symbol, args } = &inner.kind {
+            if rc_cow_symbol_is_native_runtime(symbol.as_str()) {
+                if let Ty::Applied(almide_lang::types::constructor::TypeConstructorId::Result, rargs) = &inner.ty {
+                    if rargs.len() == 2
+                        && rc_cow_needs_glue(&rargs[0])
+                        && matches!(rargs[1], Ty::String)
+                        && render_runtime_ctor_turbofish(ctx, symbol.as_str(), args, &inner.ty).is_none()
+                    {
+                        let raw = render_runtime_call(ctx, symbol, args);
+                        return rc_cow_result_glue(format!("({raw})?"), &rargs[0]);
+                    }
+                }
+            }
+        }
+    }
     let s = render_expr(ctx, inner);
     // In test functions, ? cannot be used (return type is ()).
     // Use .unwrap() instead.

--- a/tests/bytes_unwrap_callarg_test.rs
+++ b/tests/bytes_unwrap_callarg_test.rs
@@ -1,0 +1,61 @@
+//! #1296: a native-runtime call returning `Result[Bytes, String]` unwrapped
+//! with `!` directly in another call's ARGUMENT position emitted invalid Rust
+//! (the #617 RcCow glue wrapped the Ok side BEFORE `?`, so rustc back-inferred
+//! the `?` source from the consuming `&Vec<u8>` parameter and E0308'd). The
+//! unwrap now emits raw-call → `?` → glue, concretely typed end to end. Both
+//! measured family members (zlib and fs) are pinned end-to-end; the bind-first
+//! spelling stays the control.
+
+use std::process::Command;
+
+fn almide() -> &'static str {
+    env!("CARGO_BIN_EXE_almide")
+}
+
+fn run(dir: &std::path::Path, name: &str, source: &str) -> (String, String, bool) {
+    let file = dir.join(name);
+    std::fs::write(&file, source).expect("write fixture");
+    let out = Command::new(almide())
+        .arg("run")
+        .arg(&file)
+        .output()
+        .expect("run almide");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.success(),
+    )
+}
+
+#[test]
+fn zlib_bytes_unwrap_in_call_arg_compiles_and_runs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (stdout, stderr, ok) = run(
+        dir.path(),
+        "z.almd",
+        "import zlib\n\neffect fn main() -> Unit = {\n  let data = bytes.from_list([1])\n  let n = bytes.len(zlib.compress_level(data, 9)!)\n  println(\"${n}\")\n}\n",
+    );
+    assert!(ok, "in-arg unwrap must compile and run, stderr:\n{stderr}");
+    assert_eq!(stdout.trim(), "9", "compressed length of [1] at level 9");
+}
+
+#[test]
+fn fs_bytes_unwrap_in_call_arg_matches_bind_first() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("payload.bin");
+    let path_str = path.to_string_lossy().replace('\\', "/");
+    let inline = run(
+        dir.path(),
+        "a.almd",
+        &format!("import fs\n\neffect fn main() -> Unit = {{\n  fs.write(\"{path_str}\", \"hello\")!\n  let n = bytes.len(fs.read_bytes_raw(\"{path_str}\")!)\n  println(\"${{n}}\")\n}}\n"),
+    );
+    let bound = run(
+        dir.path(),
+        "b.almd",
+        &format!("import fs\n\neffect fn main() -> Unit = {{\n  fs.write(\"{path_str}\", \"hello\")!\n  let raw = fs.read_bytes_raw(\"{path_str}\")!\n  let n = bytes.len(raw)\n  println(\"${{n}}\")\n}}\n"),
+    );
+    assert!(inline.2, "in-arg unwrap must run, stderr:\n{}", inline.1);
+    assert!(bound.2, "bind-first control must run, stderr:\n{}", bound.1);
+    assert_eq!(inline.0, bound.0, "in-arg and bind-first must agree");
+    assert_eq!(inline.0.trim(), "5");
+}


### PR DESCRIPTION
Closes #1296 — found by the #1227 semantics-manifest measurement run: any `Result[Bytes, String]`-returning native runtime call unwrapped with `!` directly in another call's ARGUMENT position emitted invalid Rust.

## Mechanism

The #617 RcCow glue wrapped the Ok side BEFORE `?`: `(call.map(|__e| RcCow::from(__e)))?`. In argument position rustc back-infers the `?` source type from the consuming `&Vec<u8>` parameter (expected-type propagation beats autoderef), so the RcCow Ok is E0308 — while the bind-first spelling worked because the binding's concrete type let `&RcCow<T>` deref-coerce.

## Fix

The unwrap renderer special-cases a native RuntimeCall with a glue-needing Ok and String err: emit the RAW call, apply `?` FIRST, then glue the Ok value — `RcCow::from((raw_call)?)` is concretely typed end to end, and the argument `&` still deref-coerces. Narrow by construction: map_err template variants and test-mode `.unwrap()` keep their existing paths.

## Measured

- Both family members from the issue now compile and run: zlib repro prints `9`, fs variant prints `5`
- `tests/bytes_unwrap_callarg_test.rs`: both shapes end-to-end, plus **in-arg == bind-first agreement** as the control
- `almide test` 384/384; codegen tests 0 failed; **full `make verify-trust` exit 0** (kernel PCC accepted)