### PR TITLE
Index wasm self-host Map/Set lookup with a bucket sidecar (O(n) to O(1) keyed reads)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -854,6 +854,9 @@ jobs:
       - name: libm determinism (every platform-libm call classified; a reachable undeclared one is the #1197 class)
         run: scripts/check-libm-determinism.sh
 
+      - name: Keyed-container lookup-cost matrix (#1219 — every map/set repr rowed indexed or linear)
+        run: bash scripts/check-keyed-container-index.sh
+
       - name: Embedded payload size ratchet (#878 — the stdlib every embedder downloads)
         run: scripts/check-embedded-size.sh
 

--- a/crates/almide-interp/interp-abstain-ledger.txt
+++ b/crates/almide-interp/interp-abstain-ledger.txt
@@ -67,6 +67,7 @@ map_filter  out-of-interp-scope capability: prim.alloc_map
 map_fold  out-of-interp-scope capability: prim.alloc_map
 map_fold_heap_acc  out-of-interp-scope capability: prim.handle
 map_fold_heap_acc_skv  out-of-interp-scope capability: prim.handle
+map_index_order  out-of-interp-scope capability: prim.alloc_map
 map_insertion_order  out-of-interp-scope capability: prim.handle
 map_set_eq  out-of-interp-scope capability: prim.alloc_map
 map_set_ops  out-of-interp-scope capability: prim.alloc_map
@@ -104,6 +105,7 @@ result_list_value_int_tuple  out-of-interp-scope capability: prim.alloc_value
 result_match_rewrap_modcall  out-of-interp-scope capability: prim.handle
 result_value_int_tuple  out-of-interp-scope capability: prim.alloc_value
 scalar_if_arm_effects  out-of-interp-scope capability: prim.handle
+set_index_order  out-of-interp-scope capability: prim.handle
 set_insertion_order  out-of-interp-scope capability: prim.handle
 spread_record_share  out-of-interp-scope capability: prim.handle
 str_result_heap_bind  out-of-interp-scope capability: prim.alloc_value

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -40,8 +40,8 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-010 | [Recursive / generic ADT interpolation repr keyed by instantiation](C-008-009-010-repr.md) | 0.24.0 | active | fixture | 2 |
 | C-011 | Bare-float interpolation Display drops .0; float.to_string keeps it | 0.24.0 | active | fixture | 5 |
 | C-012 | Const-folded non-finite floats emit named constants | 0.24.0 | active | fixture | 1 |
-| C-013 | Map is a compact-ordered-dict: iteration is insertion order | 0.24.0 | active | fixture | 3 |
-| C-014 | Set is insertion-ordered and deterministic | 0.24.0 | active | fixture | 1 |
+| C-013 | Map is a compact-ordered-dict: iteration is insertion order | 0.24.0 | active | fixture | 4 |
+| C-014 | Set is insertion-ordered and deterministic | 0.24.0 | active | fixture | 2 |
 | C-015 | Structural deep equality for compound elements and heap values | 0.24.0 | active | fixture | 3 |
 | C-016 | UTF-8 codepoint-aware string ops are byte-identical | 0.24.0 | active | fixture | 2 |
 | C-017 | Empty-pattern count / last_index_of follow native codepoint/byte semantics | 0.24.0 | active | fixture | 1 |

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,12 +11,12 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-96 normative sections; 421 distinct executable fixtures.
+96 normative sections; 423 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|
-| ALS-C1 | C-013 | `spec/wasm_cross/map_insertion_order.almd` (byte-compare)<br>`spec/wasm_cross/map_filter.almd` (byte-compare)<br>`spec/wasm_cross/map_fold.almd` (byte-compare) |
-| ALS-C2 | C-014 | `spec/wasm_cross/set_insertion_order.almd` (byte-compare) |
+| ALS-C1 | C-013 | `spec/wasm_cross/map_insertion_order.almd` (byte-compare)<br>`spec/wasm_cross/map_filter.almd` (byte-compare)<br>`spec/wasm_cross/map_fold.almd` (byte-compare)<br>`spec/wasm_cross/map_index_order.almd` (byte-compare) |
+| ALS-C2 | C-014 | `spec/wasm_cross/set_insertion_order.almd` (byte-compare)<br>`spec/wasm_cross/set_index_order.almd` (byte-compare) |
 | ALS-C3 | C-015, C-124, C-185 | `spec/wasm_cross/compound_eq.almd` (byte-compare)<br>`spec/wasm_cross/deep_eq_heap.almd` (byte-compare)<br>`spec/wasm_cross/map_set_eq.almd` (byte-compare)<br>`spec/wasm_cross/value_deep_eq.almd` (byte-compare)<br>`spec/wasm_cross/fan_any_early_winner.almd` (byte-compare) |
 | ALS-C4 | C-034 | `spec/wasm_cross/list_insert_clamp.almd` (byte-compare)<br>`spec/wasm_cross/list_remove_at_oob.almd` (byte-compare)<br>`spec/wasm_cross/list_swap_oob.almd` (byte-compare)<br>`spec/wasm_cross/list_slice_oob.almd` (byte-compare)<br>`spec/wasm_cross/list_sort_short.almd` (byte-compare)<br>`spec/wasm_cross/list_with_capacity.almd` (byte-compare)<br>`spec/wasm_cross/negative_offset_and_width_totality.almd` (byte-compare)<br>`spec/wasm_cross/repeat_size_ceiling.almd` (byte-compare) |
 | ALS-C5 | C-033, C-125, C-131, C-150, C-213 | `spec/wasm_cross/alias_cow.almd` (byte-compare)<br>`spec/lang/alias_cow_test.almd` (both-target test)<br>`spec/wasm_cross/module_var_alias_cow.almd` (byte-compare)<br>`spec/wasm_cross/bytes_set_value_semantics.almd` (byte-compare)<br>`spec/wasm_cross/loop_buffer_churn.almd` (byte-compare)<br>`spec/wasm_cross/loop_push_trailing_increment.almd` (byte-compare)<br>`spec/wasm_cross/ctor_var_copy_semantics.almd` (byte-compare)<br>`spec/wasm_cross/bytes_writer_family.almd` (byte-compare) |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -238,6 +238,7 @@ evidence  = [
   { path = "spec/wasm_cross/map_insertion_order.almd", class = "fixture" },
   { path = "spec/wasm_cross/map_filter.almd", class = "fixture" },
   { path = "spec/wasm_cross/map_fold.almd", class = "fixture" },
+  { path = "spec/wasm_cross/map_index_order.almd", class = "fixture" },
 ]
 
 [[contract]]
@@ -249,6 +250,7 @@ since     = "0.24.0"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/set_insertion_order.almd", class = "fixture" },
+  { path = "spec/wasm_cross/set_index_order.almd", class = "fixture" },
 ]
 
 # ── DEEP STRUCTURAL EQUALITY ─────────────────────────────────────────

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,7 +15,7 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 61 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 282/403 fixtures cast a real 3-way vote (69%)** —
+> **Stage 2 (translation validation): 284/405 fixtures cast a real 3-way vote (70%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
 > **Stage 3 (semantics freeze): 269/269 contracts spec-keyed; syntax-element coverage

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,7 +15,7 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 61 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 284/405 fixtures cast a real 3-way vote (70%)** —
+> **Stage 2 (translation validation): 282/405 fixtures cast a real 3-way vote (69%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
 > **Stage 3 (semantics freeze): 269/269 contracts spec-keyed; syntax-element coverage
@@ -24,7 +24,7 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).
 >
-> **Stage 5 (auditability): 1 release seal(s); 34 verification gates classified
+> **Stage 5 (auditability): 1 release seal(s); 35 verification gates classified
 > (2 UNVERIFIED under a shrink-only ceiling); TOR with 9 enforced rows;
 > gap analysis consolidated in proofs/DO330-GAP.md (reference-gated).**
 <!-- stages:generated:end -->

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -178,6 +178,11 @@ class = "NEGATIVE_TESTED"
 evidence = "landing PR: a TOR row retargeted to a nonexistent instrument demonstrated to FAIL before first green"
 
 [[gate]]
+path = "scripts/check-keyed-container-index.sh"
+class = "NEGATIVE_TESTED"
+evidence = "#1363 (landing PR): five forged inputs, each diff-verified to have LANDED before the run, each demonstrated to FAIL — (1) a real index rowed linear (map_core indexed->linear:#1219) => 'NOW carries sidecar helper(s): _reindex _probe _idx_put'; (2) a scanning repr rowed indexed (map_str linear->indexed) => 'missing sidecar helper(s)'; (3) a row retargeted off its module (set_core->set_gone) => STALE row AND the orphaned module's NO-row error, so both directions of the row<->module bijection bite; (4) a bogus state word (map_if n/a->indexedish) => 'unknown state'; (5) a new repr module with no row (stdlib/map_forgeprobe.almd) => NO-row error. The FIRST probe round exposed a real weakness: a single `_reindex(` grep would pass a half-reverted index, so the marker set was tightened to all three sidecar helpers before the evidence was recorded. Restored green (19 rowed: 2 indexed, 8 linear, 9 n/a)"
+
+[[gate]]
 path = "scripts/check-als-element-coverage.sh"
 class = "NEGATIVE_TESTED"
 evidence = "landing PR: an unresolvable section (ALS-Z999) and a dropped row (UNCLASSIFIED) each demonstrated to FAIL before first green, with the below-ceiling ratchet demand firing in both"

--- a/scripts/check-keyed-container-index.sh
+++ b/scripts/check-keyed-container-index.sh
@@ -55,19 +55,25 @@ while read -r mod state _rest; do
         fail=1
         continue
     fi
-    has_index=no
-    grep -q "_reindex(" "$src" && has_index=yes
+    # The sidecar is identified by its three REQUIRED helpers (a naming convention this
+    # gate enforces, so a half-reverted index — buckets read but never rebuilt, say —
+    # is a failure, not a silent downgrade to a scan that still calls itself indexed).
+    present=""
+    missing=""
+    for marker in _reindex _probe _idx_put; do
+        if grep -q "$marker(" "$src"; then present="$present $marker"; else missing="$missing $marker"; fi
+    done
     case "$state" in
         indexed)
-            if [ "$has_index" = no ]; then
-                echo "::error::keyed-container-index: $mod is rowed 'indexed' but carries no index sidecar"
-                echo "  (expected a __${mod%%_*}_reindex helper — did the index get reverted?)"
+            if [ -n "$missing" ]; then
+                echo "::error::keyed-container-index: $mod is rowed 'indexed' but is missing sidecar helper(s):$missing"
+                echo "  (an indexed repr defines __<x>_reindex / __<x>_probe / __<x>_idx_put — was the index reverted?)"
                 fail=1
             fi
             ;;
         linear:*|n/a)
-            if [ "$has_index" = yes ]; then
-                echo "::error::keyed-container-index: $mod is rowed '$state' but NOW carries an index sidecar"
+            if [ -n "$present" ]; then
+                echo "::error::keyed-container-index: $mod is rowed '$state' but NOW carries sidecar helper(s):$present"
                 echo "  — flip its row to 'indexed' in scripts/check-keyed-container-index.sh"
                 fail=1
             fi

--- a/scripts/check-keyed-container-index.sh
+++ b/scripts/check-keyed-container-index.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# KEYED-CONTAINER LOOKUP-COST MATRIX (#1219).
+#
+# A Map/Set repr on the wasm leg either carries the BUCKET INDEX SIDECAR (O(1) keyed
+# lookup, the self-host twin of native's fingerprint index in runtime/rs/src/map.rs) or
+# it scans linearly (O(n)). That is a COMPLEXITY divergence between the legs, invisible
+# to every output-equivalence gate — a program that is fine natively falls over on wasm.
+# So the family is gated by MATRIX, never point-wise: every self-hosted map_*/set_*
+# module carries an explicit row here, and CI fails if
+#
+#   * a module exists with no row            → a new repr landed without a cost decision
+#   * a row exists with no module            → the table went stale
+#   * a row says `indexed` but the module has no index sidecar
+#   * a row says `linear:<ref>` but the module DOES have one (the row is now stale)
+#
+# COMPLETENESS RULE. Every module that resolves a KEY against its own block owns a row of
+# `indexed` or `linear:<tracking ref>`. Modules that never do a keyed lookup — pure
+# facades, renderers, folds over an already-located entry — are `n/a` and are exempt by
+# construction, not by omission.
+set -u
+export LC_ALL=C
+cd "$(dirname "$0")/.."
+
+# module            state          why
+TABLE="
+map                 n/a            facade: signatures only, no block access
+map_core            indexed        Map[Int,Int] — the scalar-KV twin (#1219)
+map_fold_hacc       n/a            folds entries in order; never resolves a key
+map_hobj            linear:#1219   Map[String,record] — heap-value repr, not yet indexed
+map_hval            linear:#1219   Map[String,List] — heap-value repr, not yet indexed
+map_if              n/a            Map[Int,Float] composes over map_core's map.set
+map_ivh             linear:#1219   Map[Int,String] — heap-value repr, not yet indexed
+map_mlo             linear:#1219   Map[String,List] ordered ops — not yet indexed
+map_msv             linear:#1219   Map[String,Value] — not yet indexed
+map_skv             linear:#1219   Map[String,Int] split-slot repr — not yet indexed
+map_str             linear:#1219   Map[String,String] paired-slot repr — not yet indexed
+map_to_string       n/a            renderer: walks entries in order
+map_typechange      n/a            re-keys through map_core's map.set
+map_vkey            n/a            normalizes a variant key to i64, then map_core
+set                 n/a            facade: signatures only, no block access
+set_core            indexed        Set[Int] — the scalar twin (#1219)
+set_str             linear:#1219   Set[String] — heap-element repr, not yet indexed
+set_to_string       n/a            renderer: walks elements in order
+set_to_string_s     n/a            renderer: walks elements in order
+"
+
+fail=0
+
+# 1. every row's module exists, and its claimed state matches the source
+while read -r mod state _rest; do
+    [ -n "${mod:-}" ] || continue
+    src="stdlib/$mod.almd"
+    if [ ! -f "$src" ]; then
+        echo "::error::keyed-container-index: row '$mod' has no stdlib/$mod.almd — the table is stale"
+        fail=1
+        continue
+    fi
+    has_index=no
+    grep -q "_reindex(" "$src" && has_index=yes
+    case "$state" in
+        indexed)
+            if [ "$has_index" = no ]; then
+                echo "::error::keyed-container-index: $mod is rowed 'indexed' but carries no index sidecar"
+                echo "  (expected a __${mod%%_*}_reindex helper — did the index get reverted?)"
+                fail=1
+            fi
+            ;;
+        linear:*|n/a)
+            if [ "$has_index" = yes ]; then
+                echo "::error::keyed-container-index: $mod is rowed '$state' but NOW carries an index sidecar"
+                echo "  — flip its row to 'indexed' in scripts/check-keyed-container-index.sh"
+                fail=1
+            fi
+            ;;
+        *)
+            echo "::error::keyed-container-index: $mod has unknown state '$state' (want indexed | linear:<ref> | n/a)"
+            fail=1
+            ;;
+    esac
+done <<< "$TABLE"
+
+# 2. every stdlib map_*/set_* module has a row
+for src in stdlib/map*.almd stdlib/set*.almd; do
+    mod="$(basename "$src" .almd)"
+    if ! grep -qE "^ *$mod +" <<< "$TABLE"; then
+        echo "::error::keyed-container-index: stdlib/$mod.almd has NO row in the lookup-cost matrix."
+        echo "  Add one to scripts/check-keyed-container-index.sh: 'indexed' if it carries the"
+        echo "  bucket sidecar, 'linear:<tracking ref>' if it still scans, 'n/a' if it never"
+        echo "  resolves a key against a block."
+        fail=1
+    fi
+done
+
+if [ "$fail" -ne 0 ]; then
+    exit 1
+fi
+
+rows=$(grep -cE "^ *[a-z_]+ +" <<< "$TABLE")
+indexed=$(grep -cE "^ *[a-z_]+ +indexed" <<< "$TABLE")
+linear=$(grep -cE "^ *[a-z_]+ +linear:" <<< "$TABLE")
+echo "keyed-container-index: $rows repr module(s) rowed — $indexed indexed, $linear linear, $((rows - indexed - linear)) n/a"

