### PR TITLE
Publish the grammar as a gated Lark artifact for decode-time constraint engines

### DIFF
--- a/docs/grammar/README.md
+++ b/docs/grammar/README.md
@@ -1,0 +1,111 @@
+# The published Almide grammar
+
+`almide.lark` is the machine-readable Almide grammar. It exists for one
+reason: **decode-time constraint engines** — [llguidance](https://github.com/guidance-ai/llguidance),
+[XGrammar](https://github.com/mlc-ai/xgrammar), OpenAI custom tools (Lark CFG
+input) — can only force syntactic validity at token-sampling time if a
+consumable CFG exists. With one, syntactically invalid Almide becomes
+*unrepresentable* rather than merely diagnosed. That is the strongest accuracy
+lever this repo has: it acts before the model can make the mistake.
+
+Evidence for the approach: CangjieBench (arXiv 2603.14501) — for a
+low-resource language, syntax-constrained generation is the best
+accuracy/cost trade-off. CRANE (arXiv 2502.09061) — constrain the *emission*,
+never the reasoning.
+
+## Files
+
+| File | What it is |
+|---|---|
+| `almide.lark` | the grammar artifact (Lark syntax, Earley + basic lexer) |
+| `negative-fixtures.txt` | invalid programs the grammar must REJECT |
+| `../../scripts/check-lark-grammar.sh` | the anti-rot gate |
+| `../../scripts/lib/lark-gate.py` | the gate's implementation |
+
+## Using it
+
+```python
+from lark import Lark
+parser = Lark(open("docs/grammar/almide.lark").read(),
+              start="start", parser="earley", lexer="basic")
+parser.parse(open("app.almd").read())
+```
+
+For llguidance / XGrammar, hand the same file to the engine's Lark front end.
+
+## The anti-rot gate — exactly what it checks
+
+A hand-written grammar rots the moment the parser changes, and a rotted
+grammar is *worse than none*: it would constrain a decoder to a language the
+compiler no longer accepts. `scripts/check-lark-grammar.sh` is what stops
+that. It asserts three independent things.
+
+**1. Lexical parity.** The `BEGIN-KEYWORDS` / `BEGIN-OPERATORS` marker blocks
+in `almide.lark` are diffed token-for-token against the `KEYWORDS` and
+`OPERATORS` tables in `crates/almide-syntax/src/lexer.rs`. Adding a keyword to
+the lexer without adding it here fails the gate, and vice versa. The
+`EXCLUDED` list is checked in both directions too: an excluded operator must
+still be a real lexer token (or the exclusion is stale) and must not also be
+declared in the grammar.
+
+**2. Corpus superset.** Every `.almd` under `spec/`, `examples/` and `stdlib/`
+is parsed with the published grammar. For each file the grammar *rejects*, the
+compiler is consulted through `almide <file> --emit-ast` — which runs the lexer
+and parser and nothing else (a type error still exits 0). If the compiler
+parses a file the grammar does not, that is a hard failure.
+
+Only that direction is required. The grammar is a deliberate **superset**:
+over-acceptance costs a decoder nothing (it merely fails to block a bad token),
+whereas under-acceptance makes a legal program unsamplable.
+
+**3. Discrimination.** Every fixture in `negative-fixtures.txt` must be
+rejected by the grammar *and* by the compiler. Without this, a grammar that
+degenerated into `.*` would sail through check 2. The gate also enforces a
+floor on the fixture count.
+
+## What the gate does NOT prove
+
+- **Not soundness.** It does not prove the grammar accepts *only* valid
+  Almide. It is a superset by construction; check 2 can only ever fail in the
+  under-accept direction, and check 3 only pins the named counterexamples in
+  `negative-fixtures.txt`.
+- **Not coverage beyond the corpus.** A syntax feature that no file in
+  `spec/`, `examples/` or `stdlib/` uses is not exercised. A new construct
+  landed *without* a spec fixture would not be caught here — which is one more
+  reason new syntax always ships with a `spec/` test.
+- **Nothing semantic.** `--emit-ast` is parse-only: types, effects, module
+  resolution and the whole checker are out of scope.
+- **Not engine portability.** The gate uses Python `lark` (Earley + basic
+  lexer). It does not prove that llguidance or XGrammar compile this exact
+  dialect; those engines accept Lark-*like* syntax with their own restrictions.
+
+## Known gaps — what the grammar cannot express
+
+These are honest limits, not bugs. Where the artifact is *looser* than the
+compiler a decoder is simply unconstrained there; where it is *tighter* the
+corpus check proves no real Almide is affected.
+
+| # | Gap | Direction |
+|---|---|---|
+| G1 | **Nested block comments.** `/* … */` is a non-greedy regex; the lexer counts nesting depth. `/* /* */ */` leaves a stray `*/`. | tighter |
+| G2 | **Heredoc dedent.** `"""…"""` is one opaque terminal. `strip_heredoc_indent` is a *value* transformation, not a syntactic one, so nothing syntactic is lost — but the artifact cannot express the closing-delimiter indentation rule. | n/a |
+| G3 | **Interpolation holes.** `${…}` is matched *lexically*, with nested `"…"`/`'…'` literals and up to three levels of `{ }` nesting. The compiler re-lexes and re-parses the hole with a sub-parser, so its contents are full expressions. A decoder is therefore **unconstrained inside a hole**, and holes nested deeper than three brace levels are rejected. This is the one place a single CFG-over-text cannot mirror the compiler's two-phase lexing. | both |
+| G4 | **Whitespace-sensitive unary minus.** `a⏎- b` continues a subtraction; `a⏎-b` (attached) starts a new statement. Token-level grammars cannot see the gap, so both readings are accepted. | looser |
+| G5 | **Diagnostics-only restrictions.** The `??` line-crossing rule (E038/#1112), terminal `??` (E038), positional-after-named arguments, and the "every parameter after the first default needs one" rule are parser *diagnostics*, not grammar. The artifact accepts them. | looser |
+| G6 | **Reserved contextual identifiers.** `as`, `where` and the type name `Fn` are matched by spelling in the compiler but are ordinary identifiers to its lexer. The artifact reserves them, so `let as = 1` — legal Almide — is rejected. No corpus file does this. `self` is deliberately *not* reserved (it is a value in every convention method body), so the bare receiver parameter is spelled as "the first parameter may omit `: Type`" — the artifact accepts `fn f(x) -> Int = 1`, which the compiler rejects. | both |
+| G7 | **`fan.<head>`.** The head name is left open (any identifier); the compiler admits only `bounded`/`timeout`/`race`/`settle`/`any`. | looser |
+| G8 | **Statement separators are required** (a newline or `;`). The compiler tolerates two statements adjacent on one line with none. Deliberate: it removes a large ambiguity and no formatted Almide relies on it. | tighter |
+| G9 | **Arithmetic precedence is flattened.** `\|>`, `>>`, `+ -`, `* / %`, `^` share one level. Precedence shapes the parse *tree*, never the set of accepted token strings, and Earley pays for depth on every column. The binding powers remain authoritative in `grammar/precedence.toml` and `Parser::infix_bp`. Boolean, comparison and range levels ARE kept separate — their non-associativity is a language fact (`a < b < c` and `0..<1..<2` are errors). | equal |
+| G10 | **Retired / rejected spellings excluded.** `&&`, `\|\|`, `++` and `..`/`..=`-as-a-range parse in the compiler *only* so it can answer with a migration hint. The artifact excludes them: a decoder must never sample them. | tighter |
+| G11 | **No depth limit.** The parser caps expression nesting at 500 (`MAX_DEPTH`); the artifact does not. | looser |
+| G12 | **Module-qualified record literals** (`mod.TypeName { … }`) are accepted after any postfix expression, not only after a bare identifier as the parser requires. | looser |
+
+## Relationship to the `grammar/` submodule
+
+[`almide/almide-grammar`](https://github.com/almide/almide-grammar) (the
+`grammar/` submodule) holds the *descriptive* keyword / precedence / TextMate
+data that the tree-sitter and VS Code generators consume. It has no consumable
+CFG, and CI never fetches it — so this artifact lives in the compiler repo,
+where the gate can reach both it and the lexer it mirrors. `almide.lark`'s
+precedence commentary points back at `grammar/precedence.toml`; the two are
+kept honest by pointing at the same source of truth, `Parser::infix_bp`.

--- a/docs/grammar/almide.lark
+++ b/docs/grammar/almide.lark
@@ -1,0 +1,647 @@
+// almide.lark — the machine-readable Almide grammar artifact.
+//
+// PURPOSE: feed decode-time constraint engines (llguidance, XGrammar, OpenAI
+// custom tools) so a sampler cannot emit syntactically invalid Almide.
+//
+// CONTRACT (what this file promises, enforced by scripts/check-lark-grammar.sh):
+//   1. CORPUS SUPERSET — every file in the checked corpus that the compiler's
+//      parser accepts, this grammar accepts. Over-acceptance is the safe
+//      direction for a decoder (it only fails to block a bad token);
+//      under-acceptance is not (it makes a legal program unrepresentable).
+//   2. LEXICAL PARITY — the keyword and operator tables below are diffed
+//      token-for-token against crates/almide-syntax/src/lexer.rs.
+//   3. DISCRIMINATION — every fixture in negative-fixtures.txt must be
+//      REJECTED, so the grammar cannot rot into `.*`.
+//
+// See README.md in this directory for the gap list (what the grammar cannot
+// express) and for exactly what the gate does and does not prove.
+//
+// Mirrors: crates/almide-syntax/src/lexer.rs   (tokens)
+//          crates/almide-syntax/src/parser/    (structure)
+//          grammar/precedence.toml             (descriptive precedence table)
+//
+// STYLE NOTE: optional elements are spelled as nullable `_o_*` helper rules
+// rather than inline `X?`. Lark expands an inline `?` combinatorially — a rule
+// with seven optionals becomes 128 productions — and an Earley recognizer pays
+// for every one of them on every column.
+
+// ═══════════════════════════════════════════════════════════════════
+// Entry
+// ═══════════════════════════════════════════════════════════════════
+
+start: _nl _o_program
+_o_program: _program
+          |
+_program: module_decl _nl _rest
+        | _rest
+_rest: _imports _nl _decls
+     | _imports
+     | _decls
+_imports: import_decl (_NL import_decl)*
+_decls: top_decl (_NL top_decl)* _nl
+
+// ═══════════════════════════════════════════════════════════════════
+// Declarations
+// ═══════════════════════════════════════════════════════════════════
+
+module_decl: MODULE module_path
+
+import_decl: IMPORT module_path DOT "{" import_names "}"
+           | IMPORT module_path _o_import_alias
+_o_import_alias: AS IDENT
+               |
+import_names: name_tok (COMMA name_tok)* _comma
+module_path: IDENT (DOT IDENT)*
+
+?top_decl: fn_decl
+         | type_decl
+         | protocol_decl
+         | top_let
+         | test_decl
+         | test_where_def
+
+// ── fn ───────────────────────────────────────────────────────────
+// [@attr…] [pub] [local|mod] [effect] fn name[G](params) -> Ty[!] [= body]
+fn_decl: _o_attrs _o_pub _o_vis _o_effect FN fn_name _o_generics "(" param_list ")" ARROW type_expr _o_bang _o_fn_body
+
+_o_fn_body: fn_body
+          |
+fn_body: EQ _nl braceless_block
+       | EQ _nl expr
+
+// A fn body that OPENS with let/var/guard is a brace-less statement block
+// (Parser::parse_braceless_block).
+braceless_block: _braceless_head (_stmt_sep stmt)* _o_stmt_sep
+_braceless_head: let_stmt | var_stmt | guard_stmt
+
+fn_name: TYPENAME DOT IDENT
+       | IDENT
+
+param_list: _nl _o_params _nl
+// The first parameter may be BARE (no `: Type`) — that is the convention
+// method's `self` receiver. The compiler accepts only the literal spelling
+// `self` there; this grammar accepts any identifier, so `self` stays an
+// ordinary identifier everywhere else (README gap G6).
+_o_params: _bare_receiver (COMMA _nl param)* _comma
+         | param (COMMA _nl param)* _comma
+         |
+_bare_receiver: IDENT
+param: _o_attrs _o_mut _param_name COLON type_expr _o_default
+_param_name: IDENT | VAR
+
+// ── type ─────────────────────────────────────────────────────────
+type_decl: _o_vis TYPE_KW TYPENAME _o_generics _o_deriving _nl EQ _nl type_expr
+_o_deriving: COLON TYPENAME (COMMA TYPENAME)*
+           |
+
+// ── protocol ─────────────────────────────────────────────────────
+protocol_decl: PROTOCOL TYPENAME _o_generics "{" _nl (protocol_method _nl)* "}"
+protocol_method: _o_effect FN fn_name _o_generics "(" param_list ")" ARROW type_expr
+
+// ── top-level let / var ──────────────────────────────────────────
+top_let: _o_top_vis _let_or_var name_tok _o_ty_ann EQ _nl expr
+_o_top_vis: PUB | LOCAL | MOD
+          |
+_let_or_var: LET | VAR
+
+// ── test ─────────────────────────────────────────────────────────
+test_decl: TEST plain_string test_where_clause* _nl block
+test_where_clause: _nl WHERE _nl _where_body
+_where_body: where_table | where_case | where_binding
+where_table: "[" _nl (where_case _seps)* _o_where_case "]"
+_o_where_case: where_case
+             |
+where_case: plain_string "[" _nl (where_binding _seps)* _o_where_binding "]"
+_o_where_binding: where_binding
+                |
+where_binding: where_path "(" where_params ")" FATARROW expr
+             | where_path EQ expr
+where_path: IDENT (DOT IDENT)*
+where_params: (pattern _comma)*
+
+test_where_def: _vis TEST _o_where "{" _nl (where_binding _def_seps)* "}"
+_o_where: WHERE
+        |
+_def_seps: (SEMI | COMMA | _NL)+
+
+// ── attributes ───────────────────────────────────────────────────
+attribute: AT attr_name _o_attr_args
+_o_attr_args: attr_args
+            |
+attr_args: "(" _nl _o_attr_arg_list ")"
+_o_attr_arg_list: attr_arg (COMMA _nl attr_arg)* _comma _nl
+                |
+attr_arg: IDENT EQ attr_value
+        | attr_value
+?attr_value: plain_string | INT | MINUS INT | TRUE | FALSE | IDENT
+?attr_name: IDENT | TYPENAME | keyword_as_name
+
+// ═══════════════════════════════════════════════════════════════════
+// Types
+// ═══════════════════════════════════════════════════════════════════
+
+?type_expr: EFFECT type_expr                      -> effect_type
+          | leading_variant
+          | record_type
+          | fn_type
+          | paren_type
+          | INT                                   -> const_type
+          | named_type
+
+leading_variant: (_nl PIPE _nl variant_case)+
+
+named_type: qualified_type_name type_tail (_nl PIPE _nl variant_case)*
+type_tail: "[" type_args "]" _o_question
+         | "(" _o_type_list ")"
+         | _o_question
+
+qualified_type_name: (IDENT DOT)* TYPENAME
+
+type_args: _nl type_expr (COMMA _nl type_expr)* _nl
+type_list: type_expr (COMMA type_expr)*
+_o_type_list: type_list
+            |
+
+fn_type: _fn_head "(" _o_type_list ")" ARROW type_expr _o_bang
+_fn_head: FN | FN_TYPENAME
+
+paren_type: "(" ")" _o_arrow_ret
+          | "(" type_expr ")" ARROW type_expr _o_bang
+          | "(" type_expr ")" _o_question
+          | "(" type_expr (COMMA type_expr)+ ")" ARROW type_expr _o_bang
+          | "(" type_expr (COMMA type_expr)+ ")" _o_question
+_o_arrow_ret: ARROW type_expr _o_bang
+            |
+
+record_type: "{" _nl _o_field_types _o_open_rest "}"
+_o_open_rest: DOTDOT _nl
+            |
+_o_field_types: field_type (_seps field_type)* _o_seps
+              |
+field_type: _o_attrs name_tok _o_field_alias COLON type_expr _o_default
+_o_field_alias: AS plain_string
+              |
+
+variant_case: TYPENAME "(" _o_type_list ")"
+            | TYPENAME "{" _nl _o_field_types "}"
+            | TYPENAME
+
+generic_params: "[" generic_param (COMMA generic_param)* "]"
+generic_param: TYPENAME _o_generic_bound
+_o_generic_bound: COLON record_type
+                | COLON TYPENAME (PLUS TYPENAME)*
+                |
+
+// ═══════════════════════════════════════════════════════════════════
+// Statements
+// ═══════════════════════════════════════════════════════════════════
+
+?stmt: let_stmt
+     | var_stmt
+     | guard_stmt
+     | assign_stmt
+     | index_assign_stmt
+     | field_assign_stmt
+     | expr
+
+// A statement separator. The compiler also tolerates NO separator between two
+// statements on one line; this grammar requires one — README gap G8.
+_stmt_sep: SEMI _nl
+         | _NL
+_o_stmt_sep: _stmt_sep
+           |
+
+let_stmt: LET "{" name_tok (COMMA _nl name_tok)* _comma "}" EQ _nl expr   -> let_record
+        | LET destructure_tuple EQ _nl expr                               -> let_tuple
+        | LET _bind_name _o_ty_ann EQ _nl expr
+
+var_stmt: VAR IDENT _o_ty_ann EQ _nl expr
+
+guard_stmt: GUARD LET _nl IDENT _nl EQ _nl expr _nl ELSE _nl expr
+          | GUARD expr ELSE _nl expr
+
+assign_stmt: IDENT EQ _nl expr
+index_assign_stmt: IDENT "[" expr "]" EQ _nl expr
+field_assign_stmt: IDENT DOT name_tok EQ _nl expr
+
+destructure_tuple: "(" (_destructure_elem _comma _nl)* ")"
+_destructure_elem: destructure_tuple | UNDERSCORE | IDENT
+_bind_name: IDENT | UNDERSCORE
+
+// ═══════════════════════════════════════════════════════════════════
+// Expressions
+//
+// A leading `_nl` marks an operator that may open a continuation line
+// (Parser::INFIX_TOKENS); `<`, `>` and `...` deliberately may not.
+// ═══════════════════════════════════════════════════════════════════
+
+?expr: bool_level
+
+// `or` / `and` — the loosest binding, and the only level whose operands are
+// full comparisons.
+?bool_level: bool_level _nl bool_op _nl cmp_level | cmp_level
+!bool_op: OR | AND
+
+// Comparison is NON-ASSOCIATIVE: `a < b < c` is a parse error, so at most one
+// comparison operator may appear here.
+?cmp_level: range_level _nl cmp_op_nl _nl range_level
+          | range_level cmp_op_bare _nl range_level
+          | range_level
+!cmp_op_nl: EQEQ | BANGEQ | LTEQ | GTEQ
+!cmp_op_bare: LT | GT
+
+// Ranges are NON-ASSOCIATIVE too — `0..<1..<2` is rejected (#899).
+?range_level: bin_level _nl DOTDOTLT _nl bin_level   -> range_exclusive
+            | bin_level DOTDOTDOT _nl bin_level      -> range_inclusive
+            | bin_level
+
+// The arithmetic / pipeline operators. Their relative BINDING POWERS live in
+// grammar/precedence.toml and Parser::infix_bp; they are flattened to a single
+// level here because the ordering changes only the parse TREE, never the SET
+// of accepted token strings — and depth is what an Earley recognizer pays for
+// on every column. See README gap G9.
+?bin_level: bin_level _nl PIPEARROW _nl pipe_match
+          | bin_level _nl bin_op _nl unary
+          | unary
+!bin_op: PIPEARROW | COMPOSE | PLUS | MINUS | STAR | SLASH | PERCENT | CARET | STARSTAR
+pipe_match: MATCH _nl "{" match_body "}"
+
+?unary: MINUS unary   -> neg
+      | NOT unary     -> logical_not
+      | postfix
+
+?postfix: primary postfix_op*
+
+postfix_op: _nl DOT TYPENAME named_record          -> qualified_record
+          | _nl DOT name_tok                       -> member
+          | DOT INT                                -> tuple_index
+          | "[" type_args "]" "(" call_args ")"    -> type_args_call
+          | "[" expr "]"                           -> index
+          | "(" call_args ")"                      -> call
+          | BANG                                   -> unwrap
+          | QQ _nl unary                           -> unwrap_or
+          | QDOT name_tok                          -> optional_chain
+          | QUESTION                               -> to_option
+
+call_args: _nl _o_call_arg_list _nl
+_o_call_arg_list: call_arg (COMMA _nl call_arg)* _comma
+                |
+?call_arg: UNDERSCORE                              -> placeholder
+         | IDENT COLON _nl expr                    -> named_arg
+         | expr COLON type_expr                    -> ascribed_arg
+         | expr
+
+// Flattened on purpose: a `literal` / `string` / `plain_string` chain of unit
+// rules costs one extra Earley prediction level at EVERY expression position.
+?primary: INT | FLOAT | TRUE | FALSE | UNDERSCORE | BREAK | CONTINUE
+        | STRING | SQ_STRING | RAW_STRING | RAW_HEREDOC | HEREDOC
+        | INTERP_STRING | HEREDOC_INTERP
+        | NONE | NONE_UC
+        | ctor_expr
+        | if_expr
+        | match_expr
+        | while_expr
+        | for_expr
+        | fan_expr
+        | record_lit
+        | spread_record
+        | block
+        | list_expr
+        | paren_expr
+        | typename_expr
+        | IDENT
+
+// The positions where the compiler demands TokenType::String specifically —
+// an INTERPOLATED string is a different token and is a parse error there.
+?plain_string: STRING | SQ_STRING | RAW_STRING | RAW_HEREDOC | HEREDOC
+
+// The four constructor keywords each have a capitalized alias that lexes to
+// the SAME token (lexer.rs KEYWORDS carries two rows for each).
+ctor_expr: SOME "(" expr ")"
+         | SOME_UC "(" expr ")"
+         | OK "(" expr ")"
+         | OK_UC "(" expr ")"
+         | ERR "(" expr ")"
+         | ERR_UC "(" expr ")"
+         | TODO "(" plain_string ")"
+
+// ── control flow ─────────────────────────────────────────────────
+
+if_expr: IF _nl LET _nl IDENT _nl EQ _nl expr _nl block _nl ELSE _nl block  -> if_let
+       | IF _nl expr _nl THEN _nl _if_branch _o_else
+_o_else: _nl ELSE _nl _if_branch
+       |
+_if_branch: assign_stmt | index_assign_stmt | field_assign_stmt | expr
+
+match_expr: MATCH _nl expr _nl "{" match_body "}"
+match_body: _nl (match_arm _seps)* _o_match_arm
+_o_match_arm: match_arm
+            |
+match_arm: pattern _o_guard FATARROW _nl expr
+_o_guard: IF expr
+        |
+
+while_expr: WHILE _nl expr _nl block
+for_expr: FOR _for_binder IN expr block
+_for_binder: UNDERSCORE
+           | IDENT
+           | "(" _for_name (COMMA _for_name)* ")"
+_for_name: IDENT | UNDERSCORE
+
+// `fan { … }`, `fan.<head> { … }`, `fan.<head>(arg) { … }`. The head NAME is
+// left open (any IDENT); the compiler restricts it to
+// bounded/timeout/race/settle/any — README gap G7.
+fan_expr: FAN DOT IDENT "(" _nl expr _nl ")" _nl block   -> fan_head_call
+        | FAN DOT IDENT _nl fan_arm_block                -> fan_head_block
+        | FAN fan_arm_block                              -> fan_block
+        | FAN                                            -> fan_name
+
+fan_arm_block: "{" _nl (expr _stmt_sep)* _o_expr "}"
+_o_expr: expr
+       |
+
+// ── grouping ─────────────────────────────────────────────────────
+
+block: "{" _nl (stmt _stmt_sep)* _o_stmt "}"
+_o_stmt: stmt
+       |
+
+record_lit: "{" _nl field_kv (_seps field_init)* _o_seps "}"
+spread_record: "{" _nl DOTDOTDOT expr (COMMA _nl field_init)* _o_seps "}"
+field_kv: name_tok COLON _nl expr
+?field_init: field_kv | name_tok
+
+list_expr: "[" _nl "]"                                                  -> empty_list
+         | "[" _nl COLON "]"                                            -> empty_map
+         | "[" _nl expr _nl (COMMA _nl expr _nl)* _comma "]"            -> list_lit
+         | "[" _nl map_entry (COMMA _nl map_entry)* _comma "]"          -> map_lit
+map_entry: expr _nl COLON _nl expr _nl
+
+paren_expr: "(" ")"                                          -> unit
+          | "(" lambda_params ")" FATARROW _nl expr          -> lambda
+          | "(" expr COLON type_expr ")"                     -> ascription
+          | "(" expr (COMMA expr)* _comma ")"                -> tuple_or_paren
+
+lambda_params: lambda_param (COMMA lambda_param)*
+             |
+?lambda_param: "(" (_for_name _comma)* ")"          -> lambda_tuple_param
+             | _for_name _o_ty_ann
+
+typename_expr: TYPENAME "[" type_args "]" "(" call_args ")"   -> ctor_type_args_call
+             | TYPENAME "(" call_args ")"                     -> ctor_call
+             | TYPENAME _nl named_record                      -> named_record_lit
+             | TYPENAME                                       -> type_name_value
+
+named_record: "{" _nl DOTDOTDOT expr (COMMA _nl field_init)* _o_seps "}"  -> named_spread
+            | "{" _nl (field_init _seps)* _o_field_init "}"               -> named_fields
+_o_field_init: field_init
+             |
+
+// ═══════════════════════════════════════════════════════════════════
+// Patterns
+// ═══════════════════════════════════════════════════════════════════
+
+?pattern: UNDERSCORE
+        | NONE | NONE_UC
+        | _some_kw "(" pattern ")"              -> some_pat
+        | _ok_kw "(" pattern ")"                -> ok_pat
+        | _err_kw "(" pattern ")"               -> err_pat
+        | "(" pattern (COMMA pattern)* ")"      -> tuple_pat
+        | "[" _o_pattern_list "]"               -> list_pat
+        | MINUS INT                             -> neg_int_pat
+        | MINUS FLOAT                           -> neg_float_pat
+        | INT | FLOAT
+        | STRING | SQ_STRING | RAW_STRING | RAW_HEREDOC | HEREDOC
+        | INTERP_STRING | HEREDOC_INTERP
+        | TRUE | FALSE
+        | ctor_pattern
+        | IDENT                                 -> bind_pat
+
+_ok_kw: OK | OK_UC
+_err_kw: ERR | ERR_UC
+_some_kw: SOME | SOME_UC
+
+_o_pattern_list: pattern (COMMA pattern)* _comma
+               |
+
+ctor_pattern: qualified_ctor "(" _o_pattern_args ")"   -> ctor_args_pat
+            | qualified_ctor record_pattern            -> ctor_record_pat
+            | qualified_ctor                           -> ctor_unit_pat
+_o_pattern_args: pattern (COMMA pattern)*
+               |
+
+qualified_ctor: _o_module_prefix TYPENAME
+_o_module_prefix: IDENT DOT
+                |
+
+record_pattern: "{" _nl (field_pattern _seps)* _o_record_pat_tail "}"
+_o_record_pat_tail: field_pattern
+                  | DOTDOT _comma _nl
+                  |
+field_pattern: name_tok _o_field_pat
+_o_field_pat: COLON pattern
+            |
+
+// ═══════════════════════════════════════════════════════════════════
+// Shared name positions and nullable helpers
+// ═══════════════════════════════════════════════════════════════════
+
+// `expect_any_name`: identifier, TypeName, or a SOFT KEYWORD used as a name.
+?name_tok: IDENT | TYPENAME | soft_keyword
+!soft_keyword: OK | OK_UC | ERR | ERR_UC | SOME | SOME_UC | NONE | NONE_UC | TODO
+!keyword_as_name: EFFECT | TYPE_KW | TEST | FN | LET | VAR | MOD | IN | FOR | MATCH
+
+_nl: _NL
+   |
+_comma: COMMA
+      |
+_seps: (COMMA | _NL)+
+_o_seps: _seps
+       |
+_attrs: (attribute _nl)+
+_o_attrs: _attrs
+        |
+_o_pub: PUB
+      |
+_vis: LOCAL | MOD
+_o_vis: _vis
+      |
+_o_effect: EFFECT
+         |
+_o_mut: MUT
+      |
+_o_generics: generic_params
+           |
+_o_bang: BANG
+       |
+_o_question: QUESTION
+           |
+_o_ty_ann: COLON type_expr
+         |
+_o_default: EQ expr
+          |
+
+// ═══════════════════════════════════════════════════════════════════
+// TERMINALS
+//
+// The two tables below are the ones scripts/check-lark-grammar.sh diffs
+// against crates/almide-syntax/src/lexer.rs. Editing the lexer without
+// editing these fails the gate.
+// ═══════════════════════════════════════════════════════════════════
+
+// ── keywords (lexer.rs KEYWORDS) ──── BEGIN-KEYWORDS ──
+// Plain STRING terminals on purpose: Lark re-types an IDENT/TYPENAME match
+// whose WHOLE text is one of these, which is exactly the compiler's rule
+// (`keyword()` runs after the identifier scan) — so `matches` stays an
+// identifier instead of lexing as `match` + `es`.
+MODULE: "module"
+IMPORT: "import"
+TYPE_KW: "type"
+PROTOCOL: "protocol"
+FOR: "for"
+IN: "in"
+FN: "fn"
+LET: "let"
+VAR: "var"
+MUT: "mut"
+IF: "if"
+THEN: "then"
+ELSE: "else"
+MATCH: "match"
+OK: "ok"
+OK_UC: "Ok"
+ERR: "err"
+ERR_UC: "Err"
+SOME: "some"
+SOME_UC: "Some"
+NONE: "none"
+NONE_UC: "None"
+TODO: "todo"
+TRUE: "true"
+FALSE: "false"
+NOT: "not"
+AND: "and"
+OR: "or"
+PUB: "pub"
+EFFECT: "effect"
+TEST: "test"
+GUARD: "guard"
+BREAK: "break"
+CONTINUE: "continue"
+WHILE: "while"
+LOCAL: "local"
+MOD: "mod"
+FAN: "fan"
+// ──── END-KEYWORDS ──
+
+// Contextual identifiers the parser matches by SPELLING, not by token type.
+// They are ordinary identifiers to the lexer; this grammar reserves them.
+// See README gap G6.
+AS: "as"
+WHERE: "where"
+FN_TYPENAME: "Fn"
+
+// ── operators & delimiters (lexer.rs OPERATORS) ──── BEGIN-OPERATORS ──
+DOTDOTDOT: "..."
+DOTDOTLT: "..<"
+ARROW: "->"
+FATARROW: "=>"
+EQEQ: "=="
+BANGEQ: "!="
+LTEQ: "<="
+COMPOSE: ">>"
+GTEQ: ">="
+PIPEARROW: "|>"
+QQ: "??"
+QDOT: "?."
+DOTDOT: ".."
+STARSTAR: "**"
+LPAREN: "("
+RPAREN: ")"
+LBRACE: "{"
+RBRACE: "}"
+LBRACKET: "["
+RBRACKET: "]"
+COMMA: ","
+DOT: "."
+COLON: ":"
+SEMI: ";"
+EQ: "="
+BANG: "!"
+LT: "<"
+GT: ">"
+PLUS: "+"
+MINUS: "-"
+STAR: "*"
+SLASH: "/"
+PERCENT: "%"
+PIPE: "|"
+CARET: "^"
+QUESTION: "?"
+UNDERSCORE: "_"
+AT: "@"
+// ──── END-OPERATORS ──
+//
+// DELIBERATELY EXCLUDED — the lexer produces these tokens ONLY so the parser
+// can emit a migration diagnostic; they are not Almide, and a decoder must
+// never be allowed to sample them. The gate checks each line is still ABSENT
+// from this grammar and PRESENT in the lexer. ──── BEGIN-EXCLUDED ──
+// EXCLUDED: "&&"   -> not Almide; the parser answers with "use `and`"
+// EXCLUDED: "||"   -> not Almide; the parser answers with "use `or`"
+// EXCLUDED: "++"   -> not Almide; the parser answers with "use `+`"
+// EXCLUDED: "..="  -> E031, a retired range spelling; write `...`
+// ──── END-EXCLUDED ──
+
+// ── identifiers ──
+IDENT: /[a-z][A-Za-z0-9_]*/
+     | /_[A-Za-z0-9_]+/
+     | /`[a-z_][A-Za-z0-9_]*`/
+TYPENAME: /[A-Z][A-Za-z0-9_]*/
+        | /`[A-Z][A-Za-z0-9_]*`/
+
+// ── numbers ── (FLOAT outranks INT so `1.5` is one token, mirroring the
+// lexer's scan_float_tail; radix forms keep their prefix in the token value)
+INT.2: /0[xX][0-9a-fA-F_]*[0-9a-fA-F][0-9a-fA-F_]*/
+     | /0[bB][01_]*[01][01_]*/
+     | /0[oO][0-7_]*[0-7][0-7_]*/
+     | /[0-9][0-9_]*/
+FLOAT.3: /[0-9][0-9_]*\.[0-9][0-9_]*([eE][+-]?[0-9]*)?/
+       | /[0-9][0-9_]*[eE][+-]?[0-9]*/
+
+// ── strings ──
+// An escape pair, and the two nested-literal shapes an interpolation hole may
+// contain: the lexer scans `${…}` quote-aware, so a nested "…" neither closes
+// the outer string nor moves the brace depth (#1073).
+_ESC: /\\[\s\S]/
+_NESTED_DQ: "\"" (/[^"\\]/ | _ESC)* "\""
+_NESTED_SQ: "'" (/[^'\\]/ | _ESC)* "'"
+_HOLE_A: /[^{}"']/ | _NESTED_DQ | _NESTED_SQ
+_HOLE_B: _HOLE_A | "{" _HOLE_A* "}"
+_HOLE_C: _HOLE_A | "{" _HOLE_B* "}"
+_HOLE: "${" _HOLE_C* "}"
+_DQ_PLAIN_ATOM: /[^"\\$]/ | _ESC | /\$(?!\{)/
+
+// String terminals outrank IDENT so the `r` of a raw string is never taken as
+// an identifier, and HEREDOC outranks HEREDOC_INTERP so a heredoc with no
+// `${` hole lexes as the plain (TokenType::String) form.
+STRING.4: "\"" _DQ_PLAIN_ATOM* "\""
+INTERP_STRING.4: "\"" _DQ_PLAIN_ATOM* _HOLE (_DQ_PLAIN_ATOM | _HOLE)* "\""
+SQ_STRING.4: "'" (/[^'\\]/ | _ESC)* "'"
+RAW_STRING.5: /r"[^"]*"/
+RAW_HEREDOC.6: /r"""[\s\S]*?"""/
+HEREDOC.6: /"""(?:(?!"""|\$\{)[\s\S])*"""/
+HEREDOC_INTERP.5: /"""[\s\S]*?"""/
+
+// ── trivia ──
+// _NL is one LINE-BREAK RUN: consecutive blank lines, and the trailing or
+// own-line comments riding on them, collapse into a single token. The compiler
+// treats them the same way (skip_newlines drops Newline and Comment alike),
+// and it keeps the grammar free of unbounded newline repetition.
+_NL.1: /(?:[ \t\r]*(?:\/\/[^\n]*|\/\*[\s\S]*?\*\/)*\n)+/
+WS_INLINE: /[ \t\r]+/
+LINE_COMMENT: /\/\/[^\n]*/
+BLOCK_COMMENT: /\/\*[\s\S]*?\*\//
+
+%ignore WS_INLINE
+%ignore LINE_COMMENT
+%ignore BLOCK_COMMENT

--- a/docs/grammar/negative-fixtures.txt
+++ b/docs/grammar/negative-fixtures.txt
@@ -1,0 +1,133 @@
+# Negative fixtures for the published grammar (docs/grammar/almide.lark).
+#
+# WHY THIS FILE EXISTS: a grammar that accepts everything would pass the
+# corpus-superset check trivially. Every fixture below must be REJECTED by the
+# published grammar AND by the compiler's own parser. The gate
+# (scripts/check-lark-grammar.sh) checks both directions, so a fixture can
+# neither rot into valid Almide nor be "satisfied" by a grammar that stopped
+# discriminating.
+#
+# Format: `### <name>` opens a fixture; every following line up to the next
+# `### ` (or EOF) is its source. Lines starting with `#` at column 0 outside a
+# fixture are comments.
+
+### missing-return-type
+fn add(a: Int, b: Int) {
+  a + b
+}
+
+### missing-eq-before-body
+fn add(a: Int, b: Int) -> Int {
+  a + b
+}
+
+### let-mut-rust-style
+fn f() -> Int = {
+  let mut x = 1
+  x
+}
+
+### bare-lambda-param
+fn f(xs: List[Int]) -> List[Int] = list.map(xs, x => x + 1)
+
+### c-style-and
+fn f(a: Bool, b: Bool) -> Bool = a && b
+
+### c-style-or
+fn f(a: Bool, b: Bool) -> Bool = a || b
+
+### elif-chain
+fn f(n: Int) -> String =
+  if n == 0 then "zero"
+  elif n == 1 then "one"
+  else "many"
+
+### match-arm-missing-fat-arrow
+fn f(x: Int) -> Int = match x {
+  0 => 1,
+  1 2,
+}
+
+### retired-exclusive-range
+fn f(n: Int) -> Int = {
+  var s = 0
+  for i in 0..n { s = s + i }
+  s
+}
+
+### retired-inclusive-range
+fn f(n: Int) -> Int = {
+  var s = 0
+  for i in 0..=n { s = s + i }
+  s
+}
+
+### ml-let-in
+fn f() -> Int = let x = 1 in x + 1
+
+### pascal-while-do
+fn f() -> Unit = {
+  var i = 0
+  while i < 3 do
+    i = i + 1
+  done
+}
+
+### chained-comparison
+fn f(a: Int, b: Int, c: Int) -> Bool = a < b < c
+
+### chained-range
+fn f() -> List[Int] = list.from_range(0..<1..<2)
+
+### cons-pattern
+fn f(xs: List[Int]) -> Int = match xs {
+  [] => 0,
+  h :: t => h,
+}
+
+### if-without-then
+fn f(a: Bool) -> Int = if a { 1 } else { 2 }
+
+### braced-import
+import { json }
+
+fn main() -> Unit = println("x")
+
+### uppercase-fn-name
+fn Add(a: Int, b: Int) -> Int = a + b
+
+### pub-on-type-decl
+pub type Point = { x: Int, y: Int }
+
+### bang-as-boolean-not
+fn f(a: Bool) -> Bool = !a
+
+### missing-pattern-before-arrow
+fn f(x: Int) -> Int = match x {
+  => 0,
+}
+
+### unclosed-block
+fn f() -> Int = {
+  let a = 1
+  a
+
+### function-keyword
+function add(a: Int, b: Int) -> Int = a + b
+
+### return-statement
+fn f() -> Int = {
+  return 1
+}
+
+### type-annotation-without-type
+fn f() -> Int = {
+  let x: = 1
+  x
+}
+
+### trailing-binary-operator
+fn f(a: Int) -> Int = a +
+
+### param-without-type
+fn add(a, b) -> Int = a + b

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -24,7 +24,7 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).
 >
-> **Stage 5 (auditability): 1 release seal(s); 33 verification gates classified
+> **Stage 5 (auditability): 1 release seal(s); 34 verification gates classified
 > (2 UNVERIFIED under a shrink-only ceiling); TOR with 9 enforced rows;
 > gap analysis consolidated in proofs/DO330-GAP.md (reference-gated).**
 <!-- stages:generated:end -->

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -181,3 +181,8 @@ evidence = "landing PR: a TOR row retargeted to a nonexistent instrument demonst
 path = "scripts/check-als-element-coverage.sh"
 class = "NEGATIVE_TESTED"
 evidence = "landing PR: an unresolvable section (ALS-Z999) and a dropped row (UNCLASSIFIED) each demonstrated to FAIL before first green, with the below-ceiling ratchet demand firing in both"
+
+[[gate]]
+path = "scripts/check-lark-grammar.sh"
+class = "MUTATION_TESTED"
+evidence = "#1310 landing PR: 5 fail directions demonstrated before first green — keyword respelled (fan->fann: parity BOTH ways + 4 corpus under-accepts), EXCLUDED '..=' re-declared in OPERATORS (leak), param type annotation made optional (negative fixture 'param-without-type' ACCEPTED), '++' fixture shown to still PARSE with the compiler (stale-fixture direction, fixture retired), and an .almd-free corpus dir (blind-gate guard)"

--- a/scripts/check-lark-grammar.sh
+++ b/scripts/check-lark-grammar.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# PUBLISHED-GRAMMAR ANTI-ROT GATE (#1310).
+#
+# docs/grammar/almide.lark is the machine-readable Almide grammar that
+# decode-time constraint engines (llguidance, XGrammar, OpenAI custom tools)
+# consume to make syntactically invalid Almide UNREPRESENTABLE at sampling
+# time. A hand-written grammar rots the moment the parser moves, and a rotted
+# grammar is worse than none — it would constrain a decoder to a language the
+# compiler no longer accepts. This gate is what stops that.
+#
+# It asserts three things (scripts/lib/lark-gate.py does the work):
+#
+#   LEXICAL PARITY   the artifact's keyword/operator tables are diffed
+#                    token-for-token against crates/almide-syntax/src/lexer.rs,
+#                    including the DELIBERATELY EXCLUDED list (`&&`, `||`,
+#                    `++`, `..=` — tokens the lexer emits only so the parser
+#                    can answer with a migration hint).
+#   CORPUS SUPERSET  every .almd in spec/ + examples/ + stdlib/ that the
+#                    COMPILER's parser accepts is accepted by the artifact.
+#                    The oracle is `almide <file> --emit-ast`, which runs
+#                    lex+parse and nothing else.
+#   DISCRIMINATION   every fixture in docs/grammar/negative-fixtures.txt is
+#                    rejected by BOTH the artifact and the compiler, so the
+#                    grammar cannot pass by degenerating into `.*`.
+#
+# WHAT IT DOES NOT PROVE: that the artifact accepts ONLY valid Almide. The
+# published grammar is deliberately a SUPERSET (over-acceptance costs a decoder
+# nothing; under-acceptance would make a legal program unsamplable), and the
+# corpus check only ever fails on the under-accept direction. See
+# docs/grammar/README.md for the enumerated gap list.
+set -euo pipefail
+export LC_ALL=C
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if ! python3 -c "import lark" 2>/dev/null; then
+  echo 'LARK GRAMMAR GATE FAIL — the python `lark` package is missing.' >&2
+  echo "  install it:  python3 -m pip install lark" >&2
+  echo "  (CI: the step that runs this script must install it first)" >&2
+  exit 1
+fi
+
+exec python3 "$ROOT/scripts/lib/lark-gate.py" "$ROOT" "$@"

--- a/scripts/lib/lark-gate.py
+++ b/scripts/lib/lark-gate.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Anti-rot gate for the published grammar artifact (docs/grammar/almide.lark).
+
+Three independent checks, all of which must pass:
+
+  LEXICAL PARITY   the keyword/operator tables in the .lark are diffed
+                   token-for-token against crates/almide-syntax/src/lexer.rs.
+                   A keyword added to (or removed from) the lexer without the
+                   artifact following fails here. The DELIBERATELY EXCLUDED
+                   list is checked too: an exclusion must still be a real lexer
+                   token (or it is stale) and must NOT be reachable from the
+                   grammar.
+
+  CORPUS SUPERSET  every .almd in the corpus that the COMPILER's parser accepts
+                   must be accepted by the published grammar. The compiler is
+                   consulted through `almide <file> --emit-ast`, which runs the
+                   lexer + parser and nothing else (a type error still exits 0).
+                   Only the direction "compiler accepts => grammar accepts" is
+                   required: over-acceptance is safe for a decoder, under-
+                   acceptance would make a legal program unrepresentable.
+
+  DISCRIMINATION   every fixture in docs/grammar/negative-fixtures.txt must be
+                   rejected by the grammar AND by the compiler. Without this a
+                   grammar that degenerated into `.*` would pass silently.
+
+Usage: lark-gate.py <repo-root> [corpus-dir …]
+Env:   ALMIDE  path to the almide binary (default: target/release/almide, then
+                $PATH)
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+try:
+    from lark import Lark
+except ImportError:  # pragma: no cover - environment guard
+    sys.exit(
+        "lark-gate: the `lark` package is required.\n"
+        "  install it with:  python3 -m pip install lark\n"
+        "  (CI: add the install to the step that runs scripts/check-lark-grammar.sh)"
+    )
+
+GRAMMAR_REL = "docs/grammar/almide.lark"
+FIXTURES_REL = "docs/grammar/negative-fixtures.txt"
+LEXER_REL = "crates/almide-syntax/src/lexer.rs"
+
+
+# ── the artifact ────────────────────────────────────────────────────
+
+
+def build_parser(grammar_text: str) -> Lark:
+    return Lark(
+        grammar_text,
+        start="start",
+        parser="earley",
+        lexer="basic",
+        propagate_positions=False,
+        maybe_placeholders=False,
+    )
+
+
+def block(text: str, name: str) -> str:
+    """The region between `BEGIN-<name>` and `END-<name>` marker comments."""
+    begin = f"BEGIN-{name}"
+    end = f"END-{name}"
+    try:
+        i = text.index(begin)
+        j = text.index(end, i)
+    except ValueError:
+        sys.exit(f"lark-gate: the {name} marker block moved or was deleted in {GRAMMAR_REL}")
+    return text[i:j]
+
+
+def lark_literals(region: str) -> set[str]:
+    """Terminal spellings declared in a marker block: `NAME[.prio]: "text"`."""
+    out = set()
+    for line in region.splitlines():
+        line = line.strip()
+        if line.startswith("//") or not line:
+            continue
+        m = re.match(r'^[A-Z_][A-Z0-9_]*(?:\.\d+)?\s*:\s*"((?:[^"\\]|\\.)*)"\s*$', line)
+        if m:
+            out.add(m.group(1).replace('\\"', '"').replace("\\\\", "\\"))
+    return out
+
+
+def lark_excluded(region: str) -> set[str]:
+    return set(re.findall(r'^//\s*EXCLUDED:\s*"([^"]+)"', region, re.M))
+
+
+# ── the compiler's tables ───────────────────────────────────────────
+
+
+def rust_table(lexer_src: str, decl: str) -> str:
+    i = lexer_src.find(decl)
+    if i < 0:
+        sys.exit(f"lark-gate: `{decl}` not found in {LEXER_REL} — the table was renamed")
+    j = lexer_src.index("];", i)
+    return lexer_src[i:j]
+
+
+def lexer_keywords(lexer_src: str) -> set[str]:
+    tbl = rust_table(lexer_src, "const KEYWORDS: &[(&str, TokenType)]")
+    return set(re.findall(r'\("([^"]+)"\s*,\s*TokenType::', tbl))
+
+
+def lexer_operators(lexer_src: str) -> set[str]:
+    tbl = rust_table(lexer_src, "const OPERATORS: &[(&str, TokenType, &str)]")
+    return set(re.findall(r'\("((?:[^"\\]|\\.)+)"\s*,\s*TokenType::', tbl))
+
+
+# ── corpus workers ──────────────────────────────────────────────────
+
+_PARSER: Lark | None = None
+
+
+def _init(grammar_text: str) -> None:
+    global _PARSER
+    _PARSER = build_parser(grammar_text)
+
+
+def _try_parse(path_str: str):
+    assert _PARSER is not None
+    src = Path(path_str).read_text(encoding="utf-8", errors="replace")
+    if not src.endswith("\n"):
+        src += "\n"
+    try:
+        _PARSER.parse(src)
+        return (path_str, None)
+    except Exception as exc:  # lark raises several unrelated exception types
+        return (path_str, str(exc).splitlines()[0])
+
+
+def parses_with_compiler(almide: str, path: Path) -> bool:
+    """The compiler's PARSE oracle: `--emit-ast` runs lex+parse only."""
+    r = subprocess.run(
+        [almide, str(path), "--emit-ast"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return r.returncode == 0
+
+
+def find_almide(root: Path) -> str:
+    env = os.environ.get("ALMIDE")
+    if env:
+        return env
+    local = root / "target" / "release" / "almide"
+    if local.exists():
+        return str(local)
+    from shutil import which
+
+    found = which("almide")
+    if not found:
+        sys.exit(
+            "lark-gate: no almide binary found.\n"
+            "  set ALMIDE=<path>, or run `cargo build --release` first."
+        )
+    return found
+
+
+# ── fixtures ────────────────────────────────────────────────────────
+
+
+def read_fixtures(path: Path) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    name: str | None = None
+    buf: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("### "):
+            if name is not None:
+                out.append((name, "\n".join(buf).strip("\n") + "\n"))
+            name = line[4:].strip()
+            buf = []
+        elif name is None:
+            continue  # header comments
+        else:
+            buf.append(line)
+    if name is not None:
+        out.append((name, "\n".join(buf).strip("\n") + "\n"))
+    return out
+
+
+# ── main ────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        sys.exit("usage: lark-gate.py <repo-root> [corpus-dir …]")
+    root = Path(sys.argv[1]).resolve()
+    corpus_dirs = sys.argv[2:] or ["spec", "examples", "stdlib"]
+
+    grammar_path = root / GRAMMAR_REL
+    grammar_text = grammar_path.read_text(encoding="utf-8")
+    lexer_src = (root / LEXER_REL).read_text(encoding="utf-8")
+
+    errors: list[str] = []
+
+    # ── 1. lexical parity ──
+    kw_lark = lark_literals(block(grammar_text, "KEYWORDS"))
+    op_lark = lark_literals(block(grammar_text, "OPERATORS"))
+    excluded = lark_excluded(block(grammar_text, "EXCLUDED"))
+    kw_rs = lexer_keywords(lexer_src)
+    op_rs = lexer_operators(lexer_src)
+
+    for missing in sorted(kw_rs - kw_lark):
+        errors.append(
+            f"keyword {missing!r} is in the lexer but not in {GRAMMAR_REL}'s KEYWORDS block"
+        )
+    for extra in sorted(kw_lark - kw_rs):
+        errors.append(
+            f"keyword {extra!r} is in {GRAMMAR_REL} but no longer in the lexer's KEYWORDS table"
+        )
+    for missing in sorted(op_rs - op_lark - excluded):
+        errors.append(
+            f"operator {missing!r} is in the lexer but neither in {GRAMMAR_REL}'s "
+            "OPERATORS block nor on its EXCLUDED list"
+        )
+    for extra in sorted(op_lark - op_rs):
+        errors.append(
+            f"operator {extra!r} is in {GRAMMAR_REL} but no longer in the lexer's OPERATORS table"
+        )
+    for stale in sorted(excluded - op_rs):
+        errors.append(
+            f"EXCLUDED {stale!r} is no longer a lexer operator — drop the stale exclusion"
+        )
+    for leaked in sorted(excluded & op_lark):
+        errors.append(f"EXCLUDED {leaked!r} is ALSO declared in the OPERATORS block")
+
+    print(
+        f"lexical parity: {len(kw_rs)} keywords, {len(op_rs)} operators "
+        f"({len(excluded)} deliberately excluded)"
+    )
+
+    # ── 2. the grammar must build ──
+    t0 = time.time()
+    try:
+        parser = build_parser(grammar_text)
+    except Exception as exc:
+        errors.append(f"the grammar does not build: {exc}")
+        return report(errors)
+    print(f"grammar builds: {len(parser.rules)} productions in {time.time() - t0:.2f}s")
+
+    almide = find_almide(root)
+
+    # ── 3. discrimination: negative fixtures ──
+    fixtures = read_fixtures(root / FIXTURES_REL)
+    if len(fixtures) < 20:
+        errors.append(
+            f"only {len(fixtures)} negative fixtures — the discrimination floor is 20"
+        )
+    with tempfile.TemporaryDirectory(prefix="lark-gate-") as tmp:
+        tmpdir = Path(tmp)
+        for name, src in fixtures:
+            accepted_by_grammar = True
+            try:
+                parser.parse(src)
+            except Exception:
+                accepted_by_grammar = False
+            if accepted_by_grammar:
+                errors.append(f"negative fixture {name!r} was ACCEPTED by the grammar")
+            f = tmpdir / f"neg_{re.sub(r'[^a-z0-9]+', '_', name)}.almd"
+            f.write_text(src, encoding="utf-8")
+            if parses_with_compiler(almide, f):
+                errors.append(
+                    f"negative fixture {name!r} PARSES with the compiler — it is not "
+                    "invalid Almide any more; fix or retire the fixture"
+                )
+    print(f"discrimination: {len(fixtures)} negative fixtures, all rejected by both")
+
+    # ── 4. corpus superset ──
+    files: list[Path] = []
+    for d in corpus_dirs:
+        files += sorted((root / d).rglob("*.almd"))
+    if not files:
+        errors.append(
+            f"corpus is EMPTY over {corpus_dirs} — a find-nothing-exit-0 gate is a blind gate"
+        )
+    t0 = time.time()
+    workers = min(os.cpu_count() or 1, 8)
+    with multiprocessing.Pool(workers, initializer=_init, initargs=(grammar_text,)) as pool:
+        results = pool.map(_try_parse, [str(f) for f in files], chunksize=8)
+    accepted = [p for p, e in results if e is None]
+    rejected = [(p, e) for p, e in results if e is not None]
+
+    disagreements = []
+    for path_str, why in rejected:
+        if parses_with_compiler(almide, Path(path_str)):
+            disagreements.append((path_str, why))
+    for path_str, why in disagreements:
+        errors.append(
+            f"UNDER-ACCEPT {Path(path_str).relative_to(root)}: the compiler parses it, "
+            f"the published grammar does not — {why}"
+        )
+    print(
+        f"corpus superset: {len(accepted)}/{len(files)} accepted by the grammar, "
+        f"{len(rejected) - len(disagreements)} rejected by both, "
+        f"{len(disagreements)} disagreements ({time.time() - t0:.1f}s, {workers} workers)"
+    )
+
+    return report(errors)
+
+
+def report(errors: list[str]) -> int:
+    if errors:
+        print("\nLARK GRAMMAR GATE FAIL", file=sys.stderr)
+        for e in errors:
+            print(f"  {e}", file=sys.stderr)
+        return 1
+    print("lark-grammar OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #1310.

`docs/grammar/almide.lark` is the machine-readable Almide grammar. It exists so
decode-time constraint engines (llguidance, XGrammar, OpenAI custom tools) can
make syntactically invalid Almide **unrepresentable at sampling time** — the
strongest accuracy lever available, because it acts before the model can make
the mistake, not after.

## The part that makes it worth doing: the anti-rot gate

A hand-written grammar rots the moment the parser changes, and a rotted grammar
is *worse than none* — it would constrain a decoder to a language the compiler
no longer accepts. `scripts/check-lark-grammar.sh` asserts three things:

1. **Lexical parity.** The `BEGIN-KEYWORDS` / `BEGIN-OPERATORS` marker blocks in
   the `.lark` are diffed token-for-token against the `KEYWORDS` and `OPERATORS`
   tables in `crates/almide-syntax/src/lexer.rs` — both directions. The
   `EXCLUDED` list (`&&`, `||`, `++`, `..=` — tokens the lexer emits *only* so
   the parser can answer with a migration hint) is checked too: an exclusion
   must still be a real lexer token, and must not also be reachable from the
   grammar.
2. **Corpus superset.** Every `.almd` under `spec/`, `examples/` and `stdlib/`
   (1210 files, ~600k tokens) is parsed with the published grammar. For every
   file the grammar rejects, the compiler is consulted through
   `almide <file> --emit-ast`, which runs lex+parse and nothing else (a *type*
   error still exits 0). Compiler-accepts ⇒ grammar-accepts, or the gate fails.
3. **Discrimination.** All 27 fixtures in `docs/grammar/negative-fixtures.txt`
   must be rejected by the grammar *and* by the compiler, so the grammar cannot
   pass check 2 by degenerating into `.*`.

Current run: **1210/1210 corpus files accepted, 0 disagreements, 27/27 negatives
rejected by both, 38 keywords / 42 operators / 4 exclusions in parity** — 59s
wall with 8 workers.

## What the gate does NOT prove

- **Not soundness.** The grammar is a deliberate **superset**: over-acceptance
  costs a decoder nothing, under-acceptance would make a legal program
  unsamplable. Check 2 can only ever fail in the under-accept direction.
- **Not coverage beyond the corpus.** New syntax landed *without* a `spec/`
  fixture would not be caught.
- **Nothing semantic** — `--emit-ast` is parse-only.
- **Not engine portability** — the gate uses Python `lark` (Earley + basic
  lexer); it does not prove llguidance/XGrammar compile this exact dialect.

`docs/grammar/README.md` carries the full, enumerated gap list (G1–G12). The
honest headline gaps: **nested block comments** (regex can't count depth),
**`${…}` hole interiors are unconstrained and capped at three brace levels**
(the compiler re-lexes and re-parses holes with a sub-parser — a single
CFG-over-text cannot mirror that two-phase lexing), **whitespace-sensitive unary
minus** (`a⏎- b` vs `a⏎-b`), and the diagnostics-only restrictions (`??`
line-crossing/E038, positional-after-named args) which are parser behaviour, not
grammar. Two deliberate tightenings: statement separators are required, and
`as`/`where`/`Fn` are reserved. Arithmetic precedence is flattened to one level
— it changes the parse *tree*, never the accepted token language, and
`grammar/precedence.toml` + `Parser::infix_bp` stay authoritative; the
boolean/comparison/range levels ARE kept because their non-associativity is a
language fact.

## Gate verification

`proofs/gate-verification.toml` gains a `MUTATION_TESTED` row. Five fail
directions were demonstrated before first green:

| mutation | what fired |
|---|---|
| keyword respelled `fan` → `fann` | parity both ways + 4 corpus under-accepts |
| `..=` re-declared in `OPERATORS` | EXCLUDED-leak check |
| param type annotation made optional | negative fixture `param-without-type` ACCEPTED |
| `++` fixture | shown to still PARSE with the compiler → stale fixture retired |
| `.almd`-free corpus dir | blind-gate (find-nothing-exit-0) guard |

## CI wiring needed (not done here — workflows untouched)

Add to the **`checks` job** in `.github/workflows/ci.yml`, after the contract
ledger step:

```yaml
      - name: Published grammar artifact (lexer parity + corpus superset + negative fixtures)
        run: |
          python3 -m pip install --quiet lark
          ALMIDE=/tmp/almide-bin/almide bash scripts/check-lark-grammar.sh
```

The `checks` job already downloads the binary to `/tmp/almide-bin/almide`, which
the gate needs for its parse oracle. No lefthook hook is proposed: the gate
requires the `lark` package, and a pre-commit hook that hard-fails on a missing
optional dependency would break every contributor's commit.

## Relationship to the `grammar/` submodule

The issue asked for the artifact in the grammar repo. It lives here instead, on
purpose: CI never fetches submodules, so a gate over there could not reach the
lexer it mirrors — and an ungated grammar is exactly the failure mode this PR
exists to prevent. `almide-grammar` keeps the descriptive keyword/precedence
data the tree-sitter and TextMate generators consume; the two point at the same
source of truth (`Parser::infix_bp`).
