### PR TITLE
Un-wall the bare err arm of a scalar-tail guard on the wasm leg

### DIFF
--- a/crates/almide-mir/src/lower/desugar_guard.rs
+++ b/crates/almide-mir/src/lower/desugar_guard.rs
@@ -94,9 +94,10 @@ pub fn desugar_fn_body_guards(program: &mut almide_ir::IrProgram) {
 
 /// TAIL ERR-RAISE IF → BIND-POSITION UNWRAP (a pre-lowering program pass, shared
 /// chain like [`desugar_fn_body_guards`], which feeds it: a fn-body guard whose
-/// else is `err(x)!` restructures into exactly this shape). A SCALAR-tail `if`
-/// whose one arm RAISES (`if c then a / b else err("…")!` — the `Unwrap` of an
-/// always-Err Result) cannot lower on the scalar tail path (no early return).
+/// else is `err(x)` / `err(x)!` restructures into exactly this shape). A
+/// SCALAR-tail `if` whose one arm RAISES (`if c then a / b else err("…")[!]` —
+/// an always-Err Result, with or without the explicit `!`; see
+/// `err_raise_inner`) cannot lower on the scalar tail path (no early return).
 /// But the SAME semantics in bind position is the machinery the `!` desugars
 /// already prove end-to-end (the lifted-Result materialization):
 ///
@@ -118,11 +119,27 @@ pub fn normalize_tail_err_raise_ifs(program: &mut almide_ir::IrProgram) {
         // (`let $g: String = $r!` is the fs.read_text class), so both normalize.
         matches!(ty, Ty::Int | Ty::Float | Ty::Bool | Ty::String)
     }
-    /// The raising arm's inner Result expr (`err(e)` out of `err(e)!`), if this
-    /// arm IS an err-raise: an `Unwrap` whose inner is a `ResultErr` ctor.
+    /// The raising arm's inner Result expr, if this arm IS an err-raise. Two
+    /// spellings, ONE meaning at a fn tail — "this function returns Err(e)":
+    ///
+    /// - `err(e)!` — an `Unwrap` over a `ResultErr` ctor (an explicit raise);
+    /// - `err(e)` — the BARE ctor. In the tail of a scalar-returning `effect
+    ///   fn` (whose compiled carrier is the synthetic `Result[T, String]`) the
+    ///   frontend accepts an `err(…)` arm against a scalar sibling arm — that
+    ///   heterogeneous `if` IS the auto-wrap ABI's carrier. This is the arm
+    ///   `guard c else err(e)` (no `!`) leaves after the guard restructure.
+    ///
+    /// The bare spelling only typechecks in that auto-wrap position (a declared
+    /// `-> Result[…]` fn rejects `if c then 1 else err("x")` with E001), so
+    /// admitting it here cannot capture a declared-Result tail.
     fn err_raise_inner(e: &IrExpr) -> Option<&IrExpr> {
-        let IrExprKind::Unwrap { expr } = &e.kind else { return None };
-        matches!(expr.kind, IrExprKind::ResultErr { .. }).then_some(expr.as_ref())
+        match &e.kind {
+            IrExprKind::Unwrap { expr } => {
+                matches!(expr.kind, IrExprKind::ResultErr { .. }).then_some(expr.as_ref())
+            }
+            IrExprKind::ResultErr { .. } => Some(e),
+            _ => None,
+        }
     }
 
     fn rewrite_tail(e: &mut IrExpr, vt: &mut VarTable) {

--- a/spec/lang/guard_test.almd
+++ b/spec/lang/guard_test.almd
@@ -88,3 +88,64 @@ test "guard in while" {
   }
   assert_eq(result, [3, 6, 9])
 }
+
+// ── guard at the tail of a SCALAR-returning effect fn ──
+// The declared return is the bare scalar, so the compiled carrier is the
+// synthetic `Result[T, String]` (the auto-wrap ABI). `guard c else err(e)` — with
+// NO `!` — leaves a bare `err(…)` arm against a scalar sibling arm; both paths
+// must produce the same value on the native and wasm legs.
+effect fn checked_double(n: Int) -> Int = {
+  guard n > 0 else err("must be positive")
+  n * 2
+}
+
+test "scalar-tail guard passes through" {
+  assert_eq(checked_double(5), ok(10))
+}
+
+test "scalar-tail guard takes the else-err early return" {
+  assert_eq(checked_double(-1), err("must be positive"))
+}
+
+// The same shape with the explicit raise spelling — one meaning, two spellings.
+effect fn checked_double_raise(n: Int) -> Int = {
+  guard n > 0 else err("must be positive")!
+  n * 2
+}
+
+test "scalar-tail guard with explicit raise agrees with the bare form" {
+  assert_eq(checked_double_raise(5), checked_double(5))
+  assert_eq(checked_double_raise(-1), checked_double(-1))
+}
+
+// A String tail, and a CHAINED guard: the whole if-chain folds into one carrier.
+effect fn sign_label(n: Int) -> String = {
+  guard n != 0 else err("zero")
+  guard n > -100 else err("too small")
+  if n > 0 then "pos" else "neg"
+}
+
+test "string scalar-tail guard chain passes through" {
+  assert_eq(sign_label(3), ok("pos"))
+  assert_eq(sign_label(-3), ok("neg"))
+}
+
+test "string scalar-tail guard chain reports the first failing guard" {
+  assert_eq(sign_label(0), err("zero"))
+  assert_eq(sign_label(-500), err("too small"))
+}
+
+// Statements BEFORE the guard stay unconditional, and a plain `if` tail with an
+// `err` arm (the hand-written form the guard restructures into) lowers the same.
+effect fn offset_checked(n: Int) -> Int = {
+  let m = n + 1
+  if m > 0 then m * 2 else err("must be positive")
+}
+
+test "scalar if-tail with an err arm passes through" {
+  assert_eq(offset_checked(4), ok(10))
+}
+
+test "scalar if-tail with an err arm returns the err" {
+  assert_eq(offset_checked(-9), err("must be positive"))
+}


### PR DESCRIPTION
`guard cond else err(...)` at the tail of a **scalar-returning** `effect fn` walled the wasm leg while its hand-written if-tail twin compiled. This lands the one-line recognizer fix, with the measurement that found it.

## What I measured

Repro (native prints `10`, wasm walls):

```almide
effect fn checked(n: Int) -> Int = {
  guard n > 0 else err("must be positive")
  n * 2
}
```

```
wall: exported `pub fn checked` is outside the MIR-lowering subset:
      scalar tail outside the value subset cannot be faithfully computed
```

**The post-desugar IR trees are structurally identical.** `DBG_LOWER_FN=checked` on the walling guard form and on the working `= if n > 0 then n * 2 else err("must be positive")` form dumps the *same* tree:

```
If
  cond BinOp
  then BinOp
  else Err(LitStr)
```

The divergence is in the `ty` metadata, which `ALMIDE_DUMP_IR=checked` exposes:

| form | body root | tail `If` node `ty` |
|---|---|---|
| working if-tail | the `If` itself | `Int` → **retyped to `Result[Int,String]`** by `auto_wrap_abi_body` |
| walling guard | a `Block` | `Int` — **never retyped** |

`ALMIDE_ABI_PROBE=1` shows both forms classify identically (`auto_wrap={"checked"}`), so the ABI decision is not the difference. `auto_wrap_abi_body` retypes only the **root** expr to the synthetic carrier `Result[T, String]`. When the body is a `Block`, the value-producing tail is the block's tail, and that node keeps the bare scalar `Int` — so `lower_tail` routes it to `lower_tail_scalar` → `lower_tail_scalar_if` → `try_lower_scalar_if` declines the `Err` arm → `lower_tail_scalar_linearized_const` → `strict_const_wall("tail")`.

Propagating the retype through the block-tail chain is *not* the fix: a can-err auto-wrap fn with a plain scalar tail (`{ let x = int.parse("3")!; x + n }`) would be retyped onto the heap leg and wall.

**The class is wider than `guard`.** Four probes, before the fix:

| source shape | wasm |
|---|---|
| `guard c else err(e)!` (with `!`) | ✅ works |
| `guard c else err(e)` (bare) | ❌ walls |
| `{ let m = …; if m > 0 then m*2 else err(e) }` hand-written | ❌ walls |
| declared `-> Result[Int,String]` + guard | ✅ works |

Row 1 works because `normalize_tail_err_raise_ifs` recognizes `Unwrap{ResultErr}` and normalizes the whole tail if-chain into the proven bind-position shape `let $r = if c then ok(T) else err(e); let $g = $r!; $g`. Rows 2 and 3 leave a **bare** `ResultErr` arm, which the recognizer did not accept.

## The fix

`err_raise_inner` in `crates/almide-mir/src/lower/desugar_guard.rs` now accepts the bare `ResultErr` leaf alongside `Unwrap{ResultErr}` — two spellings, one meaning at a fn tail ("this function returns `Err(e)`"). Everything downstream (the `classify_chain` scalar-value-leaf gate, the ok-wrap tree, the two-step bind) is unchanged, so the bare form now normalizes into exactly the shape the `!` form already proves end-to-end.

Over-firing was checked, not assumed: the bare `err(…)` arm against a scalar sibling arm **only typechecks in the auto-wrap position**. A declared-Result fn rejects it at the frontend:

```
error[E001]: type mismatch in if branches: expected Int but got Result[Int, String]
  fn f(c: Bool) -> Result[Int, String] = if c then 1 else err("x")
```

so admitting the bare spelling cannot capture a declared-Result tail. Unit-tailed guards are still declined by the existing `is_scalar_value_ty` gate, and an all-raise chain still yields `Ty::Unknown` → declined.

No new synthesized `CallFn`, so `count_ir_calls` needs no new credit; `classify_corpus` runs the same pass, so `mir == ir` holds by construction.

## Both targets, after

```
$ almide run guard.almd            $ almide run guard.almd --target wasm
10                                 10
pos                                pos
12                                 12
err: must be positive              err: must be positive
err: must be small                 err: must be small
```

Byte-identical, covering pass-through, chained guards, a `String` value leaf, and the else-err early return on both legs.

## Verification

| gate | result |
|---|---|
| `cargo test -p almide-mir --release` | 620 + 10 passed, 0 failed |
| `cargo test --release` (workspace) | exit 0, no failures |
| `almide test` | **374 via WASM, 17 native fallback, 0 failed** (of 391 files) |
| `make verify-trust` | **exit 0** — proof spine OK, claims OK, kernel oracle certified all four corpus witness sets, corpus wall total |
| `cargo test --release --test traversal_totality_lint` | ok |
| `proofs/check-wasm-fallback.sh` | RATCHET OK: 17 fallback files, all enumerated |
| `cargo test --release --test wasm_runtime_test` | 75 passed — incl. `interp_cross_target_spec` **and** `interp_abstain_ledger` |
| `scripts/check-contracts.sh` | OK — 263 contracts, 398/398 fixtures linked |
| `almide fmt --check spec/lang/guard_test.almd` | already formatted |

Ratchet delta: **0 rows pruned, 0 rows added** — no baseline entry is un-walled by this fix, and the new tests do not add one. That last part is the point, and it was measured A/B: run through the previously released `almide 0.57.0`, the new `spec/lang/guard_test.almd` reports `FALLBACK spec/lang/guard_test.almd` (0 via WASM, 1 via native fallback); with this fix it is 1 via WASM. The test genuinely catches the bug rather than passing on the native leg either way.

`classify_corpus` on the repro: 4/4 functions reach MIR, `grep -c '^d$' ownership.cert` = **0** declines.

## Tests

`spec/lang/guard_test.almd` gains 7 tests (9 → 16), all running on the wasm leg: scalar-tail guard pass-through and else-err early return, the `!` spelling agreeing with the bare one, a chained guard with a `String` tail reporting the first failing guard, and the hand-written `if`-tail-with-`err`-arm form the guard restructures into.

## Followups (not in this PR — main session owns them)

- **`spec/wasm_cross` fixture + contract ledger**: this is a new cross-target behavior (a shape that walled now runs on wasm). Contract-coupled, so deliberately left out per scope. `docs/contracts/contracts.toml` and `proofs/als-element-coverage.toml` untouched.
- **`guard let` is a different wall class, still open.** `guard let v = int.parse(s) else err(…)` desugars in the *frontend* (`lower_block_body`) into `match scrut { ok(v) => rest, _ => else }` — never reaching the `Guard` statement or these passes. It walls with a different message: *"variant (Option/Result) match in tail position outside the executable subset cannot be faithfully computed (a Const-0 would silently pick a wrong arm)"*. Native prints `10 / err: not a number`; wasm refuses. Fixing it means the variant-match tail leg, not this recognizer — scoped out honestly rather than forced.