--- a/spec/stdlib/map_index_test.almd
+++ b/spec/stdlib/map_index_test.almd
@@ -1,0 +1,138 @@
+// The Map[Int,Int] bucket index (#1219) only engages past 16 entries, so every case
+// here is deliberately larger than the threshold. The index is a sidecar over the
+// authoritative entry array; these tests pin the two places an index rots — UPSERT
+// (a present key must keep its slot, not append a shadow) and REMOVAL (a dropped key
+// must stop being findable, and re-adding it must find the NEW entry).
+fn build(n: Int, stride: Int) -> Map[Int, Int] = {
+  var m: Map[Int, Int] = map.new()
+  for i in 0..<n {
+    m[i * stride] = i
+  }
+  m
+}
+
+test "indexed map finds every key it was built from" {
+  let m = build(40, 7)
+  assert_eq(map.len(m), 40)
+  for i in 0..<40 {
+    assert_eq(map.get(m, i * 7), some(i))
+  }
+}
+
+test "indexed map misses every key it was not built from" {
+  let m = build(40, 7)
+  for i in 0..<40 {
+    assert(not map.contains(m, i * 7 + 1))
+  }
+  assert_eq(map.get(m, 99991), none)
+}
+
+test "upsert past the threshold keeps position and entry count" {
+  var m = build(40, 7)
+  for i in 0..<20 {
+    m[i * 2 * 7] = 100 + i
+  }
+  assert_eq(map.len(m), 40)
+  assert_eq(map.keys(m), map.keys(build(40, 7)))
+  for i in 0..<20 {
+    assert_eq(map.get(m, i * 2 * 7), some(100 + i))
+    assert_eq(map.get(m, (i * 2 + 1) * 7), some(i * 2 + 1))
+  }
+}
+
+test "remove past the threshold drops the key from lookups" {
+  var m = build(40, 7)
+  for i in 0..<15 {
+    m = map.remove(m, i * 2 * 7)
+  }
+  assert_eq(map.len(m), 25)
+  for i in 0..<15 {
+    assert_eq(map.get(m, i * 2 * 7), none)
+    assert(not map.contains(m, i * 2 * 7))
+  }
+  for i in 0..<40 {
+    let dropped = i % 2 == 0 and i < 30
+    let want = if dropped then none else some(i)
+    assert_eq(map.get(m, i * 7), want)
+  }
+}
+
+test "remove then re-insert resolves to the new entry" {
+  var m = build(40, 7)
+  for i in 0..<15 {
+    m = map.remove(m, i * 2 * 7)
+  }
+  for i in 0..<15 {
+    m[i * 2 * 7] = 500 + i
+  }
+  assert_eq(map.len(m), 40)
+  for i in 0..<15 {
+    assert_eq(map.get(m, i * 2 * 7), some(500 + i))
+  }
+  // the re-added keys move to the END: removal is not a tombstone
+  assert_eq(list.get(map.keys(m), 25), some(0))
+}
+
+test "merge past the threshold overrides in place and appends the rest" {
+  var b: Map[Int, Int] = map.new()
+  for i in 10..<30 {
+    b[i * 7] = 900 + i
+  }
+  let m = map.merge(build(20, 7), b)
+  assert_eq(map.len(m), 30)
+  for i in 0..<10 {
+    assert_eq(map.get(m, i * 7), some(i))
+  }
+  for i in 10..<30 {
+    assert_eq(map.get(m, i * 7), some(900 + i))
+  }
+  assert_eq(list.get(map.keys(m), 0), some(0))
+  assert_eq(list.get(map.keys(m), 29), some(29 * 7))
+}
+
+test "filter and update past the threshold stay lookup-consistent" {
+  let m = build(40, 7)
+  let f = map.filter(m, (k, v) => v % 3 == 0)
+  assert_eq(map.len(f), 14)
+  for i in 0..<40 {
+    let want = if i % 3 == 0 then some(i) else none
+    assert_eq(map.get(f, i * 7), want)
+  }
+  let u = map.update(m, 20 * 7, (v) => v + 1000)
+  assert_eq(map.len(u), 40)
+  assert_eq(map.get(u, 20 * 7), some(1020))
+  assert_eq(map.get(u, 21 * 7), some(21))
+}
+
+test "keys with identical low bits do not collide away" {
+  // a power-of-two stride puts every key in one bucket under a mask-only hash
+  let m = build(32, 1024)
+  for i in 0..<32 {
+    assert_eq(map.get(m, i * 1024), some(i))
+  }
+  var neg: Map[Int, Int] = map.new()
+  for i in 0..<32 {
+    neg[0 - (i * 3)] = i
+  }
+  assert_eq(map.len(neg), 32)
+  for i in 0..<32 {
+    assert_eq(map.get(neg, 0 - (i * 3)), some(i))
+  }
+}
+
+test "threshold crossing keeps every entry reachable" {
+  for n in [
+    15,
+    16,
+    17,
+    31,
+    32,
+    33
+  ] {
+    let m = build(n, 7)
+    assert_eq(map.len(m), n)
+    for i in 0..<n {
+      assert_eq(map.get(m, i * 7), some(i))
+    }
+  }
+}

