### PR TITLE
Stop the coverage gate littering the tree, assert the quoted theorem count, land the flight-org roadmap doc

### DIFF
--- a/docs/roadmap/active/certification-grade.md
+++ b/docs/roadmap/active/certification-grade.md
@@ -149,3 +149,13 @@ belt の思想をビルド単位の証明に拡張: 「この .wasm はこの検
 | カバレッジ工数の沼 | 安全パス限定の MC/DC から始め、全体は branch ratchet のみ |
 | Critical profile が言語を二つに割る | subset 原則 (CG-3) を gate で強制 — Critical で valid なら通常モードでも valid |
 | 認証ごっこ (誰も使わない dossier) | CG-5 は trust-layer の `make verify` と同一物の整形。独立の成果物を作らない |
+
+## 組織・実績のはしご(B/C セクション)
+
+flight-grade プログラムのうち**エンジニアリングでない**部分 — 署名できる法人、
+DER との折衝、LTS ポリシー、最初の実運用配備、サービス履歴の記録、機械筆記
+コードの認証に関する立場表明 — は
+[flight-organization.md](./flight-organization.md) に集約されている。
+以前は issue #577–#585 として queue に並んでいたが、いずれも本文で
+「エンジニアリング項目ではない」と自称しており、着手可能な作業の列に混ざると
+queue が嘘をつく。umbrella issue #586 のチェックリストが引き続き進捗を持つ。

