### PR TITLE
ALS-D1 declarations: fixture, contract C-260, coverage 20 to 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The guarantee is **continuous, with an explicit, ledger-managed scope**: "byte-i
 This claim is not prose. Every observable promise is a named contract in the [behavior-contract ledger](docs/contracts/), each traceable to executable evidence, and the numbers below are regenerated from the ledger (`scripts/gen-claims.sh`, enforced by `scripts/check-contracts.sh` in CI) so this section cannot drift from what the gates actually verify:
 
 <!-- claims:generated:start — derived from docs/contracts/contracts.toml by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
-> **Ledger: 259 contracts — 259 active, 0 flagged-for-revision.**
+> **Ledger: 260 contracts — 260 active, 0 flagged-for-revision.**
 >
 > **Divergences awaiting a fix: none.** Every contract in the ledger is
 > `active`, carrying executable evidence of class >= `fixture`. The one

--- a/crates/almide-interp/interp-abstain-ledger.txt
+++ b/crates/almide-interp/interp-abstain-ledger.txt
@@ -26,6 +26,7 @@ compound_eq  out-of-interp-scope capability: prim.handle
 compound_repr_interp  out-of-interp-scope capability: prim.handle
 compound_repr_records_interp  out-of-interp-scope capability: prim.handle
 datetime_format  out-of-interp-scope capability: prim.alloc_str
+declaration_forms  out-of-interp-scope capability: prim.handle
 effect_tuple_result_tco  out-of-interp-scope capability: prim.alloc_value
 empty_collection_annotated  out-of-interp-scope capability: prim.alloc_set
 empty_collection_fold  out-of-interp-scope capability: prim.alloc_map

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-259 contracts
+260 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -287,4 +287,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-257 | The scalar error operators evaluate identically on both targets | 0.57.1 | active | fixture | 1 |
 | C-258 | Named calls and lambdas evaluate identically on both targets | 0.57.1 | active | fixture | 1 |
 | C-259 | Variant constructor references build values eliminated identically by match on both targets | 0.57.1 | active | fixture | 1 |
+| C-260 | The declaration family compiles and runs identically on both targets | 0.57.1 | active | fixture | 1 |
 

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,7 +11,7 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-90 normative sections; 413 distinct executable fixtures.
+90 normative sections; 414 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|
@@ -25,7 +25,7 @@
 | ALS-C8 | C-038 | `spec/wasm_cross/sized_int_record_fields.almd` (byte-compare)<br>`spec/wasm_cross/sized_numeric_literals.almd` (byte-compare) |
 | ALS-C9 | C-053, C-055 | `spec/wasm_cross/list_total_order.almd` (byte-compare)<br>`spec/wasm_cross/list_float_total_order.almd` (byte-compare)<br>`spec/wasm_cross/sort_by_call_count.almd` (byte-compare) |
 | ALS-C10 | C-052, C-058 | `spec/wasm_cross/empty_collection_fold.almd` (byte-compare)<br>`spec/wasm_cross/empty_collection_annotated.almd` (byte-compare)<br>`tests/diagnostics/e018-empty-collection-element/broken.almd` (checker) |
-| ALS-D1 | C-031, C-202, C-203 | `spec/wasm_cross/json_path_edges.almd` (byte-compare)<br>`spec/wasm_cross/json_value.almd` (byte-compare)<br>`spec/wasm_cross/time_negative_trap.almd` (byte-compare)<br>`spec/wasm_cross/time_negative_scale.almd` (byte-compare)<br>`spec/wasm_cross/time_saturate.almd` (byte-compare)<br>`spec/wasm_cross/time_ops_algebra.almd` (byte-compare) |
+| ALS-D1 | C-031, C-202, C-203, C-260 | `spec/wasm_cross/json_path_edges.almd` (byte-compare)<br>`spec/wasm_cross/json_value.almd` (byte-compare)<br>`spec/wasm_cross/time_negative_trap.almd` (byte-compare)<br>`spec/wasm_cross/time_negative_scale.almd` (byte-compare)<br>`spec/wasm_cross/time_saturate.almd` (byte-compare)<br>`spec/wasm_cross/time_ops_algebra.almd` (byte-compare)<br>`spec/wasm_cross/declaration_forms.almd` (byte-compare) |
 | ALS-D2 | C-060, C-204, C-207 | `spec/wasm_cross/value_repr.almd` (byte-compare)<br>`spec/wasm_cross/fuel_bounded_boundary.almd` (byte-compare)<br>`spec/wasm_cross/fuel_block_body.almd` (byte-compare)<br>`spec/wasm_cross/fuel_bare_result.almd` (byte-compare)<br>`spec/wasm_cross/fuel_divergence_cut.almd` (byte-compare)<br>`spec/wasm_cross/fuel_dyn_charge.almd` (byte-compare)<br>`spec/wasm_cross/fuel_var_budget.almd` (byte-compare) |
 | ALS-D3 | C-063, C-205 | `spec/wasm_cross/json_gltf_walk.almd` (byte-compare)<br>`spec/wasm_cross/fuel_race_boundary.almd` (byte-compare)<br>`spec/wasm_cross/fuel_race_err_skip.almd` (byte-compare)<br>`spec/wasm_cross/fuel_bare_result.almd` (byte-compare)<br>`spec/wasm_cross/fuel_trap_cut.almd` (byte-compare)<br>`spec/wasm_cross/fuel_trap_window.almd` (byte-compare)<br>`spec/wasm_cross/fan_race_mapper.almd` (byte-compare) |
 | ALS-D4 | C-032, C-160, C-206 | `spec/wasm_cross/regex_engine.almd` (byte-compare)<br>`spec/wasm_cross/regex_fuzz_batch.almd` (byte-compare)<br>`spec/wasm_cross/bundled_pure_modules.almd` (byte-compare)<br>`spec/wasm_cross/fan_settle_tuple.almd` (byte-compare) |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -3198,3 +3198,14 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/call_lambda_ctor.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-260"
