### PR TITLE
Burn seven gate-verification rows, ceiling 9 to 2

### DIFF
--- a/docs/roadmap/active/flight-evidence-gaps.md
+++ b/docs/roadmap/active/flight-evidence-gaps.md
@@ -330,7 +330,7 @@ rank を明示して限定的に行う**こと（無限定の "flight-grade" 表
 | 成果物 | 現状 | 評価 |
 |---|---|---|
 | ツール運用要求(TOR) | CLAUDE.md の Usage 節 + TRUSTED_BASE.md が断片的に相当。DO-330 の様式(想定運用環境・入力制約・既知制限の運用回避)としては**未編纂** | **編纂済み(proofs/TOR.md)** — TOR-1〜9 の運用要求(各行が enforced-by 計器を指名、check-tor-refs.sh が参照整合を CI 強制)+ 運用視点の既知制限表。G-F6 キットへの整形が残 |
-| 検証ツール自身の検証 | checker = Coq 証明(qualified-by-proof、45 定理 + coqchk + cross-version)。**ゲートスクリプト群は負テスト文化が定着**(check-contracts は mutation テスト、監査ゲート 3 本は負テスト済み、release-seal も偽造/未記入の負テスト付き)。fuzz ハーネスに単体テスト(分類器の純関数化) | **一覧表は稼働**(proofs/gate-verification.toml + check-gate-verification.sh — 30 ゲート 5 分類、UNVERIFIED 18 は shrink-only 天井で直視)。残余 = UNVERIFIED 18 の焼却 |
+| 検証ツール自身の検証 | checker = Coq 証明(qualified-by-proof、45 定理 + coqchk + cross-version)。**ゲートスクリプト群は負テスト文化が定着**(check-contracts は mutation テスト、監査ゲート 3 本は負テスト済み、release-seal も偽造/未記入の負テスト付き)。fuzz ハーネスに単体テスト(分類器の純関数化) | **一覧表は稼働**(proofs/gate-verification.toml + check-gate-verification.sh — 33 ゲート 5 分類、UNVERIFIED は shrink-only 天井で直視)。#1244 の焼却で 18 → **2**。残余 2 本(check-host-determinism / check-browser-determinism)は wasm32 std を持つホストが要る環境ゲート |
 | 既知問題台帳の正式化 | GitHub issues + リリースノート既知制限(0.57.0 の #1229)+ `fuzz-perf` ラベル + flagged-for-revision 機構 + **リリース封印**(proofs/releases/ — v0.57.0 から、証拠のタグ束縛) | **PARTIAL** — 散在。リリース封印の `[recorded]` に known-problems 節を追加すれば形式が閉じる |
 
 **総評の更新**: 7 月の「哲学は DAL-A、証拠は DAL-D 相当」から、証拠体系は

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -25,7 +25,7 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).
 >
 > **Stage 5 (auditability): 1 release seal(s); 33 verification gates classified
-> (9 UNVERIFIED under a shrink-only ceiling); TOR with 9 enforced rows;
+> (2 UNVERIFIED under a shrink-only ceiling); TOR with 9 enforced rows;
 > gap analysis consolidated in proofs/DO330-GAP.md (reference-gated).**
 <!-- stages:generated:end -->
 

--- a/proofs/coverage.sh
+++ b/proofs/coverage.sh
@@ -60,8 +60,16 @@ cargo build --release -p almide-mir --example render_program --target-dir "$COVD
 cargo build --release --bin almide --target-dir "$COVDIR/t" 2>&1 | tail -1
 
 echo "== 2/4 run the test suites =="
-TESTBINS="$(find "$COVDIR/t/release/deps" -maxdepth 1 -type f -perm /111 ! -name '*.d' ! -name '*.dylib' | grep -E '/(almide_mir|almide_codegen|integration|lower|render)[^/]*$' || true)"
-[ -n "$TESTBINS" ] || TESTBINS="$(find "$COVDIR/t/release/deps" -maxdepth 1 -type f -perm /111 ! -name '*.d' ! -name '*.dylib')"
+# `-perm -u+x`, not `-perm /111`: the `/` form is a GNU extension and BSD find
+# (macOS) rejects it outright — the second call has no `|| true`, so under
+# `set -e` this whole gate died at step 2/4 with "illegal mode string" on every
+# non-GNU host, never reaching the ratchet it exists to enforce (#1244 round 5).
+TESTBINS="$(find "$COVDIR/t/release/deps" -maxdepth 1 -type f -perm -u+x ! -name '*.d' ! -name '*.dylib' | grep -E '/(almide_mir|almide_codegen|integration|lower|render)[^/]*$' || true)"
+[ -n "$TESTBINS" ] || TESTBINS="$(find "$COVDIR/t/release/deps" -maxdepth 1 -type f -perm -u+x ! -name '*.d' ! -name '*.dylib')"
+# No vacuous measurement: zero test binaries would still produce profraw from
+# the step-3 workloads, so the run would report a NUMBER for a suite that never
+# ran. That is the #990 failure mode again — fail instead.
+[ -n "$TESTBINS" ] || { echo "coverage: NO test binaries found under $COVDIR/t/release/deps — the discovery went blind"; exit 1; }
 i=0
 for tb in $TESTBINS; do
     i=$((i+1))

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -17,7 +17,7 @@
 #                     Honest debt: the gate may be decorative and we would
 #                     not know. Burn-down tracked by the ceiling.
 #
