### PR TITLE
Un-wall break/continue in scalar loop bodies on the v1 wasm leg (#1277)

### DIFF
--- a/crates/almide-mir/src/lower/control_p3_b.rs
+++ b/crates/almide-mir/src/lower/control_p3_b.rs
@@ -202,13 +202,7 @@ impl LowerCtx {
         let body_mark = self.live_heap_handles.len();
         self.in_frame += 1;
         self.scalar_loop_depth += 1;
-        let mut ok = true;
-        for stmt in body {
-            if self.lower_while_body_stmt(stmt).is_err() {
-                ok = false;
-                break;
-            }
-        }
+        let ok = self.lower_while_body_stmts(body).is_ok();
         self.scalar_loop_depth -= 1;
         self.in_frame -= 1;
 
@@ -267,6 +261,68 @@ impl LowerCtx {
             }
         }
         None
+    }
+
+    /// Lower a scalar-loop BODY as a statement LIST (#1277). Per-statement shapes
+    /// stay in [`Self::lower_while_body_stmt`]; the LIST level owns `continue`,
+    /// which is a statement-POSITION fact ("skip the REST of this iteration"):
+    ///   - a BARE `continue` statement makes the remaining statements unreachable
+    ///     in EVERY iteration — stop lowering here (the iteration close — the
+    ///     per-iteration drops, the for-range STEP, the back-edge — still runs);
+    ///   - `if c then continue else ()` restructures to the GUARDED REST
+    ///     `if (1-c) then { rest }` (the same shape `guard c else continue`
+    ///     already desugars to). NO branch op: on the continue path control falls
+    ///     THROUGH to the iteration close, so the for-range step still executes
+    ///     (a naive br-to-head would skip the step and loop forever).
+    /// A `continue` in any other position keeps the per-statement path's honest
+    /// decline → the loop attempt rolls back → the model fallback WALLS.
+    pub(crate) fn lower_while_body_stmts(&mut self, stmts: &[IrStmt]) -> Result<(), LowerError> {
+        for (k, stmt) in stmts.iter().enumerate() {
+            if let IrStmtKind::Expr { expr } = &stmt.kind {
+                if while_body_is_continue(expr) {
+                    return Ok(());
+                }
+                if let IrExprKind::If { cond, then, else_ } = &expr.kind {
+                    if while_body_is_continue(then) && while_body_is_unit(else_) {
+                        return self.lower_while_body_continue_guard(cond, &stmts[k + 1..]);
+                    }
+                }
+            }
+            self.lower_while_body_stmt(stmt)?;
+        }
+        Ok(())
+    }
+
+    /// The guarded-rest form of a conditional `continue`: capture the scalar cond,
+    /// negate it (`1 - c`, the conditional-break idiom), and run the REST of the
+    /// body inside an `IfThen` region. The rest re-enters
+    /// [`Self::lower_while_body_stmts`], so a conditional `break` inside it emits
+    /// its `LoopBreakUnless` INSIDE the `IfThen` region — the wasm render's named
+    /// `$brk` labels branch out of a nested `if`, and the BCE analysis already
+    /// tracks breaks at if-depth > 0 (they only shrink the iteration space).
+    /// Heap temps the rest allocates are dropped INSIDE the arm
+    /// (`drop_arm_locals`), so the unconditional iteration-end drops never see a
+    /// conditionally-initialized handle. Scalar reassignments in the rest keep
+    /// their loop-carried `SetLocal`-in-place discipline (`scalar_loop_depth`).
+    fn lower_while_body_continue_guard(
+        &mut self,
+        cond: &IrExpr,
+        rest: &[IrStmt],
+    ) -> Result<(), LowerError> {
+        let c = self.lower_scalar_value(cond).ok_or_else(|| {
+            LowerError::Unsupported("while conditional-continue cond".into())
+        })?;
+        let one = self.fresh_value();
+        self.ops.push(Op::ConstInt { dst: one, value: 1 });
+        let nc = self.fresh_value();
+        self.ops.push(Op::IntBinOp { dst: nc, op: IntOp::Sub, a: one, b: c });
+        self.ops.push(Op::IfThen { cond: nc, dst: None });
+        let mark = self.live_heap_handles.len();
+        self.lower_while_body_stmts(rest)?;
+        self.drop_arm_locals(mark);
+        self.ops.push(Op::Else { val: None });
+        self.ops.push(Op::EndIf { val: None });
+        Ok(())
     }
 
     fn lower_while_body_stmt(&mut self, stmt: &IrStmt) -> Result<(), LowerError> {
@@ -552,5 +608,33 @@ impl LowerCtx {
         let dst = self.fresh_value();
         self.ops.push(Op::IntBinOp { dst, op: IntOp::Sub, a: one, b: eq });
         Some(dst)
+    }
+}
+
+/// `e` is a `continue` (directly, or wrapped in a trivial one-entry Block) —
+/// the mirror of `lower_while_body_stmt`'s local `is_break`.
+fn while_body_is_continue(e: &IrExpr) -> bool {
+    match &e.kind {
+        IrExprKind::Continue => true,
+        IrExprKind::Block { stmts, expr } => {
+            (stmts.is_empty() && expr.as_deref().is_some_and(while_body_is_continue))
+                || (expr.is_none()
+                    && stmts.len() == 1
+                    && matches!(&stmts[0].kind,
+                        IrStmtKind::Expr { expr } if while_body_is_continue(expr)))
+        }
+        _ => false,
+    }
+}
+
+/// `e` is `()` (directly, or an empty/unit-tail Block) — the free-fn twin of
+/// `lower_while_body_stmt`'s local `is_unit`, reusable at the list level.
+fn while_body_is_unit(e: &IrExpr) -> bool {
+    match &e.kind {
+        IrExprKind::Unit => true,
+        IrExprKind::Block { stmts, expr } => {
+            stmts.is_empty() && expr.as_deref().map_or(true, while_body_is_unit)
+        }
+        _ => false,
     }
 }

