### PR TITLE
Replace the DO-330 gap page's copied ALS count with a pointer to the live ledger

### DIFF
--- a/proofs/DO330-GAP.md
+++ b/proofs/DO330-GAP.md
@@ -39,7 +39,7 @@ source: scripts/release-seal.sh
 | C-WCET (counted-loop keystone あ) | PENDING in the receipt design | flight-reference-app Slice 2 |
 | C-FAITHFUL + Ferrocene leg (keystone い) | PENDING; no qualified native toolchain in the chain | flight-reference-app Slice 3, needs Ferrocene access |
 | wasmtime qualification pedigree | unqualified COTS, procedural TOR-9 | #865 |
-| ALS syntax-element authoring | 0/73 sectioned, shrink-only | proofs/als-element-coverage.toml (freeze precondition) |
+| ALS syntax-element authoring | shrink-only ratchet; live count in the ledger's `unwritten_ceiling` and proofs/STAGE-STATUS.md | proofs/als-element-coverage.toml (freeze precondition) |
 | Durability evidence | streak meter live, day 0 | research/benchmark/fuzz-green/ (90-day milestone) |
 | Process independence | ratchet-separation gate exists; human/organizational review split is org-level work | flight-evidence-gaps F5 close note |
 | PSAC / certification planning | no plan document yet | flight-qualification §G-F6 (dossier template) |


### PR DESCRIPTION
Caught by the strict-removal agent: `proofs/DO330-GAP.md` claimed **"0/73 sectioned"** for ALS syntax-element authoring — stale since the sweep's first unit and wrong by 68 rows today (actual: 68/72).

The fix is not to update the number. That page's own preamble says numbers are "regenerable ... included by pointer rather than by copy so it cannot silently drift" — the row violated it. It now points at the ledger's `unwritten_ceiling` and `proofs/STAGE-STATUS.md`, both of which are gate-maintained, so it cannot go stale again.

Verified: check-tor-refs (every `source:` still resolves), gen-claims --check, check-contracts.