+spec      = "ALS-D1"
+title     = "The declaration family compiles and runs identically on both targets"
+statement = "ALS-D1: one program threading the declaration family — explicit import (json parse -> stringify round-trip prints [1,2]), a variant type declaration eliminated by match, top-level lets (Int and String) read from a fn body, fn and effect-fn declarations — byte-identical native <-> wasm (fixture pins 300/hi/careful/[1,2]). Protocol resolution stays with C-094/C-126; test blocks are evidenced by the whole spec/lang suite running its wasm leg. The `module` header's execution evidence is the spec/integration/modules suite (a fmt-gated fixture cannot carry one while #1323's comment-reorder bug stands). `strict` is deliberately OUTSIDE: parsed but consumed by nothing (#1321), its row stays UNWRITTEN."
+since     = "0.57.1"
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/declaration_forms.almd", class = "fixture" },
+]

--- a/docs/specs/als/expressions.md
+++ b/docs/specs/als/expressions.md
@@ -497,3 +497,26 @@ E004。
 match の網羅性は ALS-E18(E010)。
 
 テスト: `spec/wasm_cross/call_lambda_ctor.almd`(契約 C-259)。
+
+## ALS-D1 宣言(`Decl::Module` / `Decl::Import` / `Decl::Type` / `Decl::Fn` / `Decl::TopLet` / `Decl::Protocol` / `Decl::Test` / `Decl::TestWhereDef`)
+
+**受理形**: `module name`(先頭、任意)/ `import mod`(自動 import 外の
+stdlib と外部パッケージに必須 — ALS の import 規範は module-system spec)/
+`type T = Case | Case(payload)` と `type T = { fields }` / `fn f(…) -> T =
+…`・`effect fn …` / トップレベル `let NAME = value`(fn 本体から参照可)/
+`protocol P { fn sig }` と `fn T.method(…)` 実装 / `test "name" { … }`
+ブロックと `local test where` / `mod test where` 定義。
+
+**値の規範**: fixture が import(json の parse→stringify 往復)・variant
+型・トップ let(Int/String)・fn/effect fn を一本で貫き、両ターゲット同一
+(300 / hi / careful / [1,2])。`module` ヘッダの実行 evidence は
+`spec/integration/modules/` 群(実 module ヘッダで CI 毎回実行; fixture に
+置けないのは fmt の並べ替えバグ #1323 のため — fmt(valid)→invalid 族)。protocol の解決規範は既存契約
+C-094/C-126(`protocol_ufcs_inferred_lambda.almd`)が pin。test ブロックは
+`almide test` の wasm レグで常時実行される(spec/lang 全域が evidence;
+`test where` は `spec/lang/test_where_test.almd`)。
+
+**Strict は未節化**: `strict <mode>` は受理されるが現状どの層も消費しない
+(#1321 — accept-and-ignored)。裁定が下るまで UNWRITTEN 維持。
+
+テスト: `spec/wasm_cross/declaration_forms.almd`(契約 C-260)。

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,7 +15,7 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 61 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 277/397 fixtures cast a real 3-way vote (69%)** —
+> **Stage 2 (translation validation): 276/397 fixtures cast a real 3-way vote (69%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
 > **Stage 3 (semantics freeze): 260/260 contracts spec-keyed; syntax-element coverage

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,11 +15,11 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 61 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 276/396 fixtures cast a real 3-way vote (69%)** —
+> **Stage 2 (translation validation): 277/397 fixtures cast a real 3-way vote (69%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
-> **Stage 3 (semantics freeze): 259/259 contracts spec-keyed; syntax-element coverage
-> 53/73 sectioned (20 UNWRITTEN, shrink-only — the freeze precondition is 0).**
+> **Stage 3 (semantics freeze): 260/260 contracts spec-keyed; syntax-element coverage
+> 61/73 sectioned (12 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).

--- a/proofs/als-element-coverage.toml
+++ b/proofs/als-element-coverage.toml
@@ -12,7 +12,7 @@
 # the existing ALS sections (T1-T7, R-series, ...) are STDLIB-semantics
 # normative text; the syntax-element direction starts honestly at zero.
 #
-# unwritten_ceiling = "20"
+# unwritten_ceiling = "12"
 
 [[element]]
 name = "ExprKind::Int"
@@ -272,27 +272,27 @@ section = "UNWRITTEN"
 
 [[element]]
 name = "Decl::Module"
-section = "UNWRITTEN"
+section = "ALS-D1"
 
 [[element]]
 name = "Decl::Import"
-section = "UNWRITTEN"
+section = "ALS-D1"
 
 [[element]]
 name = "Decl::Type"
-section = "UNWRITTEN"
+section = "ALS-D1"
 
 [[element]]
 name = "Decl::Fn"
-section = "UNWRITTEN"
+section = "ALS-D1"
 
 [[element]]
 name = "Decl::TopLet"
-section = "UNWRITTEN"
+section = "ALS-D1"
 
 [[element]]
 name = "Decl::Protocol"
-section = "UNWRITTEN"
+section = "ALS-D1"
 
 [[element]]
 name = "Decl::Strict"
@@ -300,8 +300,8 @@ section = "UNWRITTEN"
 
 [[element]]
 name = "Decl::Test"
-section = "UNWRITTEN"
+section = "ALS-D1"
 
 [[element]]
 name = "Decl::TestWhereDef"
-section = "UNWRITTEN"
+section = "ALS-D1"

--- a/spec/wasm_cross/declaration_forms.almd
+++ b/spec/wasm_cross/declaration_forms.almd
@@ -1,0 +1,31 @@
+// @contract: C-260
+// ALS-D1 (docs/specs/als/expressions.md): the declaration family in one
+// program — explicit import (json parse/stringify round-trip), a variant
+// type declaration, top-level lets (Int and String) read from a fn body,
+// fn and effect-fn declarations. Identical observables on both targets.
+// The `module` header is deliberately absent: fmt reorders a leading
+// comment block above it into unparseable output (#1323), so a fmt-gated
+// fixture cannot carry one — the Module row's evidence is the
+// spec/integration/modules/ suite (real module headers, run every CI).
+import json
+
+type Mode = | Fast | Careful
+
+let LIMIT = 100
+
+let GREETING = "hi"
+
+fn scaled(x: Int) -> Int = x * LIMIT
+
+fn describe(m: Mode) -> String = match m {
+  Fast => "fast",
+  Careful => "careful",
+}
+
+effect fn main() -> Unit = {
+  println(int.to_string(scaled(3)))
+  println(GREETING)
+  println(describe(Careful))
+  let s = json.stringify(json.parse("[1,2]") ?? json.parse("[]")!)
+  println(s)
+}


### PR DESCRIPTION
Rows 54–61 — the declaration direction's first section and the sweep's second-biggest burn: **61/73 sectioned, UNWRITTEN 12**.

## ALS-D1 (C-260)

One program threading the family (parity `300 hi careful [1,2]`): explicit `import json` with a parse→stringify round-trip, a variant `type` eliminated by match, top-level `let`s (Int + String) read from a fn body, `fn`/`effect fn`. Protocol resolution stays with C-094/C-126; `test`/`test where` are evidenced by the whole spec/lang suite running its wasm leg.

## Two honest findings

- **#1323 (new)**: fmt reorders a leading comment block above the `module` header into unparseable output — fmt(valid)→invalid family. The unformatted file runs correctly on both targets (measured); a fmt-gated fixture therefore cannot carry a `module` header, so the Module row's execution evidence is the spec/integration/modules suite, stated in the section.
- **#1321 (new)**: `strict <mode>` parses and checks clean but NOTHING consumes it (accept-and-ignored) — its row stays UNWRITTEN pending the ○×.

## Gates

- interp voting gate green (232s); contract ledger 260 contracts / 397 fixtures; coverage **61 sectioned / 12 UNWRITTEN (ceiling 20 → 12)**