-# unverified_ceiling = "3"
+# unverified_ceiling = "2"
 
 [[gate]]
 path = "scripts/check-contracts.sh"
@@ -91,7 +91,8 @@ evidence = "#1244 round 5: no live miscompile was needed — one was PLANTED in 
 
 [[gate]]
 path = "proofs/receipt.sh"
-class = "UNVERIFIED"
+class = "NEGATIVE_TESTED"
+evidence = "#1244 round 5: the #984 guard demonstrated on the DERIVED path (no .verified-fingerprint present, so all four verdicts were really re-run). Forging the certified translation table (translation_validation.rs: Op::Dup's pattern -> a name the renderer never emits) rendered 'C-SAFE | PASS / FAIL' while C-PROVEN/C-WALL stayed PASS, and the script exited 1 with 'receipt: a verdict above is FAIL — refusing to exit green (#984)'. Restored; the VTEST cell is green again"
 
 [[gate]]
 path = "proofs/check-stdlib-purity-registry.sh"

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -17,7 +17,7 @@
 #                     Honest debt: the gate may be decorative and we would
 #                     not know. Burn-down tracked by the ceiling.
 #
-# unverified_ceiling = "5"
+# unverified_ceiling = "4"
 
 [[gate]]
 path = "scripts/check-contracts.sh"
@@ -152,7 +152,8 @@ evidence = "#1244 burn-down PR: dropped-site (UNCLASSIFIED) and bogus-verdict (B
 
 [[gate]]
 path = "scripts/check-perf-ratio.sh"
-class = "UNVERIFIED"
+class = "NEGATIVE_TESTED"
+evidence = "#1244 round 5: three forged baselines, each a REAL measurement run (bench.py --quick). fft 1.272->0.500 => 'fft 1.275 (baseline 0.500) OVER ceiling 0.700'; nbody 0.997->5.000 => 'nbody 1.004 UNDER floor 2.500 (broken bench or durable win)' — so the two-sided band both bites; the spectralnorm line deleted => 'baseline has no entry for [spectralnorm] — a gated benchmark was added without anchoring it'. Unforged run: all four ok"
 
 [[gate]]
 path = "scripts/check-rt-oracle-registry.sh"

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -17,7 +17,7 @@
 #                     Honest debt: the gate may be decorative and we would
 #                     not know. Burn-down tracked by the ceiling.
 #
-# unverified_ceiling = "4"
+# unverified_ceiling = "3"
 
 [[gate]]
 path = "scripts/check-contracts.sh"
@@ -81,7 +81,8 @@ evidence = "#1244 round 5 (coqc/ocamlopt present locally, so the gate RAN): the 
 
 [[gate]]
 path = "proofs/coverage.sh"
-class = "UNVERIFIED"
+class = "NEGATIVE_TESTED"
+evidence = "#1244 round 5: the FIRST probe exposed a real hole — `find -perm /111` is GNU-only, so on any BSD/macOS host the gate died at step 2/4 with 'illegal mode string' and never reached the ratchet; fixed portably (same PR) plus a hard error when discovery finds no test binaries (a 0-binary run would still have reported a number). Then the ratchet itself: proofs/coverage-baseline.txt forged 5819 -> 9900 gave 'COVERAGE RATCHET FAIL: TOTAL 70.09% < baseline 99.00%' on a full real measurement, and `coverage.sh --bogus` gave the #990 usage error exit 2. Measured 70.09% is above the real 58.19% floor, so the same measurement is the pass direction"
 
 [[gate]]
 path = "proofs/diff-fuzz.sh"

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -17,7 +17,7 @@
 #                     Honest debt: the gate may be decorative and we would
 #                     not know. Burn-down tracked by the ceiling.
 #
-# unverified_ceiling = "9"
+# unverified_ceiling = "8"
 
 [[gate]]
 path = "scripts/check-contracts.sh"
@@ -101,7 +101,8 @@ class = "UNVERIFIED"
 
 [[gate]]
 path = "proofs/check-wasm-exec.sh"
