### PR TITLE
ALS-S5/E22 place assignments and type ascription: contracts C-253/C-254, coverage 41 to 38

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The guarantee is **continuous, with an explicit, ledger-managed scope**: "byte-i
 This claim is not prose. Every observable promise is a named contract in the [behavior-contract ledger](docs/contracts/), each traceable to executable evidence, and the numbers below are regenerated from the ledger (`scripts/gen-claims.sh`, enforced by `scripts/check-contracts.sh` in CI) so this section cannot drift from what the gates actually verify:
 
 <!-- claims:generated:start — derived from docs/contracts/contracts.toml by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
-> **Ledger: 252 contracts — 252 active, 0 flagged-for-revision.**
+> **Ledger: 254 contracts — 254 active, 0 flagged-for-revision.**
 >
 > **Divergences awaiting a fix: none.** Every contract in the ledger is
 > `active`, carrying executable evidence of class >= `fixture`. The one

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-252 contracts
+254 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -280,4 +280,6 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-250 | Pipe and composition evaluate as plain application in order, identically on both targets | 0.57.1 | active | fixture | 1 |
 | C-251 | if let implicitly unwraps an Option scrutinee with a bare binder, identically on both targets | 0.57.1 | active | fixture | 1 |
 | C-252 | Expression statements and comments: Unit calls execute, discards are explicit, comments are invisible | 0.57.1 | active | fixture | 1 |
+| C-253 | Place assignments and type ascription behave identically on both targets | 0.57.1 | active | fixture | 1 |
+| C-254 | Type ascription supplies an expected type without changing the value on either target | 0.57.1 | active | fixture | 1 |
 

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,7 +11,7 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-84 normative sections; 408 distinct executable fixtures.
+85 normative sections; 409 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|
@@ -51,6 +51,7 @@
 | ALS-E19 | C-248 | `spec/wasm_cross/for_in_forms.almd` (byte-compare) |
 | ALS-E20 | C-250 | `spec/wasm_cross/pipe_compose_forms.almd` (byte-compare) |
 | ALS-E21 | C-251 | `spec/wasm_cross/if_let_forms.almd` (byte-compare) |
+| ALS-E22 | C-254 | `spec/wasm_cross/place_assign_ascription.almd` (byte-compare) |
 | ALS-I1 | C-041, C-066, C-071, C-086, C-121, C-122, C-130, C-149, C-146, C-159 | `spec/wasm_cross/rc_alloc_stress.almd` (byte-compare)<br>`spec/wasm_cross/host_floor_string_alloc.almd` (byte-compare)<br>`spec/wasm_cross/memory_stress.almd` (byte-compare)<br>`spec/wasm_cross/heap_arena.almd` (byte-compare)<br>`spec/wasm_cross/hof_closure_string_tail.almd` (byte-compare)<br>`spec/wasm_cross/rc_reclaim_churn.almd` (byte-compare)<br>`spec/wasm_cross/assign_alias_rc.almd` (byte-compare)<br>`spec/wasm_cross/container_alias_return.almd` (byte-compare)<br>`spec/wasm_cross/loop_outer_inplace_mutate_rc.almd` (byte-compare)<br>`spec/wasm_cross/r5_wasm_interp_alias_rc.almd` (byte-compare)<br>`spec/wasm_cross/alias_combinator_rc.almd` (byte-compare)<br>`spec/wasm_cross/string_passthrough_share.almd` (byte-compare)<br>`spec/wasm_cross/zip_view_shape.almd` (byte-compare)<br>`spec/wasm_cross/value_object_ops_share.almd` (byte-compare)<br>`spec/wasm_cross/option_unwrap_or_else_heap.almd` (byte-compare)<br>`spec/wasm_cross/map_fold_heap_acc.almd` (byte-compare)<br>`spec/wasm_cross/uoe_heap_ok_share.almd` (byte-compare)<br>`spec/wasm_cross/nested_unwrap_or_share.almd` (byte-compare)<br>`spec/wasm_cross/to_result_nested_share.almd` (byte-compare)<br>`spec/wasm_cross/to_result_custom_e.almd` (byte-compare)<br>`spec/wasm_cross/list_element_hof_chain.almd` (byte-compare)<br>`spec/wasm_cross/binary_search_duplicate_keys.almd` (byte-compare) |
 | ALS-I2 | C-040, C-059 | `spec/wasm_cross/anon_records_and_fusion.almd` (byte-compare)<br>`spec/wasm_cross/generics_mono.almd` (byte-compare)<br>`spec/wasm_cross/closures_hof.almd` (byte-compare)<br>`spec/wasm_cross/wide_function_body.almd` (byte-compare)<br>`tests/compiler_stack_test.rs` (cargo gate) |
 | ALS-I3 | C-075, C-107, C-109, C-116, C-120, C-138, C-152, C-143, C-144, C-139, C-156, C-157, C-158, C-212 | `spec/wasm_cross/r5_lowmisc_param_try_err.almd` (byte-compare)<br>`spec/wasm_cross/result_str_int_tuple.almd` (byte-compare)<br>`spec/wasm_cross/result_value_int_tuple.almd` (byte-compare)<br>`spec/wasm_cross/result_list_str_int_tuple.almd` (byte-compare)<br>`spec/wasm_cross/result_list_value_int_tuple.almd` (byte-compare)<br>`spec/wasm_cross/base64_encode.almd` (byte-compare)<br>`spec/wasm_cross/bool_literal_tail.almd` (byte-compare)<br>`spec/wasm_cross/float_parse_special.almd` (byte-compare)<br>`spec/wasm_cross/filter_map_conditional_arm.almd` (byte-compare)<br>`spec/wasm_cross/result_ctor_call_payload.almd` (byte-compare)<br>`spec/wasm_cross/result_wall_escalations.almd` (byte-compare)<br>`spec/wasm_cross/ctor_if_payload.almd` (byte-compare)<br>`spec/wasm_cross/list_element_hof_chain.almd` (byte-compare)<br>`spec/wasm_cross/result_combinators_heap_ok.almd` (byte-compare)<br>`spec/wasm_cross/opt_str_str_ctor.almd` (byte-compare)<br>`spec/wasm_cross/unannotated_toplet_generic_ctor.almd` (byte-compare)<br>`spec/wasm_cross/ctor_scalar_call_payload.almd` (byte-compare)<br>`spec/wasm_cross/hex_two_module_link.almd` (byte-compare) |