--- a/spec/stdlib/set_index_test.almd
+++ b/spec/stdlib/set_index_test.almd
@@ -1,0 +1,114 @@
+// The Set[Int] bucket index (#1219) only engages past 16 elements, so every case here
+// is deliberately larger than the threshold. The index is a sidecar over the
+// authoritative element array; these tests pin the two places an index rots —
+// RE-INSERTING a present element (it must not duplicate) and REMOVAL (a dropped
+// element must stop being found, and re-adding it must land at the end).
+fn ints(n: Int, stride: Int, base: Int) -> List[Int] = {
+  var xs: List[Int] = []
+  for i in 0..<n {
+    xs = xs + [base + i * stride]
+  }
+  xs
+}
+
+test "indexed set answers membership for everything it holds" {
+  let s = set.from_list(ints(40, 7, 0))
+  assert_eq(set.len(s), 40)
+  for i in 0..<40 {
+    assert(set.contains(s, i * 7))
+    assert(not set.contains(s, i * 7 + 1))
+  }
+}
+
+test "from_list dedups past the threshold in first-seen order" {
+  let s = set.from_list(ints(40, 3, 0) + ints(40, 3, 0))
+  assert_eq(set.len(s), 40)
+  assert_eq(set.to_list(s), ints(40, 3, 0))
+}
+
+test "re-inserting a present element does not duplicate it" {
+  var s: Set[Int] = set.new()
+  for i in 0..<40 {
+    s = set.insert(s, i * 5)
+  }
+  for i in 0..<20 {
+    s = set.insert(s, i * 5)
+  }
+  assert_eq(set.len(s), 40)
+  assert_eq(set.to_list(s), ints(40, 5, 0))
+}
+
+test "remove past the threshold drops the element from membership" {
+  var s = set.from_list(ints(40, 2, 0))
+  for i in 0..<15 {
+    s = set.remove(s, i * 4)
+  }
+  assert_eq(set.len(s), 25)
+  for i in 0..<40 {
+    let dropped = i % 2 == 0 and i < 30
+    assert_eq(set.contains(s, i * 2), not dropped)
+  }
+}
+
+test "remove then re-insert appends at the end" {
+  var s = set.from_list(ints(40, 2, 0))
+  for i in 0..<15 {
+    s = set.remove(s, i * 4)
+  }
+  for i in 0..<15 {
+    s = set.insert(s, i * 4)
+  }
+  assert_eq(set.len(s), 40)
+  for i in 0..<40 {
+    assert(set.contains(s, i * 2))
+  }
+  assert_eq(list.get(set.to_list(s), 25), some(0))
+}
+
+test "set algebra past the threshold" {
+  let a = set.from_list(ints(30, 1, 0))
+  let b = set.from_list(ints(30, 1, 15))
+  assert_eq(set.len(set.union(a, b)), 45)
+  assert_eq(set.to_list(set.intersection(a, b)), ints(15, 1, 15))
+  assert_eq(set.to_list(set.difference(a, b)), ints(15, 1, 0))
+  assert_eq(set.len(set.symmetric_difference(a, b)), 30)
+  assert(set.is_subset(set.intersection(a, b), a))
+  assert(set.is_disjoint(set.difference(a, b), b))
+}
+
+test "filter and map past the threshold stay unique and ordered" {
+  let a = set.from_list(ints(30, 1, 0))
+  assert_eq(set.to_list(set.filter(a, (x) => x % 3 == 0)), ints(10, 3, 0))
+  // x / 2 collapses pairs, so map must re-dedup to 15 elements
+  assert_eq(set.to_list(set.map(a, (x) => x / 2)), ints(15, 1, 0))
+}
+
+test "elements with identical low bits do not collide away" {
+  let p = set.from_list(ints(32, 1024, 0))
+  assert_eq(set.len(p), 32)
+  for i in 0..<32 {
+    assert(set.contains(p, i * 1024))
+  }
+  let neg = set.from_list(ints(32, 0 - 3, 0))
+  assert_eq(set.len(neg), 32)
+  for i in 0..<32 {
+    assert(set.contains(neg, 0 - (i * 3)))
+  }
+}
+
+test "threshold crossing keeps every element reachable" {
+  for n in [
+    15,
+    16,
+    17,
+    31,
+    32,
+    33
+  ] {
+    let s = set.from_list(ints(n, 7, 0))
+    assert_eq(set.len(s), n)
+    for i in 0..<n {
+      assert(set.contains(s, i * 7))
+    }
+  }
+}

--- a/spec/wasm_cross/map_index_order.almd
+++ b/spec/wasm_cross/map_index_order.almd
@@ -1,0 +1,82 @@
+// @contract: C-013
+// The wasm Map[Int,Int] block carries a BUCKET INDEX past 16 entries (#1219), the
+// self-host twin of the native fingerprint sidecar. The entries stay authoritative and
+// the index is a sidecar, so insertion order must survive every path that touches it:
+// grow across the threshold, upsert (position preserved), remove (survivors' order),
+// remove-then-reinsert (the shape where a stale index would resurrect a dead entry),
+// merge, filter and update. Every line reveals ORDER, not just counts.
+fn show(label: String, m: Map[Int, Int]) -> String = {
+  let ks = map.keys(m) |> list.map((k) => int.to_string(k)) |> list.join(",")
+  let vs = map.values(m) |> list.map((v) => int.to_string(v)) |> list.join(",")
+  "${label}: [${ks}] [${vs}]"
+}
+
+fn build(n: Int, stride: Int) -> Map[Int, Int] = {
+  var m: Map[Int, Int] = map.new()
+  for i in 0..<n {
+    m[i * stride] = i
+  }
+  m
+}
+
+fn probe(label: String, m: Map[Int, Int], n: Int, stride: Int) -> String = {
+  var hit = 0
+  var miss = 0
+  for i in 0..<n {
+    hit = hit + map.get_or(m, i * stride, 0) * (i + 1)
+    let absent = map.contains(m, i * stride + 1)
+    miss = miss + (if absent then 1 else 0)
+  }
+  "${label}: hit=${int.to_string(hit)} bogus=${int.to_string(miss)}"
+}
+
+fn main() -> Unit = {
+  // grow across the flat -> indexed threshold: 15, 16, 17 entries
+  println(show("t15", build(15, 7)))
+  println(show("t16", build(16, 7)))
+  println(show("t17", build(17, 7)))
+  let a = build(40, 7)
+  println(show("build40", a))
+  println(probe("build40", a, 40, 7))
+  // UPSERT: an existing key keeps its position and entry count
+  var b = build(40, 7)
+  for i in 0..<20 {
+    b[i * 2 * 7] = 100 + i
+  }
+  println(show("upsert", b))
+  println(probe("upsert", b, 40, 7))
+  // REMOVE: survivors keep insertion order; removed keys must MISS
+  var c = build(40, 7)
+  for i in 0..<15 {
+    c = map.remove(c, i * 2 * 7)
+  }
+  println(show("remove", c))
+  println(probe("remove", c, 40, 7))
+  // REMOVE then RE-INSERT the same keys: a stale index would report the old entry
+  var d = build(40, 7)
+  for i in 0..<15 {
+    d = map.remove(d, i * 2 * 7)
+  }
+  for i in 0..<15 {
+    d[i * 2 * 7] = 500 + i
+  }
+  println(show("reinsert", d))
+  println(probe("reinsert", d, 40, 7))
+  // MERGE: a's order first (b overrides values in place), then b-only keys
+  var e2: Map[Int, Int] = map.new()
+  for i in 10..<30 {
+    e2[i * 7] = 900 + i
+  }
+  println(show("merge", map.merge(build(20, 7), e2)))
+  // FILTER / UPDATE keep order across the indexed regime
+  println(show("filter", map.filter(a, (k, v) => v % 3 == 0)))
+  println(show("update", map.update(a, 20 * 7, (v) => v + 1000)))
+  // adversarial keys: power-of-two stride (all low bits equal) and negatives
+  let p = build(32, 1024)
+  println(probe("pow2", p, 32, 1024))
+  var q: Map[Int, Int] = map.new()
+  for i in 0..<32 {
+    q[0 - (i * 3)] = i
+  }
+  println(show("negative", q))
+}

--- a/spec/wasm_cross/set_index_order.almd
+++ b/spec/wasm_cross/set_index_order.almd
@@ -1,0 +1,77 @@
+// @contract: C-014
+// The wasm Set[Int] block carries a BUCKET INDEX past 16 elements (#1219), mirroring
+// map_core. The element array stays authoritative and the index is a sidecar, so
+// insertion order and dedup must survive every path: from_list dedup, the insert grow
+// loop, re-inserting a present element, remove, remove-then-reinsert (where a stale
+// index would resurrect a dead element), and the whole set algebra.
+fn show(label: String, s: Set[Int]) -> String = {
+  let xs = set.to_list(s) |> list.map((x) => int.to_string(x)) |> list.join(",")
+  "${label}: [${xs}]"
+}
+
+fn ints(n: Int, stride: Int, base: Int) -> List[Int] = {
+  var xs: List[Int] = []
+  for i in 0..<n {
+    xs = xs + [base + i * stride]
+  }
+  xs
+}
+
+fn probe(label: String, s: Set[Int], n: Int, stride: Int) -> String = {
+  var hit = 0
+  var miss = 0
+  for i in 0..<n {
+    let inside = set.contains(s, i * stride)
+    let outside = set.contains(s, i * stride + 1)
+    hit = hit + (if inside then 1 else 0)
+    miss = miss + (if outside then 1 else 0)
+  }
+  "${label}: hit=${int.to_string(hit)} bogus=${int.to_string(miss)}"
+}
+
+fn main() -> Unit = {
+  // grow across the flat -> indexed threshold: 15, 16, 17 elements
+  println(show("t15", set.from_list(ints(15, 7, 0))))
+  println(show("t16", set.from_list(ints(16, 7, 0))))
+  println(show("t17", set.from_list(ints(17, 7, 0))))
+  // from_list DEDUPS in first-seen order past the threshold
+  let a = set.from_list(ints(40, 3, 0) + ints(40, 3, 0))
+  println(show("dedup", a))
+  println(probe("dedup", a, 40, 3))
+  // insert grow loop, then re-inserting present elements must not change len/order
+  var b: Set[Int] = set.new()
+  for i in 0..<40 {
+    b = set.insert(b, i * 5)
+  }
+  for i in 0..<20 {
+    b = set.insert(b, i * 5)
+  }
+  println(show("insert", b))
+  println(probe("insert", b, 40, 5))
+  // REMOVE then RE-INSERT: a stale index would report a removed element as present
+  var c = set.from_list(ints(40, 2, 0))
+  for i in 0..<15 {
+    c = set.remove(c, i * 4)
+  }
+  println(show("remove", c))
+  for i in 0..<15 {
+    c = set.insert(c, i * 4)
+  }
+  println(show("reinsert", c))
+  // algebra past the threshold: order is a's then b-only, in each side's own order
+  let u1 = set.from_list(ints(30, 1, 0))
+  let u2 = set.from_list(ints(30, 1, 15))
+  println(show("union", set.union(u1, u2)))
+  println(show("inter", set.intersection(u1, u2)))
+  println(show("diff", set.difference(u1, u2)))
+  println(show("sym", set.symmetric_difference(u1, u2)))
+  let sub = set.is_subset(set.intersection(u1, u2), u1)
+  let dis = set.is_disjoint(set.difference(u1, u2), u2)
+  println("subset=${if sub then "true" else "false"} disjoint=${if dis then "true" else "false"}")
+  // filter keeps order; map re-dedups collapsed images in first-seen order
+  println(show("filter", set.filter(u1, (x) => x % 3 == 0)))
+  println(show("map", set.map(u1, (x) => x / 2)))
+  // adversarial elements: power-of-two stride (all low bits equal) and negatives
+  println(probe("pow2", set.from_list(ints(32, 1024, 0)), 32, 1024))
+  println(show("negative", set.from_list(ints(32, 0 - 3, 0))))
+}