-class = "UNVERIFIED"
+class = "MUTATION_TESTED"
+evidence = "#1244 round 5: wabt installed locally, so the gate RAN (not skipped). Two mutations of the module under test each failed it — the cell seed 4->7 gave 'FAIL exec: rc_inc cell 4 -> 5 — wasmtime got 8 want 5', and deleting rc_dec's `(if (i32.eqz $rc) (unreachable))` sentinel gave 'FAIL exec: rc_dec on rc=0 did NOT trap'; restored green"
 
 [[gate]]
 path = "proofs/check-wasm-reachability.sh"

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -17,7 +17,7 @@
 #                     Honest debt: the gate may be decorative and we would
 #                     not know. Burn-down tracked by the ceiling.
 #
-# unverified_ceiling = "6"
+# unverified_ceiling = "5"
 
 [[gate]]
 path = "scripts/check-contracts.sh"
@@ -85,7 +85,8 @@ class = "UNVERIFIED"
 
 [[gate]]
 path = "proofs/diff-fuzz.sh"
-class = "UNVERIFIED"
+class = "NEGATIVE_TESTED"
+evidence = "#1244 round 5: no live miscompile was needed — one was PLANTED in the v1 renderer (render_wasm_calls.rs int_binop_instr) and the generative net caught it at N=40 SEED=12345. IntOp::Mul => i64.add gave 'match=9 mismatch=10' with each failing program's source printed for repro; IntOp::Mul => an unassemblable mnemonic gave the other branch, 'RUNERR (v1 traps)'. Unforged: match=19 mismatch=0 runerr=0, OK"
 
 [[gate]]
 path = "proofs/receipt.sh"

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -17,7 +17,7 @@
 #                     Honest debt: the gate may be decorative and we would
 #                     not know. Burn-down tracked by the ceiling.
 #
-# unverified_ceiling = "7"
+# unverified_ceiling = "6"
 
 [[gate]]
 path = "scripts/check-contracts.sh"
@@ -76,7 +76,8 @@ evidence = "flight-evidence-gaps.md F4 close: 5 consecutive full-run greens afte
 
 [[gate]]
 path = "proofs/build-checker.sh"
-class = "UNVERIFIED"
+class = "NEGATIVE_TESTED"
+evidence = "#1244 round 5 (coqc/ocamlopt present locally, so the gate RAN): the forge went into the TRUSTED GLUE the proof does not cover — driver.ml's ownership arm rubber-stamped to `true` gave 'FAIL double_free.cert: got exit 0 want 1 (ACCEPT)', and to `false` gave 'FAIL balanced.cert: got exit 1 want 0 (REJECT)'; both the accept and the reject assertions therefore bind. Restored green (26/26)"
 
 [[gate]]
 path = "proofs/coverage.sh"

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -17,7 +17,7 @@
 #                     Honest debt: the gate may be decorative and we would
 #                     not know. Burn-down tracked by the ceiling.
 #
-# unverified_ceiling = "8"
+# unverified_ceiling = "7"
 
 [[gate]]
 path = "scripts/check-contracts.sh"
@@ -97,7 +97,8 @@ evidence = "#1244 round 2: effectful module 'fs' forged into PURE_MODULES demons
 
 [[gate]]
 path = "proofs/check-wasm-bytes.sh"
-class = "UNVERIFIED"
+class = "NEGATIVE_TESTED"
+evidence = "#1244 round 5: the forge was in the SHIPPING RENDERER, not the proof — rc_inc's `(i32.const 1)` bumped to 2 in render_wasm_p3.rs gave 'FAIL rc_inc: the RENDERER'S bytes do not match WasmEncode.rc_inc_bytes', and deleting rc_dec's double-free sentinel line gave 'FAIL rc_dec: ... do not match WasmExec.rc_dec_bytes — drift'; restored green"
 
 [[gate]]
 path = "proofs/check-wasm-exec.sh"


### PR DESCRIPTION
Round 5 of #1244. Ceiling **9 → 2**: seven rows went UNVERIFIED → evidenced, each by a forged/mutated input that was **diff-verified to have landed**, run against the real gate, then restored (green re-confirmed).

This round unblocked the "expensive/environment-gated tail" by installing the missing instruments locally (`wabt` for `wat2wasm`; Rocq 9.2 + `ocamlopt` were already present) and by shimming a PATH `almide` that IS the worktree's own `target/release/almide`, so `proofs/lib/stamp.sh`'s identity check passes without touching the user's install.

## Rows burned down

