### PR TITLE
ALS-E3/E5 partial sections: the fmt-stable halves, contracts C-261/C-262, coverage 12 to 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The guarantee is **continuous, with an explicit, ledger-managed scope**: "byte-i
 This claim is not prose. Every observable promise is a named contract in the [behavior-contract ledger](docs/contracts/), each traceable to executable evidence, and the numbers below are regenerated from the ledger (`scripts/gen-claims.sh`, enforced by `scripts/check-contracts.sh` in CI) so this section cannot drift from what the gates actually verify:
 
 <!-- claims:generated:start — derived from docs/contracts/contracts.toml by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
-> **Ledger: 260 contracts — 260 active, 0 flagged-for-revision.**
+> **Ledger: 262 contracts — 262 active, 0 flagged-for-revision.**
 >
 > **Divergences awaiting a fix: none.** Every contract in the ledger is
 > `active`, carrying executable evidence of class >= `fixture`. The one

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-260 contracts
+262 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -288,4 +288,6 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-258 | Named calls and lambdas evaluate identically on both targets | 0.57.1 | active | fixture | 1 |
 | C-259 | Variant constructor references build values eliminated identically by match on both targets | 0.57.1 | active | fixture | 1 |
 | C-260 | The declaration family compiles and runs identically on both targets | 0.57.1 | active | fixture | 1 |
+| C-261 | Canonical float values including the negative-zero sign display identically on both targets | 0.57.1 | active | fixture | 1 |
+| C-262 | The fmt-stable string escapes and the empty string evaluate identically on both targets | 0.57.1 | active | fixture | 1 |
 

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,7 +11,7 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-90 normative sections; 414 distinct executable fixtures.
+92 normative sections; 415 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|
@@ -34,7 +34,9 @@
 | ALS-D7 | C-062, C-090 | `spec/wasm_cross/bytes_rawptr.almd` (byte-compare)<br>`spec/wasm_cross/bytes_from_list_param.almd` (byte-compare) |
 | ALS-E1 | C-231 | `spec/wasm_cross/literal_int_forms.almd` (byte-compare) |
 | ALS-E2 | C-232 | `spec/wasm_cross/literal_int_forms.almd` (byte-compare) |
+| ALS-E3 | C-261 | `spec/wasm_cross/string_float_stable.almd` (byte-compare) |
 | ALS-E4 | C-233 | `spec/wasm_cross/literal_unit.almd` (byte-compare) |
+| ALS-E5 | C-262 | `spec/wasm_cross/string_float_stable.almd` (byte-compare) |
 | ALS-E6 | C-234 | `spec/wasm_cross/grouping_unary.almd` (byte-compare)<br>`spec/wasm_cross/tuple_single.almd` (byte-compare) |
 | ALS-E7 | C-235 | `spec/wasm_cross/grouping_unary.almd` (byte-compare) |
 | ALS-E8 | C-236 | `spec/wasm_cross/tuple_ops.almd` (byte-compare) |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -3209,3 +3209,25 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/declaration_forms.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-261"
+spec      = "ALS-E3"
+title     = "Canonical float values including the negative-zero sign display identically on both targets"
+statement = "ALS-E3 (partial — the fmt-stable half): decimal float literals with digits on both sides of the dot, and float.to_string's canonical display — 1.5, 0.5, the SIGN-PRESERVED -0.0, and the arithmetic result 1.75 — byte-identical native <-> wasm. The FORM half (exponents, underscores, out-of-range literals) is accepted by the parser but OPEN pending #1261's fmt-preservation ruling and is deliberately outside this contract."
+since     = "0.57.1"
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/string_float_stable.almd", class = "fixture" },
+]
+
+[[contract]]
+id        = "C-262"
+spec      = "ALS-E5"
+title     = "The fmt-stable string escapes and the empty string evaluate identically on both targets"
+statement = "ALS-E5 (partial — the fmt-stable half): `\\t` -> tab, `\\n` -> newline, `\\\\` -> one backslash (spellings AND values fmt-stable, pinned in visible brackets), and the empty string — byte-identical native <-> wasm. The FORM half (unicode escapes, heredocs, delimiter choice) and the silent-pass-through of unknown escapes are OPEN pending #1263/#1264 and deliberately outside this contract."
+since     = "0.57.1"
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/string_float_stable.almd", class = "fixture" },
+]