--- a/stdlib/map_core.almd
+++ b/stdlib/map_core.almd
@@ -12,7 +12,164 @@ else {
   else __map_find(h, len, k, i + 1)
 }
 
-fn map_new() -> Map[Int, Int] = prim.alloc_map(0)
+// ── BUCKET INDEX SIDECAR (#1219, the wasm-leg twin of native's fingerprint index) ──
+// Past a threshold entry capacity the block carries an open-addressed bucket array AFTER
+// the pair region, so keyed reads are O(1) probes instead of the O(n) `__map_find` scan.
+// The entry array stays AUTHORITATIVE (iteration/eq/repr read `len` pairs in insertion
+// order); the index is a pure sidecar, so nothing observable changes.
+//
+//   cap (the block's i64 slot count) is CANONICAL — every producer allocates through
+//   `__map_alloc`, so cap is a function of the entry capacity E alone:
+//     E <  16 (FLAT)    cap = 2E          ∈ {0, 2, 4, 8, 16}   — no index, linear scan
+//     E >= 16 (INDEXED) cap = 3E + 1      ∈ {49, 97, 193, …}
+//   The two ladders are disjoint (16 < 49), so `cap >= 49` alone decides the shape and
+//   E is recoverable: E = (cap-1)/3 indexed, cap/2 flat. An indexed block lays out
+//     slots [0, 2E)        the k/v pairs
+//     slot   2E            ilen — the entry count the buckets were built for
+//     slots [2E+1, 3E+1)   2E i32 buckets, each `entry_index + 1` (0 = EMPTY)
+//   Load factor is at most 1/2 (E entries in 2E buckets), so the linear probe always
+//   terminates on an empty bucket.
+//
+// STALENESS, not synchronization, is how the index stays honest: it is VALID iff
+// `ilen == len`, and `__map_alloc` stamps every fresh block with ilen = -1. Any producer
+// that writes entries without touching the index therefore yields an INVALID index that
+// the next read rebuilds — an index can never silently disagree with the entries. Only
+// two paths claim validity: `__map_reindex` (read-side, on demand) and the carry in
+// `map_set`/`map_merge`, which update the buckets in the same step that appends the entry.
+fn __map_pow2(n: Int, e: Int) -> Int = if e >= n then e
+else __map_pow2(n, e * 2)
+
+// The canonical slot count for a block that must hold `need` entries.
+fn __map_cap_for(need: Int) -> Int = if need <= 0 then 0
+else {
+  let e = __map_pow2(need, 1)
+  if e >= 16 then e * 3 + 1 else e * 2
+}
+
+// Entry capacity E of a block with `cap` slots (0 when the block is empty).
+fn __map_ecap(cap: Int) -> Int = if cap >= 49 then (cap - 1) / 3
+else cap / 2
+
+// Byte address of the first bucket (indexed blocks only).
+fn __map_bb(h: Int, ecap: Int) -> Int = h + 12 + ecap * 16 + 8
+
+// Byte address of the ilen validity stamp (indexed blocks only).
+fn __map_il(h: Int, ecap: Int) -> Int = h + 12 + ecap * 16
+
+// xorshift64 avalanche — shifts and xors only, so no Int overflow is possible and the
+// high bits fold down into the masked low bits (strided keys like `i * 1024` would
+// otherwise all land in one bucket).
+fn __map_mix(k: Int) -> Int = {
+  let a = prim.bxor(k, prim.bshl(k, 13))
+  let b = prim.bxor(a, prim.bshr_u(a, 7))
+  let c = prim.bxor(b, prim.bshl(b, 17))
+  prim.bxor(c, prim.bshr_u(c, 32))
+}
+
+// Entry index of key k via the buckets, or -1. Stops at the first EMPTY bucket.
+fn __map_probe(h: Int, bb: Int, mask: Int, k: Int, j: Int) -> Int = {
+  let b = prim.load32(bb + j * 4)
+  if b == 0 then 0 - 1
+  else {
+    let e = b - 1
+    let kk = prim.load64(h + 12 + e * 16)
+    if kk == k then e
+    else __map_probe(h, bb, mask, k, prim.band(j + 1, mask))
+  }
+}
+
+// First empty bucket at or after j (terminates: load factor <= 1/2).
+fn __map_probe_free(bb: Int, mask: Int, j: Int) -> Int = {
+  let b = prim.load32(bb + j * 4)
+  if b == 0 then j
+  else __map_probe_free(bb, mask, prim.band(j + 1, mask))
+}
+
+// Bind key k to entry index e. The caller guarantees k is not already indexed.
+fn __map_idx_put(bb: Int, mask: Int, k: Int, e: Int) -> Int = {
+  let j = __map_probe_free(bb, mask, prim.band(__map_mix(k), mask))
+  prim.store32(bb + j * 4, e + 1)
+  0
+}
+
+fn __map_idx_clear(bb: Int, nb: Int, j: Int) -> Int = if j >= nb then 0
+else {
+  prim.store32(bb + j * 4, 0)
+  __map_idx_clear(bb, nb, j + 1)
+}
+
+fn __map_idx_load(h: Int, bb: Int, mask: Int, len: Int, i: Int) -> Int = if i >= len then 0
+else {
+  let k = prim.load64(h + 12 + i * 16)
+  let _p = __map_idx_put(bb, mask, k, i)
+  __map_idx_load(h, bb, mask, len, i + 1)
+}
+
+// Rebuild the buckets from the `len` authoritative entries and stamp them VALID.
+// A freshly allocated block is NOT zeroed ($alloc reuses freed blocks), so clear first.
+fn __map_reindex(h: Int, ecap: Int, len: Int) -> Int = {
+  let bb = __map_bb(h, ecap)
+  let _c = __map_idx_clear(bb, ecap * 2, 0)
+  let _f = __map_idx_load(h, bb, ecap * 2 - 1, len, 0)
+  prim.store64(__map_il(h, ecap), len)
+  0
+}
+
+// READ-SIDE lookup: O(1) probe, building the index on demand for an indexed block.
+// The rebuild WRITES to a borrowed block, which is sound because the buckets are not
+// part of the value — entries, len and cap are untouched, so every observable read
+// (order, contents, repr) is identical whether or not the index happens to be built.
+fn __map_lookup(h: Int, len: Int, cap: Int, k: Int) -> Int = {
+  let ecap = __map_ecap(cap)
+  if ecap < 16 then __map_find(h, len, k, 0)
+  else {
+    let ilen = prim.load64(__map_il(h, ecap))
+    let _r = if ilen == len then 0 else __map_reindex(h, ecap, len)
+    let mask = ecap * 2 - 1
+    __map_probe(h, __map_bb(h, ecap), mask, k, prim.band(__map_mix(k), mask))
+  }
+}
+
+// PRODUCER-SIDE lookup: probe when the index is ALREADY valid, else fall back to the
+// linear scan. Never builds. A grow loop (`m[k] = v`) allocates a fresh result every
+// call, so building an index the loop then throws away would cost more than the scan.
+fn __map_find_soft(h: Int, len: Int, cap: Int, k: Int) -> Int = {
+  let ecap = __map_ecap(cap)
+  if ecap < 16 then __map_find(h, len, k, 0)
+  else {
+    let ilen = prim.load64(__map_il(h, ecap))
+    if ilen == len then {
+      let mask = ecap * 2 - 1
+      __map_probe(h, __map_bb(h, ecap), mask, k, prim.band(__map_mix(k), mask))
+    } else __map_find(h, len, k, 0)
+  }
+}
+
+// Copy `n` raw i64 slots starting at slot `start` (used to carry a valid index across
+// a same-shape rebuild — entry indices are preserved by a full copy, so the buckets are
+// still exact).
+fn __map_copy_slots(sh: Int, rh: Int, start: Int, n: Int, i: Int) -> Int = if i >= n then 0
+else {
+  let w = prim.load64(sh + 12 + (start + i) * 8)
+  prim.store64(rh + 12 + (start + i) * 8, w)
+  __map_copy_slots(sh, rh, start, n, i + 1)
+}
+
+// The ONLY allocator for a Map[Int,Int] block: canonical cap + an INVALID index stamp.
+fn __map_alloc_cap(cap: Int) -> Map[Int, Int] = {
+  let r = prim.alloc_map(cap)
+  let ecap = __map_ecap(cap)
+  let _i = if ecap < 16 then 0
+  else {
+    prim.store64(__map_il(prim.handle(r), ecap), 0 - 1)
+    0
+  }
+  r
+}
+
+fn __map_alloc(need: Int) -> Map[Int, Int] = __map_alloc_cap(__map_cap_for(need))
+
+fn map_new() -> Map[Int, Int] = __map_alloc_cap(0)
 
 fn map_len(m: Map[Int, Int]) -> Int = prim.load32(prim.handle(m) + 4)
 
@@ -21,14 +178,16 @@ fn map_is_empty(m: Map[Int, Int]) -> Bool = prim.load32(prim.handle(m) + 4) == 0
 fn map_contains(m: Map[Int, Int], k: Int) -> Bool = {
   let h = prim.handle(m)
   let len = prim.load32(h + 4)
-  let idx = __map_find(h, len, k, 0)
+  let cap = prim.load32(h + 8)
+  let idx = __map_lookup(h, len, cap, k)
   idx >= 0
 }
 
 fn map_get_or(m: Map[Int, Int], k: Int, default: Int) -> Int = {
   let h = prim.handle(m)
   let len = prim.load32(h + 4)
-  let idx = __map_find(h, len, k, 0)
+  let cap = prim.load32(h + 8)
+  let idx = __map_lookup(h, len, cap, k)
   if idx < 0 then default else prim.load64(h + 12 + idx * 16 + 8)
 }
 
@@ -53,26 +212,48 @@ fn __map_put(rh: Int, len: Int, idx: Int, k: Int, v: Int) -> Int = if idx < 0 th
   len
 }
 