| row | forged input | observed failure |
|---|---|---|
| `proofs/check-wasm-exec.sh` → MUTATION_TESTED | seed cell `4` → `7` in the `inc_4_to_5` wrapper | `FAIL exec: rc_inc cell 4 -> 5 … wasmtime got '8' want '5'` |
| ″ | deleted rc_dec's `(if (i32.eqz $rc) (then (unreachable)))` | `FAIL exec: rc_dec on rc=0 did NOT trap (the double-free sentinel did not fire)` |
| `proofs/check-wasm-bytes.sh` → NEGATIVE_TESTED | **the shipping renderer**: `render_wasm_p3.rs` `$rc_inc` `(i32.const 1)` → `2` | `FAIL rc_inc: the RENDERER'S bytes do not match WasmEncode.rc_inc_bytes — the renderer and the proof have drifted` |
| ″ | same file, rc_dec's zero-check line deleted | `FAIL rc_dec: the RENDERER'S bytes do not match WasmExec.rc_dec_bytes — drift` |
| `proofs/build-checker.sh` → NEGATIVE_TESTED | `driver.ml` (the TRUSTED GLUE the proof does not cover) ownership arm → `true` | `FAIL double_free.cert: got exit 0 want 1 (ACCEPT)` |
| ″ | same arm → `false` | `FAIL balanced.cert: got exit 1 want 0 (REJECT)` — so the ACCEPT assertions bind too |
| `proofs/diff-fuzz.sh` → NEGATIVE_TESTED | planted miscompile: `render_wasm_calls.rs` `IntOp::Mul => "i64.add"` | `match=9 wall=0 skip=21 mismatch=10 runerr=0` → `diff-fuzz: FAIL`, each failing program's source printed for repro (unforged: `match=19 mismatch=0`) |
| ″ | `IntOp::Mul` → an unassemblable mnemonic | the other branch: `RUNERR (v1 traps)` ×N |
| `scripts/check-perf-ratio.sh` → NEGATIVE_TESTED | `fft` baseline `1.272` → `0.500` | `perf-ratio: fft 1.275 (baseline 0.500, +40% budget) OVER ceiling 0.700` |
| ″ | `nbody` baseline `0.997` → `5.000` | `perf-ratio: nbody 1.004 … UNDER floor 2.500 (broken bench or durable win — re-anchor on purpose)` — the band bites on **both** sides |
| ″ | `spectralnorm` line deleted | `::error::perf-ratio: baseline has no entry for ['spectralnorm'] — a gated benchmark was added without anchoring it` |
| `proofs/coverage.sh` → NEGATIVE_TESTED | `proofs/coverage-baseline.txt` `5819` → `9900` | `COVERAGE RATCHET FAIL: TOTAL 70.09% < baseline 99.00%` (full real instrumented measurement) |
| ″ | `coverage.sh --bogus` | `usage: coverage.sh [--check|--update]`, exit 2 (the #990 branch) |
| `proofs/receipt.sh` → NEGATIVE_TESTED | certified translation table: `translation_validation.rs` `Op::Dup` → a pattern the renderer never emits | table rendered `C-SAFE \| PASS / FAIL` with C-PROVEN/C-WALL still PASS, then `receipt: a verdict above is FAIL — refusing to exit green (#984)`, exit 1 |

Each perf-ratio and coverage line above is a **real measurement run**, not a replayed number.

## Finding: coverage.sh was dead on every non-GNU host

The first coverage probe never reached the ratchet. `proofs/coverage.sh` discovered its test binaries with `find … -perm /111` — the `/` mode form is a **GNU extension**, and BSD find (macOS) rejects it outright. The second `find` call has no `|| true`, so under `set -euo pipefail` the gate died at step 2/4 with:

```
== 2/4 run the test suites ==
find: -perm: /111: illegal mode string
```

CI runs Linux, so the ratchet does gate there — but the gate was unrunnable, and un-probeable, from any macOS developer machine. Fixed portably with `-perm -u+x` in its own commit. While reading it I also closed the adjacent vacuous-measurement hole: with discovery returning nothing, `i=0` test binaries ran and the step-3 workloads still produced profraw, so the gate would have reported a coverage **number for a suite that never executed** — it now fails instead. (Same shape as #990.)

Second, smaller observation, **not** fixed here: an instrumented `cargo test --no-run` drops ~94 untracked `default_*.profraw` files into the repo root and crate dirs (build scripts run with `-C instrument-coverage` and no `LLVM_PROFILE_FILE`). They are neither gitignored nor cleaned, so a local coverage run leaves the working tree dirty and perturbs `toolchain_fingerprint`. Worth a follow-up.

## Left UNVERIFIED (2) — honestly environment-gated, re-confirmed

`scripts/check-host-determinism.sh` and `scripts/check-browser-determinism.sh` both need a compiler built for a **wasm32 Rust target**. This host has no `rustup` and its toolchain store ships only `aarch64-apple-darwin`, so `wasm32-wasip1` / `wasm32-unknown-unknown` std cannot be added — round 3's finding stands. Their semantic fail direction needs a wasm32-capable host (CI has one); probing only their vacuous-pass guards would be cheating the ledger, so the rows stay bare.