--- a/docs/specs/als/expressions.md
+++ b/docs/specs/als/expressions.md
@@ -520,3 +520,32 @@ C-094/C-126(`protocol_ufcs_inferred_lambda.almd`)が pin。test ブロックは
 (#1321 — accept-and-ignored)。裁定が下るまで UNWRITTEN 維持。
 
 テスト: `spec/wasm_cross/declaration_forms.almd`(契約 C-260)。
+
+## ALS-E3 浮動小数点リテラル(`ExprKind::Float`)— 部分節
+
+**受理形(確定分)**: 10 進小数 `1.5`・`0.5`(小数点の両側に数字必須 —
+`.5`/`1.` は parse エラー、実測)・負零 `-0.0`。指数形(`1e10`/`1E10`/
+`1.5e-3`)と下線区切り(`1_000.25`)は**受理される**が、fmt が値経由で
+綴りを再印字するため fixture で pin できない — **形の規範化は OPEN
+(#1261 の裁定待ち)**。範囲外リテラル(`1e999`)の扱いも同 issue の
+フォーク(現状 inf 飽和、fmt が unparseable `inf.0` を出す)。
+
+**値の規範(確定分)**: 型は binary64(ALS-T2)。正準表示は
+`float.to_string` — `1.5` / `0.5` / **`-0.0`(符号保存)** / 演算結果
+`1.75` を fixture が両ターゲット同一で pin。
+
+テスト: `spec/wasm_cross/string_float_stable.almd`(契約 C-261)。
+
+## ALS-E5 文字列リテラル(`ExprKind::String`)— 部分節
+
+**受理形(確定分)**: 二重引用符リテラル、空文字列 `""`、エスケープ
+`\t`・`\n`・`\\`(綴りとも fmt 安定、値を fixture が pin)。
+`\u{…}`(値置換される)・heredoc `"""…"""`(単一行へ潰される)・引用符
+選択(自動切替)は受理されるが fmt が形を保存しないため**形の規範化は
+OPEN(#1263)**。未知エスケープ(`\q`)と範囲外 `\u{…}` の黙過は
+**OPEN(#1264)** — 現状は素通りであり、これを規範とは認めない。
+
+**値の規範(確定分)**: `\t` → タブ、`\n` → 改行、`\\` → バックスラッシュ
+1 字(fixture が可視括りで pin)。空文字列は長さ 0 の値。
+
+テスト: `spec/wasm_cross/string_float_stable.almd`(契約 C-262)。

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,11 +15,11 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 61 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 276/397 fixtures cast a real 3-way vote (69%)** —
+> **Stage 2 (translation validation): 277/398 fixtures cast a real 3-way vote (69%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
-> **Stage 3 (semantics freeze): 260/260 contracts spec-keyed; syntax-element coverage
-> 61/73 sectioned (12 UNWRITTEN, shrink-only — the freeze precondition is 0).**
+> **Stage 3 (semantics freeze): 262/262 contracts spec-keyed; syntax-element coverage
+> 63/73 sectioned (10 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).

--- a/proofs/als-element-coverage.toml
+++ b/proofs/als-element-coverage.toml
@@ -12,7 +12,7 @@
 # the existing ALS sections (T1-T7, R-series, ...) are STDLIB-semantics
 # normative text; the syntax-element direction starts honestly at zero.
 #
-# unwritten_ceiling = "12"
+# unwritten_ceiling = "10"
 
 [[element]]
 name = "ExprKind::Int"
@@ -20,11 +20,11 @@ section = "ALS-E1"
 
 [[element]]
 name = "ExprKind::Float"
-section = "UNWRITTEN"
+section = "ALS-E3"
 
 [[element]]
 name = "ExprKind::String"
-section = "UNWRITTEN"
+section = "ALS-E5"
 
 [[element]]
 name = "ExprKind::InterpolatedString"

--- a/spec/wasm_cross/string_float_stable.almd
+++ b/spec/wasm_cross/string_float_stable.almd
@@ -1,0 +1,19 @@
+// @contract: C-261, C-262
+// ALS-E3/E5 (docs/specs/als/expressions.md) — the fmt-STABLE halves. The
+// form-pinning halves (float exponents/underscores, string unicode escapes,
+// heredocs, delimiter choice) are OPEN pending the fmt-preservation rulings
+// (#1261/#1263) and are deliberately absent: this fixture pins only what
+// survives the spec/ fmt gate — escape VALUES, canonical float values, and
+// the negative-zero sign. Identical observables on both targets.
+effect fn main() -> Unit = {
+  println("tab:[\t]")
+  println("nl:[\n]")
+  println("bs:[\\]")
+  println("")
+  println("solo")
+  let f = 1.5
+  println(float.to_string(f))
+  println(float.to_string(0.5))
+  println(float.to_string(-0.0))
+  println(float.to_string(1.5 + 0.25))
+}


### PR DESCRIPTION
Rows 62 and 63 — **63/73 sectioned**. The two rows everyone assumed were fully ○×-blocked turn out to have large MEASURABLE halves.

## The partial-section discipline

Each section claims ONLY what a fmt-gated fixture can pin, and NAMES its open half:

- **ALS-E3 (C-261)**: decimal floats with digits both sides of the dot, canonical display `1.5`/`0.5`/**sign-preserved `-0.0`**/arithmetic `1.75` — parity pinned. Exponents/underscores/overflow stay OPEN → #1261.
- **ALS-E5 (C-262)**: `\t`/`\n`/`\\` (spellings AND values fmt-stable, pinned in visible brackets), the empty string — parity pinned. Unicode escapes/heredocs/delimiter choice OPEN → #1263; unknown-escape silent pass-through OPEN → #1264, explicitly NOT normalized.

## Gates

- BOTH p5 gates green locally this time (interp voting AND abstain ledger — the #1324 lesson applied)
- contract ledger 262 contracts / 398 fixtures; coverage **63 sectioned / 10 UNWRITTEN (ceiling 12 → 10)**

Remaining 10: Guard/GuardLet (walls BOTH targets now — brick), OptionalChain (wall), Stmt::Error/ExprKind::Error (recovery vocabulary), Hole/Todo/Placeholder (#1325), Strict (#1321) — every row carries its blocker.