### PR TITLE
ALS-S7 guard let: fixture, contract C-266, coverage 6 to 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The guarantee is **continuous, with an explicit, ledger-managed scope**: "byte-i
 This claim is not prose. Every observable promise is a named contract in the [behavior-contract ledger](docs/contracts/), each traceable to executable evidence, and the numbers below are regenerated from the ledger (`scripts/gen-claims.sh`, enforced by `scripts/check-contracts.sh` in CI) so this section cannot drift from what the gates actually verify:
 
 <!-- claims:generated:start — derived from docs/contracts/contracts.toml by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
-> **Ledger: 265 contracts — 265 active, 0 flagged-for-revision.**
+> **Ledger: 266 contracts — 266 active, 0 flagged-for-revision.**
 >
 > **Divergences awaiting a fix: none.** Every contract in the ledger is
 > `active`, carrying executable evidence of class >= `fixture`. The one

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-265 contracts
+266 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -293,4 +293,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-263 | Recovery nodes never appear in accepted programs; a broken file still reports past its first error | 0.57.1 | active | fixture | 1 |
 | C-264 | Scalar-field optional chains yield some/none identically on both targets | 0.57.1 | active | fixture | 1 |
 | C-265 | The guard statement's pass and raise paths behave identically on both targets | 0.57.1 | active | fixture | 1 |
+| C-266 | guard let binds the success payload and raises on the failing polarity, identically on both targets | 0.57.1 | active | fixture | 1 |
 

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,7 +11,7 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-93 normative sections; 417 distinct executable fixtures.
+94 normative sections; 418 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|
@@ -90,6 +90,7 @@
 | ALS-S4 | C-022 | `spec/wasm_cross/string_from_bytes.almd` (byte-compare) |
 | ALS-S5 | C-050, C-253 | `spec/wasm_cross/string_split_rle_codepoint.almd` (byte-compare)<br>`spec/wasm_cross/place_assign_ascription.almd` (byte-compare) |
 | ALS-S6 | C-074, C-265 | `spec/wasm_cross/r5_wasm_split_replace_iterative.almd` (byte-compare)<br>`spec/wasm_cross/guard_statement.almd` (byte-compare) |
+| ALS-S7 | C-266 | `spec/wasm_cross/guard_let_statement.almd` (byte-compare) |
 | ALS-T1 | C-021 | `spec/wasm_cross/string_whitespace.almd` (byte-compare) |
 | ALS-T2 | C-024, C-210 | `spec/wasm_cross/float_parse.almd` (byte-compare)<br>`spec/wasm_cross/nan_canonical_observation.almd` (byte-compare)<br>`spec/wasm_cross/nan_canonical_bytes_write.almd` (byte-compare) |
 | ALS-T3 | C-087 | `spec/wasm_cross/json_number_unicode.almd` (byte-compare)<br>`spec/wasm_cross/json_string_span.almd` (byte-compare) |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -3264,3 +3264,14 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/guard_statement.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-266"
+spec      = "ALS-S7"
+title     = "guard let binds the success payload and raises on the failing polarity, identically on both targets"
+statement = "ALS-S7: `guard let x = scrut else err(e)` binds the Ok/Some payload for the rest of the block on the success polarity (int.parse(\"21\") -> 42 pinned) and propagates the else's err to the caller on the failing one (\"not a number\" pinned) — byte-identical native <-> wasm; chained guard lets fold into a single carrier bind (#1340). The wall that stood here was POSITIONAL, not polarity- or pattern-shaped: guard let desugars in the frontend to a BLOCK-NESTED variant match, and auto_wrap_abi_body retypes only the body ROOT to the Result carrier, so the nested match kept its scalar type and fell off the carrier-typed tail path. The fix taught the proven bind-shape normalizer about variant matches — the same machinery ALS-S6 uses."
+since     = "0.57.1"
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/guard_let_statement.almd", class = "fixture" },
+]

