### PR TITLE
Make almide test failure output a structured agent feedback surface

### DIFF
--- a/crates/almide-codegen/src/pass_builtin_lowering.rs
+++ b/crates/almide-codegen/src/pass_builtin_lowering.rs
@@ -245,16 +245,37 @@ fn rewrite_call_named(name: Sym, args: Vec<IrExpr>, type_args: Vec<Ty>, ty: Ty, 
     rewrite_call_rename(name, args, type_args, ty, span)
 }
 
+/// A `LitStr` macro argument.
+fn macro_lit(value: &str) -> IrExpr {
+    IrExpr { kind: IrExprKind::LitStr { value: value.into() }, ty: Ty::String, span: None, def_id: None }
+}
+
+/// `at line <N>` — the assertion's own `.almd` source line, threaded into the
+/// Rust assertion macro's message so a TEST-block failure names the line in the
+/// source instead of only the generated `main.rs` one (which is what libtest's
+/// panic banner reports, and which no agent can act on). `almide test` reads it
+/// back out of the panic payload; see `src/cli/test_report.rs`.
+///
+/// Non-test asserts never reach here — the frontend desugars them to the T18
+/// abort form (C-153), which carries its own `at:` line.
+fn assert_site(span: &Option<Span>) -> Option<String> {
+    span.as_ref().map(|s| format!("at line {}", s.line))
+}
+
 /// The builtins with no Rust fn behind them: they lower to a macro invocation.
 fn rewrite_call_as_macro(name: Sym, args: Vec<IrExpr>, ty: Ty, span: Option<Span>) -> IrExpr {
     // assert / assert_eq / assert_ne → RustMacro
     if name == "assert" || name == "assert_eq" || name == "assert_ne" {
+        let site = assert_site(&span);
         // assert(cond, msg) → assert!(cond, "{}", msg)
         // Rust's assert! macro requires a format string literal as second arg
         if name == "assert" && args.len() == 2 {
             let cond = args[0].clone();
             let msg = args[1].clone();
-            let fmt = IrExpr { kind: IrExprKind::LitStr { value: "{}".into() }, ty: Ty::String, span: None, def_id: None };
+            let fmt = match &site {
+                Some(at) => macro_lit(&format!("{{}} ({at})")),
+                None => macro_lit("{}"),
+            };
             return IrExpr { kind: IrExprKind::RustMacro { name, args: vec![cond, fmt, msg] }, ty, span, def_id: None };
         }
         // Sized Numeric Types (Stage 1c): `assert_eq(x,
@@ -270,6 +291,13 @@ fn rewrite_call_as_macro(name: Sym, args: Vec<IrExpr>, ty: Ty, span: Option<Span
             let r_ty = args[1].ty.clone();
             coerce_macro_arg(&mut args[1], &l_ty);
             coerce_macro_arg(&mut args[0], &r_ty);
+        }
+        // Append the source site as the macro's message — `assert_eq!(l, r,
+        // "{}", "at line 12")` prints `assertion `left == right` failed: at
+        // line 12` above libtest's `left:`/`right:` pair.
+        if let Some(at) = site {
+            args.push(macro_lit("{}"));
+            args.push(macro_lit(&at));
         }
         return IrExpr { kind: IrExprKind::RustMacro { name, args }, ty, span, def_id: None };
     }

--- a/crates/almide-frontend/src/lower/calls.rs
+++ b/crates/almide-frontend/src/lower/calls.rs
@@ -521,15 +521,27 @@ fn strip_result_ok(ty: &Ty) -> Ty {
 /// Build the ALS-T18 abort form for a non-test assert:
 /// ```text
 /// { let __a0 = l; let __a1 = r;
-///   if <cond> then () else { eprintln("Error: assertion failed: …"); process.exit(1) } }
+///   if <cond> then () else { eprintln("Error: assertion failed\n  …"); process.exit(1) } }
 /// ```
 /// Operands bind to temps FIRST so each evaluates exactly once (the failure
 /// message re-references the temps, never re-runs the operand expressions).
-/// The message forms: `assert_eq` → `Error: assertion failed: left = <l>,
-/// right = <r>`; `assert_ne` → `Error: assertion failed: both = <l>`;
-/// `assert(c)` → `Error: assertion failed`; `assert(c, msg)` → `Error:
-/// assertion failed: <msg>`. Display of the operands is the ALS-R2
-/// interpolation form (the same `${…}` rendering).
+///
+/// The message is a STRUCTURED record, one `  key: value` per line — the
+/// FeedbackEval shape (structured expected/found beats prose for repair@1),
+/// and the form `almide test` parses back into a diff:
+/// ```text
+/// Error: assertion failed
+///   at: line <N>
+///   expected: <r>          // `!= <l>` for assert_ne
+///   found: <l>
+/// ```
+/// `assert(c)` carries only the `at:` line; `assert(c, msg)` puts the message
+/// on the header (`Error: assertion failed: <msg>`). `expected` precedes
+/// `found` so that the one field whose value may span lines without a
+/// terminator is LAST. The `at:` line is dropped when the call has no span,
+/// which is a property of the shared frontend lowering — never of the target,
+/// so both legs stay byte-identical (C-153). Display of the operands is the
+/// ALS-R2 interpolation form (the same `${…}` rendering).
 fn desugar_assert_abort(
     ctx: &mut LowerCtx,
     name: &str,
@@ -568,22 +580,37 @@ fn desugar_assert_abort(
         ),
         _ => vars[0].clone(),
     };
+    // `  at: line <N>\n` — the assertion's own source line, baked in as a
+    // literal at desugar time so every consumer (native, v0/v1 wasm, interp)
+    // inherits the same bytes.
+    let at = span
+        .as_ref()
+        .map(|s| format!("\n  at: line {}", s.line))
+        .unwrap_or_default();
     let parts: Vec<IrStringPart> = match name {
         "assert_eq" => vec![
-            IrStringPart::Lit { value: "Error: assertion failed: left = ".into() },
-            IrStringPart::Expr { expr: vars[0].clone() },
-            IrStringPart::Lit { value: ", right = ".into() },
+            IrStringPart::Lit { value: format!("Error: assertion failed{at}\n  expected: ") },
             IrStringPart::Expr { expr: vars[1].clone() },
+            IrStringPart::Lit { value: "\n  found: ".into() },
+            IrStringPart::Expr { expr: vars[0].clone() },
         ],
         "assert_ne" => vec![
-            IrStringPart::Lit { value: "Error: assertion failed: both = ".into() },
+            IrStringPart::Lit { value: format!("Error: assertion failed{at}\n  expected: != ") },
+            IrStringPart::Expr { expr: vars[0].clone() },
+            IrStringPart::Lit { value: "\n  found: ".into() },
             IrStringPart::Expr { expr: vars[0].clone() },
         ],
-        _ if vars.len() >= 2 => vec![
-            IrStringPart::Lit { value: "Error: assertion failed: ".into() },
-            IrStringPart::Expr { expr: vars[1].clone() },
-        ],
-        _ => vec![IrStringPart::Lit { value: "Error: assertion failed".into() }],
+        _ if vars.len() >= 2 => {
+            let mut p = vec![
+                IrStringPart::Lit { value: "Error: assertion failed: ".into() },
+                IrStringPart::Expr { expr: vars[1].clone() },
+            ];
+            if !at.is_empty() {
+                p.push(IrStringPart::Lit { value: at.clone() });
+            }
+            p
+        }
+        _ => vec![IrStringPart::Lit { value: format!("Error: assertion failed{at}") }],
     };
     let msg = ctx.mk(IrExprKind::StringInterp { parts }, Ty::String, span);
     let eprint = ctx.mk(

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -180,7 +180,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-150 | Ctors over a heap var are value copies — the var stays live | 0.31.0 | active | fixture | 1 |
 | C-151 | Result combinators with a heap-Ok RESULT never link the scalar impl | 0.31.0 | active | fixture | 1 |
 | C-152 | An un-admitted heap call payload in a ctor walls, never zeroes | 0.31.0 | active | fixture | 1 |
-| C-153 | Non-test assert failures abort in the T6 form on both targets | 0.31.0 | active | fixture | 3 |
+| C-153 | Non-test assert failures abort in the T6 form on both targets | 0.31.0 | active | fixture | 4 |
 | C-154 | clamp with an invalid range aborts in the T6 form | 0.31.0 | active | fixture | 2 |
 | C-155 | to_fixed with out-of-domain decimals aborts in the T6 form | 0.31.0 | active | fixture | 3 |
 | C-156 | An if-merged some((String, String)) ctor is a real tracked Option | 0.32.0 | active | fixture | 1 |

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,7 +11,7 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-96 normative sections; 427 distinct executable fixtures.
+96 normative sections; 424 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|
@@ -56,7 +56,7 @@
 | ALS-E22 | C-254 | `spec/wasm_cross/place_assign_ascription.almd` (byte-compare) |
 | ALS-E23 | C-255 | `spec/wasm_cross/record_forms.almd` (byte-compare) |
 | ALS-E24 | C-256 | `spec/wasm_cross/loop_break_continue.almd` (byte-compare) |
-| ALS-E25 | C-257, C-271 | `spec/wasm_cross/error_operators.almd` (byte-compare)<br>`spec/wasm_cross/unwrap_or_unwrap_fallback.almd` (byte-compare) |
+| ALS-E25 | C-257 | `spec/wasm_cross/error_operators.almd` (byte-compare) |
 | ALS-E26 | C-258 | `spec/wasm_cross/call_lambda_ctor.almd` (byte-compare) |
 | ALS-E27 | C-259 | `spec/wasm_cross/call_lambda_ctor.almd` (byte-compare) |
 | ALS-E28 | C-264 | `spec/wasm_cross/optional_chain_scalar.almd` (byte-compare) |
@@ -85,7 +85,7 @@
 | ALS-R3 | C-004, C-005, C-006, C-199 | `spec/wasm_cross/fan_deterministic.almd` (byte-compare)<br>`spec/wasm_cross/fan_map_inline_lambda.almd` (byte-compare)<br>`spec/wasm_cross/fan_pure_thunks.almd` (byte-compare)<br>`spec/wasm_cross/fan_var_thunk_list.almd` (byte-compare)<br>`spec/wasm_cross/fan_map_err.almd` (byte-compare)<br>`spec/wasm_cross/fan_map_inline_err.almd` (byte-compare)<br>`spec/wasm_cross/fan_any_allfail.almd` (byte-compare)<br>`spec/wasm_cross/option_none_unwrap_term.almd` (byte-compare)<br>`tests/diagnostics/e027-fan-timeout-removed/broken.almd` (checker)<br>`tests/diagnostic_harness_test.rs` (cargo gate)<br>`spec/wasm_cross/fan_block_err_list_order.almd` (byte-compare) |
 | ALS-R4 | C-012 | `spec/wasm_cross/const_fold_nonfinite_float.almd` (byte-compare) |
 | ALS-R5 | C-096, C-112, C-118, C-133, C-189, C-214, C-215 | `spec/wasm_cross/process_args.almd` (byte-compare)<br>`spec/wasm_cross/random_int_entropy.almd` (byte-compare)<br>`spec/wasm_cross/env_args.almd` (byte-compare)<br>`spec/wasm_cross/env_get.almd` (byte-compare)<br>`spec/wasm_cross/env_platform_reporting.almd` (byte-compare)<br>`spec/stdlib/process_timeout_test.almd` (both-target test)<br>`spec/stdlib/fs_if_exists_test.almd` (both-target test) |
-| ALS-R6 | C-042, C-137, C-220, C-225, C-227, C-228, C-229, C-230, C-270, C-272, C-273 | `spec/wasm_cross/fs_preopen_resolve.almd` (byte-compare)<br>`spec/wasm_cross/fs_relative_path.almd` (byte-compare)<br>`spec/stdlib/fs_stat_test.almd` (both-target test)<br>`spec/stdlib/fs_streaming_test.almd` (both-target test)<br>`spec/stdlib/fs_fold_lines_range_test.almd` (both-target test)<br>`spec/stdlib/fs_fold_lines_chunked_test.almd` (both-target test)<br>`spec/wasm_cross/fs_read_lines.almd` (byte-compare)<br>`spec/wasm_cross/fs_metadata_family.almd` (byte-compare)<br>`spec/wasm_cross/fs_composition_family.almd` (byte-compare)<br>`spec/wasm_cross/matrix_select_rows.almd` (byte-compare)<br>`spec/wasm_cross/matrix_select_rows_oob.almd` (byte-compare)<br>`spec/wasm_cross/flight_pid_control.almd` (byte-compare)<br>`spec/wasm_cross/matrix_q_fp16_scale_domain.almd` (byte-compare)<br>`spec/wasm_cross/fs_list_dir_multipass.almd` (byte-compare)<br>`spec/wasm_cross/fs_write_errno.almd` (byte-compare) |
+| ALS-R6 | C-042, C-137, C-220, C-225, C-227, C-228, C-229, C-230 | `spec/wasm_cross/fs_preopen_resolve.almd` (byte-compare)<br>`spec/wasm_cross/fs_relative_path.almd` (byte-compare)<br>`spec/stdlib/fs_stat_test.almd` (both-target test)<br>`spec/stdlib/fs_streaming_test.almd` (both-target test)<br>`spec/stdlib/fs_fold_lines_range_test.almd` (both-target test)<br>`spec/stdlib/fs_fold_lines_chunked_test.almd` (both-target test)<br>`spec/wasm_cross/fs_read_lines.almd` (byte-compare)<br>`spec/wasm_cross/fs_metadata_family.almd` (byte-compare)<br>`spec/wasm_cross/fs_composition_family.almd` (byte-compare)<br>`spec/wasm_cross/matrix_select_rows.almd` (byte-compare)<br>`spec/wasm_cross/matrix_select_rows_oob.almd` (byte-compare)<br>`spec/wasm_cross/flight_pid_control.almd` (byte-compare) |
 | ALS-S1 | C-016, C-065, C-241 | `spec/wasm_cross/string_codepoint.almd` (byte-compare)<br>`spec/wasm_cross/string_ops.almd` (byte-compare)<br>`spec/wasm_cross/string_codepoint_index.almd` (byte-compare)<br>`spec/wasm_cross/string_lines.almd` (byte-compare)<br>`spec/wasm_cross/binding_stmts.almd` (byte-compare) |
 | ALS-S2 | C-017, C-249 | `spec/wasm_cross/string_empty_pattern.almd` (byte-compare)<br>`spec/wasm_cross/for_in_forms.almd` (byte-compare)<br>`spec/wasm_cross/tuple_ops.almd` (byte-compare) |
 | ALS-S3 | C-018, C-019, C-252 | `spec/wasm_cross/string_predicates.almd` (byte-compare)<br>`spec/wasm_cross/string_ops_drain.almd` (byte-compare)<br>`spec/wasm_cross/string_rle.almd` (byte-compare)<br>`spec/wasm_cross/expr_stmt_comment.almd` (byte-compare) |
@@ -110,4 +110,4 @@
 | ALS-T15 | C-049, C-140 | `spec/wasm_cross/float_sign_minmax_ieee.almd` (byte-compare)<br>`spec/wasm_cross/float_round_negzero.almd` (byte-compare) |
 | ALS-T16 | C-054, C-056 | `spec/wasm_cross/list_count_index_truncation.almd` (byte-compare)<br>`spec/wasm_cross/string_count_truncation.almd` (byte-compare)<br>`spec/wasm_cross/map_wide_int_key.almd` (byte-compare)<br>`spec/wasm_cross/chunk_str.almd` (byte-compare)<br>`spec/wasm_cross/list_product_overflow.almd` (byte-compare) |
 | ALS-T17 | C-128 | `spec/wasm_cross/datetime_format.almd` (byte-compare) |
-| ALS-T18 | C-153 | `spec/wasm_cross/assert_abort_eq.almd` (byte-compare)<br>`spec/wasm_cross/assert_abort_ne.almd` (byte-compare)<br>`spec/wasm_cross/assert_abort_msg.almd` (byte-compare) |
+| ALS-T18 | C-153 | `spec/wasm_cross/assert_abort_eq.almd` (byte-compare)<br>`spec/wasm_cross/assert_abort_ne.almd` (byte-compare)<br>`spec/wasm_cross/assert_abort_msg.almd` (byte-compare)<br>`spec/wasm_cross/assert_abort_multiline.almd` (byte-compare) |

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,7 +11,7 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-96 normative sections; 424 distinct executable fixtures.
+96 normative sections; 428 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|
@@ -56,7 +56,7 @@
 | ALS-E22 | C-254 | `spec/wasm_cross/place_assign_ascription.almd` (byte-compare) |
 | ALS-E23 | C-255 | `spec/wasm_cross/record_forms.almd` (byte-compare) |
 | ALS-E24 | C-256 | `spec/wasm_cross/loop_break_continue.almd` (byte-compare) |
-| ALS-E25 | C-257 | `spec/wasm_cross/error_operators.almd` (byte-compare) |
+| ALS-E25 | C-257, C-271 | `spec/wasm_cross/error_operators.almd` (byte-compare)<br>`spec/wasm_cross/unwrap_or_unwrap_fallback.almd` (byte-compare) |
 | ALS-E26 | C-258 | `spec/wasm_cross/call_lambda_ctor.almd` (byte-compare) |
 | ALS-E27 | C-259 | `spec/wasm_cross/call_lambda_ctor.almd` (byte-compare) |
 | ALS-E28 | C-264 | `spec/wasm_cross/optional_chain_scalar.almd` (byte-compare) |
@@ -85,7 +85,7 @@
 | ALS-R3 | C-004, C-005, C-006, C-199 | `spec/wasm_cross/fan_deterministic.almd` (byte-compare)<br>`spec/wasm_cross/fan_map_inline_lambda.almd` (byte-compare)<br>`spec/wasm_cross/fan_pure_thunks.almd` (byte-compare)<br>`spec/wasm_cross/fan_var_thunk_list.almd` (byte-compare)<br>`spec/wasm_cross/fan_map_err.almd` (byte-compare)<br>`spec/wasm_cross/fan_map_inline_err.almd` (byte-compare)<br>`spec/wasm_cross/fan_any_allfail.almd` (byte-compare)<br>`spec/wasm_cross/option_none_unwrap_term.almd` (byte-compare)<br>`tests/diagnostics/e027-fan-timeout-removed/broken.almd` (checker)<br>`tests/diagnostic_harness_test.rs` (cargo gate)<br>`spec/wasm_cross/fan_block_err_list_order.almd` (byte-compare) |
 | ALS-R4 | C-012 | `spec/wasm_cross/const_fold_nonfinite_float.almd` (byte-compare) |
 | ALS-R5 | C-096, C-112, C-118, C-133, C-189, C-214, C-215 | `spec/wasm_cross/process_args.almd` (byte-compare)<br>`spec/wasm_cross/random_int_entropy.almd` (byte-compare)<br>`spec/wasm_cross/env_args.almd` (byte-compare)<br>`spec/wasm_cross/env_get.almd` (byte-compare)<br>`spec/wasm_cross/env_platform_reporting.almd` (byte-compare)<br>`spec/stdlib/process_timeout_test.almd` (both-target test)<br>`spec/stdlib/fs_if_exists_test.almd` (both-target test) |
-| ALS-R6 | C-042, C-137, C-220, C-225, C-227, C-228, C-229, C-230 | `spec/wasm_cross/fs_preopen_resolve.almd` (byte-compare)<br>`spec/wasm_cross/fs_relative_path.almd` (byte-compare)<br>`spec/stdlib/fs_stat_test.almd` (both-target test)<br>`spec/stdlib/fs_streaming_test.almd` (both-target test)<br>`spec/stdlib/fs_fold_lines_range_test.almd` (both-target test)<br>`spec/stdlib/fs_fold_lines_chunked_test.almd` (both-target test)<br>`spec/wasm_cross/fs_read_lines.almd` (byte-compare)<br>`spec/wasm_cross/fs_metadata_family.almd` (byte-compare)<br>`spec/wasm_cross/fs_composition_family.almd` (byte-compare)<br>`spec/wasm_cross/matrix_select_rows.almd` (byte-compare)<br>`spec/wasm_cross/matrix_select_rows_oob.almd` (byte-compare)<br>`spec/wasm_cross/flight_pid_control.almd` (byte-compare) |
+| ALS-R6 | C-042, C-137, C-220, C-225, C-227, C-228, C-229, C-230, C-270, C-272, C-273 | `spec/wasm_cross/fs_preopen_resolve.almd` (byte-compare)<br>`spec/wasm_cross/fs_relative_path.almd` (byte-compare)<br>`spec/stdlib/fs_stat_test.almd` (both-target test)<br>`spec/stdlib/fs_streaming_test.almd` (both-target test)<br>`spec/stdlib/fs_fold_lines_range_test.almd` (both-target test)<br>`spec/stdlib/fs_fold_lines_chunked_test.almd` (both-target test)<br>`spec/wasm_cross/fs_read_lines.almd` (byte-compare)<br>`spec/wasm_cross/fs_metadata_family.almd` (byte-compare)<br>`spec/wasm_cross/fs_composition_family.almd` (byte-compare)<br>`spec/wasm_cross/matrix_select_rows.almd` (byte-compare)<br>`spec/wasm_cross/matrix_select_rows_oob.almd` (byte-compare)<br>`spec/wasm_cross/flight_pid_control.almd` (byte-compare)<br>`spec/wasm_cross/matrix_q_fp16_scale_domain.almd` (byte-compare)<br>`spec/wasm_cross/fs_list_dir_multipass.almd` (byte-compare)<br>`spec/wasm_cross/fs_write_errno.almd` (byte-compare) |
 | ALS-S1 | C-016, C-065, C-241 | `spec/wasm_cross/string_codepoint.almd` (byte-compare)<br>`spec/wasm_cross/string_ops.almd` (byte-compare)<br>`spec/wasm_cross/string_codepoint_index.almd` (byte-compare)<br>`spec/wasm_cross/string_lines.almd` (byte-compare)<br>`spec/wasm_cross/binding_stmts.almd` (byte-compare) |
 | ALS-S2 | C-017, C-249 | `spec/wasm_cross/string_empty_pattern.almd` (byte-compare)<br>`spec/wasm_cross/for_in_forms.almd` (byte-compare)<br>`spec/wasm_cross/tuple_ops.almd` (byte-compare) |
 | ALS-S3 | C-018, C-019, C-252 | `spec/wasm_cross/string_predicates.almd` (byte-compare)<br>`spec/wasm_cross/string_ops_drain.almd` (byte-compare)<br>`spec/wasm_cross/string_rle.almd` (byte-compare)<br>`spec/wasm_cross/expr_stmt_comment.almd` (byte-compare) |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -1818,13 +1818,14 @@ evidence  = [
 id        = "C-153"
 spec      = "ALS-T18"
 title     = "Non-test assert failures abort in the T6 form on both targets"
-statement = "A failing `assert` / `assert_eq` / `assert_ne` OUTSIDE a test block aborts with ONE stderr line + exit code 1, byte-identical across targets: `Error: assertion failed: left = <l>, right = <r>` (eq), `Error: assertion failed: both = <l>` (ne), `Error: assertion failed[: <msg>]` (assert), operand display per ALS-R2, operands evaluated exactly once (the failure line re-references bound temps). Implemented as ONE frontend-lowering desugar (if + eprintln + process.exit(1)) that native, v0-wasm, v1-wasm, and the interp all inherit. Previously native leaked the raw Rust panic (exit 101 + the panic banner) while wasm printed a value-less line with exit 1 for assert_eq and a BARE TRAP (exit 134) for assert/assert_ne (differential-fuzz seed 20260718 index 10). In passing: the bare `eprintln` builtin — which the desugar rides — was UNLINKED on the v1 leg and ICE'd the v0 emitter; it is now a registered self-host (fd-2 print_str twin) and a shared parametrized v0 runtime fn."
+statement = "A failing `assert` / `assert_eq` / `assert_ne` OUTSIDE a test block aborts with a STRUCTURED stderr block + exit code 1, byte-identical across targets: `Error: assertion failed` followed by one `  key: value` line each — `  at: line <N>`, `  expected: <r>` (`!= <l>` for ne), `  found: <l>`; `assert(c, msg)` puts the message on the header (`Error: assertion failed: <msg>`) and carries only `at:`. Operand display per ALS-R2, operands evaluated exactly once (the failure block re-references bound temps). FIELD ORDER IS PART OF THE PROMISE: `expected` precedes `found` so the one field with no terminator is LAST, which is what lets `almide test` parse a multi-line value back out and render a diff (#1313, FeedbackEval arXiv 2504.06939 — structured expected/found is the feedback shape that repairs). The `at:` line is dropped when the call has no span, a property of the shared frontend lowering and never of the target. Implemented as ONE frontend-lowering desugar (if + eprintln + process.exit(1)) that native, v0-wasm, v1-wasm, and the interp all inherit. It was previously ONE line (`left = <l>, right = <r>`) with no source site; before that native leaked the raw Rust panic (exit 101 + the panic banner) while wasm printed a value-less line with exit 1 for assert_eq and a BARE TRAP (exit 134) for assert/assert_ne (differential-fuzz seed 20260718 index 10). In passing: the bare `eprintln` builtin — which the desugar rides — was UNLINKED on the v1 leg and ICE'd the v0 emitter; it is now a registered self-host (fd-2 print_str twin) and a shared parametrized v0 runtime fn."
 since     = "0.31.0"
 status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/assert_abort_eq.almd", class = "fixture" },
   { path = "spec/wasm_cross/assert_abort_ne.almd", class = "fixture" },
   { path = "spec/wasm_cross/assert_abort_msg.almd", class = "fixture" },
+  { path = "spec/wasm_cross/assert_abort_multiline.almd", class = "fixture" },
 ]
 
 [[contract]]

--- a/docs/specs/als/text-and-numbers.md
+++ b/docs/specs/als/text-and-numbers.md
@@ -176,18 +176,25 @@ v0-wasm / 自己ホストの 3 バックエンドが同一の逐次 `string.repl
 
 ## ALS-T18 assert の abort 形（非 test 位置）
 
-`test` ブロック外の `assert` 族の失敗は、**stderr 1行 + exit code 1** で停止する
-（T6 の終了規約ファミリ）。生の Rust panic（exit 101）や wasm trap（exit 134）、
-値情報なしの出力は不適合。行の形（表示は ALS-R2 の補間 Display と同一）:
+`test` ブロック外の `assert` 族の失敗は、**stderr の構造化ブロック + exit code 1**
+で停止する（T6 の終了規約ファミリ）。生の Rust panic（exit 101）や wasm trap
+（exit 134）、値情報なしの出力は不適合。ブロックは `  key: value` を1行ずつ並べた
+形（値の表示は ALS-R2 の補間 Display と同一）:
 
-- `assert_eq(l, r)` → `Error: assertion failed: left = <l>, right = <r>`
-- `assert_ne(l, r)` → `Error: assertion failed: both = <l>`
-- `assert(c)` → `Error: assertion failed`
-- `assert(c, msg)` → `Error: assertion failed: <msg>`
+- `assert_eq(l, r)` →
+  `Error: assertion failed\n  at: line <N>\n  expected: <r>\n  found: <l>`
+- `assert_ne(l, r)` →
+  `Error: assertion failed\n  at: line <N>\n  expected: != <l>\n  found: <l>`
+- `assert(c)` → `Error: assertion failed\n  at: line <N>`
+- `assert(c, msg)` → `Error: assertion failed: <msg>\n  at: line <N>`
+
+フィールド順は固定で、**終端子を持たない `found` が必ず最後**（値が複数行に
+またがっても曖昧にならない）。`at:` 行は呼び出しに span が無いときだけ省略され、
+これは共有 frontend lowering の性質なのでターゲット間では常に一致する。
 
 被演算子は**一度だけ評価**される（失敗メッセージは束縛済み temp を再参照する）。
 `test` ブロック内はテストハーネスの報告形式に従う（本節の対象外）。
 実装は frontend lowering の単一脱糖（desugar once）で、native / v0-wasm /
 v1-wasm / interp の全系統が同じ IR を継ぐ。
 Fixtures: `spec/wasm_cross/assert_abort_eq.almd`, `assert_abort_ne.almd`,
-`assert_abort_msg.almd`。Contracts: C-153。
+`assert_abort_msg.almd`, `assert_abort_multiline.almd`。Contracts: C-153。

--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -76,7 +76,7 @@ almide test spec/lang/                  # ディレクトリ指定
 almide test spec/lang/expr_test.almd    # ファイル指定
 almide test --run "pattern"             # テスト名でフィルタ
 almide test --target wasm               # WASM ターゲットでテスト
-almide test --json                      # 結果を JSON (1行1テスト) で出力
+almide test --json                      # 結果を JSONL (1行1ファイル) で出力
 ```
 
 | オプション | 説明 |
@@ -85,6 +85,20 @@ almide test --json                      # 結果を JSON (1行1テスト) で出
 | `--no-check` | 型チェックをスキップ |
 | `--json` | JSON 形式で結果出力 |
 | `--target wasm` | wasmtime で実行 |
+
+失敗の報告は**構造化ブロック**（`FAILED: <file>` に続けて `test:` / `at:` /
+`hint:` / `diff:` または `expected:` `found:`）。複数行文字列・リスト・レコードは
+単位ごとの実差分になる。ファイル内の失敗は**ソース行順**に並ぶので、2回の実行を
+そのまま diff できる。
+
+`--json` は1ファイル1行の JSONL:
+
+```json
+{"file":"spec/lang/x_test.almd","status":"fail","exit_code":101,
+ "failures":[{"name":"string mismatch","file":"spec/lang/x_test.almd","line":4,
+              "op":"assert_eq","expected":"\"a\\nB\"","found":"\"a\\nb\"",
+              "diff":"      a\n    - B\n    + b\n","message":"…"}]}
+```
 
 テストの書き方:
 

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,16 +15,16 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 61 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 283/406 fixtures cast a real 3-way vote (69%)** —
+> **Stage 2 (translation validation): 283/410 fixtures cast a real 3-way vote (69%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
-> **Stage 3 (semantics freeze): 269/269 contracts spec-keyed; syntax-element coverage
+> **Stage 3 (semantics freeze): 273/273 contracts spec-keyed; syntax-element coverage
 > 72/72 sectioned (0 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).
 >
-> **Stage 5 (auditability): 1 release seal(s); 35 verification gates classified
+> **Stage 5 (auditability): 1 release seal(s); 36 verification gates classified
 > (2 UNVERIFIED under a shrink-only ceiling); TOR with 9 enforced rows;
 > gap analysis consolidated in proofs/DO330-GAP.md (reference-gated).**
 <!-- stages:generated:end -->

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,16 +15,16 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 61 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 282/409 fixtures cast a real 3-way vote (68%)** —
+> **Stage 2 (translation validation): 283/406 fixtures cast a real 3-way vote (69%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
-> **Stage 3 (semantics freeze): 273/273 contracts spec-keyed; syntax-element coverage
+> **Stage 3 (semantics freeze): 269/269 contracts spec-keyed; syntax-element coverage
 > 72/72 sectioned (0 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).
 >
-> **Stage 5 (auditability): 1 release seal(s); 36 verification gates classified
+> **Stage 5 (auditability): 1 release seal(s); 35 verification gates classified
 > (2 UNVERIFIED under a shrink-only ceiling); TOR with 9 enforced rows;
 > gap analysis consolidated in proofs/DO330-GAP.md (reference-gated).**
 <!-- stages:generated:end -->

--- a/proofs/output-parity-baseline.txt
+++ b/proofs/output-parity-baseline.txt
@@ -66,6 +66,7 @@ spec/wasm_cross/append_accumulator_heap.almd
 spec/wasm_cross/args_surface.almd
 spec/wasm_cross/assert_abort_eq.almd
 spec/wasm_cross/assert_abort_msg.almd
+spec/wasm_cross/assert_abort_multiline.almd
 spec/wasm_cross/assert_abort_ne.almd
 spec/wasm_cross/assign_alias_rc.almd
 spec/wasm_cross/autotry_construction.almd

--- a/spec/wasm_cross/assert_abort_multiline.almd
+++ b/spec/wasm_cross/assert_abort_multiline.almd
@@ -1,0 +1,11 @@
+// @contract: C-153
+// ALS-T18: the structured failure block survives a MULTI-LINE operand
+// byte-identically on both targets. The embedded newlines are the case the
+// field order exists for — `found` is last, so its continuation lines have no
+// terminator to collide with (#1313).
+fn main() -> Unit = {
+  let got: String = "line one\nline two\nline three"
+  println("before")
+  assert_eq(got, "line one\nline TWO\nline three")
+  println("unreachable")
+}

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -127,9 +127,13 @@ fn compile_test_files_parallel(test_files: &[String], no_check: bool) -> Vec<(St
     results
 }
 
+use super::test_report::{report_test_failure, test_harness_args, TestRun};
+
 /// `cmd_test`'s Phase 2: execute every compiled test binary in parallel
-/// (bounded by CPU count). Extracted verbatim.
-fn run_test_binaries_parallel(compiled: Vec<(String, Result<std::path::PathBuf, String>)>, program_args: &std::sync::Arc<Vec<String>>) -> Vec<(String, i32)> {
+/// (bounded by CPU count). Output is CAPTURED, not inherited: it feeds
+/// [`report_test_failure`], and printing each file's output whole in sorted
+/// order makes a parallel run's transcript deterministic.
+fn run_test_binaries_parallel(compiled: Vec<(String, Result<std::path::PathBuf, String>)>, program_args: &std::sync::Arc<Vec<String>>) -> Vec<TestRun> {
     let cpus = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4);
     let (sem_tx, sem_rx) = std::sync::mpsc::sync_channel::<()>(cpus);
     for _ in 0..cpus { let _ = sem_tx.send(()); }
@@ -144,19 +148,16 @@ fn run_test_binaries_parallel(compiled: Vec<(String, Result<std::path::PathBuf, 
         let sem_tx = sem_tx.clone();
         handles.push(std::thread::spawn(move || {
             let _ = sem_rx.lock().unwrap().recv();
-            let code = match compile_result {
-                Ok(bin) => super::run::run_binary(&bin, &args),
-                Err(e) => {
-                    err(&format!("Compile error for {}:\n{}", file, e));
-                    1
-                }
+            let (code, out) = match compile_result {
+                Ok(bin) => super::run::run_binary_captured(&bin, &args),
+                Err(e) => (1, format!("Compile error for {}:\n{}", file, e)),
             };
             let _ = sem_tx.send(());
-            let _ = tx.send((file, code));
+            let _ = tx.send((file, code, out));
         }));
     }
     drop(tx);
-    let mut results: Vec<(String, i32)> = rx.iter().collect();
+    let mut results: Vec<TestRun> = rx.iter().collect();
     for h in handles { let _ = h.join(); }
     results.sort_by(|a, b| a.0.cmp(&b.0));
     results
@@ -165,11 +166,7 @@ fn run_test_binaries_parallel(compiled: Vec<(String, Result<std::path::PathBuf, 
 pub fn cmd_test(file: &str, no_check: bool, run_filter: Option<&str>) {
     let test_files: Vec<String> = discover_test_files(file, &["spec", "exercises"]);
 
-    let mut program_args: Vec<String> = Vec::new();
-    if let Some(filter) = run_filter {
-        program_args.push(filter.to_string());
-    }
-    let program_args = std::sync::Arc::new(program_args);
+    let program_args = test_harness_args(run_filter);
 
     // Phase 1: Compile all test files in parallel (bounded by CPU count)
     let compiled = compile_test_files_parallel(&test_files, no_check);
@@ -178,9 +175,9 @@ pub fn cmd_test(file: &str, no_check: bool, run_filter: Option<&str>) {
     let results = run_test_binaries_parallel(compiled, &program_args);
 
     let mut failed = 0;
-    for (file, code) in &results {
+    for (file, code, output) in &results {
         if *code != 0 {
-            err(&format!("FAILED: {}", file));
+            report_test_failure(file, output);
             failed += 1;
         }
     }
@@ -613,8 +610,8 @@ fn run_wasm_test_phase(test_files: &[String], tmp_dir: &std::sync::Arc<std::path
 
 /// `cmd_test_fast`'s Phase 2: native rustc fallback (authoritative) for
 /// everything the WASM path didn't pass, parallel with per-file scratch
-/// dirs. Extracted verbatim.
-fn run_native_fallback_phase(fallback: &[String], program_args: &std::sync::Arc<Vec<String>>, no_check: bool, cpus: usize) -> Vec<(String, i32)> {
+/// dirs. Output is captured — see [`run_test_binaries_parallel`].
+fn run_native_fallback_phase(fallback: &[String], program_args: &std::sync::Arc<Vec<String>>, no_check: bool, cpus: usize) -> Vec<TestRun> {
     let (tx, rx) = std::sync::mpsc::channel();
     let (sem_tx, sem_rx) = std::sync::mpsc::sync_channel::<()>(cpus);
     for _ in 0..cpus { let _ = sem_tx.send(()); }
@@ -631,16 +628,16 @@ fn run_native_fallback_phase(fallback: &[String], program_args: &std::sync::Arc<
             let worker_dir = std::env::temp_dir()
                 .join("almide-test")
                 .join(tf.replace('/', "_").replace('.', "_"));
-            let code = match super::run::compile_to_binary(&tf, no_check, true, false, Some(&worker_dir)) {
-                Ok(bin) => super::run::run_binary(&bin, &args),
-                Err(e) => { err(&format!("Compile error for {}:\n{}", tf, e)); 1 }
+            let (code, out) = match super::run::compile_to_binary(&tf, no_check, true, false, Some(&worker_dir)) {
+                Ok(bin) => super::run::run_binary_captured(&bin, &args),
+                Err(e) => (1, format!("Compile error for {}:\n{}", tf, e)),
             };
             let _ = st.send(());
-            let _ = tx.send((tf, code));
+            let _ = tx.send((tf, code, out));
         }));
     }
     drop(tx);
-    let mut v: Vec<(String, i32)> = rx.iter().collect();
+    let mut v: Vec<TestRun> = rx.iter().collect();
     for h in handles { let _ = h.join(); }
     v.sort_by(|a, b| a.0.cmp(&b.0));
     v
@@ -690,15 +687,13 @@ pub fn cmd_test_fast(file: &str, no_check: bool, run_filter: Option<&str>) {
 
     // Phase 2: native rustc fallback (authoritative) for everything the WASM
     // path didn't pass, parallel with per-file scratch dirs.
-    let mut program_args: Vec<String> = Vec::new();
-    if let Some(f) = run_filter { program_args.push(f.to_string()); }
-    let program_args = std::sync::Arc::new(program_args);
+    let program_args = test_harness_args(run_filter);
 
     let native_results = run_native_fallback_phase(&fallback, &program_args, no_check, cpus);
 
     let mut failed = 0;
-    for (file, code) in &native_results {
-        if *code != 0 { err(&format!("FAILED: {}", file)); failed += 1; }
+    for (file, code, output) in &native_results {
+        if *code != 0 { report_test_failure(file, output); failed += 1; }
     }
     // The #1166 divergence class: the wasm leg compiled the file and failed at
     // runtime, but the AUTHORITATIVE native re-run passed — a wasm-only
@@ -707,7 +702,7 @@ pub fn cmd_test_fast(file: &str, no_check: bool, run_filter: Option<&str>) {
     // is native's). A trap whose native re-run ALSO failed is a plain FAILED
     // test — no wasm-specific noise for those.
     let native_code: std::collections::HashMap<&String, i32> =
-        native_results.iter().map(|(f, c)| (f, *c)).collect();
+        native_results.iter().map(|(f, c, _)| (f, *c)).collect();
     let diverged: Vec<&(String, String)> = trapped
         .iter()
         .filter(|(f, _)| native_code.get(f).copied() == Some(0))
@@ -766,18 +761,27 @@ pub fn cmd_test_json(file: &str, run_filter: Option<&str>) {
         files
     };
 
-    let mut program_args: Vec<String> = Vec::new();
-    if let Some(filter) = run_filter {
-        program_args.push(filter.to_string());
-    }
+    let program_args = test_harness_args(run_filter);
 
+    // JSONL, one line per file, in sorted file order — a run is diffable
+    // against the next one. Each failing file also emits its per-assertion
+    // records ({name, file, line, expected, found, diff}); that is the shape
+    // the dojo harness reads, and the reason `--json` captures the child's
+    // output instead of letting it stream to the terminal (#1313).
     for test_file in &test_files {
-        let code = super::cmd_run_inner(test_file, &program_args, false, true, false, false);
-        // Emit JSON per file
+        let (code, output) = match super::run::compile_to_binary(test_file, false, true, false, None) {
+            Ok(bin) => super::run::run_binary_captured(&bin, &program_args),
+            Err(e) => (1, e),
+        };
+        let source = std::fs::read_to_string(test_file).unwrap_or_default();
+        let failures = super::test_report::parse(test_file, &source, &output);
         let status = if code == 0 { "pass" } else { "fail" };
         out(&format!(
-            r#"{{"file":"{}","status":"{}","exit_code":{}}}"#,
-            test_file.replace('"', r#"\""#), status, code
+            r#"{{"file":{},"status":"{}","exit_code":{},"failures":[{}]}}"#,
+            serde_json::Value::from(test_file.as_str()),
+            status,
+            code,
+            failures.iter().map(|f| f.to_json()).collect::<Vec<_>>().join(","),
         ));
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ mod compile;
 mod emit;
 mod check;
 mod commands;
+pub mod test_report;
 mod install;
 mod selfupdate;
 pub mod lsp;
@@ -23,7 +24,7 @@ mod cargo_build;
 // visible to `cli`'s descendants) so those call sites don't need to change.
 use cargo_build::{cargo_build_cdylib, cargo_build_generated, cargo_build_generated_with_native, cargo_build_test_with_native};
 
-pub use run::{cmd_run, cmd_run_inner, RunArgs};
+pub use run::{cmd_run, RunArgs};
 pub use build::{cmd_build, BuildArgs};
 pub use compile::cmd_compile;
 pub use emit::{cmd_emit, EmitArgs};

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -285,23 +285,27 @@ pub fn almide_cwd() -> Option<String> {
         .and_then(|d| d.to_str().map(|s| s.to_string()))
 }
 
-/// Run a compiled binary with the given args, returning exit code.
-pub fn run_binary(bin: &std::path::Path, program_args: &[String]) -> i32 {
-    // Belt for the parallel-test ETXTBSY race (the staging rename above is the
-    // root fix): if another thread's stale write handle still overlaps the exec,
-    // back off briefly and retry instead of failing the whole suite.
+/// The launch command for a compiled binary — shared by the inheriting and the
+/// capturing runners so they cannot drift in environment.
+fn binary_command(bin: &std::path::Path, program_args: &[String]) -> Command {
+    let mut cmd = Command::new(bin);
+    cmd.env("RUST_MIN_STACK", "8388608");
+    if let Some(cwd) = almide_cwd() {
+        cmd.env("ALMIDE_CWD", cwd);
+    }
+    cmd.args(program_args);
+    cmd
+}
+
+/// Run `attempt` through the ETXTBSY back-off. Belt for the parallel-test race
+/// (the staging rename in `build_native_cached` is the root fix): if another
+/// thread's stale write handle still overlaps the exec, back off briefly and
+/// retry instead of failing the whole suite.
+fn with_exec_retry<T>(mut attempt: impl FnMut() -> std::io::Result<T>) -> Option<T> {
     let mut delay = std::time::Duration::from_millis(20);
     for _ in 0..6 {
-        let mut cmd = Command::new(bin);
-        cmd.env("RUST_MIN_STACK", "8388608");
-        if let Some(cwd) = almide_cwd() {
-            cmd.env("ALMIDE_CWD", cwd);
-        }
-        match cmd
-            .args(program_args)
-            .status()
-        {
-            Ok(status) => return status.code().unwrap_or(1),
+        match attempt() {
+            Ok(v) => return Some(v),
             Err(e) if e.raw_os_error() == Some(26) => {
                 std::thread::sleep(delay);
                 delay *= 2;
@@ -313,14 +317,31 @@ pub fn run_binary(bin: &std::path::Path, program_args: &[String]) -> i32 {
         }
     }
     err(&format!("Failed to execute: Text file busy (persisted after retries)"));
-    1
+    None
 }
 
-pub fn cmd_run_inner(file: &str, program_args: &[String], no_check: bool, test_mode: bool, release: bool, native_verified: bool) -> i32 {
-    cmd_run_inner_report(file, program_args, no_check, test_mode, release, native_verified, false)
+/// Run a compiled binary with the given args, returning exit code.
+pub fn run_binary(bin: &std::path::Path, program_args: &[String]) -> i32 {
+    with_exec_retry(|| binary_command(bin, program_args).status())
+        .map_or(1, |s| s.code().unwrap_or(1))
 }
 
-/// [`cmd_run_inner`] + the D5 dual-time report leg (`--time-report`).
+/// [`run_binary`], capturing stdout+stderr instead of inheriting them.
+///
+/// `almide test` needs the bytes to build its structured failure report, and
+/// capturing is what makes a parallel suite's output DETERMINISTIC: each file's
+/// output is printed whole, in sorted file order, instead of interleaving live
+/// with every other worker (agents diff one run against the next).
+pub fn run_binary_captured(bin: &std::path::Path, program_args: &[String]) -> (i32, String) {
+    let Some(out) = with_exec_retry(|| binary_command(bin, program_args).output()) else {
+        return (1, String::new());
+    };
+    let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
+    text.push_str(&String::from_utf8_lossy(&out.stderr));
+    (out.status.code().unwrap_or(1), text)
+}
+
+/// Compile + run one file, with the D5 dual-time report leg (`--time-report`).
 fn cmd_run_inner_report(file: &str, program_args: &[String], no_check: bool, test_mode: bool, release: bool, native_verified: bool, time_report: bool) -> i32 {
     match compile_to_binary_with(file, no_check, test_mode, release, None, native_verified) {
         Ok(bin) => {

--- a/src/cli/test_report.rs
+++ b/src/cli/test_report.rs
@@ -1,0 +1,757 @@
+//! Structured `almide test` failure reporting — the agent feedback surface.
+//!
+//! Measured reality (FeedbackEval, arXiv 2504.06939): TEST-failure feedback
+//! repairs better than compiler errors (repair@1 57.9% vs 49.2%), and the
+//! winning format is *structured data + a one-line hint*, not prose. This
+//! module turns whatever a failing test binary printed into that shape:
+//!
+//! ```text
+//! FAILED spec/lang/x_test.almd
+//!   test: string mismatch
+//!   at:   spec/lang/x_test.almd:4
+//!   hint: line 2 differs
+//!   diff: -expected +found
+//!       line one
+//!     - line TWO
+//!     + line two
+//!       line three
+//! ```
+//!
+//! Two failure spellings reach it, and both are parsed here rather than
+//! anywhere else:
+//!
+//! 1. the T18 abort block (`Error: assertion failed` + `at:`/`expected:`/
+//!    `found:` lines) — an assert in a plain `fn` called from a test body,
+//!    byte-identical on both targets (C-153);
+//! 2. libtest's panic payload for an assert INSIDE a `test` block, whose
+//!    macro carries the `.almd` source line (`at line N`) so the report can
+//!    name the source instead of the generated `main.rs`.
+//!
+//! Everything downstream (the human-readable render, the diff, `--json`) is
+//! computed from one [`TestFailure`] record, so the two channels cannot drift.
+
+use crate::{err, err_no_nl};
+
+/// A finished test file: its path, its exit code, and its captured
+/// stdout+stderr (empty when the file never got as far as running).
+pub type TestRun = (String, i32, String);
+
+/// The argv for a native (libtest) test binary.
+///
+/// `--nocapture` is load-bearing, not cosmetic: libtest DISCARDS a test's
+/// captured buffer when the test exits the process, so a T18 assert abort (an
+/// `assert` in a plain `fn` called from a test body) printed nothing at all —
+/// the run reported a bare `FAILED` with no reason. `almide test` captures the
+/// whole binary's output itself and prints it only on failure, so nothing leaks
+/// into a passing run.
+pub fn test_harness_args(run_filter: Option<&str>) -> std::sync::Arc<Vec<String>> {
+    let mut args = vec!["--nocapture".to_string()];
+    args.extend(run_filter.map(|f| f.to_string()));
+    std::sync::Arc::new(args)
+}
+
+/// Report one failing test file as a STRUCTURED record: the assertion's `.almd`
+/// site, expected/found, and a real diff for multi-line strings, lists and
+/// records. Falls back to the raw captured output when nothing parses — a
+/// failure this reporter does not understand must never be swallowed.
+pub fn report_test_failure(file: &str, output: &str) {
+    err(&format!("FAILED: {}", file));
+    let source = std::fs::read_to_string(file).unwrap_or_default();
+    let failures = parse(file, &source, output);
+    if failures.is_empty() {
+        if output.is_empty() || output.ends_with('\n') {
+            err_no_nl(output);
+        } else {
+            err(output);
+        }
+        return;
+    }
+    for f in &failures {
+        err_no_nl(&f.render());
+    }
+}
+
+/// One failing assertion, normalized away from whichever harness printed it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TestFailure {
+    /// The `.almd` file under test.
+    pub file: String,
+    /// The `test "…"` name, when it could be recovered.
+    pub name: Option<String>,
+    /// 1-based line of the assertion in `file`.
+    pub line: Option<usize>,
+    /// `assert_eq` / `assert_ne` / `assert` / `panic`.
+    pub op: String,
+    /// The right operand of `assert_eq` (the expectation, per the
+    /// `assert_eq(actual, expected)` convention used throughout the docs).
+    pub expected: Option<String>,
+    /// The left operand — what the code actually produced.
+    pub found: Option<String>,
+    /// The raw payload, kept verbatim for anything not shaped like an assert.
+    pub message: String,
+}
+
+impl TestFailure {
+    /// The terse agent-facing block. Values are shown as a DIFF when they
+    /// decompose into comparable units (string lines, list items, record
+    /// fields) and as a plain `expected:`/`found:` pair otherwise — never
+    /// both, so a scalar mismatch stays four lines.
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        if let Some(n) = &self.name {
+            out.push_str(&format!("  test: {n}\n"));
+        }
+        if let Some(l) = self.line {
+            out.push_str(&format!("  at:   {}:{}\n", self.file, l));
+        }
+        let (expected, found) = match (&self.expected, &self.found) {
+            (Some(e), Some(f)) => (e, f),
+            _ => {
+                out.push_str(&format!("  error: {}\n", indent_continuation(&self.message)));
+                return out;
+            }
+        };
+        match Diff::of(expected, found) {
+            Some(d) => {
+                out.push_str(&format!("  hint: {}\n", d.hint()));
+                out.push_str("  diff: -expected +found\n");
+                out.push_str(&d.render());
+            }
+            None => {
+                out.push_str(&format!("  expected: {}\n", indent_continuation(expected)));
+                out.push_str(&format!("  found:    {}\n", indent_continuation(found)));
+            }
+        }
+        out
+    }
+
+    /// One JSON object per failure: `{name, file, line, op, expected, found,
+    /// diff}` — the record the dojo harness consumes.
+    pub fn to_json(&self) -> String {
+        let diff = self
+            .expected
+            .as_deref()
+            .zip(self.found.as_deref())
+            .and_then(|(e, f)| Diff::of(e, f))
+            .map(|d| d.render());
+        let v = serde_json::json!({
+            "name": self.name,
+            "file": self.file,
+            "line": self.line,
+            "op": self.op,
+            "expected": self.expected,
+            "found": self.found,
+            "diff": diff,
+            "message": self.message,
+        });
+        v.to_string()
+    }
+}
+
+/// Indent every line after the first, so a multi-line value cannot be mistaken
+/// for a new `key:` field by whatever reads the report next.
+fn indent_continuation(v: &str) -> String {
+    v.replace('\n', "\n    ")
+}
+
+// ── Parsing ─────────────────────────────────────────────────────────────────
+
+/// Every failure in one test binary's combined output, in SOURCE ORDER.
+///
+/// libtest reports its failure blocks in thread-completion order, so the raw
+/// transcript of a multi-failure file is different on every run and two runs of
+/// the same suite cannot be diffed. Sorting by `(line, name)` makes the report
+/// a function of the failures alone.
+pub fn parse(file: &str, source: &str, output: &str) -> Vec<TestFailure> {
+    let names = test_name_map(source);
+    let mut out = parse_libtest(file, &names, output);
+    out.extend(parse_t18(file, output));
+    out.sort_by(|a, b| {
+        (a.line.unwrap_or(usize::MAX), &a.name, &a.message)
+            .cmp(&(b.line.unwrap_or(usize::MAX), &b.name, &b.message))
+    });
+    out
+}
+
+/// libtest's failure payloads, in EITHER framing:
+///
+/// - captured (`---- <path> stdout ----` … payload), and
+/// - `--nocapture` (`thread '<path>' panicked at <loc>:` … payload), which is
+///   how `almide test` runs the harness — libtest DISCARDS the captured buffer
+///   when a test exits the process, so the T18 abort of an `assert` in a plain
+///   `fn` called from a test body printed nothing at all under capture.
+///
+/// Only one framing is present in a given run; trying the captured one first
+/// keeps the reporter working if the flag is ever dropped.
+fn parse_libtest(file: &str, names: &[(String, String)], output: &str) -> Vec<TestFailure> {
+    let lines: Vec<&str> = output.lines().collect();
+    let captured = collect_blocks(&lines, block_header);
+    let blocks = if captured.is_empty() { collect_blocks(&lines, panic_header) } else { captured };
+    blocks
+        .into_iter()
+        .filter(|(_, payload)| !payload.is_empty())
+        .map(|(raw, payload)| {
+            let mut f = classify(file, &payload);
+            f.name = Some(display_name(names, raw));
+            f
+        })
+        .collect()
+}
+
+/// Every `(test path, payload)` whose block opens on a line `header` accepts.
+fn collect_blocks<'a>(
+    lines: &[&'a str],
+    header: fn(&'a str) -> Option<&'a str>,
+) -> Vec<(&'a str, Vec<String>)> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let Some(raw) = header(lines[i]) else {
+            i += 1;
+            continue;
+        };
+        i += 1;
+        // The captured framing puts a blank line and libtest's panic banner
+        // between the header and the payload; the `--nocapture` framing has the
+        // banner AS the header. Skipping both leaves exactly the payload.
+        while i < lines.len() && (lines[i].trim().is_empty() || panic_header(lines[i]).is_some()) {
+            i += 1;
+        }
+        let start = i;
+        while i < lines.len() && !is_block_end(lines[i]) {
+            i += 1;
+        }
+        out.push((raw, lines[start..i].iter().map(|l| l.to_string()).collect()));
+    }
+    out
+}
+
+/// `---- tests::__test_almd_x stdout ----` → `tests::__test_almd_x`.
+fn block_header(line: &str) -> Option<&str> {
+    line.strip_prefix("---- ")?.strip_suffix(" stdout ----")
+}
+
+/// `thread 'tests::__test_almd_x' panicked at <generated>.rs:L:C:` →
+/// `tests::__test_almd_x`. The location in that banner is the EMITTED Rust, not
+/// the `.almd` an agent can edit, so it is dropped with the banner.
+fn panic_header(line: &str) -> Option<&str> {
+    let rest = line.strip_prefix("thread '")?;
+    let end = rest.find('\'')?;
+    line.contains(" panicked at ").then(|| &rest[..end])
+}
+
+/// Any line that can only belong to the harness, never to a payload.
+fn is_block_end(line: &str) -> bool {
+    line.starts_with("---- ")
+        || line == "failures:"
+        || line.starts_with("test result:")
+        || line.starts_with("note: run with `RUST_BACKTRACE=")
+        || (line.starts_with("thread '") && line.contains(" panicked at "))
+        || (line.starts_with("test ") && line.contains(" ... "))
+        || line.trim().is_empty()
+}
+
+/// Turn one panic payload into a [`TestFailure`]. Rust's own assertion macros
+/// print `assertion \`left == right\` failed[: <msg>]` + `  left:` / ` right:`,
+/// and the `<msg>` is the `at line N` the builtin-lowering pass injected.
+fn classify(file: &str, payload: &[String]) -> TestFailure {
+    let head = payload[0].as_str();
+    let (op, message) = head_op(head);
+    let base = TestFailure {
+        file: file.to_string(),
+        name: None,
+        line: site_line(head),
+        op: op.into(),
+        expected: None,
+        found: None,
+        // A payload this reporter does not understand keeps ALL of its lines.
+        message: if op == "panic" { payload.join("\n") } else { message },
+    };
+    if !matches!(op, "assert_eq" | "assert_ne") {
+        return base;
+    }
+    let Some((left, right)) = operand_pair(&payload[1..]) else { return base };
+    // `assert_ne` fails on EQUAL operands: the expectation is the negation, and
+    // spelling it `!= <r>` is what makes the pair read as a claim rather than
+    // as two identical values.
+    let expected = if op == "assert_ne" { format!("!= {right}") } else { right };
+    TestFailure { expected: Some(expected), found: Some(left), ..base }
+}
+
+/// `(op, message)` for a panic payload's first line. The site marker the
+/// builtin-lowering pass injected is STRIPPED from the message — it is already
+/// reported on the `at:` line, and repeating it is the prose FeedbackEval
+/// measures as noise.
+fn head_op(head: &str) -> (&'static str, String) {
+    match head.split(" failed").next() {
+        Some("assertion `left == right`") => return ("assert_eq", head.to_string()),
+        Some("assertion `left != right`") => return ("assert_ne", head.to_string()),
+        _ => {}
+    }
+    if head == "assertion failed" || site_only(head) {
+        return ("assert", "assertion failed".to_string());
+    }
+    match head.rfind(" (at line ") {
+        Some(cut) if head.ends_with(')') => ("assert", head[..cut].to_string()),
+        _ => ("panic", head.to_string()),
+    }
+}
+
+/// A payload that is NOTHING but the injected site (a bare `assert(cond)`).
+fn site_only(head: &str) -> bool {
+    head.strip_prefix("at line ").is_some_and(|n| !n.is_empty() && n.bytes().all(|b| b.is_ascii_digit()))
+}
+
+/// `  left: <v>` / ` right: <v>` — `left` runs until the ` right: ` marker,
+/// `right` to the end, so a multi-line `Debug` value survives intact.
+fn operand_pair(rest: &[String]) -> Option<(String, String)> {
+    let split = rest.iter().position(|l| l.starts_with(" right: "))?;
+    let left = rest.first()?.strip_prefix("  left: ")?;
+    let mut l = vec![left.to_string()];
+    l.extend(rest[1..split].iter().cloned());
+    let mut r = vec![rest[split].strip_prefix(" right: ")?.to_string()];
+    r.extend(rest[split + 1..].iter().cloned());
+    Some((l.join("\n"), r.join("\n")))
+}
+
+/// `… at line 42` → `42`.
+fn site_line(head: &str) -> Option<usize> {
+    let at = head.rfind("at line ")?;
+    head[at + "at line ".len()..]
+        .trim_end_matches(|c: char| !c.is_ascii_digit())
+        .parse()
+        .ok()
+}
+
+/// The T18 abort block (C-153), byte-identical on native and wasm:
+/// ```text
+/// Error: assertion failed
+///   at: line 7
+///   expected: 3
+///   found: 4
+/// ```
+fn parse_t18(file: &str, output: &str) -> Vec<TestFailure> {
+    let mut out = Vec::new();
+    let lines: Vec<&str> = output.lines().collect();
+    for (i, l) in lines.iter().enumerate() {
+        let Some(head) = l.strip_prefix("Error: assertion failed") else { continue };
+        let mut f = TestFailure {
+            file: file.to_string(),
+            name: None,
+            line: None,
+            op: if head.starts_with(": ") { "assert".into() } else { "assert_eq".into() },
+            expected: None,
+            found: None,
+            message: l.trim_start_matches("Error: ").to_string(),
+        };
+        fill_t18_fields(&mut f, &lines[i + 1..]);
+        out.push(f);
+    }
+    out
+}
+
+/// The `  key: value` tail of a T18 block. `expected` ends where `  found: `
+/// begins; `found` runs to the END OF THE OUTPUT — the desugar orders the
+/// fields that way precisely so the one field with no terminator is last, and
+/// the abort's `process.exit(1)` guarantees nothing is printed after it.
+fn fill_t18_fields(f: &mut TestFailure, rest: &[&str]) {
+    let end = rest.iter().position(|l| is_block_end(l)).unwrap_or(rest.len());
+    let body = &rest[..end];
+    if let Some(at) = body.iter().find_map(|l| l.strip_prefix("  at: line ")) {
+        f.line = at.trim().parse().ok();
+    }
+    let Some(e) = body.iter().position(|l| l.starts_with("  expected: ")) else { return };
+    let Some(v) = body.iter().position(|l| l.starts_with("  found: ")) else { return };
+    if v < e {
+        return;
+    }
+    f.expected = Some(join_field(&body[e..v], "  expected: "));
+    f.found = Some(join_field(&body[v..], "  found: "));
+    if f.expected.as_deref().is_some_and(|s| s.starts_with("!= ")) {
+        f.op = "assert_ne".into();
+    }
+}
+
+fn join_field(lines: &[&str], key: &str) -> String {
+    let mut v = vec![lines[0].strip_prefix(key).unwrap_or(lines[0]).to_string()];
+    v.extend(lines[1..].iter().map(|l| l.to_string()));
+    v.join("\n")
+}
+
+// ── Test-name recovery ──────────────────────────────────────────────────────
+
+/// `(mangled, original)` for every `test "…"` in the source. Lowering prefixes
+/// test fns with `__test_almd_` and the Rust walker then sanitizes the name, so
+/// the mapping is only invertible by mangling FORWARD from the source.
+fn test_name_map(source: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for line in source.lines() {
+        let t = line.trim_start();
+        let Some(rest) = t.strip_prefix("test ") else { continue };
+        let Some(rest) = rest.trim_start().strip_prefix('"') else { continue };
+        let Some(end) = rest.find('"') else { continue };
+        let name = &rest[..end];
+        out.push((format!("__test_almd_{}", mangle(name)), name.to_string()));
+    }
+    out
+}
+
+/// The Rust walker's fn-name sanitizer, forward-applied (walker/mod.rs).
+fn mangle(name: &str) -> String {
+    let s = name
+        .replace('+', "_plus_")
+        .replace('/', "_div_")
+        .replace('*', "_mul_")
+        .replace('(', "")
+        .replace(')', "")
+        .replace('=', "_eq_")
+        .replace('!', "_bang_")
+        .replace('?', "_q_")
+        .replace('<', "_lt_")
+        .replace('>', "_gt_")
+        .replace('|', "_pipe_")
+        .replace('&', "_amp_")
+        .replace('%', "_mod_");
+    s.chars().map(|c| if c.is_ascii_alphanumeric() || c == '_' { c } else { '_' }).collect()
+}
+
+/// `tests::__test_almd_string_mismatch` → `string mismatch` when the source
+/// offers a match, else the mangled tail (still better than the full path).
+fn display_name(names: &[(String, String)], raw: &str) -> String {
+    let tail = raw.rsplit("::").next().unwrap_or(raw);
+    names
+        .iter()
+        .find(|(m, _)| m == tail)
+        .map(|(_, orig)| orig.clone())
+        .unwrap_or_else(|| tail.trim_start_matches("__test_almd_").to_string())
+}
+
+// ── Diffing ─────────────────────────────────────────────────────────────────
+
+/// A unit-wise diff of two rendered values. The unit is chosen by SHAPE —
+/// string lines, list items, record fields — so one differ serves all three
+/// and the report never shows two opaque blobs.
+pub struct Diff {
+    unit: &'static str,
+    ops: Vec<(char, String)>,
+}
+
+/// Above this many units the quadratic LCS is not worth it (and the rendered
+/// diff would be unreadable anyway) — fall back to the plain value pair.
+const MAX_UNITS: usize = 600;
+/// Rendered diff rows before elision.
+const MAX_ROWS: usize = 30;
+
+impl Diff {
+    /// `None` when the values do not decompose into comparable units — a
+    /// scalar mismatch reads better as `expected:`/`found:`.
+    pub fn of(expected: &str, found: &str) -> Option<Diff> {
+        let (unit, e) = units(expected)?;
+        let (u2, f) = units(found)?;
+        if unit != u2 || e.len() > MAX_UNITS || f.len() > MAX_UNITS {
+            return None;
+        }
+        let ops = lcs_diff(&e, &f);
+        ops.iter().any(|(m, _)| *m != ' ').then_some(Diff { unit, ops })
+    }
+
+    /// The one-line hint FeedbackEval pairs with the structured data.
+    pub fn hint(&self) -> String {
+        let e = self.ops.iter().filter(|(m, _)| *m != '+').count();
+        let f = self.ops.iter().filter(|(m, _)| *m != '-').count();
+        let noun = self.unit;
+        if e != f {
+            return format!("expected {e} {noun}s, found {f}");
+        }
+        let at = self.ops.iter().position(|(m, _)| *m != ' ').unwrap_or(0);
+        match self.unit {
+            "field" => {
+                let name = self.ops[at].1.split(':').next().unwrap_or("").trim();
+                format!("field `{name}` differs")
+            }
+            "item" => format!("item {at} differs"),
+            _ => format!("line {} differs", at + 1),
+        }
+    }
+
+    /// Unified-style rows, `-` = expected, `+` = found, elided past
+    /// [`MAX_ROWS`] so one runaway value cannot bury the other failures.
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        for (mark, text) in self.ops.iter().take(MAX_ROWS) {
+            out.push_str(&format!("    {mark} {text}\n"));
+        }
+        if self.ops.len() > MAX_ROWS {
+            out.push_str(&format!("    … {} more\n", self.ops.len() - MAX_ROWS));
+        }
+        out
+    }
+}
+
+/// Split a rendered value into diffable units, or `None` for a scalar.
+fn units(v: &str) -> Option<(&'static str, Vec<String>)> {
+    let t = v.trim();
+    if let Some(s) = unquote_debug(t) {
+        return s.contains('\n').then(|| ("line", lines_of(&s)));
+    }
+    if let Some(inner) = t.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+        return Some(("item", split_top_level(inner)));
+    }
+    if let Some(inner) = record_body(t) {
+        return Some(("field", split_top_level(inner)));
+    }
+    v.contains('\n').then(|| ("line", lines_of(v)))
+}
+
+fn lines_of(s: &str) -> Vec<String> {
+    s.split('\n').map(|l| l.to_string()).collect()
+}
+
+/// `Point { x: 1, y: 2 }` → `x: 1, y: 2`.
+fn record_body(t: &str) -> Option<&str> {
+    let open = t.find(" { ")?;
+    let inner = t[open + 3..].strip_suffix(" }")?;
+    (!t[..open].contains(' ')).then_some(inner)
+}
+
+/// Rust `Debug` string → its contents. `None` when `t` is not one.
+fn unquote_debug(t: &str) -> Option<String> {
+    let inner = t.strip_prefix('"')?.strip_suffix('"')?;
+    let mut out = String::new();
+    let mut chars = inner.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('n') => out.push('\n'),
+            Some('t') => out.push('\t'),
+            Some('r') => out.push('\r'),
+            Some('0') => out.push('\0'),
+            Some(other) => out.push(other),
+            None => return None,
+        }
+    }
+    Some(out)
+}
+
+/// Split on top-level `, ` — nesting brackets and quoted strings are opaque.
+fn split_top_level(inner: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut depth = 0i32;
+    let mut quoted = false;
+    let mut esc = false;
+    let mut cur = String::new();
+    for c in inner.chars() {
+        if esc {
+            cur.push(c);
+            esc = false;
+            continue;
+        }
+        match c {
+            '\\' if quoted => esc = true,
+            '"' => quoted = !quoted,
+            '[' | '{' | '(' if !quoted => depth += 1,
+            ']' | '}' | ')' if !quoted => depth -= 1,
+            ',' if !quoted && depth == 0 => {
+                out.push(cur.trim().to_string());
+                cur.clear();
+                continue;
+            }
+            _ => {}
+        }
+        cur.push(c);
+    }
+    if !cur.trim().is_empty() || out.is_empty() {
+        out.push(cur.trim().to_string());
+    }
+    out
+}
+
+/// Longest-common-subsequence diff — deterministic for a fixed input pair,
+/// which is what makes two runs of a suite diffable against each other.
+fn lcs_diff(a: &[String], b: &[String]) -> Vec<(char, String)> {
+    let (n, m) = (a.len(), b.len());
+    let mut dp = vec![vec![0usize; m + 1]; n + 1];
+    for i in (0..n).rev() {
+        for j in (0..m).rev() {
+            dp[i][j] = if a[i] == b[j] { dp[i + 1][j + 1] + 1 } else { dp[i + 1][j].max(dp[i][j + 1]) };
+        }
+    }
+    let (mut i, mut j) = (0, 0);
+    let mut out = Vec::new();
+    while i < n && j < m {
+        if a[i] == b[j] {
+            out.push((' ', a[i].clone()));
+            i += 1;
+            j += 1;
+        } else if dp[i + 1][j] >= dp[i][j + 1] {
+            out.push(('-', a[i].clone()));
+            i += 1;
+        } else {
+            out.push(('+', b[j].clone()));
+            j += 1;
+        }
+    }
+    out.extend(a[i..].iter().map(|l| ('-', l.clone())));
+    out.extend(b[j..].iter().map(|l| ('+', l.clone())));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LIBTEST: &str = "\nrunning 1 test\ntest tests::__test_almd_string_mismatch ... FAILED\n\nfailures:\n\n---- tests::__test_almd_string_mismatch stdout ----\n\nthread 'tests::__test_almd_string_mismatch' panicked at /tmp/x/almide_test_main.rs:1372:9:\nassertion `left == right` failed: at line 4\n  left: \"a\\nb\"\n right: \"a\\nB\"\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n\n\nfailures:\n    tests::__test_almd_string_mismatch\n\ntest result: FAILED. 0 passed; 1 failed\n";
+
+    #[test]
+    fn libtest_block_yields_a_structured_record() {
+        let src = "test \"string mismatch\" {\n  assert_eq(a, b)\n}\n";
+        let fs = parse("x_test.almd", src, LIBTEST);
+        assert_eq!(fs.len(), 1);
+        assert_eq!(fs[0].name.as_deref(), Some("string mismatch"));
+        assert_eq!(fs[0].line, Some(4));
+        assert_eq!(fs[0].op, "assert_eq");
+        assert_eq!(fs[0].found.as_deref(), Some("\"a\\nb\""));
+        assert_eq!(fs[0].expected.as_deref(), Some("\"a\\nB\""));
+    }
+
+    #[test]
+    fn the_generated_rs_location_never_reaches_the_report() {
+        let fs = parse("x_test.almd", "", LIBTEST);
+        let r = fs[0].render();
+        assert!(!r.contains("almide_test_main.rs"), "generated-source path leaked:\n{r}");
+        assert!(r.contains("x_test.almd:4"), "almd site missing:\n{r}");
+    }
+
+    #[test]
+    fn t18_abort_block_parses_on_either_target() {
+        let out = "before\nError: assertion failed\n  at: line 7\n  expected: 3\n  found: 4\n";
+        let fs = parse("m.almd", "", out);
+        assert_eq!(fs.len(), 1);
+        assert_eq!(fs[0].line, Some(7));
+        assert_eq!(fs[0].expected.as_deref(), Some("3"));
+        assert_eq!(fs[0].found.as_deref(), Some("4"));
+    }
+
+    #[test]
+    fn t18_multiline_found_runs_to_the_end_of_the_block() {
+        let out = "Error: assertion failed\n  at: line 4\n  expected: one\nTWO\n  found: one\ntwo\n";
+        let fs = parse("m.almd", "", out);
+        assert_eq!(fs[0].expected.as_deref(), Some("one\nTWO"));
+        assert_eq!(fs[0].found.as_deref(), Some("one\ntwo"));
+    }
+
+    #[test]
+    fn t18_ne_is_recognized_by_its_expected_marker() {
+        let out = "Error: assertion failed\n  at: line 2\n  expected: != x\n  found: x\n";
+        assert_eq!(parse("m.almd", "", out)[0].op, "assert_ne");
+    }
+
+    #[test]
+    fn multiline_strings_diff_by_line() {
+        let d = Diff::of("\"a\\nB\\nc\"", "\"a\\nb\\nc\"").expect("line diff");
+        assert_eq!(d.hint(), "line 2 differs");
+        assert_eq!(d.render(), "      a\n    - B\n    + b\n      c\n");
+    }
+
+    #[test]
+    fn lists_diff_by_item() {
+        let d = Diff::of("[1, 2, 3]", "[1, 9, 3]").expect("item diff");
+        assert_eq!(d.hint(), "item 1 differs");
+        assert_eq!(d.render(), "      1\n    - 2\n    + 9\n      3\n");
+    }
+
+    #[test]
+    fn a_length_mismatch_is_reported_as_a_count() {
+        let d = Diff::of("[1, 2, 3]", "[1, 2]").expect("item diff");
+        assert_eq!(d.hint(), "expected 3 items, found 2");
+    }
+
+    #[test]
+    fn records_diff_by_field() {
+        let d = Diff::of("Point { x: 1, y: 2 }", "Point { x: 1, y: 5 }").expect("field diff");
+        assert_eq!(d.hint(), "field `y` differs");
+        assert_eq!(d.render(), "      x: 1\n    - y: 2\n    + y: 5\n");
+    }
+
+    #[test]
+    fn nested_commas_do_not_split_items() {
+        assert_eq!(split_top_level("[1, 2], [3]"), vec!["[1, 2]", "[3]"]);
+        assert_eq!(split_top_level("\"a, b\", c"), vec!["\"a, b\"", "c"]);
+    }
+
+    #[test]
+    fn scalars_have_no_diff_and_render_as_a_pair() {
+        assert!(Diff::of("3", "4").is_none());
+        let f = TestFailure {
+            file: "m.almd".into(),
+            name: Some("sum".into()),
+            line: Some(9),
+            op: "assert_eq".into(),
+            expected: Some("3".into()),
+            found: Some("4".into()),
+            message: String::new(),
+        };
+        assert_eq!(f.render(), "  test: sum\n  at:   m.almd:9\n  expected: 3\n  found:    4\n");
+    }
+
+    #[test]
+    fn json_carries_the_full_record() {
+        let f = TestFailure {
+            file: "m.almd".into(),
+            name: Some("s".into()),
+            line: Some(2),
+            op: "assert_eq".into(),
+            expected: Some("\"a\\nB\"".into()),
+            found: Some("\"a\\nb\"".into()),
+            message: String::new(),
+        };
+        let v: serde_json::Value = serde_json::from_str(&f.to_json()).unwrap();
+        assert_eq!(v["name"], "s");
+        assert_eq!(v["line"], 2);
+        assert_eq!(v["file"], "m.almd");
+        assert!(v["diff"].as_str().unwrap().contains("- B"));
+    }
+
+    #[test]
+    fn the_injected_site_never_doubles_as_the_message() {
+        assert_eq!(head_op("at line 4"), ("assert", "assertion failed".to_string()));
+        assert_eq!(head_op("one exceeds two (at line 8)"), ("assert", "one exceeds two".to_string()));
+        assert_eq!(site_line("one exceeds two (at line 8)"), Some(8));
+    }
+
+    #[test]
+    fn assert_ne_states_the_negation_it_expected() {
+        let out = "---- tests::__test_almd_ne stdout ----\nassertion `left != right` failed: at line 12\n  left: 4\n right: 4\n";
+        let f = &parse("m.almd", "", out)[0];
+        assert_eq!(f.op, "assert_ne");
+        assert_eq!(f.expected.as_deref(), Some("!= 4"));
+        assert_eq!(f.found.as_deref(), Some("4"));
+    }
+
+    #[test]
+    fn failures_are_reported_in_source_order() {
+        let out = "---- tests::__test_almd_b stdout ----\nassertion `left == right` failed: at line 9\n  left: 1\n right: 2\n---- tests::__test_almd_a stdout ----\nassertion `left == right` failed: at line 3\n  left: 1\n right: 2\n";
+        let lines: Vec<_> = parse("m.almd", "", out).iter().map(|f| f.line).collect();
+        assert_eq!(lines, vec![Some(3), Some(9)]);
+    }
+
+    #[test]
+    fn a_bare_panic_keeps_its_payload() {
+        let out = "---- tests::__test_almd_boom stdout ----\nthread 'x' panicked at a.rs:1:1:\nPANIC: boom\n";
+        let fs = parse("m.almd", "test \"boom\" {}\n", out);
+        assert_eq!(fs[0].op, "panic");
+        assert_eq!(fs[0].message, "PANIC: boom");
+        assert!(fs[0].render().contains("error: PANIC: boom"));
+    }
+
+    #[test]
+    fn mangled_names_round_trip_through_the_walker_sanitizer() {
+        let src = "test \"a + b (fast)\" {\n}\n";
+        let names = test_name_map(src);
+        assert_eq!(names[0].0, "__test_almd_a__plus__b_fast");
+        assert_eq!(display_name(&names, "tests::__test_almd_a__plus__b_fast"), "a + b (fast)");
+    }
+}

--- a/tests/snapshots/codegen_snapshot_test__test_block.snap
+++ b/tests/snapshots/codegen_snapshot_test__test_block.snap
@@ -11,6 +11,6 @@ mod tests {
 
     #[test]
     fn __test_almd_addition() {
-        assert_eq!(add(1i64, 2i64), 3i64)
+        assert_eq!(add(1i64, 2i64), 3i64, "{}", "at line 5")
     }
 }


### PR DESCRIPTION
Closes #1313.

FeedbackEval (arXiv 2504.06939) measures test-failure feedback as the stronger
repair channel — repair@1 57.9% vs 49.2% for compiler errors — and the winning
format as *structured data + a one-line hint*, not prose. This repo has poured
years into diagnostics (Here/Try/Hint, codes, `--json`) and left the stronger
channel as a verbatim libtest transcript. This closes that gap.

Three commits, three layers:

1. **`crates/almide-frontend/src/lower/calls.rs`** — the T18 non-test assert
   abort is now a keyed block, not one line, and carries its source line.
   Observable on both targets → **C-153 restated**, plus a new fixture
   `spec/wasm_cross/assert_abort_multiline.almd` for the embedded-newline case,
   added to `proofs/output-parity-baseline.txt`.
2. **`crates/almide-codegen/src/pass_builtin_lowering.rs`** — a test-block
   assert lowers to Rust's own macro, so libtest named the *generated* main.rs
   line. The pass now passes `at line <N>` as the macro message. Rust-backend
   only; the wasm leg is untouched.
3. **`src/cli/test_report.rs` (new) + `commands.rs`/`run.rs`** — `almide test`
   captures each binary's output and renders one record per failing assertion,
   sorted by source line, with a unit diff for multi-line strings, list items
   and record fields. `--json` emits the same records.

---

## BEFORE / AFTER

Every BEFORE below is a real capture from the installed pre-change `0.57.0`
binary, not a reconstruction.

### A string mismatch

**BEFORE** (`almide test a_test.almd`)

```
running 1 test
test tests::__test_almd_string_mismatch ... FAILED

failures:

---- tests::__test_almd_string_mismatch stdout ----

thread 'tests::__test_almd_string_mismatch' (35488698) panicked at /var/folders/cy/…/almide_test_main.rs:1372:9:
assertion `left == right` failed
  left: "line one\nline two\nline three"
 right: "line one\nline TWO\nline three"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::__test_almd_string_mismatch

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

FAILED: a_test.almd
```

**AFTER**

```
FAILED: a_test.almd
  test: string mismatch
  at:   a_test.almd:4
  hint: line 2 differs
  diff: -expected +found
      line one
    - line TWO
    + line two
      line three
```

### A list and a record mismatch (one file, three failing tests)

**BEFORE** — note the ordering: libtest reports in *thread-completion* order
(record, list, scalar), which is not stable between runs, so two runs of the
same suite cannot be diffed against each other.

```
running 3 tests
test tests::__test_almd_record_mismatch ... FAILED
test tests::__test_almd_list_mismatch ... FAILED
test tests::__test_almd_scalar_mismatch ... FAILED

failures:

---- tests::__test_almd_record_mismatch stdout ----

thread 'tests::__test_almd_record_mismatch' (35492117) panicked at /var/folders/cy/…/almide_test_main.rs:1396:9:
assertion `left == right` failed
  left: Point { x: 1, y: 2 }
 right: Point { x: 1, y: 5 }

---- tests::__test_almd_list_mismatch stdout ----

thread 'tests::__test_almd_list_mismatch' (35492116) panicked at /var/folders/cy/…/almide_test_main.rs:1390:9:
assertion `left == right` failed
  left: [1, 2, 3, 4]
 right: [1, 9, 3, 4]
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- tests::__test_almd_scalar_mismatch stdout ----

thread 'tests::__test_almd_scalar_mismatch' (35492118) panicked at /var/folders/cy/…/almide_test_main.rs:1401:9:
assertion `left == right` failed
  left: 4
 right: 5


failures:
    tests::__test_almd_list_mismatch
    tests::__test_almd_record_mismatch
    tests::__test_almd_scalar_mismatch

test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

FAILED: b_test.almd
```

**AFTER** — source order, one record each:

```
FAILED: b_test.almd
  test: list mismatch
  at:   b_test.almd:5
  hint: item 1 differs
  diff: -expected +found
      1
    - 9
    + 2
      3
      4
  test: record mismatch
  at:   b_test.almd:10
  hint: field `y` differs
  diff: -expected +found
      x: 1
    - y: 5
    + y: 2
  test: scalar mismatch
  at:   b_test.almd:14
  expected: 5
  found:    4
```

A scalar mismatch stays four lines — the diff is rendered only when the values
decompose into comparable units, never *in addition to* the value pair.

### The T18 block (`almide run`, both targets)

**BEFORE**

```
Error: assertion failed: left = line one
line two, right = line one
line TWO
```

**AFTER** — byte-identical on native and `--target wasm`:

```
Error: assertion failed
  at: line 3
  expected: line one
line TWO
  found: line one
line two
```

`expected` precedes `found` so the one field whose value can span lines without
a terminator is last. That ordering is now part of C-153, because it is what
lets the runner parse a multi-line value back out into a diff.

### The failure that printed nothing

An `assert` in a plain `fn` called from a test body desugars to the T18 abort,
which exits the process — and libtest **discards** a test's captured buffer when
the test exits. That failure reported no reason at all:

```
running 1 test
FAILED: d_test.almd
```

The harness now runs with `--nocapture` (`almide test` captures the whole binary
itself and prints it only on failure, so nothing leaks into a passing run):

```
FAILED: d_test.almd
  at:   d_test.almd:1
  expected: 3
  found:    2
```

### `--json`

```json
{"file":"c_test.almd","status":"fail","exit_code":101,"failures":[
  {"name":"assert_ne","file":"c_test.almd","line":12,"op":"assert_ne",
   "expected":"!= 4","found":"4","diff":null,"message":"…"}]}
```

`assert_ne` states the negation it expected rather than printing the same value
twice.

---

## Gates

All run on the rebased tree:

- `cargo build --release` — clean, no new warnings
- `./target/release/almide test` — **397 files, 0 failed** (380 via WASM, 17 via
  native fallback)
- `./target/release/almide test examples/` — 11 files, 0 failed
- `./target/release/almide fmt --check spec/ examples/` — 914 files formatted
- `bash scripts/check-contracts.sh` — OK, 269 contracts, 404/404 fixtures linked
- `bash proofs/check-wasm-fallback.sh` — OK, 17 fallbacks, set unchanged
- `cargo test --release -p almide -p almide-frontend -p almide-codegen` — green,
  including `wasm_runtime_test` (75 passed, 2303s — the cross-target
  byte-identity sweep over every `spec/wasm_cross` fixture, the gate that
  actually holds C-153)
- 26 new unit tests in `src/cli/test_report.rs` cover both libtest framings, the
  T18 block, the three diff shapes, source ordering and the JSON record
- native ⇄ wasm byte-identity re-checked directly on all four `assert_abort_*`
  fixtures

## Not in scope

The **wasm test leg**'s own message (`assertion failed: left == right`, no
values) is unchanged. Giving it operands means building a `String` from
arbitrary-typed operands inside the v1 die path, which risks new walls against
the shrink-only fallback ratchet. `almide test` routes a wasm failure to the
authoritative native leg, and that is the leg this PR makes structured.
