### PR TITLE
ALS-S6 guard statements: fixture, contract C-265, coverage 7 to 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The guarantee is **continuous, with an explicit, ledger-managed scope**: "byte-i
 This claim is not prose. Every observable promise is a named contract in the [behavior-contract ledger](docs/contracts/), each traceable to executable evidence, and the numbers below are regenerated from the ledger (`scripts/gen-claims.sh`, enforced by `scripts/check-contracts.sh` in CI) so this section cannot drift from what the gates actually verify:
 
 <!-- claims:generated:start — derived from docs/contracts/contracts.toml by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
-> **Ledger: 264 contracts — 264 active, 0 flagged-for-revision.**
+> **Ledger: 265 contracts — 265 active, 0 flagged-for-revision.**
 >
 > **Divergences awaiting a fix: none.** Every contract in the ledger is
 > `active`, carrying executable evidence of class >= `fixture`. The one

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-264 contracts
+265 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -292,4 +292,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-262 | The fmt-stable string escapes and the empty string evaluate identically on both targets | 0.57.1 | active | fixture | 1 |
 | C-263 | Recovery nodes never appear in accepted programs; a broken file still reports past its first error | 0.57.1 | active | fixture | 1 |
 | C-264 | Scalar-field optional chains yield some/none identically on both targets | 0.57.1 | active | fixture | 1 |
+| C-265 | The guard statement's pass and raise paths behave identically on both targets | 0.57.1 | active | fixture | 1 |
 

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,7 +11,7 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-93 normative sections; 416 distinct executable fixtures.
+93 normative sections; 417 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|
@@ -89,7 +89,7 @@
 | ALS-S3 | C-018, C-019, C-252 | `spec/wasm_cross/string_predicates.almd` (byte-compare)<br>`spec/wasm_cross/string_ops_drain.almd` (byte-compare)<br>`spec/wasm_cross/string_rle.almd` (byte-compare)<br>`spec/wasm_cross/expr_stmt_comment.almd` (byte-compare) |
 | ALS-S4 | C-022 | `spec/wasm_cross/string_from_bytes.almd` (byte-compare) |
 | ALS-S5 | C-050, C-253 | `spec/wasm_cross/string_split_rle_codepoint.almd` (byte-compare)<br>`spec/wasm_cross/place_assign_ascription.almd` (byte-compare) |
-| ALS-S6 | C-074 | `spec/wasm_cross/r5_wasm_split_replace_iterative.almd` (byte-compare) |
+| ALS-S6 | C-074, C-265 | `spec/wasm_cross/r5_wasm_split_replace_iterative.almd` (byte-compare)<br>`spec/wasm_cross/guard_statement.almd` (byte-compare) |
 | ALS-T1 | C-021 | `spec/wasm_cross/string_whitespace.almd` (byte-compare) |
 | ALS-T2 | C-024, C-210 | `spec/wasm_cross/float_parse.almd` (byte-compare)<br>`spec/wasm_cross/nan_canonical_observation.almd` (byte-compare)<br>`spec/wasm_cross/nan_canonical_bytes_write.almd` (byte-compare) |
 | ALS-T3 | C-087 | `spec/wasm_cross/json_number_unicode.almd` (byte-compare)<br>`spec/wasm_cross/json_string_span.almd` (byte-compare) |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -3253,3 +3253,14 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/optional_chain_scalar.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-265"
+spec      = "ALS-S6"
+title     = "The guard statement's pass and raise paths behave identically on both targets"
+statement = "ALS-S6: `guard cond else err(e)` is an EARLY EXIT — on the true path the following statements run and the tail value flows out (10 pinned); on the false path the else's err propagates to the caller, where a `!` or match receives it (\"must be positive\" pinned) — byte-identical native <-> wasm. Both raise spellings (`err(e)` and `err(e)!`) normalize identically since #1336, which found the recognizer accepted only the Unwrap-wrapped leaf: the class was wider than guard (a hand-written `{ let m = ..; if m > 0 then m * 2 else err(e) }` walled the same way). `guard let` is a separate class (frontend-desugared to a tail-position variant match, still walled) and is outside this contract."
+since     = "0.57.1"
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/guard_statement.almd", class = "fixture" },
+]

--- a/docs/specs/als/expressions.md
+++ b/docs/specs/als/expressions.md
@@ -583,3 +583,23 @@ AST に回復ノードが**ゼロ**であること、(2) 壊れたファイル�
 
 テスト: `spec/wasm_cross/optional_chain_scalar.almd`(契約 C-264)、
 `spec/lang/optional_chain_test.almd`(wasm レグ 4 ケース)。