--- a/docs/roadmap/active/flight-organization.md
+++ b/docs/roadmap/active/flight-organization.md
@@ -1,0 +1,168 @@
+# Flight-grade: the organization and track-record rungs
+
+The [flight-grade program](https://github.com/almide/almide/issues/586) has three
+sections. Section A — **engineering** — stays in the issue tracker, because each
+item is code, proof, or a gate someone can land. Sections B and C are not: they
+are a legal entity, an engagement plan, a funding sequence, a first customer.
+They were filed as issues #577–#585 and each one said so in its own body
+(*"Not an engineering item; tracked here for program completeness"*).
+
+Nine such issues in a queue of engineering work make the queue lie about how much
+of it is actionable. They live here instead. **The umbrella issue #586 keeps its
+checklist** — this document holds the detail those issues carried, verbatim in
+substance, so closing them lost nothing.
+
+Status markers are the ones the issues carried when they were folded in
+(2026-08-13): ❌ not started, ◑ partially addressed.
+
+---
+
+## B — Organization
+
+### B1. A legal entity able to sign dossiers and carry liability  ❌
+*(was #577)*
+
+Certification authorities and primes contract with entities, not repositories:
+audit responses, liability, and dossier signatures require a legal person. The
+agent-assisted workflow can produce the evidence; only an entity can sign it.
+Ferrocene and AdaCore exist as companies for exactly this reason.
+
+**What**: decide the corporate form and jurisdiction; define what the entity
+warrants (toolchain behaviour per dossier) vs. what stays open source.
+
+**Exit criteria**: an entity exists that can sign a release dossier and enter a
+support contract.
+
+### B2. A multi-decade LTS policy and versioning commitment  ❌
+*(was #578)*
+
+Aircraft programs outlive toolchains: adopters need a written commitment about
+how long a pinned toolchain version receives fixes, how Known Problems are
+communicated, and how upgrades are qualified.
+
+**What**: an LTS policy document — support horizon per qualified release,
+backport rules, deprecation rules consistent with the stability contract, Known
+Problems notification channel.
+
+**Exit criteria**: published LTS policy referenced from the dossier.
+
+### B3. Certification-authority relationships (DER / notified-body engagement)  ❌
+*(was #579)*
+
+Qualification is negotiated, not submitted: early engagement with designated
+engineering representatives / notified bodies shapes what evidence counts
+*before* it is produced at scale.
+
+**What**: identify the first target regime (likely the first customer's: a space
+agency software standard or a UAS authority before civil avionics), and engage an
+experienced consultant/DER for a gap assessment against the dossier.
+
+**Exit criteria**: a written gap assessment from someone who has taken a tool
+through qualification.
+
+### B4. Qualification engineering beyond the solo-plus-agents model  ❌
+*(was #580)*
+
+Qualification work has irreducibly human parts: audit interviews, signed reviews,
+accountable judgment calls. The current model (one human + an agent fleet)
+produces evidence at unusual speed but cannot satisfy independence-of-verification
+expectations alone.
+
+**What**: define the minimal team — at least one qualification engineer with
+prior tool-qualification experience and an independent-verification role — and
+document the independence story: who verifies what, and what the agents' output
+counts as.
+
+**Exit criteria**: independence-of-verification structure documented and staffed
+for the first qualification attempt.
+
+### B5. Funding the climb from trust-market revenue  ◑
+*(was #581 — a strategy exists in the trust-layer roadmap)*
+
+Qualification is a multi-year cost centre; the agent/wasm sandbox trust market is
+the revenue and evidence engine that pays for it. Same evidence machinery,
+earlier buyers — not a detour from the regulated goal but its funding path.
+
+**What**: sequence trust-layer monetization (receipts, capability containment,
+the MCP wedge) so dossier-grade evidence accumulates as a product side effect;
+earmark the qualification budget explicitly.
+
+**Exit criteria**: a funded plan in which the qualification milestones (B1–B4 and
+the #574 data package) have a revenue source.
+
+**Ref**: [trust-layer.md](./trust-layer.md)
+
+---
+
+## C — Track record
+
+### C1. The first regulated-adjacent deployment, to start the service-history clock  ❌
+*(was #582)*
+
+Product service history is itself certification currency, and it only accumulates
+in real deployments. Smallsat flight software and UAS (specific category) have
+materially lower entry barriers than civil avionics and produce exactly the right
+kind of operational record.
+
+**What**: identify and win one design partner flying Almide-generated code
+(Critical profile once available) in a space or UAS context; instrument for
+problem reporting from day one.
+
+**Exit criteria**: Almide code operating in a fielded space/UAS system with
+service history being recorded.
+
+### C2. The deployment ladder  ❌
+*(was #583)*
+
+Nobody starts at flight controls. The ladder: ground/verification tooling (that
+market is also regulated, and nearer) → space/UAS items → low-assurance airborne
+items (DAL-D/C class) → higher levels. Each rung produces customers, evidence,
+and history for the next.
+
+**What**: write the ladder as a living document — target regimes per rung, what
+evidence each rung consumes and produces, and the promotion criteria between
+rungs.
+
+**Exit criteria**: ladder document in `docs/roadmap/` with the current rung
+explicit.
+
+### C3. Service-history and problem-reporting record-keeping  ❌
+*(was #584 — depends on C1)*
+
+Service history only counts if it is recorded in an audit-ready way: versions in
+service, exposure time, problems found, dispositions, and the feedback loop into
+Known Problems.
+
+**What**: a lightweight in-service record format tied to the release dossier and
+the flagged-contracts ledger; every deployment from C1 onward reports through it.
+
+**Exit criteria**: record-keeping format defined and in use by the first
+deployment.
+
+### C4. A published position on certifying machine-written code  ❌
+*(was #585)*
+
+Assurance frameworks assume human authors; regulators (the EASA AI roadmap, FAA
+counterparts) are actively working out what AI-assisted development means. A
+toolchain born machine-writer-first with mechanical evidence is the answer that
+side of the table does not yet have — and being part of that conversation early
+is how a newcomer gets chosen rather than tolerated.
+
+**What**: a position paper — how spec-keyed contracts, per-build certificates,
+and the evidence ladder discharge development-assurance expectations when the
+author is a model — and engagement with the relevant working groups.
+
+**Exit criteria**: paper published; at least one regulator / industry
+working-group interaction on record.
+
+---
+
+## Critical path (unchanged)
+
+#563 (longest lead) → #572 + #573 (the technical bet: the qualified-generator
+model) → **C1** (the history clock) → #574 + **B1** (a signable package).
+Everything else feeds these.
+
+**Ref**: [certification-grade.md](./certification-grade.md),
+[flight-qualification.md](./flight-qualification.md),
+[trust-layer.md](./trust-layer.md)

--- a/proofs/check.sh
+++ b/proofs/check.sh
@@ -59,6 +59,34 @@ if [ "$got" -ne "$want" ]; then
 fi
 echo "  ok   $got/$want assumptions audits answered 'Closed under the global context'"
 
+# (d) The audited-theorem COUNT is quoted verbatim in two human-facing trust
+# documents. It was hand-written and nothing checked it: by 2026-08-13 both said
+# "37 audited theorems" while the real count was 73 — stale by 36, and nobody
+# noticed until a PR happened to touch the neighbourhood. A number in a trust
+# document that no gate reads is exactly the claim-drift this spine exists to
+# prevent, so assert it HERE, where the authoritative count is computed.
+#
+# Deliberately a plain equality, not a regeneration: these two files are prose
+# written by hand, and a generator would have to own their whole text. The gate
+# names the file and the fix instead.
+# cwd is proofs/ (the `cd` at the top), so these are siblings.
+COUNT_DOCS=(TRUSTED_BASE.md receipt.sh)
+for doc in "${COUNT_DOCS[@]}"; do
+  quoted="$(grep -oE '[0-9]+ audited theorems' "$doc" | grep -oE '^[0-9]+' | sort -u)"
+  if [ -z "$quoted" ]; then
+    echo "FAIL: $doc no longer quotes an 'N audited theorems' count — the claim was"
+    echo "  deleted rather than updated, so nothing states the spine's size any more."
+    exit 1
+  fi
+  if [ "$(printf '%s\n' "$quoted" | wc -l | tr -d ' ')" -ne 1 ] || [ "$quoted" -ne "$want" ]; then
+    echo "FAIL: $doc claims '$(printf '%s' "$quoted" | tr '\n' '/')' audited theorems"
+    echo "  but the spine has $want. Update the number in that file (and check for a"
+    echo "  SECOND occurrence — the count appears once per document by convention)."
+    exit 1
+  fi
+done
+echo "  ok   both trust documents quote the measured count ($want audited theorems)"
+
 # Detector drill (the gate.sh tamper-drill pattern): compile a scratch module
 # whose theorem DOES rest on an Axiom and prove the grep above would have seen
 # it — so the assertion can never rot into matching nothing.

--- a/proofs/coverage.sh
+++ b/proofs/coverage.sh
@@ -51,13 +51,43 @@ cd "$ROOT"
 # measured the WRONG binary twice (0.00% over 4 stray files reported as data,
 # 2026-07-03), so each step here is explicit and its artifact is checked.
 COVDIR="$ROOT/target/coverage"
-rm -rf "$COVDIR"; mkdir -p "$COVDIR"
+rm -rf "$COVDIR"; mkdir -p "$COVDIR/build"
+
+# `-C instrument-coverage` also instruments BUILD SCRIPTS and proc-macro hosts,
+# which then RUN during the build with no LLVM_PROFILE_FILE set — so they drop
+# `default_<hash>_<n>.profraw` into their own cwd, i.e. the repo root and the
+# crate dirs (~94 files per run, #1361). Two problems, neither about coverage
+# numbers: the working tree goes dirty right after a gate run (easy to
+# `git add -A` by accident), and `stamp.sh`'s toolchain_fingerprint hashes
+# untracked files, so a coverage run makes `receipt.sh` unable to reuse a
+# `make verify-trust` result.
+#
+# Point the build steps' profraw at $COVDIR/build/ — one level DOWN, so the
+# merge glob `$COVDIR/*.profraw` below does not pick it up. Build-script
+# coverage is not data we want in the report (llvm-cov is scoped by -object
+# anyway); we just want it to land somewhere harmless.
 export RUSTFLAGS="-C instrument-coverage"
 
+# Anything that still escapes (a child process that resets the variable) is
+# swept on the way out, on every exit path. Scoped to llvm's own default
+# profraw naming, never inside target/, and it reports what it removed rather
+# than deleting silently.
+sweep_stray_profraw() {
+    local stray
+    stray="$(find "$ROOT" -maxdepth 3 -name 'default_*_*.profraw' -not -path "$ROOT/target/*" 2>/dev/null || true)"
+    [ -n "$stray" ] || return 0
+    printf '%s\n' "$stray" | while read -r f; do rm -f "$f"; done
+    echo "coverage: swept $(printf '%s\n' "$stray" | wc -l | tr -d ' ') stray default_*.profraw (#1361)"
+}
+trap sweep_stray_profraw EXIT
+
 echo "== 1/4 instrumented build (almide-mir + almide-codegen tests, render_program, the almide CLI) =="
-cargo test -p almide-mir -p almide-codegen --release --no-run --target-dir "$COVDIR/t" 2>&1 | tail -1
-cargo build --release -p almide-mir --example render_program --target-dir "$COVDIR/t" 2>&1 | tail -1
-cargo build --release --bin almide --target-dir "$COVDIR/t" 2>&1 | tail -1
+LLVM_PROFILE_FILE="$COVDIR/build/host-%m-%p.profraw" \
+  cargo test -p almide-mir -p almide-codegen --release --no-run --target-dir "$COVDIR/t" 2>&1 | tail -1
+LLVM_PROFILE_FILE="$COVDIR/build/host-%m-%p.profraw" \
+  cargo build --release -p almide-mir --example render_program --target-dir "$COVDIR/t" 2>&1 | tail -1
+LLVM_PROFILE_FILE="$COVDIR/build/host-%m-%p.profraw" \
+  cargo build --release --bin almide --target-dir "$COVDIR/t" 2>&1 | tail -1
 
 echo "== 2/4 run the test suites =="
 # `-perm -u+x`, not `-perm /111`: the `/` form is a GNU extension and BSD find


### PR DESCRIPTION
Three pieces of housekeeping in the proof/evidence layer, one commit each. Closes #1361.

## 1. `coverage.sh` no longer litters the working tree (#1361)

`-C instrument-coverage` also instruments **build scripts and proc-macro hosts**, which then run during the build with no `LLVM_PROFILE_FILE` set — so they drop `default_<hash>_<n>.profraw` into their own cwd: the repo root and the crate dirs. Two costs, neither about coverage numbers: the tree goes dirty right after a gate run (easy to `git add -A` by accident), and `stamp.sh`'s `toolchain_fingerprint` hashes untracked files, so one coverage run stops `receipt.sh` reusing a `make verify-trust` result.

Fix: point the three build steps' profraw at `$COVDIR/build/` — one level **down**, so the merge glob `$COVDIR/*.profraw` does not pick it up (build-script coverage is not data the report wants; `llvm-cov` is scoped by `-object` anyway). Plus an `EXIT` trap that sweeps anything which still escapes, scoped to llvm's own default naming, never inside `target/`, and reporting what it removed rather than deleting silently.

**Measured, full run:** 75 host profraw files landed in `target/coverage/build/`; the merge glob saw 4 (the real data); **stray files in the tree afterwards: 0**. Ratchet still works: TOTAL 70.07% ≥ floor 58.19%. (The ~94-file "before" figure is #1361's own measurement, not re-measured here — re-running the unfixed script costs another full instrumented build.)

## 2. The audited-theorem count is asserted, not just written down (found via #1356)

`proofs/TRUSTED_BASE.md` and `proofs/receipt.sh` each quote "N audited theorems". Both were hand-written and **nothing read them**: they said `37` while the real count was `73` — stale by 36, noticed only because a PR happened to touch the neighbourhood. A number in a trust document that no gate reads is exactly the claim-drift this spine exists to prevent.

`proofs/check.sh` already computes the authoritative count (`grep -cE '^Print Assumptions'` over `SPINE_FILES`), so the assertion lives there, next to it. Deliberately a plain equality rather than a regeneration: these are hand-written prose files, and a generator would have to own their whole text — the gate names the file and the fix instead. It also fails if the claim is **deleted** rather than updated.

**A/B proven, per this repo's own rule that an unverified gate may be decorative:**
```
green:  ok   both trust documents quote the measured count (82 audited theorems)

forged 82 -> 81 in TRUSTED_BASE.md:
FAIL: TRUSTED_BASE.md claims '81' audited theorems
  but the spine has 82. Update the number in that file (and check for a
  SECOND occurrence — the count appears once per document by convention).
```
Restored afterwards; `bash proofs/check.sh` green end to end (kernel-checked, axiom-clean, coqchk re-verified, wasmtime byte-execution grounded).

## 3. `docs/roadmap/active/flight-organization.md`

The detail from #577–#585, folded out of the issue queue when they were closed (see the umbrella comment on #586). It rides here rather than in its own PR for a reason worth recording: **`ci.yml` excludes `docs/**`, and all 13 required checks belong to that workflow, so a docs-only PR reports zero of 13 and can never merge** — measured on #1351, which is still BLOCKED with 0 checks. This PR touches `proofs/`, so CI runs. #1351 is superseded and will be closed.

That gap deserves its own fix (drop the path negations so every PR can satisfy the required set); the companion-workflow workaround is worse, since a PR touching both docs and code matches both filters and a no-op run can report the same check name as the real one.