### PR TITLE
Disable codopsy's no-unsafe rule with the rationale recorded inline (kernel B 88 to A 94)

### DIFF
--- a/.codopsyrc.json
+++ b/.codopsyrc.json
@@ -1,5 +1,15 @@
 {
+  "//": "RULING 2026-08-13 (user ○): `no-unsafe` is OFF because almide-kernel's",
+  "//2": "SIMD paths (q1_0.rs, silu.rs, simd_wasm.rs, q1_0_packed.rs) are hand-",
+  "//3": "written intrinsics — `unsafe` there is the POINT, not a smell, and the",
+  "//4": "warnings alone held the crate at B (88) while every other touched crate",
+  "//5": "is A. Turning the rule off repo-wide (codopsy has no per-path scoping)",
+  "//6": "trades a real signal elsewhere for an honest kernel score: if a NON-SIMD",
+  "//7": "crate ever needs `unsafe`, that is a design review question, not a lint",
+  "//8": "one — the trust spine (kernel-proven PCC + corpus wall) is what actually",
+  "//9": "gates memory safety here, and it does not read this file.",
   "rules": {
+    "no-unsafe": false,
     "no-any": "warning",
     "no-console": "info",
     "no-var": "warning",


### PR DESCRIPTION
User ruling (○ with 'コメントで残すこと'): almide-kernel sat at **B (88)** while every other touched crate was A, and the entire gap was `no-unsafe` warnings over its hand-written SIMD paths (q1_0.rs, silu.rs, simd_wasm.rs, q1_0_packed.rs) where `unsafe` **is the point, not a smell**.

## Measured

- `.codopsyrc.json` with `"no-unsafe": false` (the README's documented disable form — `"off"` as a severity does NOT disable, measured: score unchanged at 88)
- almide-kernel: **88/B → 94/A**

## The rationale is IN the file

Nine `//` comment lines above the rules block record why, per the ruling: codopsy has no per-path scoping, so this trades a repo-wide signal for an honest kernel score; a non-SIMD crate reaching for `unsafe` is a design-review question rather than a lint one; and memory safety here is actually gated by the trust spine (kernel-proven PCC + corpus wall), which does not read this file. A future reader gets the reasoning without archaeology.