### PR TITLE
Fold a non-root tail variant match with a raise leaf into the proven bind shape, un-walling guard let on wasm

### DIFF
--- a/crates/almide-mir/src/lower/desugar_guard.rs
+++ b/crates/almide-mir/src/lower/desugar_guard.rs
@@ -92,9 +92,9 @@ pub fn desugar_fn_body_guards(program: &mut almide_ir::IrProgram) {
     }
 }
 
-/// TAIL ERR-RAISE IF → BIND-POSITION UNWRAP (a pre-lowering program pass, shared
-/// chain like [`desugar_fn_body_guards`], which feeds it: a fn-body guard whose
-/// else is `err(x)` / `err(x)!` restructures into exactly this shape). A
+/// TAIL ERR-RAISE BRANCH → BIND-POSITION UNWRAP (a pre-lowering program pass,
+/// shared chain like [`desugar_fn_body_guards`], which feeds it: a fn-body guard
+/// whose else is `err(x)` / `err(x)!` restructures into exactly this shape). A
 /// SCALAR-tail `if` whose one arm RAISES (`if c then a / b else err("…")[!]` —
 /// an always-Err Result, with or without the explicit `!`; see
 /// `err_raise_inner`) cannot lower on the scalar tail path (no early return).
@@ -109,8 +109,27 @@ pub fn desugar_fn_body_guards(program: &mut almide_ir::IrProgram) {
 /// Both orientations (raise in then / raise in else) normalize. Only the
 /// FN-BODY tail chain is rewritten (same scope as the guard pass); no calls
 /// are added or removed, so the caps `mir == ir` invariant holds.
+///
+/// The same normalization covers the tail-position variant `match` with a raise
+/// leaf — the shape `guard let v = int.parse(s) else err("…")` desugars to. That
+/// rewrite happens in the FRONTEND (`lower_block_body`), so it never reaches the
+/// MIR `Guard` statement or the `if`-restructure above; it arrives here already
+/// shaped as
+///
+///   { match int.parse(s) { ok(v) => v * 2, _ => err("…") } }
+///
+/// nested one level under the fn-body Block. That one level is the whole
+/// difference: the auto-wrap ABI retype (`auto_wrap_abi_body`) rewrites the ty of
+/// the body ROOT only, so a BARE `= match … { ok(v) => v*2, err(_) => err("…") }`
+/// tail carries the `Result[Int, String]` carrier and lowers through the proven
+/// heap-tail match, while the identical match one level down keeps its `Int` ty,
+/// falls to `lower_tail_scalar_match`, and hits the variant-match wall. Folding
+/// the non-root branch into the Result-typed bind shape puts it back on the same
+/// proven path. Root branches are left ALONE (they lower today — normalizing them
+/// would take a working shape off a proven path, the over-reach that regressed the
+/// first heap-`??` attempt).
 pub fn normalize_tail_err_raise_ifs(program: &mut almide_ir::IrProgram) {
-    use almide_ir::{IrExpr, IrExprKind, IrStmt, IrStmtKind, Mutability, VarTable};
+    use almide_ir::{IrExpr, IrExprKind, IrMatchArm, IrStmt, IrStmtKind, Mutability, VarTable};
     use almide_lang::types::constructor::TypeConstructorId;
     use almide_lang::types::Ty;
 
@@ -142,10 +161,13 @@ pub fn normalize_tail_err_raise_ifs(program: &mut almide_ir::IrProgram) {
         }
     }
 
-    fn rewrite_tail(e: &mut IrExpr, vt: &mut VarTable) {
+    /// `root` = this expr IS the function body (not nested under a Block tail).
+    /// A root `match` already carries the auto-wrap ABI's Result carrier and
+    /// lowers as-is, so only NON-root matches normalize (see the pass doc).
+    fn rewrite_tail(e: &mut IrExpr, vt: &mut VarTable, root: bool) {
         match &mut e.kind {
             IrExprKind::Block { stmts, expr: Some(t) } => {
-                rewrite_tail(t, vt);
+                rewrite_tail(t, vt, false);
                 // FLATTEN a Block-valued tail into THIS block (its statements run
                 // unconditionally before the tail value; VarIds are unique, and the
                 // lowering already rides nested-block locals to the enclosing scope —
@@ -160,27 +182,36 @@ pub fn normalize_tail_err_raise_ifs(program: &mut almide_ir::IrProgram) {
                     }
                 }
             }
-            IrExprKind::If { .. } => rewrite_tail_if_arm(e, vt),
+            IrExprKind::If { .. } => rewrite_tail_raise_branch(e, vt),
+            // The `guard let` shape: a variant (Option/Result) `match` in a
+            // NON-root tail with a raise leaf. Gated on a variant subject —
+            // that is the class the tail wall rejects, and the class the
+            // bind-position value-match machinery is proven over.
+            IrExprKind::Match { subject, .. }
+                if !root && crate::lower::is_variant_ty(&subject.ty) =>
+            {
+                rewrite_tail_raise_branch(e, vt)
+            }
             _ => {}
         }
     }
 
-    /// The `If` arm's whole body, moved out of [`rewrite_tail`]'s match — same
+    /// The branch arm's whole body, moved out of [`rewrite_tail`]'s match — same
     /// "outer name router unchanged, arm body to a named helper" split used
     /// throughout this pass family (e.g. [`rewrite_tail_block`] above). A
     /// sibling nested `fn` in the same block as `rewrite_tail`, so it shares
     /// that block's other nested-fn items (`is_scalar_value_ty`,
     /// `err_raise_inner`) exactly as the inline arm body did.
     ///
-    /// Fold the WHOLE guard if-CHAIN (any nesting of raise arms and one
-    /// value-ty leaf class) into ONE Result-typed if tree: every VALUE
-    /// leaf wraps in ok(…), every RAISE leaf sheds its `!` — so a chained
-    /// guard (`validate_age`'s two guards) normalizes to a single bind +
-    /// unwrap instead of nesting ok() around inner binds (which no
-    /// lowering path executes). `classify_chain` returns the uniform
-    /// value-leaf ty and the raise arms' Err ty, or None outside the
-    /// subset (a leaf that is neither).
-    fn rewrite_tail_if_arm(e: &mut IrExpr, vt: &mut VarTable) {
+    /// Fold the WHOLE guard BRANCH-CHAIN (any nesting of `if`s and variant
+    /// `match`es mixing raise arms and one value-ty leaf class) into ONE
+    /// Result-typed branch tree: every VALUE leaf wraps in ok(…), every RAISE
+    /// leaf sheds its `!` — so a chained guard (`validate_age`'s two guards, or
+    /// two stacked `guard let`s) normalizes to a single bind + unwrap instead of
+    /// nesting ok() around inner binds (which no lowering path executes).
+    /// `classify_chain` returns the uniform value-leaf ty and the raise arms' Err
+    /// ty, or None outside the subset (a leaf that is neither).
+    fn rewrite_tail_raise_branch(e: &mut IrExpr, vt: &mut VarTable) {
         // Look through the empty-Block wrappers the guard restructure leaves
         // around each continuation (`if c then { <inner if> } else E`).
         fn peel(e: &IrExpr) -> &IrExpr {
@@ -201,15 +232,37 @@ pub fn normalize_tail_err_raise_ifs(program: &mut almide_ir::IrProgram) {
                 // A raise leaf: no value ty contributed; err ty named.
                 return Some((Ty::Unknown, Some(a[1].clone())));
             }
+            /// Unify two leaf classifications: `Unknown` (a raise leaf, which
+            /// contributes no value ty) yields to the other side; two concrete
+            /// value tys must agree, else the chain is outside the subset.
+            fn unify(a: &Ty, b: &Ty) -> Option<Ty> {
+                match (a, b) {
+                    (Ty::Unknown, v) | (v, Ty::Unknown) => Some(v.clone()),
+                    (x, y) if x == y => Some(x.clone()),
+                    _ => None,
+                }
+            }
             if let IrExprKind::If { then, else_, .. } = &e.kind {
                 let (t_val, t_err) = classify_chain(then)?;
                 let (e_val, e_err) = classify_chain(else_)?;
-                let val = match (&t_val, &e_val) {
-                    (Ty::Unknown, v) | (v, Ty::Unknown) => (*v).clone(),
-                    (a, b) if a == b => (*a).clone(),
-                    _ => return None,
-                };
-                return Some((val, t_err.or(e_err)));
+                return Some((unify(&t_val, &e_val)?, t_err.or(e_err)));
+            }
+            // A variant `match` is the same chain node with N arms. A GUARDED
+            // arm declines: the rewrite keeps the arms verbatim, and the
+            // bind-position value-match subset the fold targets is proven over
+            // un-guarded constructor arms only.
+            if let IrExprKind::Match { arms, .. } = &e.kind {
+                let mut val = Ty::Unknown;
+                let mut err = None;
+                for arm in arms {
+                    if arm.guard.is_some() {
+                        return None;
+                    }
+                    let (a_val, a_err) = classify_chain(&arm.body)?;
+                    val = unify(&val, &a_val)?;
+                    err = err.or(a_err);
+                }
+                return Some((val, err));
             }
             Some((e.ty.clone(), None))
         }
@@ -237,6 +290,27 @@ pub fn normalize_tail_err_raise_ifs(program: &mut almide_ir::IrProgram) {
                     def_id: None,
                 };
             }
+            // The variant-`match` chain node: subject and patterns verbatim
+            // (the arm binders keep binding exactly what they bound), only the
+            // arm BODIES are lifted to the Result carrier.
+            if let IrExprKind::Match { subject, arms } = &e.kind {
+                return IrExpr {
+                    kind: IrExprKind::Match {
+                        subject: subject.clone(),
+                        arms: arms
+                            .iter()
+                            .map(|arm| IrMatchArm {
+                                pattern: arm.pattern.clone(),
+                                guard: arm.guard.clone(),
+                                body: to_result_tree(&arm.body, result_ty),
+                            })
+                            .collect(),
+                    },
+                    ty: result_ty.clone(),
+                    span: e.span.clone(),
+                    def_id: None,
+                };
+            }
             IrExpr {
                 kind: IrExprKind::ResultOk { expr: Box::new(e.clone()) },
                 ty: result_ty.clone(),
@@ -244,10 +318,10 @@ pub fn normalize_tail_err_raise_ifs(program: &mut almide_ir::IrProgram) {
                 def_id: None,
             }
         }
-        let (new_then, new_else) = {
-            let IrExprKind::If { then, else_, .. } = &e.kind else { unreachable!() };
-            (to_result_tree(then, &result_ty), to_result_tree(else_, &result_ty))
-        };
+        // The WHOLE branch tree lifted to the Result carrier — for an `if` this is
+        // literally the old per-arm `to_result_tree` pair reassembled, for a
+        // `match` it is the arms with their patterns intact.
+        let result_branch = to_result_tree(e, &result_ty);
         // Two-step bind: the Result-if materializes into a TRACKED var first
         // (the heap-result-if BIND machinery seeds its match shape), then the
         // bind-position `!` unwraps THAT var — the exact subject class the
@@ -264,24 +338,11 @@ pub fn normalize_tail_err_raise_ifs(program: &mut almide_ir::IrProgram) {
             Mutability::Let,
             None,
         );
-        let result_if = IrExpr {
-            kind: IrExprKind::If {
-                cond: match &e.kind {
-                    IrExprKind::If { cond, .. } => cond.clone(),
-                    _ => unreachable!(),
-                },
-                then: Box::new(new_then),
-                else_: Box::new(new_else),
-            },
-            ty: result_ty.clone(),
-            span: e.span.clone(),
-            def_id: None,
-        };
         let bind_r = IrStmt {
             kind: IrStmtKind::Bind {
                 var: r,
                 ty: result_ty.clone(),
-                value: result_if,
+                value: result_branch,
                 mutability: Mutability::Let,
             },
             span: None,
@@ -328,7 +389,7 @@ pub fn normalize_tail_err_raise_ifs(program: &mut almide_ir::IrProgram) {
         .iter_mut()
         .chain(modules.iter_mut().flat_map(|m| m.functions.iter_mut()))
     {
-        rewrite_tail(&mut func.body, var_table);
+        rewrite_tail(&mut func.body, var_table, true);
     }
 }
 

--- a/spec/lang/guard_let_test.almd
+++ b/spec/lang/guard_let_test.almd
@@ -41,3 +41,72 @@ test "guard let unwraps Ok" {
 test "guard let takes the else exit on Err" {
   assert_eq(unwrap_res(err("x")), 0 - 99)
 }
+
+// ── guard let at the tail of a SCALAR-returning effect fn, else = RAISE ──
+// The `guard let` above all take a VALUE else-branch. When the else RAISES
+// (`else err(e)`) inside an effect fn whose declared return is a bare scalar, the
+// compiled carrier is the synthetic `Result[T, String]` (the auto-wrap ABI) — and
+// the frontend has already turned the whole thing into `match scrut { ok(v) =>
+// rest, _ => err(e) }` sitting one level under the fn-body Block. That one level
+// used to lose the auto-wrap retype (which lands on the body ROOT only) and hit
+// the tail variant-match wall on the wasm leg. Both paths must now produce the
+// same value on the native and wasm legs.
+effect fn parse_twice(s: String) -> Int = {
+  guard let v = int.parse(s) else err("not a number")
+  v * 2
+}
+
+test "guard let raise: Result scrutinee passes the payload through" {
+  assert_eq(parse_twice("21"), ok(42))
+}
+
+test "guard let raise: Result scrutinee raises on Err" {
+  assert_eq(parse_twice("zz"), err("not a number"))
+}
+
+// The OPTION polarity of the same shape (the some/none pair, tag inverted).
+effect fn head_twice(xs: List[Int]) -> Int = {
+  guard let v = list.first(xs) else err("empty")
+  v * 2
+}
+
+test "guard let raise: Option scrutinee passes the payload through" {
+  assert_eq(head_twice([21, 1]), ok(42))
+}
+
+test "guard let raise: Option scrutinee raises on None" {
+  assert_eq(head_twice([]), err("empty"))
+}
+
+// CHAINED guard lets with raising elses: the whole branch chain folds into ONE
+// carrier, so the FIRST failing guard names the error.
+effect fn sum_first_two(xs: List[Int]) -> Int = {
+  guard let a = list.get(xs, 0) else err("no first")
+  guard let b = list.get(xs, 1) else err("no second")
+  a + b
+}
+
+test "guard let raise: chained guards keep both bindings in scope" {
+  assert_eq(sum_first_two([3, 4, 5]), ok(7))
+}
+
+test "guard let raise: chained guards report the first failing guard" {
+  assert_eq(sum_first_two([3]), err("no second"))
+  assert_eq(sum_first_two([]), err("no first"))
+}
+
+// A HEAP (String) payload and value, and a statement BEFORE the guard — the
+// pre-guard statement stays unconditional.
+effect fn shout(m: Map[String, String], k: String) -> String = {
+  let key = string.trim(k)
+  guard let v = map.get(m, key) else err("missing key")
+  string.to_upper(v)
+}
+
+test "guard let raise: String payload passes through" {
+  assert_eq(shout(map.from_list([("a", "hi")]), " a "), ok("HI"))
+}
+
+test "guard let raise: String payload raises on a missing key" {
+  assert_eq(shout(map.from_list([("a", "hi")]), "zz"), err("missing key"))
+}


### PR DESCRIPTION
`guard let v = <fallible> else err("…")` compiled on native and **walled on wasm**:

```
wall: variant (Option/Result) match in tail position outside the executable
subset cannot be faithfully computed (a Const-0 would silently pick a wrong arm)
```

## What I measured

`guard let` desugars in the FRONTEND (`lower_block_body`, crates/almide-frontend/src/lower/expressions.rs) into `match scrut { ok(v) => rest, _ => else_expr }`, so it never reaches the MIR `Guard` statement or the #1336 `desugar_guard.rs` passes. I probed the surrounding space to find what actually distinguishes the walling shape. **The trigger is neither the polarity nor the wildcard arm — it is one level of Block nesting.**

| probe | shape (effect fn `-> Int` unless noted) | native | wasm BEFORE | wasm AFTER |
|---|---|---|---|---|
| p2 | **bare** fn tail `= match int.parse(s) { ok(v) => v*2, err(_) => err("…") }` | `42` | `42` | `42` |
| p7 | same, wildcard arm `_ => err("…")` | `42` | `42` | `42` |
| p8 | Option, bare tail `match list.first(xs) { some(v) => v*2, _ => err(…) }` | `42` | `42` | `42` |
| p9 | Option, bare tail, `none => err(…)` | `42` | `42` | `42` |
| **p6** | **the same match wrapped in a Block** `= { match … }` | `42` | **WALL** | `42` |
| **p1** | `guard let v = int.parse(s) else err(…)` (desugars to p6) | `42` | **WALL** | `42` |
| **p18** | p1, err path | `Error: not a number` rc=1 | **WALL** | `Error: not a number` rc=1 |
| **p5** | `guard let v = list.first(xs) else err(…)` (Option) | `42` | **WALL** | `42` |
| **p24** | p5, none path | `Error: empty` rc=1 | **WALL** | `Error: empty` rc=1 |
| **p15** | a statement before the `guard let` | `42` | **WALL** | `42` |
| **p22/23** | two chained `guard let`s with raising elses | `7` / `Error: no second` | **WALL** | `7` / `Error: no second` |
| **p25** | String (heap) payload + value via `map.get` | `HI` / `Error: missing key` | **WALL** | `HI` / `Error: missing key` |
| p10 | Block-wrapped match, **no raise** (`err(_) => 0-1`) | `42`/`-1` | `42`/`-1` | `42`/`-1` |
| p11 | p10 in an effect fn | `42`/`-1` | `42`/`-1` | `42`/`-1` |
| p12 | `guard let … else { 0-1 }` (value else, no raise) | `42`/`-1` | `42`/`-1` | `42`/`-1` |
| p4 | pure fn `guard let … else { d }` (the existing spec shape) | `50`/`7` | `50`/`7` | `50`/`7` |
| p13 | declared `-> Result[Int, String]`, Block-wrapped match | `42` | `42` | `42` |
| p3 | scalar **bind** `let r = match … { ok(v) => v*2, err(_) => err(…) }` | `42` | WALL | WALL (untouched — a different gap, see followups) |

Every AFTER cell is byte-identical between the two legs, on **both** the value path and the raise path.

## Root cause

`auto_wrap_abi_body` (crates/almide-mir/src/lower/mod_c.rs) rewrites the ty of the **body ROOT only** — `IrExpr { ty: Ty::result(func.ret_ty, Ty::String), ..func.body.clone() }`. So:

- a **bare** tail match (p2) *is* the root: it carries the `Result[Int, String]` carrier, `is_heap_ty` is true, and it lowers through the already-proven heap-tail match;
- the **same match one level down** under a Block (p6, and therefore every `guard let`) keeps its `Int` ty, so `lower_tail` peels the Block, lands in `lower_tail_scalar_match` → `lower_tail_scalar_variant_match`, and the err arm (a `ResultErr`, not an `Int`) is outside `try_lower_variant_value_match`'s subset → the wall.

p13 is the control: give the fn a **declared** `-> Result[Int, String]` and the identical Block-wrapped match lowers fine. The carrier is the whole difference.

## The fix

Route (a) from the brief — reach the already-proven bind shape instead of writing new lowering. `normalize_tail_err_raise_ifs` (crates/almide-mir/src/lower/desugar_guard.rs) already folds a fn-tail `if`-chain with a raise leaf into

```
let $r: Result[T, E] = <branch tree, value leaves ok(…)-wrapped, raise leaves shorn of !>
let $g: T = $r!
$g
```

It only knew `If` nodes. This PR teaches the same fold the **variant `match`** node — `classify_chain` and `to_result_tree` each gain one arm, and the construction site drops its hand-rolled `If` reassembly for `to_result_tree(e, &result_ty)` over the whole tree (for an `if` that is literally the old per-arm pair reassembled — a pure refactor). The arm patterns and binders are carried through verbatim; only arm BODIES are lifted to the carrier. Chained guards fall out of the same recursion, which is why p22/p23 fold into **one** bind rather than nested `ok()`s.

Two deliberate narrowings, both measured rather than assumed:

- **NON-root matches only.** A root match lowers today (p2/p7/p8/p9); normalizing it would take a working shape off a proven path — the same over-reach that regressed the first whole-body heap-`??` attempt.
- **Variant (Option/Result) subjects only** — that is the class the wall rejects and the class the bind-position value-match machinery is proven over. Guarded arms decline.

## Verification (all local, `PATH=/opt/homebrew/bin` armed)

- `cargo test -p almide-mir --release` — pass
- `almide test` — **374 via WASM, 17 via native fallback, 0 failed (of 391 files)**
- `make verify-trust` — **exit 0**. The proven checker ACCEPTs, zero REJECTs: ownership 53410 heap objects, names 7063 witnesses, caps 1808, caps-transitive 154; `lower_function` total over 6435 corpus functions; Rocq kernel oracle re-certified all four witness sets
- `cargo test --release --test traversal_totality_lint` — pass
- `proofs/check-wasm-fallback.sh` — `WASM COVERAGE RATCHET OK: 17 fallback file(s)`
- `cargo test --release --test wasm_runtime_test` — 75 passed, including `interp_cross_target_spec` **and** `interp_abstain_ledger`
- `almide fmt --check spec/lang/guard_let_test.almd` — clean

**Ratchet delta: 0 rows, and that is the honest number.** `spec/lang/guard_let_test.almd` was never in `proofs/wasm-fallback-baseline.txt` — its existing `guard let`s all take a *value* else, which lowered on the scalar path. This fix un-walls a **shape**, not a file, so there is no STALE row to prune. The 8 new tests land in that same file, which `almide test` reports as running **via WASM**; a regression would push it into fallback and fail the ratchet.

No new synthesized `CallFn` — the fold adds only `ResultOk`/`ResultErr` ctors and an `Unwrap`, and the classify side runs the identical pass (`classify_corpus_b.rs:354`), so `count_ir_calls` needs no credit and `mir == ir` holds (confirmed by verify-trust).

## Followups for the main session

1. **ALS `Stmt::GuardLet`** is still `section = "UNWRITTEN"` in `proofs/als-element-coverage.toml`; the raise-else form now lowers on both legs, so the row is authorable. Not touched here per the repo boundary.
2. **No `spec/wasm_cross` fixture** — contract-coupled, so left to the session that owns the ledger. The natural fixture is p1+p18 (Result) and p5+p24 (Option) with a `// @contract:` header.
3. **Scalar bind-position variant match with a raise leaf still walls** (p3): `let r = match int.parse(s) { ok(v) => v*2, err(_) => err("…") }` → `variant (Option/Result) match bound to a let/var outside the executable subset`. Unrelated to `guard let` (no source construct desugars to it), untouched here.
4. **Pre-existing bug, hit while probing**: a hand-written *nested* Result-typed match in bind position fails on **both** legs with `[COMPILER BUG] internal type resolution failed before codegen — 2 expression(s) still carry an unresolved … type`, naming `branch_lift_synth_0` with `var name=a/b ty=Unknown`. Repro:
   ```almide
   effect fn f(xs: List[Int]) -> Int = {
     let r: Result[Int, String] = match list.get(xs, 0) {
       ok(a) => match list.get(xs, 1) { ok(b) => ok(a + b), _ => err("2") },
       _ => err("1"),
     }
     r!
   }
   ```
   The binder types are lost when the continuation is lifted. Worth its own issue.