+
+## ALS-S6 guard 文(`Stmt::Guard`)
+
+**受理形**: `guard cond else raise-expr` — 文位置。`raise-expr` は
+`err(e)` または `err(e)!`(両綴りが同一に正規化される、#1336)。
+`if` の else 無し版ではなく**早期脱出**であり、続く文は cond が真の
+経路にのみ属する。
+
+**値の規範**: cond が真なら素通りして後続が走る(fixture: `checked(5)!`
+→ 10)。偽なら else の err が呼び出し元へ伝搬する — 呼び出し側の `!` や
+match が受け取る(fixture: `checked(-3)` の err を match が拾って
+"must be positive")。両ターゲット同一。
+
+**scalar/heap の境界**: スカラー値のガードは #1336 で両レグ live。
+`guard let x = e else …`(`Stmt::GuardLet`)は**別クラス** — フロント
+エンドで variant match へ脱糖され、tail 位置の variant match ブリックに
+当たるため wasm では wall(loud)。当該ブリック待ちで UNWRITTEN 維持。
+
+テスト: `spec/wasm_cross/guard_statement.almd`(契約 C-265)、
+`spec/lang/guard_test.almd`(wasm レグ)。

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,11 +15,11 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 61 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 278/399 fixtures cast a real 3-way vote (69%)** —
+> **Stage 2 (translation validation): 279/400 fixtures cast a real 3-way vote (69%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
-> **Stage 3 (semantics freeze): 264/264 contracts spec-keyed; syntax-element coverage
-> 66/73 sectioned (7 UNWRITTEN, shrink-only — the freeze precondition is 0).**
+> **Stage 3 (semantics freeze): 265/265 contracts spec-keyed; syntax-element coverage
+> 67/73 sectioned (6 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).

--- a/proofs/als-element-coverage.toml
+++ b/proofs/als-element-coverage.toml
@@ -12,7 +12,7 @@
 # the existing ALS sections (T1-T7, R-series, ...) are STDLIB-semantics
 # normative text; the syntax-element direction starts honestly at zero.
 #
-# unwritten_ceiling = "7"
+# unwritten_ceiling = "6"
 
 [[element]]
 name = "ExprKind::Int"
@@ -252,7 +252,7 @@ section = "ALS-S5"
 
 [[element]]
 name = "Stmt::Guard"
-section = "UNWRITTEN"
+section = "ALS-S6"
 
 [[element]]
 name = "Stmt::GuardLet"

--- a/spec/wasm_cross/guard_statement.almd
+++ b/spec/wasm_cross/guard_statement.almd
@@ -1,0 +1,23 @@
+// @contract: C-265
+// ALS-S6 (docs/specs/als/expressions.md): the guard statement — a scalar
+// early return whose else-arm raises. Both paths pinned: the guard passes
+// (value flows to the tail) and the guard fails (the else err propagates
+// out through the caller's `!`, caught here by match). Un-walled on the
+// wasm leg by #1336: the bare `ResultErr` leaf now normalizes into the
+// proven bind-position raise shape, exactly as the `err(e)!` spelling did.
+// `guard let` is a SEPARATE class (frontend-desugared to a variant match in
+// tail position, still walled) and is deliberately absent.
+effect fn checked(n: Int) -> Int = {
+  guard n > 0 else err("must be positive")
+  n * 2
+}
+
+effect fn main() -> Unit = {
+  println(int.to_string(checked(5)!))
+  let bad: Result[Int, String] = checked(-3)
+  let msg = match bad {
+    ok(v) => int.to_string(v),
+    err(e) => e,
+  }
+  println(msg)
+}


### PR DESCRIPTION
Row 67 — **67/73 sectioned**, landing on the brick #1336 just cleared.

## ALS-S6 (C-265)

Parity `10` / `must be positive`: guard is an EARLY EXIT — the true path runs the following statements and the tail value flows out; the false path propagates the else's err to the caller, where `!` or match receives it. Both raise spellings (`err(e)` and `err(e)!`) normalize identically since #1336.

The section records that fix's finding honestly: the recognizer had accepted only the Unwrap-wrapped leaf, so the walling class was **wider than guard** — a hand-written `{ let m = ..; if m > 0 then m * 2 else err(e) }` walled the same way. `guard let` is a separate class (frontend-desugared to a tail-position variant match, still walled) and stays UNWRITTEN.

## Gates

- both p5 gates green (interp voting + abstain ledger); contract ledger 265 contracts / 400 fixtures
- coverage **67 sectioned / 6 UNWRITTEN (ceiling 7 → 6)**