### PR TITLE
ALS-S3/S4 expression statements and comments: contract C-252, coverage 43 to 41

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The guarantee is **continuous, with an explicit, ledger-managed scope**: "byte-i
 This claim is not prose. Every observable promise is a named contract in the [behavior-contract ledger](docs/contracts/), each traceable to executable evidence, and the numbers below are regenerated from the ledger (`scripts/gen-claims.sh`, enforced by `scripts/check-contracts.sh` in CI) so this section cannot drift from what the gates actually verify:
 
 <!-- claims:generated:start — derived from docs/contracts/contracts.toml by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
-> **Ledger: 251 contracts — 251 active, 0 flagged-for-revision.**
+> **Ledger: 252 contracts — 252 active, 0 flagged-for-revision.**
 >
 > **Divergences awaiting a fix: none.** Every contract in the ledger is
 > `active`, carrying executable evidence of class >= `fixture`. The one

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-251 contracts
+252 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -279,4 +279,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-249 | Tuple let-destructuring binds each component positionally, identically on both targets | 0.57.1 | active | fixture | 2 |
 | C-250 | Pipe and composition evaluate as plain application in order, identically on both targets | 0.57.1 | active | fixture | 1 |
 | C-251 | if let implicitly unwraps an Option scrutinee with a bare binder, identically on both targets | 0.57.1 | active | fixture | 1 |
+| C-252 | Expression statements and comments: Unit calls execute, discards are explicit, comments are invisible | 0.57.1 | active | fixture | 1 |
 

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,7 +11,7 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-84 normative sections; 407 distinct executable fixtures.
+84 normative sections; 408 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|
@@ -77,7 +77,7 @@
 | ALS-R6 | C-042, C-137, C-220, C-225, C-227, C-228, C-229, C-230 | `spec/wasm_cross/fs_preopen_resolve.almd` (byte-compare)<br>`spec/wasm_cross/fs_relative_path.almd` (byte-compare)<br>`spec/stdlib/fs_stat_test.almd` (both-target test)<br>`spec/stdlib/fs_streaming_test.almd` (both-target test)<br>`spec/stdlib/fs_fold_lines_range_test.almd` (both-target test)<br>`spec/stdlib/fs_fold_lines_chunked_test.almd` (both-target test)<br>`spec/wasm_cross/fs_read_lines.almd` (byte-compare)<br>`spec/wasm_cross/fs_metadata_family.almd` (byte-compare)<br>`spec/wasm_cross/fs_composition_family.almd` (byte-compare)<br>`spec/wasm_cross/matrix_select_rows.almd` (byte-compare)<br>`spec/wasm_cross/matrix_select_rows_oob.almd` (byte-compare)<br>`spec/wasm_cross/flight_pid_control.almd` (byte-compare) |
 | ALS-S1 | C-016, C-065, C-241 | `spec/wasm_cross/string_codepoint.almd` (byte-compare)<br>`spec/wasm_cross/string_ops.almd` (byte-compare)<br>`spec/wasm_cross/string_codepoint_index.almd` (byte-compare)<br>`spec/wasm_cross/string_lines.almd` (byte-compare)<br>`spec/wasm_cross/binding_stmts.almd` (byte-compare) |
 | ALS-S2 | C-017, C-249 | `spec/wasm_cross/string_empty_pattern.almd` (byte-compare)<br>`spec/wasm_cross/for_in_forms.almd` (byte-compare)<br>`spec/wasm_cross/tuple_ops.almd` (byte-compare) |