--- a/docs/specs/als/expressions.md
+++ b/docs/specs/als/expressions.md
@@ -603,3 +603,25 @@ match が受け取る(fixture: `checked(-3)` の err を match が拾って
 
 テスト: `spec/wasm_cross/guard_statement.almd`(契約 C-265)、
 `spec/lang/guard_test.almd`(wasm レグ)。
+
+## ALS-S7 guard let 文(`Stmt::GuardLet`)
+
+**受理形**: `guard let x = scrut else raise-expr` — 文位置。`scrut` は
+Result / Option、`x` は Ok / Some のペイロードに束縛され、後続文の全域で
+可視。else アームは raise(`err(e)` / `err(e)!`)。
+
+**値の規範**: 成功極性なら束縛して素通り(fixture: `int.parse("21")` →
+v=21 → 42)。失敗極性なら else の err が呼び出し元へ伝搬する(fixture:
+`doubled("x")` の err を match が拾って "not a number")。両ターゲット
+同一。連鎖した guard let は単一の carrier 束縛に畳まれる(#1340)。
+
+**ブロック入れ子の裁定(#1340 の発見)**: guard let はフロントエンドで
+**ブロックに入れ子の variant match** へ脱糖される。裸の tail match は
+以前から両レグ live だったが、ブロック 1 段の入れ子で wall していた —
+`auto_wrap_abi_body` が本体の**ルートのみ**を Result キャリアに retype
+するため。したがって壁の原因は極性でも wildcard アームでもなく**位置**で
+あり、修正は「証明済みの bind 形へ正規化する認識器」に variant match を
+教えることだった(ALS-S6 と同じ機構の別の顔)。
+
+テスト: `spec/wasm_cross/guard_let_statement.almd`(契約 C-266)、
+`spec/lang/guard_let_test.almd`(wasm レグ)。

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,11 +15,11 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 61 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 279/400 fixtures cast a real 3-way vote (69%)** —
+> **Stage 2 (translation validation): 280/401 fixtures cast a real 3-way vote (69%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
-> **Stage 3 (semantics freeze): 265/265 contracts spec-keyed; syntax-element coverage
-> 67/73 sectioned (6 UNWRITTEN, shrink-only — the freeze precondition is 0).**
+> **Stage 3 (semantics freeze): 266/266 contracts spec-keyed; syntax-element coverage
+> 68/73 sectioned (5 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).

--- a/proofs/als-element-coverage.toml
+++ b/proofs/als-element-coverage.toml
@@ -12,7 +12,7 @@
 # the existing ALS sections (T1-T7, R-series, ...) are STDLIB-semantics
 # normative text; the syntax-element direction starts honestly at zero.
 #
-# unwritten_ceiling = "6"
+# unwritten_ceiling = "5"
 
 [[element]]
 name = "ExprKind::Int"
@@ -256,7 +256,7 @@ section = "ALS-S6"
 
 [[element]]
 name = "Stmt::GuardLet"
-section = "UNWRITTEN"
+section = "ALS-S7"
 
 [[element]]
 name = "Stmt::Expr"

--- a/spec/wasm_cross/guard_let_statement.almd
+++ b/spec/wasm_cross/guard_let_statement.almd
@@ -1,0 +1,22 @@
+// @contract: C-266
+// ALS-S7 (docs/specs/als/expressions.md): the guard-let statement — bind
+// the Ok/Some payload and early-exit on the failing polarity. Both paths
+// pinned for a Result scrutinee: the parse succeeds (payload flows to the
+// tail) and it fails (the else err propagates to the caller, caught here by
+// match). Un-walled on the wasm leg by #1340: the frontend desugars guard
+// let into a BLOCK-nested variant match, and the block nesting — not the
+// polarity — was what kept it off the carrier-typed tail path.
+effect fn doubled(s: String) -> Int = {
+  guard let v = int.parse(s) else err("not a number")
+  v * 2
+}
+
+effect fn main() -> Unit = {
+  println(int.to_string(doubled("21")!))
+  let bad: Result[Int, String] = doubled("x")
+  let msg = match bad {
+    ok(v) => int.to_string(v),
+    err(e) => e,
+  }
+  println(msg)
+}


### PR DESCRIPTION
Row 68 — **68/73 sectioned**, and with it **the compiler-side tail of the sweep reaches zero**: every remaining row is blocked on a design ruling, not on a brick.

## ALS-S7 (C-266)

Parity `42` / `not a number`: the success polarity binds the payload for the rest of the block, the failing one propagates the else's err to the caller. Chained guard lets fold into a single carrier bind (#1340).

The section records #1340's finding, which is the interesting part: the wall was **positional**, not polarity- or pattern-shaped. A bare tail variant match was already live on both legs in all four spellings; wrapping it in ONE block walled it, because `auto_wrap_abi_body` retypes only the body ROOT to the Result carrier. Same machinery as ALS-S6, different face.

## Gates

- both p5 gates green (interp voting + abstain ledger); contract ledger 266 contracts / 401 fixtures
- coverage **68 sectioned / 5 UNWRITTEN (ceiling 6 → 5)**