### PR TITLE
Un-wall scalar-field optional chains on the wasm leg via shared-cut-point helper desugar

### DIFF
--- a/crates/almide-optimize/src/optimize/mod.rs
+++ b/crates/almide-optimize/src/optimize/mod.rs
@@ -8,6 +8,7 @@
 
 mod branch_lift;
 mod dce;
+mod optional_chain;
 mod propagate;
 
 use almide_ir::*;
@@ -45,6 +46,13 @@ pub fn optimize_program(program: &mut IrProgram) {
 
     // Pass 4: dead code elimination again (propagation may create new dead bindings)
     dce::eliminate_dead_code(program);
+
+    // Pass 5a: optional-chain desugar — `p?.f` → a call to a synthesized tail-match
+    // helper (`optional_chain_synth_N`), the shape both backends prove out in every
+    // position (bind, call argument, `??` operand). Runs AFTER DCE (only surviving
+    // chains synthesize a helper) and BEFORE branch-lift (same shared-cut-point
+    // discipline; the produced call is not a branch, so order is for clarity only).
+    optional_chain::desugar_optional_chains(program);
 
     // Pass 5: branch-lift — hoist heap-typed `let`-bound `if`/`match` into tail
     // helper functions so the v1 trust-spine wasm renderer can lower them (it

--- a/crates/almide-optimize/src/optimize/optional_chain.rs
+++ b/crates/almide-optimize/src/optimize/optional_chain.rs
@@ -1,0 +1,224 @@
+//! Optional-chain desugar: rewrite `p?.f` into a call to a synthesized tail
+//! helper function so BOTH backends (and the v1 trust-spine wasm renderer in
+//! particular) see a proven shape.
+//!
+//! ## The problem this solves
+//!
+//! `p?.f` reaches the shared pipeline as `IrExprKind::OptionalChain`. The
+//! MIR-side desugar (`almide-mir/src/lower/mod_c.rs::desugar_optional_chain`)
+//! rewrites it into `match p { some(x) => some(x.f), none => none }` — but it
+//! runs AFTER `optimize::optimize_program`, so `branch_lift::lift_heap_branch_binds`
+//! (which runs HERE, at the shared cut point) never sees the match. The
+//! let-bound form then falls to the MIR tail-duplication desugar, which copies
+//! the call-bearing continuation into both arms of a match over an untracked
+//! subject — the "match over an UNTRACKED subject with a call-bearing arm"
+//! wall. An ARG-position chain (`int.to_string(np?.x ?? -9)`) walls too: a
+//! `??` over a non-Var Option operand in call-argument position is not
+//! lowerable, while `??` over a CALL operand is (measured).
+//!
+//! ## The fix (validated empirically, the branch_lift discipline)
+//!
+//! Rewrite the chain into a call to a fresh top-level helper whose BODY is the
+//! some/none match in tail position — the shape `try_lower_variant_value_match`
+//! already renders for scalar and heap payloads:
+//!
+//! ```almide
+//! fn optional_chain_synth_0(s: Pt?) -> Int? = match s { some(x) => some(x.x), none => none }
+//! // …
+//! let px = optional_chain_synth_0(p)          // bind position: proven heap call-result
+//! println(int.to_string(optional_chain_synth_0(np) ?? -9))  // arg position: proven ?? operand
+//! ```
+//!
+//! A Named call is a proven shape in EVERY position (bind, call argument,
+//! `??` operand, tail), so one desugar covers all chain sites uniformly. The
+//! subject expression moves into the argument slot — still evaluated exactly
+//! once, in the same order.
+//!
+//! ## Why this lives in `almide-optimize`
+//!
+//! Same reason as `branch_lift` (see its module docs): `optimize_program` is
+//! the shared cut point, so the v1 trust-spine path, the native codegen path,
+//! AND the interp/classify counters all see the identical rewritten tree —
+//! the helper call is a real IR `Call` node counted by `count_ir_calls`, and
+//! the MIR lowering emits exactly one `CallFn` for it (`mir == ir` by
+//! construction). Running before mono means the helper is monomorphized and
+//! linked like any other user function.
+//!
+//! ## Scope (minimal blast radius)
+//!
+//! Fires only for a chain whose subject type is a concrete `Option[P]`, whose
+//! result type is a concrete `Option[F]`, AND whose field `F` is a SCALAR
+//! (Int/Float/Bool/…). Two decline classes keep their existing route (the
+//! native codegen node + the MIR-side desugar) exactly as before:
+//!
+//! - `TypeVar`/`Unknown` anywhere in those types (a generic fn body pre-mono,
+//!   or checker error recovery) — a helper fn cannot carry the enclosing fn's
+//!   type variables.
+//! - a HEAP field (`u?.name` over `name: String`): the helper's
+//!   `Option[String]`-returning tail match does NOT lower on the v1 spine
+//!   (measured: the user-written identical helper walls "heap-result `match`
+//!   … would move out an empty deferred heap value"), while the existing MIR
+//!   route passes the unwrap_operators test-mode corpus shapes today.
+//!   Desugaring it here would trade a passing shape for an unlinked-call wall
+//!   — declined until the heap-payload variant-return brick lands.
+
+use almide_base::intern::sym;
+use almide_ir::visit_mut::{walk_expr_mut, IrMutVisitor};
+use almide_ir::*;
+use almide_lang::types::{constructor::TypeConstructorId, is_heap_ty, Ty};
+
+/// Rewrite every concrete-typed `OptionalChain` into a synthesized-helper call.
+pub fn desugar_optional_chains(program: &mut IrProgram) {
+    let mut counter: u32 = 0;
+
+    // Root program: function bodies + top-level let initializers share the
+    // program-wide `var_table` (the branch_lift region discipline).
+    {
+        let IrProgram { functions, top_lets, var_table, .. } = &mut *program;
+        let mut d = ChainDesugarer { vt: var_table, counter: &mut counter, new_funcs: Vec::new() };
+        for func in functions.iter_mut() {
+            d.visit_expr_mut(&mut func.body);
+        }
+        for tl in top_lets.iter_mut() {
+            d.visit_expr_mut(&mut tl.value);
+        }
+        let lifted = d.new_funcs;
+        functions.extend(lifted);
+    }
+
+    // Imported modules: each carries its own `var_table`, so helpers synthesized
+    // from a module's functions live in that module (their VarIds index the
+    // module's table, not the program's).
+    for module in program.modules.iter_mut() {
+        let IrModule { functions, top_lets, var_table, .. } = &mut *module;
+        let mut d = ChainDesugarer { vt: var_table, counter: &mut counter, new_funcs: Vec::new() };
+        for func in functions.iter_mut() {
+            d.visit_expr_mut(&mut func.body);
+        }
+        for tl in top_lets.iter_mut() {
+            d.visit_expr_mut(&mut tl.value);
+        }
+        let lifted = d.new_funcs;
+        functions.extend(lifted);
+    }
+}
+
+struct ChainDesugarer<'a> {
+    vt: &'a mut VarTable,
+    counter: &'a mut u32,
+    new_funcs: Vec<IrFunction>,
+}
+
+impl IrMutVisitor for ChainDesugarer<'_> {
+    fn visit_expr_mut(&mut self, e: &mut IrExpr) {
+        // Bottom-up: a chained subject (`a?.b` inside another chain's subject)
+        // is rewritten first, so the outer helper's argument is already a call.
+        walk_expr_mut(self, e);
+        let (subj_ty, payload_ty, field_ty, field) = {
+            let IrExprKind::OptionalChain { expr, field } = &e.kind else {
+                return;
+            };
+            let Ty::Applied(TypeConstructorId::Option, subj_args) = &expr.ty else {
+                return;
+            };
+            let [payload_ty] = subj_args.as_slice() else {
+                return;
+            };
+            let Ty::Applied(TypeConstructorId::Option, res_args) = &e.ty else {
+                return;
+            };
+            let [field_ty] = res_args.as_slice() else {
+                return;
+            };
+            // A generic-context chain (pre-mono TypeVar) or an error-recovery
+            // Unknown keeps the node — a helper fn cannot carry the enclosing
+            // fn's type variables, and the existing paths still cover it.
+            if payload_ty.has_unresolved_deep() || field_ty.has_unresolved_deep() {
+                return;
+            }
+            // A HEAP field keeps the node: the helper's Option[heap]-returning
+            // tail match walls on the v1 spine (see module docs) while the
+            // existing route covers the corpus shapes — declining preserves
+            // today's behavior for that class byte-for-byte.
+            if is_heap_ty(field_ty) {
+                return;
+            }
+            (expr.ty.clone(), payload_ty.clone(), field_ty.clone(), *field)
+        };
+        let res_ty = e.ty.clone();
+        let span = e.span;
+
+        // Synthesize `fn optional_chain_synth_N(s: Option[P]) -> Option[F] =
+        //   match s { some(x) => some(x.field), none => none }`.
+        // NOT `__`-prefixed: the codegen builtin-lowering pass rewrites every
+        // `__`-prefixed Named CALL to a runtime intrinsic (`almide_rt_<name>`),
+        // which would mismatch this real user-fn definition on the native path
+        // (the branch_lift_synth naming precedent).
+        let id = *self.counter;
+        *self.counter = id + 1;
+        let func_name = sym(&format!("optional_chain_synth_{}", id));
+        let subj_var = self.vt.alloc(sym("ocs_subj"), subj_ty.clone(), Mutability::Let, span);
+        let payload_var = self.vt.alloc(sym("ocs_payload"), payload_ty.clone(), Mutability::Let, span);
+
+        let mk = |kind: IrExprKind, ty: Ty| IrExpr { kind, ty, span, def_id: None };
+        let payload_read = mk(IrExprKind::Var { id: payload_var }, payload_ty.clone());
+        let member = mk(IrExprKind::Member { object: Box::new(payload_read), field }, field_ty);
+        let some_body = mk(IrExprKind::OptionSome { expr: Box::new(member) }, res_ty.clone());
+        let none_body = mk(IrExprKind::OptionNone, res_ty.clone());
+        let subj_read = mk(IrExprKind::Var { id: subj_var }, subj_ty.clone());
+        let arms = vec![
+            IrMatchArm {
+                pattern: IrPattern::Some {
+                    inner: Box::new(IrPattern::Bind { var: payload_var, ty: payload_ty }),
+                },
+                guard: None,
+                body: some_body,
+            },
+            IrMatchArm { pattern: IrPattern::None, guard: None, body: none_body },
+        ];
+        let body = mk(IrExprKind::Match { subject: Box::new(subj_read), arms }, res_ty.clone());
+
+        self.new_funcs.push(IrFunction {
+            name: func_name,
+            params: vec![IrParam {
+                var: subj_var,
+                ty: subj_ty,
+                name: sym("ocs_subj"),
+                borrow: ParamBorrow::Own,
+                is_mut: false,
+                open_record: None,
+                default: None,
+                attrs: vec![],
+            }],
+            ret_ty: res_ty.clone(),
+            body,
+            is_effect: false,
+            is_test: false,
+            generics: None,
+            extern_attrs: vec![],
+            export_attrs: vec![],
+            attrs: vec![],
+            visibility: IrVisibility::Private,
+            doc: None,
+            blank_lines_before: 0,
+            def_id: None,
+            mutated_params: vec![],
+            module_origin: None,
+        });
+
+        // Replace the chain with `optional_chain_synth_N(<subject>)` — the
+        // subject expression becomes the (single) argument, evaluated exactly
+        // once in the same position it occupied before.
+        let IrExprKind::OptionalChain { expr, .. } = std::mem::replace(
+            &mut e.kind,
+            IrExprKind::OptionNone,
+        ) else {
+            unreachable!("checked above");
+        };
+        e.kind = IrExprKind::Call {
+            target: CallTarget::Named { name: func_name },
+            args: vec![*expr],
+            type_args: vec![],
+        };
+    }
+}