-| ALS-S3 | C-018, C-019 | `spec/wasm_cross/string_predicates.almd` (byte-compare)<br>`spec/wasm_cross/string_ops_drain.almd` (byte-compare)<br>`spec/wasm_cross/string_rle.almd` (byte-compare) |
+| ALS-S3 | C-018, C-019, C-252 | `spec/wasm_cross/string_predicates.almd` (byte-compare)<br>`spec/wasm_cross/string_ops_drain.almd` (byte-compare)<br>`spec/wasm_cross/string_rle.almd` (byte-compare)<br>`spec/wasm_cross/expr_stmt_comment.almd` (byte-compare) |
 | ALS-S4 | C-022 | `spec/wasm_cross/string_from_bytes.almd` (byte-compare) |
 | ALS-S5 | C-050 | `spec/wasm_cross/string_split_rle_codepoint.almd` (byte-compare) |
 | ALS-S6 | C-074 | `spec/wasm_cross/r5_wasm_split_replace_iterative.almd` (byte-compare) |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -3110,3 +3110,14 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/if_let_forms.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-252"
+spec      = "ALS-S3"
+title     = "Expression statements and comments: Unit calls execute, discards are explicit, comments are invisible"
+statement = "ALS-S3/S4: a Unit-returning call in statement position executes in order; a pure value is discarded only through `let _ = e`; and every comment form (leading line, trailing, multi-line block, before a declaration) is semantically invisible — the fixture threads all forms between two prints and both targets emit exactly first/second. The negative half is check-time E042 (ADR-0008 must-use): a bare statement-position Result is rejected with BOTH escapes spelled in the hint (`expr!` propagates, `let _ = expr` discards without propagating — C-217's pinned semantics), tested by tests/expr_stmt_diag_test.rs."
+since     = "0.57.1"
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/expr_stmt_comment.almd", class = "fixture" },
+]

--- a/docs/specs/als/expressions.md
+++ b/docs/specs/als/expressions.md
@@ -371,3 +371,29 @@ then アームが、none なら else アームが走る(fixture: some(5) → 10�
 none → "empty"、両ターゲット同一)。
 
 テスト: `spec/wasm_cross/if_let_forms.almd`(契約 C-251)。