@@ -79,7 +80,7 @@
 | ALS-S2 | C-017, C-249 | `spec/wasm_cross/string_empty_pattern.almd` (byte-compare)<br>`spec/wasm_cross/for_in_forms.almd` (byte-compare)<br>`spec/wasm_cross/tuple_ops.almd` (byte-compare) |
 | ALS-S3 | C-018, C-019, C-252 | `spec/wasm_cross/string_predicates.almd` (byte-compare)<br>`spec/wasm_cross/string_ops_drain.almd` (byte-compare)<br>`spec/wasm_cross/string_rle.almd` (byte-compare)<br>`spec/wasm_cross/expr_stmt_comment.almd` (byte-compare) |
 | ALS-S4 | C-022 | `spec/wasm_cross/string_from_bytes.almd` (byte-compare) |
-| ALS-S5 | C-050 | `spec/wasm_cross/string_split_rle_codepoint.almd` (byte-compare) |
+| ALS-S5 | C-050, C-253 | `spec/wasm_cross/string_split_rle_codepoint.almd` (byte-compare)<br>`spec/wasm_cross/place_assign_ascription.almd` (byte-compare) |
 | ALS-S6 | C-074 | `spec/wasm_cross/r5_wasm_split_replace_iterative.almd` (byte-compare) |
 | ALS-T1 | C-021 | `spec/wasm_cross/string_whitespace.almd` (byte-compare) |
 | ALS-T2 | C-024, C-210 | `spec/wasm_cross/float_parse.almd` (byte-compare)<br>`spec/wasm_cross/nan_canonical_observation.almd` (byte-compare)<br>`spec/wasm_cross/nan_canonical_bytes_write.almd` (byte-compare) |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -3121,3 +3121,25 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/expr_stmt_comment.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-253"
+spec      = "ALS-S5"
+title     = "Place assignments and type ascription behave identically on both targets"
+statement = "ALS-S5/E22: list-element `xs[i] = v`, record-field `p.x = v`, and map-key `m[k] = v` (upsert: insert-if-absent, overwrite-if-present — 6 then 100 pinned) all observe the new value on the next read, byte-identical native <-> wasm (fixture pins 21/12/6/100/7); the OOB-write abort stays C-067's ruling. The type-ascription expression `(e: T)` supplies an expected type without changing the value or its runtime representation."
+since     = "0.57.1"
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/place_assign_ascription.almd", class = "fixture" },
+]
+
+[[contract]]
+id        = "C-254"
+spec      = "ALS-E22"
+title     = "Type ascription supplies an expected type without changing the value on either target"
+statement = "ALS-E22: `(e: T)` — the value is `e` unchanged ((7: Int) -> 7 pinned byte-identical), the ascription only feeds the checker's expected type and leaves the runtime representation untouched. Shares the place-assignment fixture with C-253 (the S5/E22 pair landed together)."
+since     = "0.57.1"
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/place_assign_ascription.almd", class = "fixture" },
+]

--- a/docs/specs/als/expressions.md
+++ b/docs/specs/als/expressions.md
@@ -397,3 +397,25 @@ pin。
 宣言単位で担持)。
 
 テスト: `spec/wasm_cross/expr_stmt_comment.almd`(契約 C-252)。
