### PR TITLE
Remove the strict declaration from the language surface (#1321)

### DIFF
--- a/crates/almide-syntax/src/ast.rs
+++ b/crates/almide-syntax/src/ast.rs
@@ -392,7 +392,6 @@ pub enum Decl {
     },
     TopLet { name: Sym, #[serde(rename = "type")] ty: Option<TypeExpr>, value: Expr, #[serde(default)] mutable: bool, #[serde(default)] visibility: Visibility, #[serde(skip)] span: Option<Span> },
     Protocol { name: Sym, #[serde(default)] generics: Option<Vec<GenericParam>>, methods: Vec<ProtocolMethod>, #[serde(skip)] span: Option<Span> },
-    Strict { mode: String, #[serde(skip)] span: Option<Span> },
     Test { name: String, body: Expr, #[serde(default)] where_clauses: Vec<TestWhere>, #[serde(skip)] span: Option<Span> },
     /// `local test where { ... }` — file-scoped test environment
     TestWhereDef { scope: TestWhereScope, clauses: Vec<TestWhere>, #[serde(skip)] span: Option<Span> },
@@ -461,7 +460,7 @@ pub fn visit_decl_exprs_mut(decl: &mut Decl, f: &mut impl FnMut(&mut Expr)) {
             for wc in clauses.iter_mut() { visit_test_where_exprs_mut(wc, f); }
         }
         Decl::Module { .. } | Decl::Import { .. } | Decl::Type { .. } |
-        Decl::Protocol { .. } | Decl::Strict { .. } => {}
+        Decl::Protocol { .. } => {}
     }
 }
 

--- a/crates/almide-syntax/src/lexer.rs
+++ b/crates/almide-syntax/src/lexer.rs
@@ -22,7 +22,7 @@ pub enum TokenType {
     Module, Import, Type, Protocol, For, In, Fn, Let, Var, Mut,
     If, Then, Else, Match, Ok, Err, Some, None, Todo,
     True, False, Not, And, Or,
-    Strict, Pub, Effect, Test,
+    Pub, Effect, Test,
     Guard, Break, Continue, While, Local, Mod, Fan,
     // Delimiters
     LParen, RParen, LBrace, RBrace, LBracket, RBracket,
@@ -742,7 +742,7 @@ const KEYWORDS: &[(&str, TokenType)] = &[
     ("todo", TokenType::Todo),
     ("true", TokenType::True), ("false", TokenType::False),
     ("not", TokenType::Not), ("and", TokenType::And),
-    ("or", TokenType::Or), ("strict", TokenType::Strict),
+    ("or", TokenType::Or),
     ("pub", TokenType::Pub), ("effect", TokenType::Effect),
     ("test", TokenType::Test),
     ("guard", TokenType::Guard), ("break", TokenType::Break),

--- a/crates/almide-syntax/src/parser/collections.rs
+++ b/crates/almide-syntax/src/parser/collections.rs
@@ -168,7 +168,7 @@ impl Parser {
             | TokenType::Fn | TokenType::Effect
             | TokenType::Pub | TokenType::Local | TokenType::Mod
             | TokenType::Type | TokenType::Protocol
-            | TokenType::Test | TokenType::Strict | TokenType::At
+            | TokenType::Test | TokenType::At
             | TokenType::RBrace
         )
     }

--- a/crates/almide-syntax/src/parser/declarations.rs
+++ b/crates/almide-syntax/src/parser/declarations.rs
@@ -186,9 +186,6 @@ impl Parser {
         if self.check(TokenType::Var) {
             return Some(self.parse_top_let(Visibility::Public, true));
         }
-        if self.check(TokenType::Strict) {
-            return Some(self.parse_strict_decl());
-        }
         if self.check(TokenType::Test) {
             return Some(self.parse_test_decl());
         }
@@ -502,13 +499,6 @@ impl Parser {
         self.expect(TokenType::Arrow)?;
         let return_type = self.parse_type_expr()?;
         Ok(ProtocolMethod { name, params, return_type, effect })
-    }
-
-    fn parse_strict_decl(&mut self) -> Result<Decl, String> {
-        let span = self.current_span();
-        self.expect(TokenType::Strict)?;
-        let mode = self.expect_ident()?.to_string();
-        Ok(Decl::Strict { mode, span: Some(span) })
     }
 
     fn parse_test_where_def(&mut self) -> Result<Decl, String> {

--- a/crates/almide-syntax/src/parser/hints/keyword_typo.rs
+++ b/crates/almide-syntax/src/parser/hints/keyword_typo.rs
@@ -65,6 +65,17 @@ pub fn check(ctx: &HintContext) -> Option<HintResult> {
         });
     }
 
+    // `strict <mode>` — a declaration that parsed, checked, and was consumed by
+    // nothing (#1321). Removed from the language; `strict` is a plain identifier
+    // again, so a top-level `strict effects` lands here as an unexpected Ident.
+    if value == "strict" && ctx.got.token_type == TokenType::Ident {
+        return Some(HintResult {
+            message: Some("'strict' declarations were removed from Almide".into()),
+            hint: "The 'strict types' / 'strict effects' declaration enabled no checking — \
+                   delete the line. Effect propagation is already always checked (E041/E042).".into(),
+        });
+    }
+
     // Import after declarations
     if value == "import" && ctx.got.token_type == TokenType::Import {
         return Some(HintResult {

--- a/crates/almide-syntax/src/parser/recovery.rs
+++ b/crates/almide-syntax/src/parser/recovery.rs
@@ -27,7 +27,7 @@ impl Parser {
                         | TokenType::Type | TokenType::Test | TokenType::Pub
                         | TokenType::Protocol
                         | TokenType::Local | TokenType::Mod
-                        | TokenType::Strict | TokenType::At
+                        | TokenType::At
                     ) {
                         break;
                     }
@@ -45,7 +45,7 @@ impl Parser {
                 TokenType::Fn | TokenType::Effect
                 | TokenType::Pub | TokenType::Local | TokenType::Mod
                 | TokenType::Type | TokenType::Protocol
-                | TokenType::Test | TokenType::Strict | TokenType::At => {
+                | TokenType::Test | TokenType::At => {
                     break;
                 }
                 TokenType::Newline => {
@@ -54,7 +54,7 @@ impl Parser {
                         TokenType::Fn | TokenType::Effect
                         | TokenType::Pub | TokenType::Local | TokenType::Mod
                         | TokenType::Type | TokenType::Protocol
-                        | TokenType::Test | TokenType::Strict | TokenType::At
+                        | TokenType::Test | TokenType::At
                         | TokenType::EOF
                     ) {
                         break;

--- a/crates/almide-tools/src/fmt.rs
+++ b/crates/almide-tools/src/fmt.rs
@@ -725,7 +725,6 @@ fn fmt_decl(out: &mut String, decl: &Decl, depth: usize) {
             if let Some(n) = names { w!(out, ".{{{}}}", join_syms(n, ", ")); }
             if let Some(a) = alias { w!(out, " as {a}"); }
         }
-        Decl::Strict { mode, .. } => w!(out, "{i}strict \"{mode}\""),
         Decl::Type { .. } => fmt_decl_type(out, decl, depth),
         Decl::TopLet { .. } => fmt_decl_top_let(out, decl, depth),
         Decl::Fn { .. } => fmt_decl_fn(out, decl, depth),

--- a/docs/GRAMMAR.md
+++ b/docs/GRAMMAR.md
@@ -14,7 +14,7 @@ import      = "import" dotted_path
               | "as" IDENT )?                             (* alias: import self as app *)
 dotted_path = IDENT ("." IDENT)*                          (* import pkg.submodule *)
 
-decl        = type_decl | fn_decl | protocol_decl | top_let | strict_decl | test_decl
+decl        = type_decl | fn_decl | protocol_decl | top_let | test_decl
 
 type_decl   = ("local" | "mod")? "type" TYPENAME generic_params?
               (":" TYPENAME ("," TYPENAME)*)?             (* conventions: type Name: Eq, Repr *)
@@ -32,7 +32,6 @@ protocol_decl   = "protocol" TYPENAME generic_params? "{" protocol_method* "}"
 protocol_method = "effect"? "fn" fn_name generic_params? "(" params ")" "->" type
 
 top_let     = "pub"? ("local" | "mod")? ("let" | "var") name (":" type)? "=" expr
-strict_decl = "strict" IDENT
 test_decl   = "test" STRING where_clause* block           (* where: table cases / binds / call stubs *)
 generic_params = "[" gparam ("," gparam)* "]"
 gparam      = TYPENAME (":" (TYPENAME ("+" TYPENAME)* | "{" fields "}"))?   (* bounds; structural bound *)

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -90,15 +90,18 @@ Numeric literals support `_` as a visual separator (e.g., `1_000_000`).
 
 Block comments nest: `/* outer /* inner */ still outer */` is valid.
 
-### 1.5 Keywords (35)
+### 1.5 Keywords (34)
 
 ```
 module  import  type    protocol for     in      fn      let
 var     mut     if      then     else    match   ok      err
 some    none    todo    true     false   not     and     or
-strict  pub     effect  test     guard   break   continue while
+pub     effect  test    guard    break   continue while
 local   mod     fan
 ```
+
+`strict` was removed — the `strict types` / `strict effects` declaration
+enabled no checking, so the word is an ordinary identifier again.
 
 ### 1.6 Operators and Delimiters
 
@@ -165,7 +168,7 @@ text
 Program   ::= ImportDecl* TopDecl*
 
 TopDecl   ::= TypeDecl | ProtocolDecl | FnDecl
-            | TopLetDecl | StrictDecl | TestDecl
+            | TopLetDecl | TestDecl
 
 Stmt      ::= LetStmt | VarStmt | AssignStmt | GuardStmt | Expr
 
@@ -1160,18 +1163,7 @@ almide test --run "pattern"      # filter by name
 
 ---
 
-## 15. Strict Mode
-
-```
-strict types      // require all type annotations
-strict effects    // fully check effect propagation
-```
-
-Declared at the top of a file. Enables stricter compiler checking.
-
----
-
-## 16. Naming Conventions
+## 15. Naming Conventions
 
 ### Predicates
 
@@ -1191,11 +1183,11 @@ The `is_` prefix convention is used for predicates in the stdlib: `string.is_emp
 
 ---
 
-## 17. Standard Library
+## 16. Standard Library
 
 959 functions across 41 modules, defined in pure Almide (`stdlib/*.almd`). Runtime implementation: 100%.
 
-### 17.1 Auto-Imported Modules
+### 16.1 Auto-Imported Modules
 
 **string** (41 functions):
 `trim`, `trim_start`, `trim_end`, `split`, `join`, `len`, `lines`, `pad_start`, `pad_end`, `starts_with`, `ends_with`, `slice`, `to_bytes`, `from_bytes`, `contains`, `to_upper`, `to_lower`, `to_int`, `replace`, `char_at`, `chars`, `index_of`, `repeat`, `count`, `reverse`, `is_empty`, `is_digit`, `is_alpha`, `is_alphanumeric`, `is_whitespace`, `strip_prefix`, `strip_suffix`, `capitalize`, `is_upper`, `is_lower`, `codepoint`, `from_codepoint`, `replace_first`, `last_index_of`, `to_float`
@@ -1236,7 +1228,7 @@ Date/time operations: `now`, `year`, `month`, `day`, `hour`, `minute`, `second`,
 Also auto-imported: `bytes`, `matrix`, and the sized numeric modules
 (`int8`/`int16`/`int32`, `uint8`/`uint16`/`uint32`/`uint64`, `float32`).
 
-### 17.2 Import-Required Modules
+### 16.2 Import-Required Modules
 
 **fs** (24 functions, all effect):
 `read_text`, `read_bytes`, `read_lines`, `write`, `write_bytes`, `append`, `mkdir_p`, `exists`, `is_dir`, `is_file`, `remove`, `list_dir`, `copy`, `rename`, `remove_dir`, `metadata`, `glob`, `walk_dir`, `read_dir`, `create_dir`, `symlink`, `read_link`, `canonical`, `temp_dir`
@@ -1268,12 +1260,12 @@ Also auto-imported: `bytes`, `matrix`, and the sized numeric modules
 **http** (26 functions, effect):
 HTTP client operations.
 
-### 17.3 Bundled Modules (Pure Almide, import required)
+### 16.3 Bundled Modules (Pure Almide, import required)
 
 `args`, `path`, `html`, `mem` — plus opt-in codecs `base64`, `hex`, `zlib` and
 `net`. (The former `time`/`encoding`/`hash`/`url`/`csv` modules were removed.)
 
-### 17.4 Built-in Functions
+### 16.4 Built-in Functions
 
 Available everywhere without import:
 
@@ -1289,7 +1281,7 @@ There is no `print` function (use `io.print` for no-newline output). `println` r
 
 ---
 
-## 18. Entry Point
+## 17. Entry Point
 
 ```
 effect fn main(args: List[String]) -> Result[Unit, AppError] = {
@@ -1306,9 +1298,9 @@ effect fn main(args: List[String]) -> Result[Unit, AppError] = {
 
 ---
 
-## 19. Codegen Architecture
+## 18. Codegen Architecture
 
-### 19.1 Multi-Target
+### 18.1 Multi-Target
 
 Almide compiles to multiple targets:
 
@@ -1317,7 +1309,7 @@ Almide compiles to multiple targets:
 | **Rust** | Production | Full ownership analysis, borrow/clone passes |
 | **WASM** | Production | Direct emit (linear memory, WASI) |
 
-### 19.2 Codegen v3 Pipeline
+### 18.2 Codegen v3 Pipeline
 
 Three-layer architecture: IR -> Nanopass -> Templates.
 
@@ -1344,7 +1336,7 @@ Target source code
 
 Templates are defined in TOML files (`codegen/templates/*.toml`), separating syntax from semantics.
 
-### 19.3 Cross-Target Semantics
+### 18.3 Cross-Target Semantics
 
 | Feature | Rust | WASM |
 |---------|------|------|
@@ -1358,7 +1350,7 @@ Templates are defined in TOML files (`codegen/templates/*.toml`), separating syn
 
 ---
 
-## 20. Prohibitions
+## 19. Prohibitions
 
 | # | Prohibited | Reason |
 |---|---|---|
@@ -1379,13 +1371,13 @@ Templates are defined in TOML files (`codegen/templates/*.toml`), separating syn
 
 ---
 
-## 21. Compiler Diagnostics
+## 20. Compiler Diagnostics
 
-### 21.1 One Error, One Root Cause
+### 20.1 One Error, One Root Cause
 
 Cascading derived errors are suppressed. A single root cause is presented.
 
-### 21.2 Structured Error Output
+### 20.2 Structured Error Output
 
 ```json
 {
@@ -1397,7 +1389,7 @@ Cascading derived errors are suppressed. A single root cause is presented.
 }
 ```
 
-### 21.3 Rejected Syntax Hints
+### 20.3 Rejected Syntax Hints
 
 The compiler recognizes common syntax from other languages and provides actionable hints:
 
@@ -1415,7 +1407,7 @@ The compiler recognizes common syntax from other languages and provides actionab
   Hint: Use 'and' for logical AND.
 ```
 
-### 21.4 Auto-Fix Candidates
+### 20.4 Auto-Fix Candidates
 
 - Missing imports
 - Type conversion candidates
@@ -1423,7 +1415,7 @@ The compiler recognizes common syntax from other languages and provides actionab
 - Missing `effect` modifier
 - Suggest `effect fn` when pure function calls effectful code
 
-### 21.5 Official Formatter
+### 20.5 Official Formatter
 
 ```bash
 almide fmt app.almd
@@ -1436,7 +1428,7 @@ almide fmt app.almd
 
 ---
 
-## 22. Typing Rules
+## 21. Typing Rules
 
 ### Variables
 
@@ -1536,7 +1528,7 @@ G |- _ : T                      G |- todo(msg) : T
 
 ---
 
-## 23. Complete Example
+## 22. Complete Example
 
 ```
 import fs
@@ -1595,7 +1587,7 @@ test "with_description updates correctly" {
 
 ---
 
-## 24. Evaluation Metrics
+## 23. Evaluation Metrics
 
 | Metric | Definition |
 |---|---|

--- a/docs/specs/als/expressions.md
+++ b/docs/specs/als/expressions.md
@@ -516,8 +516,7 @@ C-094/C-126(`protocol_ufcs_inferred_lambda.almd`)が pin。test ブロックは
 `almide test` の wasm レグで常時実行される(spec/lang 全域が evidence;
 `test where` は `spec/lang/test_where_test.almd`)。
 
-**Strict は未節化**: `strict <mode>` は受理されるが現状どの層も消費しない
-(#1321 — accept-and-ignored)。裁定が下るまで UNWRITTEN 維持。
+**Strict は撤去済み**: `strict <mode>` は受理されるだけで何も消費しない宣言だった(#1321)。裁定(2026-08-13)により**文法から削除** — 効かない検査モードを約束する形は言語に残さない。以後 `strict` は通常の識別子であり、宣言として書けばパースエラーになる。
 
 テスト: `spec/wasm_cross/declaration_forms.almd`(契約 C-260)。
 

--- a/docs/specs/language.md
+++ b/docs/specs/language.md
@@ -1,4 +1,4 @@
-> Last updated: 2026-08-06
+> Last updated: 2026-08-13
 
 # Almide Language Specification
 
@@ -426,14 +426,6 @@ test "addition works" {
 The body is a brace-delimited block expression.
 
 テスト: All `spec/lang/*_test.almd` files contain `test` blocks.
-
-### 4.8 Strict Mode
-
-```
-strict warnings
-```
-
-Enables stricter compiler diagnostics.
 
 ---
 

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -19,7 +19,7 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
 > **Stage 3 (semantics freeze): 266/266 contracts spec-keyed; syntax-element coverage
-> 68/73 sectioned (5 UNWRITTEN, shrink-only — the freeze precondition is 0).**
+> 68/72 sectioned (4 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).

--- a/proofs/als-element-coverage.toml
+++ b/proofs/als-element-coverage.toml
@@ -12,7 +12,7 @@
 # the existing ALS sections (T1-T7, R-series, ...) are STDLIB-semantics
 # normative text; the syntax-element direction starts honestly at zero.
 #
-# unwritten_ceiling = "5"
+# unwritten_ceiling = "4"
 
 [[element]]
 name = "ExprKind::Int"
@@ -293,10 +293,6 @@ section = "ALS-D1"
 [[element]]
 name = "Decl::Protocol"
 section = "ALS-D1"
-
-[[element]]
-name = "Decl::Strict"
-section = "UNWRITTEN"
 
 [[element]]
 name = "Decl::Test"

--- a/tests/diagnostics/strict-decl-removed/broken.almd
+++ b/tests/diagnostics/strict-decl-removed/broken.almd
@@ -1,0 +1,3 @@
+strict effects
+
+fn double(n: Int) -> Int = n * 2

--- a/tests/diagnostics/strict-decl-removed/fixed.almd
+++ b/tests/diagnostics/strict-decl-removed/fixed.almd
@@ -1,0 +1,1 @@
+fn double(n: Int) -> Int = n * 2

--- a/tests/diagnostics/strict-decl-removed/meta.toml
+++ b/tests/diagnostics/strict-decl-removed/meta.toml
@@ -1,0 +1,2 @@
+expects_error = "'strict' declarations were removed from Almide"
+hint_substring = "delete the line"

--- a/tests/lexer_test.rs
+++ b/tests/lexer_test.rs
@@ -113,7 +113,6 @@ fn lex_all_keywords() {
         ("err", TokenType::Err),
         ("some", TokenType::Some),
         ("none", TokenType::None),
-        ("strict", TokenType::Strict),
         ("local", TokenType::Local),
         ("mod", TokenType::Mod),
     ];
@@ -141,6 +140,16 @@ fn lex_type_name() {
 fn lex_question_as_separate_token() {
     let toks = tokens("empty?");
     assert_eq!(toks, vec![(TokenType::Ident, "empty".into()), (TokenType::Question, "?".into())]);
+}
+
+/// `strict` was a keyword introducing the `strict <mode>` declaration, which
+/// parsed, checked, and was consumed by nothing (#1321). The declaration was
+/// removed from the language, and with it the keyword: `strict` is an ordinary
+/// identifier again.
+#[test]
+fn lex_strict_is_an_ordinary_identifier() {
+    let toks = tokens("strict");
+    assert_eq!(toks, vec![(TokenType::Ident, "strict".into())]);
 }
 
 #[test]


### PR DESCRIPTION
Ruling (×, 「そこまでいらない」) on making `strict` a check-time error: remove the declaration from the language surface instead. `strict <mode>` parsed, passed check, and was consumed by nothing outside `fmt` — a form that promises a checking mode and delivers silence (#1321).

## What was removed

| Site | Change |
|---|---|
| `crates/almide-syntax/src/ast.rs` | `Decl::Strict` variant + its `visit_decl_exprs_mut` arm |
| `crates/almide-syntax/src/parser/declarations.rs` | the `parse_keyword_top_decl` arm and `parse_strict_decl` |
| `crates/almide-syntax/src/lexer.rs` | `TokenType::Strict` + the `("strict", …)` keyword-table row |
| `crates/almide-syntax/src/parser/{recovery,collections}.rs` | 4 declaration-sync-point sets |
| `crates/almide-tools/src/fmt.rs` | the `Decl::Strict` printing arm |

`grep -rn "TokenType::Strict\|Decl::Strict" --include="*.rs" .` (excluding `target/`) returns **0 hits** after the change.

## Corpus check before removal

`grep -rn "^strict "` over `spec/ stdlib/ examples/ tools/ docs/` → **0** declaration uses. The only textual hits were the spec prose removed here (`docs/SPEC.md` §15, `docs/GRAMMAR.md` `strict_decl`, `docs/specs/language.md` §4.8) plus unrelated words (`restrict`, `stricter`, `parse_int_strict`).

## `strict` is a plain identifier again

Measured, both targets, same bytes:

```
$ cat b.almd
import io
effect fn main() -> Unit = {
  let strict = 41
  io.print("${strict + 1}\n")
}
$ almide run b.almd            → 42   (exit 0)
$ almide run b.almd --target wasm → 42   (exit 0)
```

`cargo test --release --test lexer_test` gained `lex_strict_is_an_ordinary_identifier` (measured: `strict` lexes as `(Ident, "strict")`), and the keyword-table case dropped `strict`.

## The tombstone (no new machinery)

A top-level `strict effects` is now an unexpected `Ident`, which lands in the existing `HintScope::TopLevel` table (`parser/hints/keyword_typo.rs`) beside `def`/`class`/`impl`/`return`. Six added lines, no new error code, no new diagnostic path. Measured:

```
error: 'strict' declarations were removed from Almide at line 1:1
  --> a.almd:1:1
  here: strict effects
  hint: The 'strict types' / 'strict effects' declaration enabled no checking —
        delete the line. Effect propagation is already always checked (E041/E042).
```

Pinned by `tests/diagnostics/strict-decl-removed/` (broken/fixed pair + `meta.toml`); no `EXXX.md` needed because the hint carries no code (same shape as the existing `bang-not` fixture).

## ALS element ledger — it moved, and I had to touch main's file

`scripts/lib/als-element-enumerate.py` reads the AST enums, so dropping `Decl::Strict` moved the universe **73 → 72** (measured before: 73, after: 72). `Decl::Strict` was one of the 6 `UNWRITTEN` rows, and `scripts/check-als-element-coverage.sh` fails both on a stale row and on `unwritten < ceiling`, so the ledger had to change in this PR:

- deleted the `Decl::Strict` row and ratcheted `unwritten_ceiling` down one
- `scripts/gen-claims.sh` re-derived `proofs/STAGE-STATUS.md`
- `docs/specs/als/expressions.md`'s **Strict は未節化** paragraph became false and is rewritten as a removal note (wording supplied by the main session, which owns `docs/specs/als/`)

The branch was then rebased onto `develop` after #1342 (ALS-S7 `guard let`) landed, which had already taken the ceiling 6 → 5 and sectioned `Stmt::GuardLet`. **Numbers below are re-measured on the rebased tree, not the pre-rebase ones**: ceiling 5 → 4, `STAGE-STATUS` 68/73 (5 UNWRITTEN) → 68/72 (4 UNWRITTEN).

Gate after: `als-element-coverage OK: 72 element(s) — 68 sectioned, 4 UNWRITTEN (ceiling 4; freeze precondition: 0)`.

## Docs

`docs/SPEC.md`: keyword count 35 → 34, `strict` dropped from the keyword block with a one-line removal note (§1.1's `?`-suffix removal is the precedent), `StrictDecl` dropped from `TopDecl`, §15 Strict Mode deleted and §§16–24 renumbered to 15–23. Side effect worth noting: `docs/design/REJECTED_PATTERNS.md` cites "SPEC §19" for the operator-overloading ban, which was §20 — the renumber makes that reference correct. `docs/GRAMMAR.md`: `strict_decl` production and its `decl` alternative deleted. `docs/specs/language.md`: §4.8 deleted (it was the last subsection of §4, so nothing renumbers).

## Gates run locally

Every row below was re-run on the **rebased** HEAD (`1220aff48`), after `cargo build --release`.

| Gate | Result |
|---|---|
| `cargo test --release -p almide-syntax -p almide-tools` | 62 + 6 + 7 passed, 0 failed |
| `cargo test --release --test lexer_test` | 43 passed |
| `cargo test --release --test parser_test` | 93 passed |
| `cargo test --release --test fuzz_test` | 6 passed |
| `cargo test --release --test diagnostic_harness_test` | 3 passed |
| `cargo test --release --test diagnostic_coverage_test` | 4 passed |
| `cargo test --release --test traversal_totality_lint` | 1 passed |
| `cargo test --release --test wasm_runtime_test` | 75 passed (incl. `interp_cross_target_spec`, `interp_abstain_ledger`) |
| `almide test` | 374 via WASM, 17 via native fallback, **0 failed** (391 files) |
| `make verify-trust` | exit 0 |
| `almide fmt --check spec/ examples/` | 901 files already formatted |
| `almide docs-gen --check` | ok |
| `scripts/check-contracts.sh` | 266 contracts, flagged 0, 401/401 fixtures linked |
| `scripts/check-als-element-coverage.sh` | 72 elements, 68 sectioned, 4 UNWRITTEN (ceiling 4) |

Note for anyone reproducing `make verify-trust` on macOS: `proofs/check-stdlib-purity-registry.sh` uses `declare -A`, so `/bin/bash` 3.2 fails it with `line 51: args: unbound variable`. Putting a bash ≥ 4 on `PATH` (here `/run/current-system/sw/bin`) is what makes it pass; it is not a code failure.

Closes nothing on its own — #1321 stays open for the main session to close.