--- a/spec/lang/optional_chain_test.almd
+++ b/spec/lang/optional_chain_test.almd
@@ -1,0 +1,39 @@
+// Optional chaining `p?.f` over SCALAR record fields — the shared-pipeline
+// optional_chain_synth helper route (crates/almide-optimize/src/optimize/
+// optional_chain.rs): some AND none paths, in bind position, call-argument
+// position, and over a call subject. All shapes run the wasm leg (previously
+// the "match over an UNTRACKED subject" wall). Heap (String) fields keep the
+// pre-existing MIR route — covered in unwrap_operators_test.almd.
+type Pt = { x: Int, y: Int }
+
+// The call-subject fn uses a heap-carrying record: a `T?`-returning tail `if`
+// over an ALL-SCALAR record is a separate pre-existing wall ("heap-result `if`
+// … would move out an empty deferred heap value"), unrelated to `?.`.
+type User = { name: String, age: Int }
+
+fn find_user(flag: Bool) -> User? = if flag then some({ name: "ann", age: 4 })
+else none
+
+test "optional chain scalar some bind" {
+  let p: Pt? = some({ x: 3, y: 4 })
+  let px = p?.x
+  assert_eq(px ?? 0, 3)
+}
+
+test "optional chain scalar none bind" {
+  let np: Pt? = none
+  let nx = np?.x
+  assert_eq(nx ?? -9, -9)
+}
+
+test "optional chain scalar arg position" {
+  let p: Pt? = some({ x: 3, y: 4 })
+  assert_eq(int.to_string(p?.x ?? 0), "3")
+  let np: Pt? = none
+  assert_eq(int.to_string(np?.x ?? -9), "-9")
+}
+
+test "optional chain call subject" {
+  assert_eq(find_user(true)?.age ?? -1, 4)
+  assert_eq(find_user(false)?.age ?? -1, -1)
+}