+
+## ALS-S5 場所代入(`Stmt::IndexAssign` / `Stmt::FieldAssign`)
+
+**受理形**: リスト要素 `xs[i] = v`、レコードフィールド `p.x = v`、マップ
+キー `m[k] = v`(存在キーは上書き、不在キーは挿入 — upsert)。対象は
+`var` 束縛(`let` への場所代入は不変性違反、ALS-S1 の E009 系)。
+
+**値の規範**: 代入後の読みは新値を観測する(fixture: 21 / 12 / 6 / 100、
+両ターゲット同一)。値意味論 — 代入は共有を通じて漏れない(COW)。**範囲外
+インデックス書きは実行時中断**(統一メッセージ + exit 1、C-067 の裁定)。
+
+テスト: `spec/wasm_cross/place_assign_ascription.almd`(契約 C-253)、
+範囲外は `spec/wasm_cross/index_bounds_write_heap.almd`(C-067)。
+
+## ALS-E22 型注釈式(`ExprKind::TypeAscription`)
+
+**受理形**: `(e: T)` — 式位置の型注釈。
+
+**値の規範**: 値は `e` のまま、型検査の期待型として `T` を供給する
+(fixture: `(7: Int)` → 7)。実行時表現に影響しない。
+
+テスト: `spec/wasm_cross/place_assign_ascription.almd`(契約 C-253)。

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,11 +15,11 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 61 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 271/391 fixtures cast a real 3-way vote (69%)** —
+> **Stage 2 (translation validation): 272/392 fixtures cast a real 3-way vote (69%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
-> **Stage 3 (semantics freeze): 252/252 contracts spec-keyed; syntax-element coverage
-> 32/73 sectioned (41 UNWRITTEN, shrink-only — the freeze precondition is 0).**
+> **Stage 3 (semantics freeze): 254/254 contracts spec-keyed; syntax-element coverage
+> 35/73 sectioned (38 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).

--- a/proofs/als-element-coverage.toml
+++ b/proofs/als-element-coverage.toml
@@ -12,7 +12,7 @@
 # the existing ALS sections (T1-T7, R-series, ...) are STDLIB-semantics
 # normative text; the syntax-element direction starts honestly at zero.
 #
-# unwritten_ceiling = "41"
+# unwritten_ceiling = "38"
 
 [[element]]
 name = "ExprKind::Int"
@@ -220,7 +220,7 @@ section = "ALS-E9"
 
 [[element]]
 name = "ExprKind::TypeAscription"
-section = "UNWRITTEN"
+section = "ALS-E22"
 
 [[element]]
 name = "ExprKind::Error"
@@ -244,11 +244,11 @@ section = "ALS-S1"
 
 [[element]]
 name = "Stmt::IndexAssign"
-section = "UNWRITTEN"
+section = "ALS-S5"
 
 [[element]]
 name = "Stmt::FieldAssign"
-section = "UNWRITTEN"
+section = "ALS-S5"
 
 [[element]]
 name = "Stmt::Guard"

--- a/spec/wasm_cross/place_assign_ascription.almd
+++ b/spec/wasm_cross/place_assign_ascription.almd
@@ -1,0 +1,23 @@
+// @contract: C-253, C-254
+// ALS-S5/E22 (docs/specs/als/expressions.md): place assignments — list
+// element `xs[i] = v`, record field `p.x = v`, map key `m[k] = v` (an
+// upsert) — and the type-ascription expression `(e: T)`. Identical
+// observables on both targets. The OOB-write abort ruling is C-067's
+// (index_bounds_write_heap.almd).
+type Pt = { x: Int, y: Int }
+
+effect fn main() -> Unit = {
+  var xs = [1, 2, 3]
+  xs[1] = 20
+  println(int.to_string(xs[0] + xs[1]))
+  var p = { x: 1, y: 2 }
+  p.x = 10
+  println(int.to_string(p.x + p.y))
+  var m = ["a": 1]
+  m["b"] = 5
+  println(int.to_string((m["a"] ?? 0) + (m["b"] ?? 0)))
+  m["a"] = 100
+  println(int.to_string(m["a"] ?? 0))
+  let t = (7: Int)
+  println(int.to_string(t))
+}


### PR DESCRIPTION
Rows 33–35 of the syntax-element direction — **35/73 sectioned, UNWRITTEN 38**.

## ALS-S5 場所代入 (C-253)

Parity `21 12 6 100 7`: list-element `xs[1] = 20`, record-field `p.x = 10`, and map-key upsert with **both halves pinned** (insert-if-absent → 6, overwrite-if-present → 100). Value semantics: assignment never leaks through sharing (COW). The OOB-write abort stays C-067's ruling, cross-referenced not duplicated.

## ALS-E22 型注釈式 (C-254)

`(e: T)` supplies the checker's expected type and leaves value + runtime representation untouched (`(7: Int)` → 7).

## Gates

- interp voting gate green (236s); fixture fmt-clean
- contract ledger: 254 contracts / 392 fixtures, links symmetric (the bidirectional gate demanded C-254 for the E22 heading before it would go green — working as designed)
- als-element-coverage: **35 sectioned / 38 UNWRITTEN (ceiling 41 → 38)**