-// GEOMETRIC capacity (#1219): grow the copy's slot count by doubling epochs instead of the
-// exact (len+1)*2. The $alloc free-list reuses only EXACT-size blocks, so an exact-size grow
-// loop (`m = map.set(m, k, v)`, the lowered form of `m[k] = v` / `map.insert`) frees a
-// never-reusable block every call — O(n^2) bytes and an O(n) dead-list walk per alloc. With a
-// stable epoch size the block freed by the PREVIOUS rebind is an exact head match: O(1) reuse,
-// O(n) total memory. Slack slots past 2*len are never read (len governs iteration/eq/repr —
-// filter/remove results already carry cap slack), so observable behavior is unchanged.
+// Carry a VALID source index into the same-shape result (entry indices survive a full
+// copy, so the buckets stay exact) and extend it with the appended key. A stale source
+// index, or a grow that changed the bucket count, simply leaves the result INVALID for
+// the next read to rebuild. Returns 0 (a statement helper).
+fn __map_idx_carry(sh: Int, rh: Int, secap: Int, necap: Int, len: Int, idx: Int, k: Int) -> Int = if necap < 16 then 0
+else if necap != secap then 0
+else {
+  let ilen = prim.load64(__map_il(sh, secap))
+  if ilen != len then 0
+  else {
+    let _c = __map_copy_slots(sh, rh, secap * 2, secap + 1, 0)
+    if idx >= 0 then 0
+    else {
+      let _p = __map_idx_put(__map_bb(rh, necap), necap * 2 - 1, k, len)
+      prim.store64(__map_il(rh, necap), len + 1)
+      0
+    }
+  }
+}
+
+// GEOMETRIC capacity (#1219): the slot count comes from `__map_cap_for`, a doubling ladder
+// keyed on the entry capacity, instead of the exact (len+1)*2. The $alloc free-list reuses
+// only EXACT-size blocks, so an exact-size grow loop (`m = map.set(m, k, v)`, the lowered
+// form of `m[k] = v` / `map.insert`) frees a never-reusable block every call — O(n^2) bytes
+// and an O(n) dead-list walk per alloc. With a stable epoch size the block freed by the
+// PREVIOUS rebind is an exact head match: O(1) reuse, O(n) total memory. Slack slots past
+// 2*len are never read (len governs iteration/eq/repr — filter/remove results already carry
+// cap slack), so observable behavior is unchanged.
 fn map_set(m: Map[Int, Int], k: Int, v: Int) -> Map[Int, Int] = {
   let sh = prim.handle(m)
   let len = prim.load32(sh + 4)
   let cap = prim.load32(sh + 8)
-  let need = (len + 1) * 2
-  let slots = if need > cap then (if cap * 2 > need then cap * 2 else need)
-  else cap
-  let r = prim.alloc_map(slots)
+  let idx = __map_find_soft(sh, len, cap, k)
+  let need = if idx < 0 then len + 1 else len
+  let want = __map_cap_for(need)
+  let slots = if want > cap then want else cap
+  let r = __map_alloc_cap(slots)
   let rh = prim.handle(r)
   let _c = __map_copy(sh, rh, len, 0)
-  let idx = __map_find(sh, len, k, 0)
   let w = __map_put(rh, len, idx, k, v)
   prim.store32(rh + 4, w)
+  let _x = __map_idx_carry(sh, rh, __map_ecap(cap), __map_ecap(slots), len, idx, k)
   r
 }
 
@@ -89,11 +270,13 @@ else {
   }
 }
 