### PR DESCRIPTION
## What

`p?.x` (ExprKind::OptionalChain) over a scalar record field now runs on the wasm leg instead of walling. The desugar moves to the shared optimize cut point (`crates/almide-optimize/src/optimize/optional_chain.rs`): each concrete, scalar-field chain becomes a call to a synthesized tail-match helper (`fn optional_chain_synth_N(s: Option[P]) -> Option[F] = match s { some(x) => some(x.f), none => none }`) — the same proven-shape discipline as `branch_lift_synth_*`, and a Named call lowers in every position (bind, call argument, `??` operand).

## Why the old route walled (measured on develop)

`desugar_optional_chain` lived only in almide-mir (`mod_c.rs`), AFTER `optimize::lift_heap_branch_binds` — so the branch lift never saw the desugared match. The MIR tail-duplication desugar then copied the call-bearing continuation into both arms of a match over an untracked subject:

- native: `3` / `-9` (correct)
- wasm: `wall: match over an UNTRACKED subject with a call-bearing arm cannot take the both-arms linearization`

The user-written `let px = match p { some(v) => some(v.x), none => none }` worked because branch_lift outlined it (`let v2 = Call(Named)(v0)` in the LOWER-BODY dump) — the OptionalChain path simply never reached that machinery.

## Measured after