--- a/crates/almide-mir/src/lower/desugar_loop_b.rs
+++ b/crates/almide-mir/src/lower/desugar_loop_b.rs
@@ -342,50 +342,85 @@ pub fn desugar_loop_unwrap(body: &IrExpr, next_var: &mut u32) -> Option<IrExpr> 
 
 /// BREAK elimination — rewrite the FIRST `for`/`while` loop whose body carries a `break` into
 /// the flag form: `var __bk = false` before the loop; each `break` (admitted ONLY as a WHOLE
-/// `if` arm — the shape `guard c else break` desugars to, with the iteration's remainder nested
-/// in the opposite arm, so nothing in the same iteration follows the flag-set) becomes
-/// `{ __bk = true }`; a ForIn guards its body on `not __bk` (finite iterable — the remaining
-/// no-op iterations terminate, the `desugar_loop_unwrap` precedent), a While injects
-/// `not __bk and cond` (the body holds the induction update, so a body-guard alone would spin).
-/// A `break`/`continue` anywhere else declines — the loop keeps its honest wall. Count-invariant
+/// `if` arm ON THE BODY'S TRAILING STATEMENT SPINE — the shape `guard c else break` desugars
+/// to, with the iteration's remainder nested in the opposite arm, so nothing in the same
+/// iteration follows the flag-set) becomes `{ __bk = true }`; a ForIn guards its body on
+/// `not __bk` (finite iterable — the remaining no-op iterations terminate, the
+/// `desugar_loop_unwrap` precedent), a While injects `not __bk and cond` (the body holds the
+/// induction update, so a body-guard alone would spin).
+/// The trailing-spine requirement is CHECKED, not assumed (#1277 measurement): the flag-set
+/// only defers the exit to the next loop-head test, so for a NON-trailing break
+/// (`if c then break` with statements after it) the rewrite ran the rest of the break
+/// iteration — v1 native+wasm printed a deferred-break value where v0/interp break
+/// immediately (probe `for k in 0..<10 { if k > 3 then break\n last = k }` → v1 `4`, v0 `3`).
+/// A `break`/`continue` anywhere else declines — the shape routes to the scalar-loop
+/// machinery's immediate `LoopBreakUnless`, or keeps its honest wall. Count-invariant
 /// (flag literals only), so the shared-desugar caps accounting holds.
 pub fn desugar_loop_break(body: &IrExpr, next_var: &mut u32) -> Option<IrExpr> {
     let IrExprKind::Block { stmts, expr: tail } = &body.kind else {
         return None;
     };
-    fn scan_breaks(e: &IrExpr, any: &mut bool, bad: &mut bool) {
+    /// FORBID scan for NON-TRAILING positions: any Break/Continue reachable in
+    /// `e` (outside a nested loop's own scope) is an unadmitted position.
+    fn scan_forbid(e: &IrExpr, bad: &mut bool) {
         use almide_ir::visit::{walk_expr, IrVisitor};
-        struct S<'a> {
-            any: &'a mut bool,
+        struct F<'a> {
             bad: &'a mut bool,
         }
-        impl IrVisitor for S<'_> {
+        impl IrVisitor for F<'_> {
             fn visit_expr(&mut self, e: &IrExpr) {
                 match &e.kind {
-                    // A whole-arm break is consumed by the rewrite WITHOUT descending, so a
-                    // visit reaching a BARE Break/Continue here is an unadmitted position.
-                    IrExprKind::If { cond, then, else_ } => {
-                        self.visit_expr(cond);
-                        for arm in [then, else_] {
-                            if matches!(&arm.kind, IrExprKind::Break) {
-                                *self.any = true;
-                            } else {
-                                self.visit_expr(arm);
-                            }
-                        }
-                    }
                     IrExprKind::Break | IrExprKind::Continue => *self.bad = true,
                     IrExprKind::ForIn { .. } | IrExprKind::While { .. } => {} // own scope
                     _ => walk_expr(self, e),
                 }
             }
         }
-        S { any, bad }.visit_expr(e);
+        F { bad }.visit_expr(e);
+    }
+    fn scan_forbid_stmts(stmts: &[IrStmt], bad: &mut bool) {
+        let blk = loop_uw_node(IrExprKind::Block { stmts: stmts.to_vec(), expr: None }, Ty::Unit);
+        scan_forbid(&blk, bad);
+    }
+    /// TRAILING-SPINE scan: a BARE `break` as a WHOLE `if` arm is admissible
+    /// (`any`); statements BEFORE the spine position, `if` conditions, and any
+    /// other Break/Continue shape (a bare statement break, a block-wrapped arm
+    /// break — `rewrite_breaks` only fixes whole arms) mark `bad`.
+    fn scan_trailing(e: &IrExpr, any: &mut bool, bad: &mut bool) {
+        match &e.kind {
+            IrExprKind::If { cond, then, else_ } => {
+                scan_forbid(cond, bad);
+                for arm in [then, else_] {
+                    if matches!(&arm.kind, IrExprKind::Break) {
+                        *any = true;
+                    } else {
+                        scan_trailing(arm, any, bad);
+                    }
+                }
+            }
+            IrExprKind::Block { stmts, expr } => match expr.as_deref() {
+                Some(t) => {
+                    scan_forbid_stmts(stmts, bad);
+                    scan_trailing(t, any, bad);
+                }
+                None => scan_trailing_stmts(stmts, any, bad),
+            },
+            IrExprKind::ForIn { .. } | IrExprKind::While { .. } => {} // own scope
+            IrExprKind::Break | IrExprKind::Continue => *bad = true,
+            _ => scan_forbid(e, bad),
+        }
+    }
+    fn scan_trailing_stmts(stmts: &[IrStmt], any: &mut bool, bad: &mut bool) {
+        let Some((last, init)) = stmts.split_last() else { return };
+        scan_forbid_stmts(init, bad);
+        match &last.kind {
+            IrStmtKind::Expr { expr } => scan_trailing(expr, any, bad),
+            _ => scan_forbid_stmts(std::slice::from_ref(last), bad),
+        }
     }
     let has_admissible_break = |lbody: &[IrStmt]| -> Option<bool> {
-        let blk = loop_uw_node(IrExprKind::Block { stmts: lbody.to_vec(), expr: None }, Ty::Unit);
         let (mut any, mut bad) = (false, false);
-        scan_breaks(&blk, &mut any, &mut bad);
+        scan_trailing_stmts(lbody, &mut any, &mut bad);
         if bad {
             return None; // unadmitted break/continue position — decline the whole pass
         }

--- a/crates/almide-mir/src/lower/scalar_for.rs
+++ b/crates/almide-mir/src/lower/scalar_for.rs
@@ -16,7 +16,10 @@ impl LowerCtx {
     /// ONCE before the loop (v0 builds the range once). Restricted to the runnable subset:
     /// a LITERAL `start` (so the index local is a fresh, distinct `ConstInt` — safe to
     /// mutate, never aliasing a caller value), a scalar-lowerable `end`, an Int loop var
-    /// (no tuple), no `break`/`continue`, and a heap-reassign-free body (the
+    /// (no tuple), `break`/`continue` only in the statement positions
+    /// [`LowerCtx::lower_while_body_stmts`] recognizes (a conditional `continue`
+    /// becomes the guarded rest, so the implicit STEP below still runs on the
+    /// continue path — #1277), and a heap-reassign-free body (the
     /// `scalar_loop_depth` rule errors otherwise). Returns false (rolled back) when out of
     /// subset; `lower_for_in` then falls back to its sound model-one-iteration form.
     pub(crate) fn try_lower_scalar_for_range(
@@ -72,16 +75,15 @@ impl LowerCtx {
         let body_mark = self.live_heap_handles.len();
         self.in_frame += 1;
         self.scalar_loop_depth += 1;
-        let mut ok = true;
-        for stmt in body {
-            if let Err(e) = self.lower_while_body_stmt(stmt) {
+        let ok = match self.lower_while_body_stmts(body) {
+            Ok(()) => true,
+            Err(e) => {
                 crate::trace::trace("ALMIDE_DBG_ELEM", || {
                     format!("[for-range] body stmt declined: {e:?}")
                 });
-                ok = false;
-                break;
+                false
             }
-        }
+        };
         self.scalar_loop_depth -= 1;
         self.in_frame -= 1;
         if !ok {
@@ -115,7 +117,9 @@ impl LowerCtx {
     /// (`drop_arm_locals`), the markers no-op in the cert (it verifies ONE balanced iteration), the
     /// `i < len` guard runs the body the REAL number of times (0 for an empty list — closing the
     /// model-one-iteration bug that ran a heap-element body ONCE on a garbage handle). GATED to a
-    /// `List[scalar]` / heap-element list, a matching loop-var type, no tuple/break/continue.
+    /// `List[scalar]` / heap-element list, a matching loop-var type, no tuple;
+    /// `break`/`continue` only in the statement positions
+    /// [`LowerCtx::lower_while_body_stmts`] recognizes (#1277).
     pub(crate) fn try_lower_scalar_for_list(
         &mut self,
         var: VarId,
@@ -467,13 +471,7 @@ impl LowerCtx {
         let body_mark = self.live_heap_handles.len();
         self.in_frame += 1;
         self.scalar_loop_depth += 1;
-        let mut ok = true;
-        for stmt in body {
-            if self.lower_while_body_stmt(stmt).is_err() {
-                ok = false;
-                break;
-            }
-        }
+        let ok = self.lower_while_body_stmts(body).is_ok();
         self.scalar_loop_depth -= 1;
         self.in_frame -= 1;
         if !ok {

--- a/crates/almide-mir/src/render_wasm/tests_part5_c.rs
+++ b/crates/almide-mir/src/render_wasm/tests_part5_c.rs
@@ -674,3 +674,97 @@ fn heap_and_fn_captures_execute_and_free_via_drop_closure() {
         assert_eq!(out, "Hello, world\n20\n108");
     }
 }
+
+#[test]
+fn while_continue_break_executes_on_wasmtime() {
+    // #1277: `continue` in a scalar while body lowers as the GUARDED REST
+    // (`if (1-c) then { rest }` — no branch op), and the conditional `break`
+    // inside that rest emits its `LoopBreakUnless` INSIDE the `IfThen` region
+    // (named `$brk` labels branch out of a nested wasm `if`). Byte-matches v0:
+    // s = 1+2+4+5+6 = 18 (i=3 skipped by continue), i = 7 (break before s += 7).
+    let src = "effect fn main() -> Unit = {\n\
+        var i = 0\n\
+        var s = 0\n\
+        while i < 10 {\n\
+          i = i + 1\n\
+          if i == 3 then continue\n\
+          if i > 6 then break\n\
+          s = s + i\n\
+        }\n\
+        println(int.to_string(s))\n\
+        println(int.to_string(i)) }\n";
+    let prog = lower_source(src);
+    assert!(
+        prog.functions.iter().any(|f| f.name == "main"),
+        "the scalar-loop machinery must admit the #1277 repro (continue = guarded rest)"
+    );
+    if let Some(out) = build_and_run("while_continue_break", &render_wasm_program(&prog)) {
+        assert_eq!(out, "18\n7");
+    }
+}
+
+#[test]
+fn for_range_continue_still_steps_on_wasmtime() {
+    // #1277: `continue` in a for-range body must still run the implicit index
+    // STEP (the step is emitted after the body; the guarded-rest form falls
+    // through to it — a br-to-head would skip it and loop forever).
+    // acc = 0+1+3+4 = 8 (j=2 skipped).
+    let src = "effect fn main() -> Unit = {\n\
+        var acc = 0\n\
+        for j in 0..<5 {\n\
+          if j == 2 then continue\n\
+          acc = acc + j\n\
+        }\n\
+        println(int.to_string(acc)) }\n";
+    let prog = lower_source(src);
+    assert!(prog.functions.iter().any(|f| f.name == "main"));
+    if let Some(out) = build_and_run("for_range_continue", &render_wasm_program(&prog)) {
+        assert_eq!(out, "8");
+    }
+}
+
+#[test]
+fn mid_body_break_is_immediate_on_wasmtime() {
+    // Pins the `desugar_loop_break` positional tightening (#1277 measurement):
+    // a NON-trailing `if c then break` must break IMMEDIATELY (v0/interp
+    // semantics — `last` stays 3), not defer past the rest of the iteration
+    // (the old flag rewrite printed 4). The shape now routes to the scalar
+    // machinery's `LoopBreakUnless` at the statement position.
+    let src = "effect fn main() -> Unit = {\n\
+        var last = 0\n\
+        for k in 0..<10 {\n\
+          if k > 3 then break\n\
+          last = k\n\
+        }\n\
+        println(int.to_string(last)) }\n";
+    let prog = lower_source(src);
+    assert!(prog.functions.iter().any(|f| f.name == "main"));
+    if let Some(out) = build_and_run("mid_body_break_immediate", &render_wasm_program(&prog)) {
+        assert_eq!(out, "3");
+    }
+}
+
+#[test]
+fn continue_outside_recognized_positions_still_walls() {
+    // #1277 scope pin: a `continue` with statements BEFORE it inside the arm is
+    // NOT in the guarded-rest subset — the scalar attempt declines and the
+    // model-one-iteration fallback keeps the LOUD wall (no wrong value). The
+    // walled `main` is absent from the lowered program.
+    let src = "effect fn main() -> Unit = {\n\
+        var i = 0\n\
+        var s = 0\n\
+        while i < 5 {\n\
+          i = i + 1\n\
+          if i == 2 then {\n\
+            s = s + 100\n\
+            continue\n\
+          }\n\
+          s = s + i\n\
+        }\n\
+        println(int.to_string(s)) }\n";
+    let prog = lower_source(src);
+    assert!(
+        !prog.functions.iter().any(|f| f.name == "main"),
+        "a continue outside the recognized statement positions must keep the honest wall"
+    );
+}

--- a/spec/lang/loop_break_continue_test.almd
+++ b/spec/lang/loop_break_continue_test.almd
@@ -1,0 +1,132 @@
+// Statement-position break/continue in loop bodies (#1277).
+// `continue` lowers as the guarded rest (the same restructure `guard … else
+// continue` desugars to), so the for-range STEP still runs on the continue
+// path; a mid-body `break` exits IMMEDIATELY — statements after it in the
+// same iteration must NOT run (the deferred-break flag form is positionally
+// gated to the trailing statement spine).
+// ── the #1277 repro shape: continue + break in one while body ──
+fn while_continue_break() -> Int = {
+  var i = 0
+  var s = 0
+  while i < 10 {
+    i = i + 1
+    if i == 3 then continue
+    else ()
+    if i > 6 then break
+    else ()
+    s = s + i
+  }
+  s * 100 + i
+}
+
+test "while continue+break (issue #1277 repro)" {
+  // s = 1+2+4+5+6 = 18 (i=3 skipped), i = 7 (break before s += 7)
+  assert_eq(while_continue_break(), 1807)
+}
+
+// ── while: mid-body break is immediate ──
+fn while_break_immediate() -> Int = {
+  var i = 0
+  var s = 0
+  while i < 100 {
+    i = i + 1
+    if i > 6 then break
+    else ()
+    s = s + i
+  }
+  s * 100 + i
+}
+
+test "while mid-body break skips the rest of the iteration" {
+  // s = 1+..+6 = 21, i = 7
+  assert_eq(while_break_immediate(), 2107)
+}
+
+// ── for-range: continue must still run the index step ──
+fn for_range_continue() -> Int = {
+  var acc = 0
+  for j in 0..<5 {
+    if j == 2 then continue
+    else ()
+    acc = acc + j
+  }
+  acc
+}
+
+test "for-range continue still steps" {
+  assert_eq(for_range_continue(), 8)
+}
+
+// ── for-range: mid-body break is immediate ──
+fn for_range_break_immediate() -> Int = {
+  var last = 0
+  for k in 0..<10 {
+    if k > 3 then break
+    else ()
+    last = k
+  }
+  last
+}
+
+test "for-range mid-body break skips the rest of the iteration" {
+  assert_eq(for_range_break_immediate(), 3)
+}
+
+// ── for over a list: continue ──
+fn for_list_continue() -> Int = {
+  var acc = 0
+  for x in [1, 2, 3, 4] {
+    if x == 2 then continue
+    else ()
+    acc = acc + x
+  }
+  acc
+}
+
+test "for-list continue" {
+  assert_eq(for_list_continue(), 8)
+}
+
+// ── nested: inner while carries both continue and break ──
+fn nested_continue_break() -> Int = {
+  var total = 0
+  for _k in 0..<3 {
+    var m = 0
+    while m < 10 {
+      m = m + 1
+      if m == 2 then continue
+      else ()
+      if m > 4 then break
+      else ()
+      total = total + m
+    }
+  }
+  total
+}
+
+test "nested loops: inner continue+break" {
+  // inner sum per outer pass = 1+3+4 = 8; three passes = 24
+  assert_eq(nested_continue_break(), 24)
+}
+
+// ── interleaved continues around a break ──
+fn interleaved() -> Int = {
+  var s = 0
+  var n = 0
+  while n < 20 {
+    n = n + 1
+    if n % 2 == 0 then continue
+    else ()
+    if n > 10 then break
+    else ()
+    if n % 3 == 0 then continue
+    else ()
+    s = s + n
+  }
+  s * 100 + n
+}
+
+test "interleaved continue/break/continue" {
+  // odd n up to 10, minus multiples of 3: 1+5+7 = 13; break at n=11
+  assert_eq(interleaved(), 1311)
+}


### PR DESCRIPTION
Fixes #1277: the v1 wasm renderer walled on `break`/`continue` in loop bodies. Two changes, both measured on BOTH targets byte-for-byte.

## 1. `continue` lowers as the guarded rest (no new Op)

`lower_while_body_stmts` (new, list-level) handles statement-position `continue` in the scalar-loop machinery: `if c then continue else ()` restructures to `IfThen(1-c) { rest } Else EndIf` — the same restructure `guard c else continue` already gets from `rewrite_guard_stmt_list`. No branch op: the continue path falls through to the iteration close, so the for-range STEP still runs (a br-to-head would have skipped it and spun). A conditional `break` inside the guarded rest emits its `LoopBreakUnless` inside the `IfThen` region (named `$brk` labels; the BCE scan already tracks if-depth breaks). Heap temps in the rest drop inside the arm. Wired into `try_lower_scalar_while`, `try_lower_scalar_for_range`, and `run_scalar_loop_body` (for-list/for-map). `continue` in any other position keeps the loud wall (pinned by test).

## 2. Found + fixed a live wrong-value: `desugar_loop_break` over-admission

While measuring the baseline I found the flag rewrite admitted `if c then break` at ANY statement position, but its soundness argument ("nothing in the same iteration follows the flag-set") only holds on the trailing statement spine. Measured divergence: `for k in 0..<10 { if k > 3 then break\n last = k }` printed **4 on v1 native AND wasm** (deferred break — `last = k` ran in the break iteration) vs **3 on v0 `--target rust` emission and the interp** (immediate). The 2-way gate was blind because `almide run` native prefers the v1 render — both legs shared the bug. The admission scan is now positional (trailing spine only); non-trailing breaks route to the scalar machinery's immediate `LoopBreakUnless`.

## Measured

- Issue repro: native `18\n7`, wasm `18\n7` (was: wall). Byte-identical.
- Mid-body for-range break probe: native `3`, wasm `3` (was: v1 both-legs `4`, v0 `3`).
- Edge probes (list-loop continue, heap temp println in guarded rest, bare continue, nested inner while continue+break inside for, interleaved continue/break/continue): byte-identical native vs wasm, values hand-checked.
- Unrecognized-position continue (statements before it in the arm): still walls loudly, native 113 (pinned by `continue_outside_recognized_positions_still_walls`).
- `cargo test -p almide-mir --release`: 620 lib + all harnesses, 0 failed (4 new tests included).
- `almide test`: 389 files — 372 via WASM, 17 via native fallback, 0 failed. New `spec/lang/loop_break_continue_test.almd` runs via WASM.
- `proofs/check-wasm-fallback.sh`: RATCHET OK, 17 fallback files, zero stale / zero new — no baseline delta (none of the ledgered walls were break/continue-blocked).
- `make verify-trust`: exit 0 — kernel-proven PCC checker ACCEPTs all four witness sets (ownership 53012 heap objects, names 7002, caps 1776, caps-transitive 148); WALL totality over 6377 corpus fns; claims/axiom gates OK.
- `cargo test --release --test traversal_totality_lint`: ok.

## Follow-ups (main session owns)

- `spec/wasm_cross/` parity fixture + `C-NNN` contract row for statement-position break/continue (the fixture needs the contract row this PR must not add). The ExprKind::Break/Continue ALS coverage rows can now be written.
- Consider a contract/regression note for the `desugar_loop_break` deferred-break class (v1-both-legs-agree divergences are invisible to the 2-way gate; the interp would have dissented had a fixture existed).