### PR TITLE
Link the six Fan rows to ALS-R3 with the accepted-forms paragraph, coverage 33 to 27

### DIFF
--- a/docs/specs/als/runtime.md
+++ b/docs/specs/als/runtime.md
@@ -25,6 +25,19 @@ Contracts: C-008, C-009, C-010, C-011。
 
 ## ALS-R3 fan 並行コンビネータの決定性
 
+**受理形**(構文要素方向: `ExprKind::Fan` / `FanBounded` / `FanRace` /
+`FanRaceMap` / `FanSettle` / `FanTimeout`): リスト形 `fan.map(xs, (x) =>
+…)`・`fan.bounded(n, xs, f)`、ブロック形 `fan.any { a(); b() }` /
+`fan.settle { … }`。全形が **effect fn 文脈必須**。`fan.map` の mapper は
+**Result を返す契約**(裸の値は検査時拒否、`(x) => ok(…)` へ誘導 —
+any/settle の thunk は auto-wrap、map の mapper はしない)。
+`fan.settle { a; b }` の返りは **Result のタプル**(要素数 = thunk 数)。
+`fan.race`(0.42.0 で削除 — 決定モデル下では `thunks[0]()` と同値で、名前
+だけが壁時計レースを騙っていた)と `fan.timeout`(0.29.0 で削除)は
+**存在しない** — どちらも検査時 E027 tombstone(C-004 の裁定)。AST 上の
+`FanRace` / `FanRaceMap` / `FanTimeout` ノードはこの tombstone 診断の
+担い手としてのみ残る。
+
 `fan.race`・`fan.any`・`fan.map`・`fan.settle` の結果は**リスト順で決定的**
 （最初に完了したものではなく、引数リストの先頭から評価した最初の該当）。
 エラーは ALS-R1 の統一 abort 形で表面化する。`fan.timeout` は言語に**存在

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -19,7 +19,7 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
 > **Stage 3 (semantics freeze): 256/256 contracts spec-keyed; syntax-element coverage
-> 40/73 sectioned (33 UNWRITTEN, shrink-only — the freeze precondition is 0).**
+> 46/73 sectioned (27 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).

--- a/proofs/als-element-coverage.toml
+++ b/proofs/als-element-coverage.toml
@@ -12,7 +12,7 @@
 # the existing ALS sections (T1-T7, R-series, ...) are STDLIB-semantics
 # normative text; the syntax-element direction starts honestly at zero.
 #
-# unwritten_ceiling = "33"
+# unwritten_ceiling = "27"
 
 [[element]]
 name = "ExprKind::Int"
@@ -104,27 +104,27 @@ section = "ALS-E14"
 
 [[element]]
 name = "ExprKind::Fan"
-section = "UNWRITTEN"
+section = "ALS-R3"
 
 [[element]]
 name = "ExprKind::FanBounded"
-section = "UNWRITTEN"
+section = "ALS-R3"
 
 [[element]]
 name = "ExprKind::FanRace"
-section = "UNWRITTEN"
+section = "ALS-R3"
 
 [[element]]
 name = "ExprKind::FanRaceMap"
-section = "UNWRITTEN"
+section = "ALS-R3"
 
 [[element]]
 name = "ExprKind::FanTimeout"
-section = "UNWRITTEN"
+section = "ALS-R3"
 
 [[element]]
 name = "ExprKind::FanSettle"
-section = "UNWRITTEN"
+section = "ALS-R3"
 
 [[element]]
 name = "ExprKind::ForIn"


### PR DESCRIPTION
Rows 41–46 of the syntax-element direction — **46/73 sectioned, UNWRITTEN 27**. The biggest single burn of the sweep, and a documentation-only unit: the evidence already existed.

## What this is

ALS-R3 (fan determinism) already carried the value norms and contracts C-004/005/006 with four spec/wasm_cross fixtures — what it lacked was the syntax-element half. This adds the 受理形 paragraph (measured, not assumed):

- list forms `fan.map(xs, (x) => …)` / `fan.bounded(n, xs, f)`; block forms `fan.any { }` / `fan.settle { }`; all require an effect-fn context
- **`fan.map` mappers must return Result** (bare values are a check-time rejection steering to `(x) => ok(…)` — any/settle thunks auto-wrap, map mappers do not; measured this session)
- **`fan.settle` returns a TUPLE of Results** (arity = thunk count; measured — the CHEATSHEET's "List[Result]" line is stale, noted below)
- `fan.race` (0.42.0) and `fan.timeout` (0.29.0) are E027 tombstones per C-004's ruling — the FanRace/FanRaceMap/FanTimeout AST nodes remain solely as the tombstone diagnostic's carriers, which is exactly why their rows section to R3

## Followup noted

docs/CHEATSHEET.md still says `fan.settle` → `List[Result[T, String]]` — stale vs the measured tuple return; will fix with the next docs pass.