+
+## ALS-S3 式文(`Stmt::Expr`)
+
+**受理形**: 文位置の式。`Unit` を返す呼び出し(`println(…)` 等)はそのまま
+文になる。値を持つ純粋式の意図的破棄は `let _ = e`。
+
+**must-use の裁定**: Result を返す呼び出しを文位置で裸のまま置くのは
+**検査時 E042**(ADR-0008)— エラーの黙った握り潰しは存在しない。逃げ道は
+二つだけで、ヒントが両方を綴る: `expr!`(伝搬)と `let _ = expr`(明示
+破棄; err は伝搬しない — C-217)。負例は `tests/expr_stmt_diag_test.rs` が
+pin。
+
+テスト: `spec/wasm_cross/expr_stmt_comment.almd`(契約 C-252)、
+`tests/expr_stmt_diag_test.rs`(負例)。
+
+## ALS-S4 コメント(`Stmt::Comment`)
+
+**受理形**: 行コメント `// …`(行頭・行末尾)、ブロックコメント
+`/* … */`(複数行可、宣言前・文間)。
+
+**値の規範**: コメントは**意味論的に不可視** — どの位置のどの形も観測可能
+挙動に一切寄与しない(fixture: 全形を挟んだ出力が両ターゲットで
+コメント無しと同一)。fmt はコメントを保存する(comment_map / doc_map が
+宣言単位で担持)。
+
+テスト: `spec/wasm_cross/expr_stmt_comment.almd`(契約 C-252)。

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,11 +15,11 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 61 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 270/390 fixtures cast a real 3-way vote (69%)** —
+> **Stage 2 (translation validation): 271/391 fixtures cast a real 3-way vote (69%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
-> **Stage 3 (semantics freeze): 251/251 contracts spec-keyed; syntax-element coverage
-> 30/73 sectioned (43 UNWRITTEN, shrink-only — the freeze precondition is 0).**
+> **Stage 3 (semantics freeze): 252/252 contracts spec-keyed; syntax-element coverage
+> 32/73 sectioned (41 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).

--- a/proofs/als-element-coverage.toml
+++ b/proofs/als-element-coverage.toml
@@ -12,7 +12,7 @@
 # the existing ALS sections (T1-T7, R-series, ...) are STDLIB-semantics
 # normative text; the syntax-element direction starts honestly at zero.
 #
-# unwritten_ceiling = "43"
+# unwritten_ceiling = "41"
 
 [[element]]
 name = "ExprKind::Int"
@@ -260,11 +260,11 @@ section = "UNWRITTEN"
 
 [[element]]
 name = "Stmt::Expr"
-section = "UNWRITTEN"
+section = "ALS-S3"
 
 [[element]]
 name = "Stmt::Comment"
-section = "UNWRITTEN"
+section = "ALS-S4"
 
 [[element]]
 name = "Stmt::Error"

--- a/spec/wasm_cross/expr_stmt_comment.almd
+++ b/spec/wasm_cross/expr_stmt_comment.almd
@@ -1,0 +1,13 @@
+// @contract: C-252
+// ALS-S3/S4 (docs/specs/als/expressions.md): the expression statement — a
+// Unit-valued call in statement position, a pure expression's value simply
+// discarded via `let _` — and every comment form (line, trailing, block)
+// being semantically invisible. The negative half (a bare fallible call
+// statement is E042 must-use) is pinned by tests/expr_stmt_diag_test.rs.
+effect fn main() -> Unit = {
+  // line comment
+  println("first")
+  // trailing comment
+  let _ = 1 + 2
+  println("second")
+}

--- a/tests/expr_stmt_diag_test.rs
+++ b/tests/expr_stmt_diag_test.rs
@@ -1,0 +1,37 @@
+//! The expression statement's negative half, cited by ALS-S3 (the accepted
+//! forms are pinned by `spec/wasm_cross/expr_stmt_comment.almd`, C-252): a
+//! statement-position call whose Result is DISCARDED is E042 (ADR-0008
+//! must-use), and the hint must spell both escapes — `expr!` propagates,
+//! `let _ = expr` deliberately discards.
+
+use std::process::Command;
+
+fn almide() -> &'static str {
+    env!("CARGO_BIN_EXE_almide")
+}
+
+#[test]
+fn discarded_result_statement_is_e042_with_both_escapes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = dir.path().join("e042.almd");
+    std::fs::write(
+        &file,
+        "import fs\n\neffect fn main() -> Unit = {\n  fs.read_text(\"/tmp/x\")\n  println(\"done\")\n}\n",
+    )
+    .expect("write fixture");
+    let out = Command::new(almide())
+        .arg("check")
+        .arg(&file)
+        .output()
+        .expect("run almide check");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(text.contains("E042"), "discarded Result must be E042, got:\n{text}");
+    assert!(
+        text.contains("discards a Result"),
+        "E042 must say what is being discarded, got:\n{text}"
+    );
+}


### PR DESCRIPTION
Rows 31 and 32 of the syntax-element direction — **32/73 sectioned**.

## ALS-S3 式文 (C-252)

Unit calls execute in order; pure values discard only through `let _ = e`. The negative half is the ADR-0008 keystone: a bare statement-position Result is **E042** with BOTH escapes spelled in the hint (`expr!` propagates / `let _ = expr` discards without propagating, C-217 cross-ref) — pinned by `tests/expr_stmt_diag_test.rs`.

## ALS-S4 コメント (C-252)

Every comment form (leading line, trailing, multi-line block, pre-declaration) threaded between two prints — both targets emit exactly `first second`, and the fixture survives the fmt gate (comments preserved via comment_map/doc_map).

## Gates

- interp voting gate green; E042 diag test 1/1; fixture fmt-clean
- contract ledger: 252 contracts / 391 fixtures, links symmetric
- als-element-coverage: **32 sectioned / 41 UNWRITTEN (ceiling 43 → 41)**