+// The result is a FRESH block, so its index is born invalid — removal shifts every
+// survivor's entry index, and rebuilding on the next read is exactly as cheap as
+// patching would be. This is why an index here cannot rot: it is never carried.
 fn map_remove(m: Map[Int, Int], k: Int) -> Map[Int, Int] = {
   let sh = prim.handle(m)
   let len = prim.load32(sh + 4)
-  let slots = len * 2
-  let r = prim.alloc_map(slots)
+  let r = __map_alloc(len)
   let rh = prim.handle(r)
   let w = __map_remove_fill(sh, len, rh, k, 0, 0)
   prim.store32(rh + 4, w)
@@ -147,19 +330,38 @@ fn __map_get_some(h: Int, idx: Int) -> Int? = {
 fn map_get(m: Map[Int, Int], k: Int) -> Int? = {
   let h = prim.handle(m)
   let len = prim.load32(h + 4)
-  let idx = __map_find(h, len, k, 0)
+  let cap = prim.load32(h + 8)
+  let idx = __map_lookup(h, len, cap, k)
   if idx < 0 then __map_none() else __map_get_some(h, idx)
 }
 
 // map.merge — clone a, then insert every entry of b (b's keys override a's value in place,
 // b's new keys append). Result order: a's order (overridden values) then b's new keys (b order).
-fn __map_merge_addb(rh: Int, bh: Int, blen: Int, j: Int, w: Int) -> Int = if j >= blen then w
+// Append (k,v) to the half-built result and keep its index EXACT in the same step: an
+// overwrite touches no key, an append binds the new key to its entry index and advances
+// the ilen stamp. The index therefore stays valid for the whole merge — without this the
+// per-key `__map_find` would make merge O(a*b).
+fn __map_merge_put(rh: Int, ecap: Int, w: Int, idx: Int, k: Int, v: Int) -> Int = {
+  let w2 = __map_put(rh, w, idx, k, v)
+  let _i = if ecap < 16 then 0
+  else if idx >= 0 then 0
+  else {
+    let _p = __map_idx_put(__map_bb(rh, ecap), ecap * 2 - 1, k, w)
+    prim.store64(__map_il(rh, ecap), w + 1)
+    0
+  }
+  w2
+}
+
+fn __map_merge_addb(rh: Int, ecap: Int, bh: Int, blen: Int, j: Int, w: Int) -> Int = if j >= blen then w
 else {
   let k = prim.load64(bh + 12 + j * 16)
   let v = prim.load64(bh + 12 + j * 16 + 8)
-  let idx = __map_find(rh, w, k, 0)
-  let w2 = __map_put(rh, w, idx, k, v)
-  __map_merge_addb(rh, bh, blen, j + 1, w2)
+  let mask = ecap * 2 - 1
+  let idx = if ecap < 16 then __map_find(rh, w, k, 0)
+  else __map_probe(rh, __map_bb(rh, ecap), mask, k, prim.band(__map_mix(k), mask))
+  let w2 = __map_merge_put(rh, ecap, w, idx, k, v)
+  __map_merge_addb(rh, ecap, bh, blen, j + 1, w2)
 }
 
 fn map_merge(a: Map[Int, Int], b: Map[Int, Int]) -> Map[Int, Int] = {
@@ -167,11 +369,12 @@ fn map_merge(a: Map[Int, Int], b: Map[Int, Int]) -> Map[Int, Int] = {
   let bh = prim.handle(b)
   let alen = prim.load32(ah + 4)
   let blen = prim.load32(bh + 4)
-  let slots = (alen + blen) * 2
-  let r = prim.alloc_map(slots)
+  let r = __map_alloc(alen + blen)
   let rh = prim.handle(r)
+  let ecap = __map_ecap(prim.load32(rh + 8))
   let _c = __map_copy(ah, rh, alen, 0)
-  let w = __map_merge_addb(rh, bh, blen, 0, alen)
+  let _i = if ecap < 16 then 0 else __map_reindex(rh, ecap, alen)
+  let w = __map_merge_addb(rh, ecap, bh, blen, 0, alen)
   prim.store32(rh + 4, w)
   r
 }
@@ -189,11 +392,11 @@ else {
 fn map_update(m: Map[Int, Int], k: Int, f: (Int) -> Int) -> Map[Int, Int] = {
   let sh = prim.handle(m)
   let len = prim.load32(sh + 4)
-  let slots = len * 2
-  let r = prim.alloc_map(slots)
+  let cap = prim.load32(sh + 8)
+  let r = __map_alloc(len)
   let rh = prim.handle(r)
   let _c = __map_copy(sh, rh, len, 0)
-  let idx = __map_find(sh, len, k, 0)
+  let idx = __map_find_soft(sh, len, cap, k)
   let _u = __map_update_at(rh, idx, f)
   prim.store32(rh + 4, len)
   r
@@ -219,8 +422,7 @@ else {
 fn map_filter(m: Map[Int, Int], f: (Int, Int) -> Bool) -> Map[Int, Int] = {
   let sh = prim.handle(m)
   let len = prim.load32(sh + 4)
-  let slots = len * 2
-  let r = prim.alloc_map(slots)
+  let r = __map_alloc(len)
   let rh = prim.handle(r)
   let w = __map_filter_fill(sh, len, rh, f, 0, 0)
   prim.store32(rh + 4, w)

--- a/stdlib/set_core.almd
+++ b/stdlib/set_core.almd
@@ -13,26 +13,200 @@ else {
   else __set_has(dh, count, x, i + 1)
 }
 
+// ── BUCKET INDEX SIDECAR (#1219) ── the Set[Int] mirror of map_core's index, same
+// discipline: the element array stays AUTHORITATIVE (insertion-ordered, `len` governs
+// iteration/eq/repr) and the buckets are a pure sidecar, so nothing observable changes.
+//
+//   cap (the block's i64 slot count) is CANONICAL — every producer allocates through
+//   `__set_alloc`, so cap is a function of the element capacity E alone:
+//     E <  16 (FLAT)    cap = E        ∈ {0, 1, 2, 4, 8}  — no index, linear scan
+//     E >= 16 (INDEXED) cap = 2E + 1   ∈ {33, 65, 129, …}
+//   Disjoint ladders (8 < 33), so `cap >= 33` decides the shape and E = (cap-1)/2.
+//   An indexed block lays out
+//     slots [0, E)       the elements
+//     slot   E           ilen — the element count the buckets were built for
+//     slots [E+1, 2E+1)  2E i32 buckets, each `element_index + 1` (0 = EMPTY)
+//   Load factor is at most 1/2, so the linear probe always terminates on an empty bucket.
+//
+// The index is VALID iff `ilen == len`, and `__set_alloc` stamps every fresh block with
+// ilen = -1: a producer that writes elements without touching the buckets yields an
+// INVALID index that the next read rebuilds, so the two can never silently disagree.
+fn __set_pow2(n: Int, e: Int) -> Int = if e >= n then e
+else __set_pow2(n, e * 2)
+
+fn __set_cap_for(need: Int) -> Int = if need <= 0 then 0
+else {
+  let e = __set_pow2(need, 1)
+  if e >= 16 then e * 2 + 1 else e
+}
+
+fn __set_ecap(cap: Int) -> Int = if cap >= 33 then (cap - 1) / 2
+else cap
+
+fn __set_il(h: Int, ecap: Int) -> Int = h + 12 + ecap * 8
+
+fn __set_bb(h: Int, ecap: Int) -> Int = h + 12 + ecap * 8 + 8
+
+// xorshift64 avalanche (shifts/xors only — no Int overflow, and the high bits fold down
+// into the masked low bits so strided elements do not all collide).
+fn __set_mix(x: Int) -> Int = {
+  let a = prim.bxor(x, prim.bshl(x, 13))
+  let b = prim.bxor(a, prim.bshr_u(a, 7))
+  let c = prim.bxor(b, prim.bshl(b, 17))
+  prim.bxor(c, prim.bshr_u(c, 32))
+}
+
+fn __set_probe(h: Int, bb: Int, mask: Int, x: Int, j: Int) -> Int = {
+  let b = prim.load32(bb + j * 4)
+  if b == 0 then 0 - 1
+  else {
+    let e = b - 1
+    let xx = prim.load64(h + 12 + e * 8)
+    if xx == x then e
+    else __set_probe(h, bb, mask, x, prim.band(j + 1, mask))
+  }
+}
+
+fn __set_probe_free(bb: Int, mask: Int, j: Int) -> Int = {
+  let b = prim.load32(bb + j * 4)
+  if b == 0 then j
+  else __set_probe_free(bb, mask, prim.band(j + 1, mask))
+}
+
+fn __set_idx_put(bb: Int, mask: Int, x: Int, e: Int) -> Int = {
+  let j = __set_probe_free(bb, mask, prim.band(__set_mix(x), mask))
+  prim.store32(bb + j * 4, e + 1)
+  0
+}
+
+fn __set_idx_clear(bb: Int, nb: Int, j: Int) -> Int = if j >= nb then 0
+else {
+  prim.store32(bb + j * 4, 0)
+  __set_idx_clear(bb, nb, j + 1)
+}
+
+fn __set_idx_load(h: Int, bb: Int, mask: Int, len: Int, i: Int) -> Int = if i >= len then 0
+else {
+  let x = prim.load64(h + 12 + i * 8)
+  let _p = __set_idx_put(bb, mask, x, i)
+  __set_idx_load(h, bb, mask, len, i + 1)
+}
+
+// Rebuild the buckets from the `len` authoritative elements and stamp them VALID.
+// $alloc hands back reused (non-zeroed) blocks, so clear before filling.
+fn __set_reindex(h: Int, ecap: Int, len: Int) -> Int = {
+  let bb = __set_bb(h, ecap)
+  let _c = __set_idx_clear(bb, ecap * 2, 0)
+  let _f = __set_idx_load(h, bb, ecap * 2 - 1, len, 0)
+  prim.store64(__set_il(h, ecap), len)
+  0
+}
+
+// Start a half-built block with an EMPTY but VALID index, so a dedup fill can probe and
+// extend it element by element (`__set_add_ix`) instead of rescanning.
+fn __set_idx_init(h: Int, ecap: Int) -> Int = if ecap < 16 then 0
+else {
+  let _c = __set_idx_clear(__set_bb(h, ecap), ecap * 2, 0)
+  prim.store64(__set_il(h, ecap), 0)
+  0
+}
+
+// READ-SIDE membership: O(1) probe, building the index on demand. The rebuild writes to a
+// borrowed block, which is sound because the buckets are not part of the value — elements,
+// len and cap are untouched, so every observable read is identical either way.
+fn __set_has_ix(h: Int, len: Int, cap: Int, x: Int) -> Bool = {
+  let ecap = __set_ecap(cap)
+  if ecap < 16 then __set_has(h, len, x, 0)
+  else {
+    let ilen = prim.load64(__set_il(h, ecap))
+    let _r = if ilen == len then 0 else __set_reindex(h, ecap, len)
+    let mask = ecap * 2 - 1
+    __set_probe(h, __set_bb(h, ecap), mask, x, prim.band(__set_mix(x), mask)) >= 0
+  }
+}
+
+// Membership against a FINISHED block (handle + its own len/cap header).
+fn __set_member(h: Int, x: Int) -> Bool = {
+  let len = prim.load32(h + 4)
+  let cap = prim.load32(h + 8)
+  __set_has_ix(h, len, cap, x)
+}
+
+// PRODUCER-SIDE membership: probe when the index is ALREADY valid, else linear scan.
+// Never builds — a grow loop throws its result away every call, so building an index for
+// it would cost more than the scan it replaces.
+fn __set_has_soft(h: Int, len: Int, cap: Int, x: Int) -> Bool = {
+  let ecap = __set_ecap(cap)
+  if ecap < 16 then __set_has(h, len, x, 0)
+  else {
+    let ilen = prim.load64(__set_il(h, ecap))
+    if ilen == len then {
+      let mask = ecap * 2 - 1
+      __set_probe(h, __set_bb(h, ecap), mask, x, prim.band(__set_mix(x), mask)) >= 0
+    } else __set_has(h, len, x, 0)
+  }
+}
+
+// Membership in the first `w` elements of a HALF-BUILT block whose index was primed by
+// `__set_idx_init` and kept exact by `__set_add_ix`.
+fn __set_has_at(h: Int, ecap: Int, w: Int, x: Int) -> Bool = if ecap < 16 then __set_has(h, w, x, 0)
+else {
+  let mask = ecap * 2 - 1
+  __set_probe(h, __set_bb(h, ecap), mask, x, prim.band(__set_mix(x), mask)) >= 0
+}
+
+// Append x at position w of a half-built block, keeping its index exact. Returns w+1.
+fn __set_add_ix(h: Int, ecap: Int, w: Int, x: Int) -> Int = {
+  prim.store64(h + 12 + w * 8, x)
+  let _i = if ecap < 16 then 0
+  else {
+    let _p = __set_idx_put(__set_bb(h, ecap), ecap * 2 - 1, x, w)
+    prim.store64(__set_il(h, ecap), w + 1)
+    0
+  }
+  w + 1
+}
+
+fn __set_copy_slots(sh: Int, rh: Int, start: Int, n: Int, i: Int) -> Int = if i >= n then 0
+else {
+  let w = prim.load64(sh + 12 + (start + i) * 8)
+  prim.store64(rh + 12 + (start + i) * 8, w)
+  __set_copy_slots(sh, rh, start, n, i + 1)
+}
+
+// The ONLY allocator for a Set[Int] block: canonical cap + an INVALID index stamp.
+fn __set_alloc_cap(cap: Int) -> Set[Int] = {
+  let r = prim.alloc_set(cap)
+  let ecap = __set_ecap(cap)
+  let _i = if ecap < 16 then 0
+  else {
+    prim.store64(__set_il(prim.handle(r), ecap), 0 - 1)
+    0
+  }
+  r
+}
+
+fn __set_alloc(need: Int) -> Set[Int] = __set_alloc_cap(__set_cap_for(need))
+
 // Append each not-yet-present element of list `xh` (length xlen) into the set block `sh`,
 // growing the unique count `w`. Returns the final unique count (= the set's len).
-fn __set_fill(xh: Int, xlen: Int, sh: Int, i: Int, w: Int) -> Int = if i >= xlen then w
+fn __set_fill(xh: Int, xlen: Int, sh: Int, ecap: Int, i: Int, w: Int) -> Int = if i >= xlen then w
 else {
   let x = prim.load64(xh + 12 + i * 8)
-  let present = __set_has(sh, w, x, 0)
-  if present then __set_fill(xh, xlen, sh, i + 1, w)
-  else {
-    prim.store64(sh + 12 + w * 8, x)
-    __set_fill(xh, xlen, sh, i + 1, w + 1)
-  }
+  let present = __set_has_at(sh, ecap, w, x)
+  if present then __set_fill(xh, xlen, sh, ecap, i + 1, w)
+  else __set_fill(xh, xlen, sh, ecap, i + 1, __set_add_ix(sh, ecap, w, x))
 }
 
 fn set_from_list(xs: List[Int]) -> Set[Int] = {
   let xh = prim.handle(xs)
   let xlen = prim.load32(xh + 4)
-  let s = prim.alloc_set(xlen)
+  let s = __set_alloc(xlen)
   // over-alloc xlen slots; patch len to the unique count
   let sh = prim.handle(s)
-  let u = __set_fill(xh, xlen, sh, 0, 0)
+  let ecap = __set_ecap(prim.load32(sh + 8))
+  let _i = __set_idx_init(sh, ecap)
+  let u = __set_fill(xh, xlen, sh, ecap, 0, 0)
   prim.store32(sh + 4, u)
   // len field := unique count
   s
@@ -45,7 +219,8 @@ fn set_is_empty(s: Set[Int]) -> Bool = prim.load32(prim.handle(s) + 4) == 0
 fn set_contains(s: Set[Int], x: Int) -> Bool = {
   let h = prim.handle(s)
   let len = prim.load32(h + 4)
-  __set_has(h, len, x, 0)
+  let cap = prim.load32(h + 8)
+  __set_has_ix(h, len, cap, x)
 }
 
 // Copy the set's first `len` Int elements into a fresh List block.
@@ -69,15 +244,15 @@ fn set_to_list(s: Set[Int]) -> List[Int] = {
 // observable order. Each op over-allocs, fills, and patches len. Helpers share __set_has.
 // Append b's elements (handle bh, len blen) NOT already in the a-portion (first `alen` slots of
 // result rh), growing the unique count w. Used by union (a already copied into rh).
-fn __set_addb(alen: Int, bh: Int, blen: Int, rh: Int, j: Int, w: Int) -> Int = if j >= blen then w
+// b's own elements are already unique, so probing the WHOLE built prefix `w` (the copied
+// a-portion plus the b-elements already appended) decides membership exactly as the
+// a-portion-only scan did — and it lets the incremental index answer in O(1).
+fn __set_addb(bh: Int, blen: Int, rh: Int, ecap: Int, j: Int, w: Int) -> Int = if j >= blen then w
 else {
   let x = prim.load64(bh + 12 + j * 8)
-  let inA = __set_has(rh, alen, x, 0)
-  if inA then __set_addb(alen, bh, blen, rh, j + 1, w)
-  else {
-    prim.store64(rh + 12 + w * 8, x)
-    __set_addb(alen, bh, blen, rh, j + 1, w + 1)
-  }
+  let inA = __set_has_at(rh, ecap, w, x)
+  if inA then __set_addb(bh, blen, rh, ecap, j + 1, w)
+  else __set_addb(bh, blen, rh, ecap, j + 1, __set_add_ix(rh, ecap, w, x))
 }
 
 fn set_union(a: Set[Int], b: Set[Int]) -> Set[Int] = {
@@ -85,48 +260,48 @@ fn set_union(a: Set[Int], b: Set[Int]) -> Set[Int] = {
   let bh = prim.handle(b)
   let alen = prim.load32(ah + 4)
   let blen = prim.load32(bh + 4)
-  let cap = alen + blen
-  let r = prim.alloc_set(cap)
+  let r = __set_alloc(alen + blen)
   let rh = prim.handle(r)
+  let ecap = __set_ecap(prim.load32(rh + 8))
   let _c = __set_copy(ah, rh, alen, 0)
   // a's elements first (a's order)
-  let w = __set_addb(alen, bh, blen, rh, 0, alen)
+  let _i = if ecap < 16 then 0 else __set_reindex(rh, ecap, alen)
+  let w = __set_addb(bh, blen, rh, ecap, 0, alen)
   prim.store32(rh + 4, w)
   r
 }
 
 // Append a's elements that ARE in b (intersection, a's order).
-fn __set_inter(ah: Int, alen: Int, bh: Int, blen: Int, rh: Int, i: Int, w: Int) -> Int = if i >= alen then w
+fn __set_inter(ah: Int, alen: Int, bh: Int, rh: Int, i: Int, w: Int) -> Int = if i >= alen then w
 else {
   let x = prim.load64(ah + 12 + i * 8)
-  let inB = __set_has(bh, blen, x, 0)
+  let inB = __set_member(bh, x)
   if inB then {
     prim.store64(rh + 12 + w * 8, x)
-    __set_inter(ah, alen, bh, blen, rh, i + 1, w + 1)
-  } else __set_inter(ah, alen, bh, blen, rh, i + 1, w)
+    __set_inter(ah, alen, bh, rh, i + 1, w + 1)
+  } else __set_inter(ah, alen, bh, rh, i + 1, w)
 }
 
 fn set_intersection(a: Set[Int], b: Set[Int]) -> Set[Int] = {
   let ah = prim.handle(a)
   let bh = prim.handle(b)
   let alen = prim.load32(ah + 4)
-  let blen = prim.load32(bh + 4)
-  let r = prim.alloc_set(alen)
+  let r = __set_alloc(alen)
   let rh = prim.handle(r)
-  let w = __set_inter(ah, alen, bh, blen, rh, 0, 0)
+  let w = __set_inter(ah, alen, bh, rh, 0, 0)
   prim.store32(rh + 4, w)
   r
 }
 
 // Append a's elements NOT in b (difference, a's order).
-fn __set_diff(ah: Int, alen: Int, bh: Int, blen: Int, rh: Int, i: Int, w: Int) -> Int = if i >= alen then w
+fn __set_diff(ah: Int, alen: Int, bh: Int, rh: Int, i: Int, w: Int) -> Int = if i >= alen then w
 else {
   let x = prim.load64(ah + 12 + i * 8)
-  let inB = __set_has(bh, blen, x, 0)
-  if inB then __set_diff(ah, alen, bh, blen, rh, i + 1, w)
+  let inB = __set_member(bh, x)
+  if inB then __set_diff(ah, alen, bh, rh, i + 1, w)
   else {
     prim.store64(rh + 12 + w * 8, x)
-    __set_diff(ah, alen, bh, blen, rh, i + 1, w + 1)
+    __set_diff(ah, alen, bh, rh, i + 1, w + 1)
   }
 }
 
@@ -134,20 +309,19 @@ fn set_difference(a: Set[Int], b: Set[Int]) -> Set[Int] = {
   let ah = prim.handle(a)
   let bh = prim.handle(b)
   let alen = prim.load32(ah + 4)
-  let blen = prim.load32(bh + 4)
-  let r = prim.alloc_set(alen)
+  let r = __set_alloc(alen)
   let rh = prim.handle(r)
-  let w = __set_diff(ah, alen, bh, blen, rh, 0, 0)
+  let w = __set_diff(ah, alen, bh, rh, 0, 0)
   prim.store32(rh + 4, w)
   r
 }
 
 // All of a's first `alen` elements present in b?
-fn __set_all_in(ah: Int, alen: Int, bh: Int, blen: Int, i: Int) -> Bool = if i >= alen then true
+fn __set_all_in(ah: Int, alen: Int, bh: Int, i: Int) -> Bool = if i >= alen then true
 else {
   let x = prim.load64(ah + 12 + i * 8)
-  let inB = __set_has(bh, blen, x, 0)
-  if inB then __set_all_in(ah, alen, bh, blen, i + 1)
+  let inB = __set_member(bh, x)
+  if inB then __set_all_in(ah, alen, bh, i + 1)
   else false
 }
 
@@ -155,58 +329,70 @@ fn set_is_subset(a: Set[Int], b: Set[Int]) -> Bool = {
   let ah = prim.handle(a)
   let bh = prim.handle(b)
   let alen = prim.load32(ah + 4)
-  let blen = prim.load32(bh + 4)
-  __set_all_in(ah, alen, bh, blen, 0)
+  __set_all_in(ah, alen, bh, 0)
 }
 
 // None of a's first `alen` elements present in b?
-fn __set_none_in(ah: Int, alen: Int, bh: Int, blen: Int, i: Int) -> Bool = if i >= alen then true
+fn __set_none_in(ah: Int, alen: Int, bh: Int, i: Int) -> Bool = if i >= alen then true
 else {
   let x = prim.load64(ah + 12 + i * 8)
-  let inB = __set_has(bh, blen, x, 0)
+  let inB = __set_member(bh, x)
   if inB then false
-  else __set_none_in(ah, alen, bh, blen, i + 1)
+  else __set_none_in(ah, alen, bh, i + 1)
 }
 
 fn set_is_disjoint(a: Set[Int], b: Set[Int]) -> Bool = {
   let ah = prim.handle(a)
   let bh = prim.handle(b)
   let alen = prim.load32(ah + 4)
-  let blen = prim.load32(bh + 4)
-  __set_none_in(ah, alen, bh, blen, 0)
+  __set_none_in(ah, alen, bh, 0)
 }
 
 // ── Set construction (closure-free, Int) ── new/insert/remove/symmetric_difference. Each
 // returns a fresh owned Set (v0's insert/remove clone-then-mutate).
 // An empty Set[Int] — a 0-length block. alloc_set(0) already sets len=0.
-fn set_new() -> Set[Int] = prim.alloc_set(0)
+fn set_new() -> Set[Int] = __set_alloc_cap(0)
 
-// Append x to result `rh` (which holds `slen` elements) iff absent; return the new count.
-fn __set_addone(rh: Int, slen: Int, x: Int) -> Int = {
-  let present = __set_has(rh, slen, x, 0)
-  if present then slen
+// Carry a VALID source index into the same-shape result (element indices survive a full
+// copy) and extend it with the appended element. A stale source index, or a grow that
+// changed the bucket count, leaves the result INVALID for the next read to rebuild.
+fn __set_idx_carry(sh: Int, rh: Int, secap: Int, necap: Int, len: Int, present: Bool, x: Int) -> Int = if necap < 16 then 0
+else if necap != secap then 0
+else {
+  let ilen = prim.load64(__set_il(sh, secap))
+  if ilen != len then 0
   else {
-    prim.store64(rh + 12 + slen * 8, x)
-    slen + 1
+    let _c = __set_copy_slots(sh, rh, secap, secap + 1, 0)
+    if present then 0
+    else {
+      let _p = __set_idx_put(__set_bb(rh, necap), necap * 2 - 1, x, len)
+      prim.store64(__set_il(rh, necap), len + 1)
+      0
+    }
   }
 }
 
 // GEOMETRIC capacity (#1219), same reasoning as map_core's map_set: a `s = set.insert(s, x)`
 // grow loop with exact-size allocs defeats the $alloc exact-size free-list (O(n^2) bytes, O(n)
-// dead-list walk per alloc); doubling epochs make the previously freed block an exact head
-// match. Slack past len is never read (len governs iteration/eq/repr).
+// dead-list walk per alloc); the `__set_cap_for` doubling ladder makes the previously freed
+// block an exact head match. Slack past len is never read (len governs iteration/eq/repr).
 fn set_insert(s: Set[Int], x: Int) -> Set[Int] = {
   let sh = prim.handle(s)
   let slen = prim.load32(sh + 4)
   let scap = prim.load32(sh + 8)
-  let need = slen + 1
-  let cap = if need > scap then (if scap * 2 > need then scap * 2 else need)
-  else scap
-  let r = prim.alloc_set(cap)
+  let present = __set_has_soft(sh, slen, scap, x)
+  let want = __set_cap_for(if present then slen else slen + 1)
+  let cap = if want > scap then want else scap
+  let r = __set_alloc_cap(cap)
   let rh = prim.handle(r)
   let _c = __set_copy(sh, rh, slen, 0)
-  let w = __set_addone(rh, slen, x)
+  let w = if present then slen
+  else {
+    prim.store64(rh + 12 + slen * 8, x)
+    slen + 1
+  }
   prim.store32(rh + 4, w)
+  let _x = __set_idx_carry(sh, rh, __set_ecap(scap), __set_ecap(cap), slen, present, x)
   r
 }
 
@@ -221,10 +407,13 @@ else {
   }
 }
 
+// The result is a FRESH block, so its index is born invalid — removal shifts every
+// survivor's element index, and the next read rebuilds. An index cannot rot here
+// because it is never carried across a removal.
 fn set_remove(s: Set[Int], x: Int) -> Set[Int] = {
   let sh = prim.handle(s)
   let slen = prim.load32(sh + 4)
-  let r = prim.alloc_set(slen)
+  let r = __set_alloc(slen)
   let rh = prim.handle(r)
   let w = __set_remove_fill(sh, slen, rh, x, 0, 0)
   prim.store32(rh + 4, w)
@@ -233,14 +422,14 @@ fn set_remove(s: Set[Int], x: Int) -> Set[Int] = {
 
 // Append b's elements NOT in the ORIGINAL a (handle ah, len alen), growing count w. Used by
 // symmetric_difference after the a-not-in-b part is already written (disjoint, so no re-dedup).
-fn __set_addb_nota(ah: Int, alen: Int, bh: Int, blen: Int, rh: Int, j: Int, w: Int) -> Int = if j >= blen then w
+fn __set_addb_nota(ah: Int, bh: Int, blen: Int, rh: Int, j: Int, w: Int) -> Int = if j >= blen then w
 else {
   let x = prim.load64(bh + 12 + j * 8)
-  let inA = __set_has(ah, alen, x, 0)
-  if inA then __set_addb_nota(ah, alen, bh, blen, rh, j + 1, w)
+  let inA = __set_member(ah, x)
+  if inA then __set_addb_nota(ah, bh, blen, rh, j + 1, w)
   else {
     prim.store64(rh + 12 + w * 8, x)
-    __set_addb_nota(ah, alen, bh, blen, rh, j + 1, w + 1)
+    __set_addb_nota(ah, bh, blen, rh, j + 1, w + 1)
   }
 }
 
@@ -249,12 +438,11 @@ fn set_symmetric_difference(a: Set[Int], b: Set[Int]) -> Set[Int] = {
   let bh = prim.handle(b)
   let alen = prim.load32(ah + 4)
   let blen = prim.load32(bh + 4)
-  let cap = alen + blen
-  let r = prim.alloc_set(cap)
+  let r = __set_alloc(alen + blen)
   let rh = prim.handle(r)
-  let w1 = __set_diff(ah, alen, bh, blen, rh, 0, 0)
+  let w1 = __set_diff(ah, alen, bh, rh, 0, 0)
   // a not in b (a's order)
-  let w2 = __set_addb_nota(ah, alen, bh, blen, rh, 0, w1)
+  let w2 = __set_addb_nota(ah, bh, blen, rh, 0, w1)
   // then b not in a (b's order)
   prim.store32(rh + 4, w2)
   r
@@ -278,7 +466,7 @@ else {
 fn set_filter(s: Set[Int], f: (Int) -> Bool) -> Set[Int] = {
   let sh = prim.handle(s)
   let n = prim.load32(sh + 4)
-  let r = prim.alloc_set(n)
+  let r = __set_alloc(n)
   let rh = prim.handle(r)
   let count = __set_filter_fill(rh, sh, f, n, 0, 0)
   prim.store32(rh + 4, count)
@@ -311,24 +499,23 @@ fn set_any(s: Set[Int], f: (Int) -> Bool) -> Bool = {
 // set.map — apply f to each element, collecting UNIQUE results (f may collapse distinct inputs
 // to the same output, so the mapped values MUST be re-deduped, exactly v0's `.map(f).collect()`
 // into an AlmideSet). Append f(x) iff not already present; first-seen order. Int->Int.
-fn __set_map_fill(dh: Int, sh: Int, f: (Int) -> Int, n: Int, i: Int, w: Int) -> Int = if i >= n then w
+fn __set_map_fill(dh: Int, sh: Int, f: (Int) -> Int, ecap: Int, n: Int, i: Int, w: Int) -> Int = if i >= n then w
 else {
   let x = prim.load64(sh + 12 + i * 8)
   let y = f(x)
-  let present = __set_has(dh, w, y, 0)
-  if present then __set_map_fill(dh, sh, f, n, i + 1, w)
-  else {
-    prim.store64(dh + 12 + w * 8, y)
-    __set_map_fill(dh, sh, f, n, i + 1, w + 1)
-  }
+  let present = __set_has_at(dh, ecap, w, y)
+  if present then __set_map_fill(dh, sh, f, ecap, n, i + 1, w)
+  else __set_map_fill(dh, sh, f, ecap, n, i + 1, __set_add_ix(dh, ecap, w, y))
 }
 
 fn set_map(s: Set[Int], f: (Int) -> Int) -> Set[Int] = {
   let sh = prim.handle(s)
   let n = prim.load32(sh + 4)
-  let r = prim.alloc_set(n)
+  let r = __set_alloc(n)
   let rh = prim.handle(r)
-  let w = __set_map_fill(rh, sh, f, n, 0, 0)
+  let ecap = __set_ecap(prim.load32(rh + 8))
+  let _i = __set_idx_init(rh, ecap)
+  let w = __set_map_fill(rh, sh, f, ecap, n, 0, 0)
   prim.store32(rh + 4, w)
   r
 }


### PR DESCRIPTION
Closes the read-side half of #1219 (issue stage 2): the self-hosted wasm `Map[Int,Int]`
and `Set[Int]` blocks now carry a bucket index sidecar past 16 entries, so keyed lookup is
O(1) instead of the O(n) `__map_find` / `__set_has` scan. This is the wasm-leg twin of the
native fingerprint index that landed in a712f2cba — before this PR the same program was
O(n) native and O(n²) on wasm, a divergence no output-equivalence gate can see.

## Measured (M4 Pro, wasmtime, median of 3, same binary build for before/after)

Benchmark: insert N keys, then look up all N. Phases timed separately in-program with
`datetime.monotonic_ns()`, so the two legs are measured by the same instrument.

### Map — `m[k] = i` build, then `map.get_or` read loop

| leg | n | build before | build after | **lookup before** | **lookup after** |
|---|---:|---:|---:|---:|---:|
| wasm | 2 000 | 1 554 µs | 1 610 µs | **765 µs** | **29 µs** (26×) |
| wasm | 20 000 | 150 310 µs | 153 759 µs | **74 791 µs** | **248 µs** (302×) |
| native | 2 000 | 106 µs | 96 µs | 25 µs | 24 µs |
| native | 20 000 | 885 µs | 756 µs | 300 µs | 253 µs |

### Set — `set.insert` build, then `set.contains` probe loop

| leg | n | build before | build after | **probe before** | **probe after** |
|---|---:|---:|---:|---:|---:|
| wasm | 2 000 | 1 431 µs | 1 505 µs | **758 µs** | **28 µs** (27×) |
| wasm | 20 000 | 145 973 µs | 142 948 µs | **74 919 µs** | **232 µs** (323×) |
| native | 2 000 | 2 335 µs | 2 053 µs | 25 µs | 22 µs |
| native | 20 000 | 141 023 µs | 140 369 µs | 249 µs | 258 µs |

**The curve changed, not just the number.** 10× more data costs, on the wasm lookup phase:

| | before | after | native (reference) |
|---|---:|---:|---:|
| map lookup, 2 000 → 20 000 | **97.8×** (quadratic) | **8.6×** (linear) | 12× |
| set probe, 2 000 → 20 000 | **98.8×** (quadratic) | **8.3×** (linear) | 10× |

wasm keyed lookup is now the same order *and* the same magnitude as native (248 µs vs
253 µs at n=20 000). Variance: shared dev box, first rep is often warm-up-inflated
(the two 1.9 ms outliers in the before-set), so medians of 3 are reported; build-phase
deltas (≤ +4 %) sit inside the run-to-run spread and are not a real regression.

**Still O(n²): the BUILD loop.** That is copy-dominated, not find-dominated — `m[k] = v`
lowers to the persistent rebind `m = map.set(m, k, v)`, which copies every entry on every
call. Killing it needs the in-place uniquely-owned insert (issue stage 1, a trust-spine
crossing with the C-033 alias/cow matrix), so #1219 stays open for that arc.

## Design — how the index cannot rot

Entries stay **authoritative** (insertion-ordered, `len` governs iteration/eq/repr); the
buckets are a pure sidecar, so nothing observable changes.

- **Layout is derived from `cap` alone.** Every producer allocates through one choke point
  (`__map_alloc` / `__set_alloc`), so the slot count is a function of the entry capacity E:
  flat `cap = 2E` (E < 16) vs indexed `cap = 3E + 1` (E ≥ 16). The two ladders are disjoint
  (16 < 49), so `cap >= 49` decides the shape with no flag bit and no ambiguity.
- **Validity is a stamp, not a discipline.** An indexed block stores `ilen`, the entry count
  the buckets were built for, and the index is valid **iff `ilen == len`**. Fresh blocks are
  stamped `-1` by the allocator. A producer that writes entries without touching the buckets
  therefore yields an *invalid* index that the next read rebuilds — it can never silently
  disagree with the entries. `$alloc` hands back non-zeroed reused blocks, so a rebuild
  clears before filling.
- **UPSERT**: `map_set` resolves the key first; a present key rewrites the value in place
  (entry index unchanged ⇒ buckets still exact), an absent key appends at `len` and, when the
  source index was valid and the shape did not change, the carried copy binds the new key and
  advances `ilen`. Same for `set_insert`.
- **REMOVE**: removal shifts every survivor's entry index, so the result is a fresh block with
  an invalid stamp and is rebuilt on the next read. The index is *never carried across a
  removal* — the classic rot path is structurally absent. `spec/*/(map|set)_index_*` cover
  remove-then-reinsert, where a stale index would resurrect the dead entry.
- **Hash**: xorshift64 over shifts/xors only (no Int overflow), folding high bits into the
  masked low bits — `i * 1024` keys would otherwise all land in one bucket. Load factor ≤ ½
  (E entries in 2E buckets), so the linear probe always terminates on an empty bucket.
- `map_merge` / `set_union` / `set_from_list` / `set_map` keep the half-built result's index
  exact in the same step that appends, so their dedup passes drop from O(a·b) to O(a+b).

Producer-side lookups (`map_set`, `map_update`, `set_insert`) probe only when the index is
*already* valid and otherwise scan — a grow loop discards its result every call, so building
an index for it would cost more than the scan it replaces.

## Evidence

- `spec/wasm_cross/map_index_order.almd` (**C-013**) and `spec/wasm_cross/set_index_order.almd`
  (**C-014**) — new fixtures in the indexed regime (the existing ones are all below the
  threshold, so nothing pinned the indexed path across legs). Byte-identical native == wasm,
  verified by `wasm_cross_target_spec`.
- `spec/stdlib/map_index_test.almd`, `spec/stdlib/set_index_test.almd` — upsert, remove,
  remove-then-reinsert, merge/union algebra, filter/update/map, adversarial keys
  (power-of-two stride, negatives, zero), and 15/16/17/31/32/33 threshold crossings. Both
  run on the WASM leg.
- `scripts/check-keyed-container-index.sh` — the **matrix gate** the family rule demands.
  Every `stdlib/map*.almd` / `stdlib/set*.almd` carries an explicit row: `indexed`,
  `linear:<ref>`, or `n/a` (never resolves a key). CI fails on a module with no row, a row
  with no module, a row claiming `indexed` without the sidecar helpers, or a stale `linear`
  row that now has them. Today: 2 indexed, 8 linear (all tracked to #1219 — the String-keyed
  and heap-value reprs), 9 n/a.

### The new gate is classified in `proofs/gate-verification.toml` (NEGATIVE_TESTED)

Five forged inputs, each **diff-verified to have landed** before the run, each demonstrated
to FAIL, then restored green:

| forge | verdict |
|---|---|
| real index rowed linear (`map_core indexed → linear:#1219`) | `NOW carries sidecar helper(s): _reindex _probe _idx_put` |
| scanning repr rowed indexed (`map_str linear → indexed`) | `missing sidecar helper(s)` |
| row retargeted off its module (`set_core → set_gone`) | STALE row **and** the orphaned module's NO-row error |
| bogus state word (`map_if n/a → indexedish`) | `unknown state 'indexedish'` |
| new repr module with no row (`stdlib/map_forgeprobe.almd`) | NO-row error |

The first probe round **exposed a real weakness**: a single `_reindex(` grep would have
passed a half-reverted index (buckets read but never rebuilt). The marker set was tightened
to all three sidecar helpers *before* the evidence was recorded. UNVERIFIED count unchanged
at 2 (ceiling 2).

### Interp abstain ledger — direction reviewed, not regenerated over

`crates/almide-interp/interp-abstain-ledger.txt` gains exactly **two lines, both of them the
two fixtures this PR adds**; nothing was removed or reworded. The evaluated count is
**unchanged at 282** (fixtures 403 → 405, abstains 121 → 123), so **no fixture moved from
evaluated to abstained** — this is not coverage hiding inside a perf win. Both new abstains
land on the pre-existing `prim.alloc_map` / `prim.handle` capability class that every sibling
Map/Set cross fixture already sits in (`alias_cow`, `map_insertion_order`,
`set_insertion_order`, `map_filter`, `map_fold`); a `Map[Int,Int]` fixture cannot avoid it,
because reaching `map_core` at all means reaching the self-host prim path (the interp-heap
arc, #1226). `scripts/gen-claims.sh` re-derived the stage block: Stage 2 282/405 (69 %),
Stage 5 gates 33 → 34.

## Gates run green

`cargo build --release` · `almide test` (399 files, 382 via WASM, **17 native fallback —
unchanged**, 0 failed) · `almide fmt --check spec/ examples/` (917 files) ·
`scripts/check-contracts.sh` (269 contracts, 405/405 fixtures linked) ·
`cargo test --release --test wasm_runtime_test` (full binary — `wasm_cross_target_spec` and
both p5 gates together) · `check-gate-verification.sh` (34 gates) ·
`check-keyed-container-index.sh` · `check-ratchet-separation.sh` · `check-embedded-size.sh` ·
`check-semantics-manifest.sh` · `check-scalar-read-audit.sh` · `check-forbidden-impurities.sh` ·
`check-workflows.sh`