- Task repro (`let px = p?.x` bind + `np?.x ?? -9` inline in call-arg): native `3`/`-9`, wasm `3`/`-9` — byte-identical.
- New `spec/lang/optional_chain_test.almd` (some/none, bind/arg/call-subject): 4 tests, passes **via WASM** (not fallback).
- `spec/lang/unwrap_operators_test.almd` (`?.name` String + `?.age` Int): still `1 via WASM, 0 fallback`.

## Honest scope

- **Scalar fields** (`Int`/`Bool`/`Float`/…): desugared, un-walled.
- **Heap fields** (`u?.name` over `String`): DECLINED — kept on the existing MIR route byte-for-byte. Measured: the user-written identical helper (`fn getname(u: User?) -> String? = match u { some(v) => some(v.name), none => none }`) walls today with "heap-result `match` … would move out an empty deferred heap value" — a pre-existing heap-payload variant-return brick, not an OptionalChain issue. Desugaring it would trade unwrap_operators' passing wasm leg for an unlinked-call wall.
- Generic/pre-mono (`TypeVar`) and error-recovery (`Unknown`) chains: declined, existing route.

## Gates (all measured on this branch)

- `cargo test -p almide-mir --release`: 620+ passed, 0 failed
- `almide test` (wasm-armed): 391 files, 0 failed, **374 via WASM / 17 fallback** — fallback set identical to baseline (ratchet delta 0, no new rows, no pruned rows: this fix un-walls a class no ledger row named — the walling shapes lived in main-mode programs, not test files)
- `make verify-trust`: exit 0 — WALL OK (total over 6406 corpus fns), WALLED-REAL RATCHET OK (0), PCC ACCEPT (ownership 53148 objects / names 7034 / caps 1795 / caps-transitive 153), kernel oracle re-verification
- `cargo test --release --test traversal_totality_lint`: ok
- `proofs/check-wasm-fallback.sh`: WASM COVERAGE RATCHET OK (17, all enumerated)
- `cargo test --release --test wasm_runtime_test`: interp_cross_target_spec + interp_abstain_ledger ok (no wasm_cross fixture added — no ledger regen needed)

Counting discipline: the helper call is a real IR `Call` in the shared tree, so `count_ir_calls` and the MIR CallFn agree by construction (no classify_corpus credit needed — confirmed by the caps ACCEPT above).

## Followups (main session owns)

- ALS: `ExprKind::OptionalChain` row is `section = "UNWRITTEN"` in `proofs/als-element-coverage.toml` — can now be sectioned for the scalar-field class (heap-field limitation must be stated).
- `spec/wasm_cross` fixture + `C-NNN` contract for `?.` cross-target equivalence (contract-coupled, deliberately not added here).
- The heap-field brick: `Option[String]`-returning tail match ("would move out an empty deferred heap value") also blocks user-written helpers — worth its own brick; lifting it auto-extends this desugar by deleting the `is_heap_ty(field_ty)` decline.
- Separate pre-existing wall found while testing: a `T?`-returning tail `if` over an ALL-scalar record (`fn mk(flag: Bool) -> Pt? = if flag then some({x:3,y:4}) else none`) walls ("heap-result `if` … empty deferred heap value") while the same shape over a heap-carrying record lowers. Unrelated to `?.`.
