### PR TITLE
Fix a template-substitution miscompile the flat_map array lowering exposed, and stop anchoring the machine-dependent listbuild ratios

### DIFF
--- a/crates/almide-codegen/src/walker/expressions_control.rs
+++ b/crates/almide-codegen/src/walker/expressions_control.rs
@@ -252,14 +252,57 @@ fn rewrite_legacy_almd_rec_names(ctx: &RenderContext, out: &mut String) {
     }
 }
 
+/// Substitute an `InlineRust` template's `{name}` placeholders in ONE PASS over
+/// the template.
+///
+/// The obvious loop — `out = out.replace("{a}", rendered_a)` per arg — re-scans
+/// text it has already inserted, so an ARGUMENT whose rendered form contains a
+/// later placeholder gets rewritten by the next iteration. That is reachable
+/// from ordinary source: `list.flat_map(xs, (s) => ["{e1}", s])` lowers to the
+/// array template `[{e0}, {e1}]`, and substituting `{e0}` first inserts the
+/// user's string literal `"{e1}"`, which the `{e1}` pass then overwrote with
+/// `s` — the program printed `s,A,s,B` instead of `{e1},A,{e1},B`. Silent wrong
+/// code, no diagnostic.
+///
+/// Scanning once and emitting fixes the class rather than the instance: inserted
+/// text is never examined again, so no argument can be interpreted as template
+/// syntax whatever a string literal happens to contain. A `{...}` with no
+/// matching arg is emitted verbatim, as before (templates carry unfilled
+/// defaults). Each arg is rendered at most once even when its placeholder
+/// appears twice, which the per-arg loop also guaranteed and which matters here
+/// — re-rendering nested expressions is how a concat chain once went
+/// exponential.
 fn render_expr_inline_rust(ctx: &RenderContext, expr: &IrExpr) -> String {
     let IrExprKind::InlineRust { template, args } = &expr.kind else { unreachable!() };
-    let mut out = template.clone();
-    for (name, arg) in args {
-        let rendered = render_expr(ctx, arg);
-        let placeholder = format!("{{{}}}", name.as_str());
-        out = out.replace(&placeholder, &rendered);
+    let rendered: Vec<(&str, String)> = args.iter()
+        .map(|(name, arg)| (name.as_str(), render_expr(ctx, arg)))
+        .collect();
+
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template.as_str();
+    while let Some(open) = rest.find('{') {
+        out.push_str(&rest[..open]);
+        let after = &rest[open + 1..];
+        match after.find('}').and_then(|close| {
+            let name = &after[..close];
+            rendered.iter()
+                .find(|(n, _)| *n == name)
+                .map(|(_, text)| (text.as_str(), close))
+        }) {
+            Some((text, close)) => {
+                out.push_str(text);
+                rest = &after[close + 1..];
+            }
+            // Not a placeholder we can fill (no `}`, or an unknown name):
+            // emit the brace and carry on from just after it.
+            None => {
+                out.push('{');
+                rest = after;
+            }
+        }
     }
+    out.push_str(rest);
+
     rewrite_legacy_almd_rec_names(ctx, &mut out);
     out
 }

--- a/docs/project/BENCHMARKS.md
+++ b/docs/project/BENCHMARKS.md
@@ -80,6 +80,16 @@ Median of 15 interleaved runs; all three shapes produce byte-identical output,
 checked before timing. The three ratios are within run-to-run noise of each
 other on this box — the point of the table is that the spread is gone.
 
+**Read the ratio column as machine-specific, not as a property of the
+language.** Unlike the arithmetic kernels above, this workload's cost is
+allocation, and the two allocators disagree: the same commit measured on the
+ubuntu-latest CI runner reads **0.91×** on the preallocated row — Almide
+*beating* the reference, because glibc `calloc` hands back zero pages that
+`Vec::with_capacity` + push has to fault in — against 1.57× here. What is
+stable across both machines, and what CI therefore gates, is the *relation*
+between the three shapes (1.018× here, 1.045× on the runner), not any row's
+absolute ratio.
+
 It was not. The A/B at 2^22 (median of 11, same run):
 
 | Build shape (2^22) | Before | After |

--- a/research/benchmark/perf/README.md
+++ b/research/benchmark/perf/README.md
@@ -108,10 +108,15 @@ nothing is published that `bench.py` did not produce.
   `flat_map`'s intermediate list. That is an MSR problem before it is a perf
   problem — the idiom docs are the in-context material that steers generated
   code, so "recommended" and "fast" have to name the same shape. The three now
-  sit within 2% of each other. `check-perf-ratio.sh` gates each row's ratio
-  like every other benchmark AND gates the relation between them directly
-  (`IDIOM_CEILING`), because the ratios drifting apart is the failure this
-  family exists to catch.
+  sit within 2% of each other. What `check-perf-ratio.sh` gates for this family
+  is the RELATION between the rows (`IDIOM_CEILING`), not each row's ratio
+  against Rust: the absolute ratio here turns out to be strongly
+  architecture-dependent — 1.58 on an M4 Pro and 0.91 on the ubuntu-latest CI
+  runner from the same commit, because the workload's cost is allocation rather
+  than arithmetic and the two allocators behave differently. So this is the one
+  family where "the ratio cancels the machine" does not hold; the rows are
+  reported like onebrc, and the relation — 1.018x locally, 1.045x on CI — is
+  what carries a gate.
 
 ## Run
 

--- a/scripts/check-perf-ratio.sh
+++ b/scripts/check-perf-ratio.sh
@@ -39,7 +39,23 @@ BASELINE_FILE="scripts/perf-ratio-baseline.txt"
 BUDGET_PCT="${PERF_RATIO_BUDGET_PCT:-40}"
 RUNS="${PERF_RATIO_RUNS:-3}"
 # Gated pairs: bench -> same-shape rust-ref variant.
-PAIRS="nbody=rust:nbody_unrolled spectralnorm=rust:spectralnorm fasta=rust:fasta fft=rust:fft listbuild=rust:listbuild listbuild-append=rust:listbuild listbuild-comb=rust:listbuild"
+#
+# The three `listbuild` rows are deliberately NOT here. Their almide/rust ratio
+# turns out to be strongly ARCHITECTURE-dependent — the ratchet's founding
+# assumption, "the ratio cancels the machine", does not hold for a workload
+# whose cost is allocation rather than arithmetic. Same commit, same day:
+# `listbuild` reads 1.58 on an M4 Pro and 0.91 on the ubuntu-latest CI runner
+# (where Almide BEATS the reference, glibc calloc handing back zero pages that
+# `Vec::with_capacity` + push has to fault in). A per-row anchor would sit ~16%
+# off the two-sided floor on one of the two machines and flake there, and
+# re-anchoring per architecture is not something a single committed baseline
+# can express. So the rows are MEASURED and REPORTED below (same policy the
+# README states for onebrc), and what is gated is the relation between them —
+# which is the property #1337 is about and which IS machine-stable: 1.018x on
+# the M4 Pro, 1.045x on the CI runner, from the same commit.
+PAIRS="nbody=rust:nbody_unrolled spectralnorm=rust:spectralnorm fasta=rust:fasta fft=rust:fft"
+# Rows measured for the record and printed, but not anchored (see above).
+REPORTED="listbuild listbuild-append listbuild-comb"
 # IDIOM GATE (#1337). The three listbuild rows build the SAME result three
 # ways, so beyond each row's own ratio there is a relation between them that
 # the mission depends on: CLAUDE.md and docs/CHEATSHEET.md tell authors (and
@@ -70,14 +86,15 @@ python3 research/benchmark/perf/bench.py \
   --bench nbody,spectralnorm,fasta,fft,listbuild,listbuild-append,listbuild-comb \
   --label ratchet --out "$out"
 
-python3 - "$out" "$BASELINE_FILE" "$BUDGET_PCT" "$PAIRS" "$MIN_SECONDS" "$IDIOM_CEILING" <<'PY'
+python3 - "$out" "$BASELINE_FILE" "$BUDGET_PCT" "$PAIRS" "$MIN_SECONDS" "$IDIOM_CEILING" "$REPORTED" <<'PY'
 import json, sys
 
-out_path, baseline_path, budget_pct, pairs_arg, min_s, idiom_ceiling = sys.argv[1:7]
+out_path, baseline_path, budget_pct, pairs_arg, min_s, idiom_ceiling, reported_arg = sys.argv[1:8]
 budget = float(budget_pct)
 min_s = float(min_s)
 idiom_ceiling = float(idiom_ceiling)
 pairs = dict(p.split("=", 1) for p in pairs_arg.split())
+reported = reported_arg.split()
 
 data = json.load(open(out_path))["results"]
 ratios = {}
@@ -126,6 +143,12 @@ for bench, ratio in sorted(ratios.items()):
         verdict = f"UNDER floor {floor:.3f} (broken bench or durable win — re-anchor on purpose)"
         failed = True
     print(f"perf-ratio: {bench:16s} {ratio:.3f} (baseline {base:.3f}, +{budget:.0f}% budget) {verdict}")
+
+for bench in reported:
+    v = data[bench]["variants"]
+    nat = v[f"{bench}/native"]["median"]
+    ref = v[f"{bench}/rust:listbuild"]["median"]
+    print(f"perf-ratio: {bench:16s} {nat / ref:.3f} (reported, not anchored — machine-dependent)")
 
 # The listbuild idiom relation (#1337): the RECOMMENDED combinator shape
 # against the `var` + `for` append loop it is documented to replace, from this

--- a/scripts/perf-ratio-baseline.txt
+++ b/scripts/perf-ratio-baseline.txt
@@ -6,14 +6,10 @@ fasta 1.152
 # row stopped spending ~8% of its wall clock building its own input (#1338).
 # Transform output is bit-identical across the change.
 fft 1.176
-# listbuild: the same 2^23-element materializing build written three ways
-# (#1337). All three now sit on the same ~1.6x, which is the materialization
-# cost #1004 tracks and NOT a property of the shape — the shape spread was the
-# `flat_map` intermediate, and it is gone. The relation between the rows is
-# gated separately (IDIOM_CEILING in check-perf-ratio.sh); these three anchor
-# each row against handwritten Rust the way every other benchmark is anchored.
-listbuild 1.575
-listbuild-append 1.607
-listbuild-comb 1.646
+# The three `listbuild` rows (#1337) are measured but deliberately NOT anchored
+# here: their almide/rust ratio is architecture-dependent (1.58 on an M4 Pro,
+# 0.91 on the ubuntu-latest CI runner, same commit), so no single number can
+# hold on both. `check-perf-ratio.sh` gates the machine-STABLE relation between
+# those rows instead — see the PAIRS/REPORTED comment there.
 nbody 0.997
 spectralnorm 1.001

--- a/spec/stdlib/list_flat_map_array_test.almd
+++ b/spec/stdlib/list_flat_map_array_test.almd
@@ -50,6 +50,22 @@ test "flat_map tail literal of heap elements" {
   assert_eq(nested |> list.map((g) => show(g)) |> list.join("/"), "1/1,1/2/2,2")
 }
 
+test "flat_map array elements that look like template placeholders" {
+  // The array form is emitted as an InlineRust template whose placeholders are
+  // `{e0}`, `{e1}`, … A STRING LITERAL spelling one of those names is ordinary
+  // source, and it must survive as data: substituting one argument must never
+  // make the next argument's pass reinterpret the text it just inserted. This
+  // printed "s,A,s,B" before the substitution became single-pass.
+  let out = ["A", "B"] |> list.flat_map((s) => ["{e1}", s])
+  assert_eq(list.join(out, ","), "{e1},A,{e1},B")
+  // Same hazard from the other side: a literal naming the FIRST placeholder,
+  // and one naming a placeholder that does not exist.
+  let mixed = ["x"] |> list.flat_map((s) => [s, "{e0}", "{zz}"])
+  assert_eq(list.join(mixed, ","), "x,{e0},{zz}")
+  // An unbalanced brace is data too.
+  assert_eq(list.join(["y"] |> list.flat_map((s) => [s, "{e1"]), ","), "y,{e1")
+}
+
 test "flat_map shapes the rewrite declines — same answers" {
   // Tail is a CALL, not a literal: stays on the Vec-returning form.
   assert_eq(show([1, 2, 3] |> list.flat_map(pair)), "1,10,2,20,3,30")


### PR DESCRIPTION
Two follow-ups to #1362 (#1337 / #1338), each found by looking at what that PR
actually did rather than at whether its tests were green.

## 1. An argument could be reinterpreted as template syntax

`render_expr_inline_rust` filled a template's `{name}` holes with one
`String::replace` per argument, which re-scans text it has already inserted. An
argument whose **rendered** form contains a later placeholder therefore got
rewritten by the next iteration.

#1362 made that reachable from ordinary source, because a fixed-arity
`flat_map` tail now lowers to the array template `[{e0}, {e1}]`:

```almide
["A", "B"] |> list.flat_map((s) => ["{e1}", s])
```

`{e0}` is substituted first, inserting the user's string literal `"{e1}"`,
which the `{e1}` pass then overwrites with `s`. Measured on the merged binary:

```
$ almide run collide.almd
s,A,s,B          # expected: {e1},A,{e1},B
```

Silent wrong code, no diagnostic — a string literal read as compiler syntax.

**Fix:** scan the template once and emit, so inserted text is never examined
again. That closes the class rather than the instance: no argument can be
interpreted as template syntax whatever a literal happens to contain. Unknown
and unbalanced `{...}` are emitted verbatim exactly as before — templates carry
unfilled defaults, and Rust code in a template legitimately contains braces
(block bodies, closures, `format!("{}")`, `{{` escapes). Each argument is still
rendered at most once even when its placeholder appears twice, which matters:
re-rendering nested expressions is how a concat chain once went exponential.

Four new rows in `spec/stdlib/list_flat_map_array_test.almd` cover a literal
naming a later placeholder, an earlier one, one that does not exist, and an
unbalanced brace. The first is the exact expression that printed `s,A,s,B`
above, so the test is A/B'd against the bug rather than merely green.

## 2. The listbuild rows should not have been anchored

The ratchet's founding assumption is that the almide/rust **ratio cancels the
machine**. #1362's first CI run showed that does not hold for a workload whose
cost is allocation rather than arithmetic — same commit, same day:

| row | M4 Pro | ubuntu-latest (CI) |
|---|---:|---:|
| `listbuild` | 1.58 | **0.91** (Almide *beats* the reference) |
| `listbuild-append` | 1.61 | 1.46 |
| `listbuild-comb` | 1.65 | 1.52 |

glibc `calloc` hands back zero pages that `Vec::with_capacity` + push has to
fault in, so the preallocated shape wins on Linux and loses on Apple Silicon.
The 1.575 anchor **passed** CI — sitting ~16% off the two-sided floor. It would
have flaked on the next slow runner, and no single committed baseline can
express a per-architecture anchor.

So the three rows are now **measured and reported** (the policy the README
already states for onebrc) rather than anchored, and what carries a gate is the
**relation** between them — the property #1337 is actually about, and the one
that is machine-stable because it is a ratio of ratios taken inside one run:

- **1.018x** on the M4 Pro
- **1.045x** on the ubuntu-latest CI runner
- **0.941x** on a local run taken while a parallel `cargo test --workspace` had
  the box at load 30 — the same run in which the *anchored* `fasta` row read
  1.856 and tripped its ceiling, on a benchmark nothing in this branch touches

That last line is the argument: under load heavy enough to knock an anchored
row out of its band, the relation held. Ceiling stays 1.15x; recomputed on the
pre-#1337 measurement it reads 1.662x, so it still fails on the bug it exists
for.

## Gates

```
cargo build --release
./target/release/almide test                          # 397 files, 0 failed
./target/release/almide fmt --check spec/ examples/   # 912 files already formatted
bash scripts/check-contracts.sh                       # 268 contracts, flagged 0
cargo test --workspace
ALMIDE_BIN=target/release/almide bash scripts/check-perf-ratio.sh
```
