### PR TITLE
Ship an MCP server and a Claude Code plugin so agents reach the compiler as typed calls

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "almide",
+  "description": "Almide compiler tooling for agents.",
+  "owner": {
+    "name": "Almide",
+    "url": "https://github.com/almide"
+  },
+  "plugins": [
+    {
+      "name": "almide",
+      "source": "./tools/claude-plugin",
+      "description": "MCP tools for the Almide compiler (check / test / API outline / explain / fmt-check) plus the .almd language server.",
+      "category": "development",
+      "tags": ["almide", "compiler", "language-server", "mcp"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -271,6 +271,18 @@ Single source of truth for Almide syntax — keywords, operators, precedence, an
 
 - **VS Code** — [vscode-almide](https://github.com/almide/vscode-almide) — Syntax highlighting, bracket matching, comment toggling, code folding
 - **Tree-sitter** — [tree-sitter-almide](https://github.com/almide/tree-sitter-almide) — Tree-sitter grammar for editors that support it (Neovim, Helix, Zed)
+- **LSP** — built into the binary: `almide lsp` (hover, completion, documentSymbol, formatting, definition, signatureHelp, codeAction)
+
+### Agent Support — MCP
+
+Agents are a user class here, and for this language they are *the* user class. `almide mcp` serves the compiler over the Model Context Protocol, so a model calls `check` / `test` / API-outline / `explain` / `fmt --check` as typed tools and reads JSON instead of parsing rendered text — the step where accuracy leaks.
+
+```bash
+/plugin marketplace add almide/almide     # Claude Code: MCP tools + the .almd LSP
+/plugin install almide@almide
+```
+
+See [docs/mcp.md](./docs/mcp.md) for the tool list, the JSON shapes, and what is deliberately not structured yet.
 
 ### Playground — [playground](https://github.com/almide/playground)
 
@@ -282,6 +294,7 @@ Browser-based compiler and runner. The Almide compiler runs as WASM — no serve
 - [docs/SPEC.md](./docs/SPEC.md) — Full language specification
 - [docs/GRAMMAR.md](./docs/GRAMMAR.md) — EBNF grammar + stdlib reference
 - [docs/CHEATSHEET.md](./docs/CHEATSHEET.md) — Quick reference for AI code generation
+- [docs/mcp.md](./docs/mcp.md) — MCP server + Claude Code plugin: the agent-facing compiler surface
 - [docs/design/DESIGN.md](./docs/design/DESIGN.md) — Design philosophy and trade-offs
 - [docs/design/EQUIVALENCE.md](./docs/design/EQUIVALENCE.md) — The byte-identity claim: scope, ledger mechanics, evidence layers
 - [docs/TRUST-SPINE.md](./docs/TRUST-SPINE.md) — v1 proof-carrying compilation architecture

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,105 @@
+# Almide for agents: MCP server + Claude Code plugin
+
+> Last updated: 2026-08-13
+
+An agent reaching the compiler through a shell has to parse human-formatted
+text to learn anything. That parsing step is where accuracy leaks, and this
+repo is scored on exactly one metric: how accurately an LLM writes and modifies
+Almide. `almide mcp` removes the step — the same answers arrive as typed tool
+calls with JSON results.
+
+The compiler is the only implementation: every tool runs the CLI in a
+subprocess and reads the machine-readable output it already produces. There is
+no second code path that could drift.
+
+## Install
+
+The plugin configures both servers; it does not ship the binary, so install
+Almide first and make sure it is on `PATH`.
+
+```bash
+# 1. the compiler (also provides `almide lsp` and `almide mcp`)
+make install                     # or: cargo build --release && cp target/release/almide ~/.local/bin/
+almide --version
+
+# 2. the plugin, from this repo's own marketplace
+/plugin marketplace add almide/almide
+/plugin install almide@almide
+```
+
+That gives a Claude Code session:
+
+- **MCP tools** — the five below, namespaced `mcp__plugin_almide_compiler__<tool>`
+- **LSP** — `almide lsp` for `.almd` files (hover, completion, documentSymbol,
+  formatting, definition, signatureHelp, codeAction)
+
+Any other MCP client works too; the server is a plain stdio server:
+
+```json
+{
+  "mcpServers": {
+    "almide": { "command": "almide", "args": ["mcp"] }
+  }
+}
+```
+
+Verify by hand — the server speaks newline-delimited JSON-RPC 2.0 on stdio:
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | almide mcp
+```
+
+## Tools
+
+| Tool | Runs | Returns |
+|---|---|---|
+| `almide_check` | `almide check --json` | `{ok, errors, warnings, diagnostics[]}` — each diagnostic is `{level, code, message, hint, here, try, try_replace, context, file, line, col, end_col, secondary}` |
+| `almide_test` | `almide test --json` | `{ok, files_passed, files_failed, files[], runner_output_unstructured}` |
+| `almide_api` | `almide ide outline --json`, `almide ide stdlib-snapshot --json` | the public declarations of a file, of `@stdlib/<module>`, or of `@stdlib` (core snapshot), with exact signatures |
+| `almide_explain` | `almide explain <CODE>` | the diagnostic's reference page (markdown) |
+| `almide_fmt_check` | `almide fmt --check --json` | `{checked, unformatted[], unreadable[], verify_failed, ok}` |
+
+`try` is a copy-pasteable fix snippet and `try_replace` is the span it
+replaces, so a fix can be applied mechanically rather than re-derived.
+
+## Rules this surface follows
+
+**Read-only by default.** No tool writes a source file. `fmt` is exposed only
+in its `--check` form; applying it is `almide fmt <path>` in a shell, where the
+edit shows up in the agent's own transcript. `almide_test` is the one tool with
+a side effect — it compiles and executes the tests, which writes build
+artifacts under `target/` — and it says so in its description and in its MCP
+annotations (`readOnlyHint: false`).
+
+**Structured beats prose.** A diagnostic arrives as fields, never as a rendered
+block.
+
+**No scraping.** Where the CLI has no machine-readable form, the raw text is
+returned verbatim in a field whose name ends in `_unstructured`, and the tool
+says which issue tracks the gap. Regex-scraping a rendered diagnostic would
+reintroduce exactly the fragility this server exists to remove.
+
+## What is NOT structured yet
+
+- **Per-test failure detail** (#1313). `almide test --json` reports per-FILE
+  pass/fail; the failing assertion's expected/found is the test runner's own
+  text, returned as `runner_output_unstructured`.
+- **Fix-it applicability** (#1312). `try` / `try_replace` are present, but not
+  yet tagged machine-applicable vs. needs-review, so an agent should re-check
+  after applying one.
+- **Parse-error codes.** A syntax error now reaches `check --json` as JSON (it
+  used to be text-only), but those diagnostics carry an empty `code`, so
+  `almide_explain` has nothing to look up for them.
+- **`almide compile --json`** (the full module interface with ABI layout) is
+  CLI-only. `almide_api` covers the signature-level question an agent actually
+  asks; the ABI detail belongs to binding generators.
+
+## Files
+
+| Path | What |
+|---|---|
+| `src/cli/mcp.rs` | protocol: stdio JSON-RPC, initialize / tools/list / tools/call / ping |
+| `src/cli/mcp_tools.rs` | the catalog and the CLI invocations behind it |
+| `tools/claude-plugin/.claude-plugin/plugin.json` | Claude Code plugin (MCP + LSP) |
+| `.claude-plugin/marketplace.json` | this repo as a plugin marketplace |
+| `tests/mcp_test.rs` | end-to-end gate: drives the real binary over stdio |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -93,6 +93,9 @@ reintroduce exactly the fragility this server exists to remove.
 - **`almide compile --json`** (the full module interface with ABI layout) is
   CLI-only. `almide_api` covers the signature-level question an agent actually
   asks; the ABI detail belongs to binding generators.
+- **`almide ide doc <symbol>`** (signature + doc comment for ONE symbol) has no
+  `--json` form, so it is not exposed rather than scraped. `almide_api` answers
+  the same question at signature level for a whole module.
 
 ## Files
 

--- a/docs/roadmap/ALL_AXES.md
+++ b/docs/roadmap/ALL_AXES.md
@@ -177,8 +177,11 @@ definition / signatureHelp / codeAction）。playground、VS Code 拡張、tree-
 **残っている行（agent 向け surface）**:
 - #1312 applicability タグ付き fix-it → `almide fix` の診断駆動化
 - #1313 `almide test` 失敗出力の構造化（expected/found diff + `--json`）
-- [#1333](https://github.com/almide/almide/issues/1333) **MCP サーバ / Claude Code plugin 定義** —
-  2026 年のエージェント流通経路であり、LSP がある以上コストは数日
+- ~~[#1333](https://github.com/almide/almide/issues/1333) **MCP サーバ / Claude Code plugin 定義**~~
+  — **着地済み**: `almide mcp`（stdio MCP、ツール 5 本）と `tools/claude-plugin/`（MCP + LSP）、
+  `.claude-plugin/marketplace.json`。各ツールは CLI の既存 JSON 出力をサブプロセス経由で
+  読むだけで、MCP 専用の出力経路は作らない（[docs/mcp.md](../mcp.md)）。
+  未構造化のまま残るのは #1313 のテスト失敗詳細と #1312 の applicability タグ
 - #1314 snapshot テスト内蔵（主流言語に内蔵例がない差別化空白）
 
 ---

--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -1,6 +1,6 @@
 # CLI Specification
 
-> Last updated: 2026-07-25
+> Last updated: 2026-08-13
 
 ## Overview
 
@@ -120,9 +120,22 @@ almide check --effects                  # 各関数のエフェクト分析を�
 | オプション | 説明 |
 |---|---|
 | `--deny-warnings` | 警告をエラー扱い |
-| `--json` | 診断を JSON で出力（エディタ統合用） |
+| `--json` | 診断を JSON で出力（1 行 1 診断、エディタ/エージェント統合用） |
 | `--explain <code>` | エラーコード (E001〜E030, E420) の説明 |
 | `--effects` | 各関数のエフェクト/ケイパビリティ分析 |
+
+`--json` の 1 行は
+`{level, code, message, hint, here, try, try_replace, context, file, line, col, end_col, secondary}`。
+`try` は貼り付け可能な修正スニペット、`try_replace` はそれが置換するスパン。
+
+**構文エラーも JSON で出る**: トップレベル宣言が 1 つも成立しないファイルは
+`Parser::parse` が `Err` を返し、共有の `parse_file` は人間向けテキストを stderr に出して
+終了する。`--json` はパーサから診断を直接取り出してこの経路でも JSON を出す
+（LLM が最も多く出すエラー種別が唯一テキストのままだった）。終了コードは従来通り
+`1`（パースできなかったファイル）— 既存ゲートが黙って成功に反転しないため。
+型エラーのみの場合は従来通り終了コード `0` で、判定は JSON の `level` を読む。
+
+テスト: `tests/mcp_test.rs`（`json_check_reports_a_total_parse_failure_as_json`）
 
 エラーコード:
 
@@ -151,9 +164,27 @@ E001〜E030 + E420 の全コード解説は [../diagnostics/](../diagnostics/) �
 almide fmt                              # src/**/*.almd を整形
 almide fmt app.almd                     # 指定ファイルを整形
 almide fmt --check                      # 差分があれば非ゼロで終了（CI 用）
+almide fmt --check --json               # 同じゲートを JSON 1 オブジェクトで（機械可読）
 almide fmt --dry-run                    # 書き込みせず差分表示
 almide fmt --no-import-edit stdlib/     # import 行を一切触らず整形(splice-context ソース用)
 ```
+
+| オプション | 説明 |
+|---|---|
+| `--check` | 比較のみ。未整形ファイルを stderr に列挙し、あれば終了コード 1 |
+| `--json` | `--check` の機械可読版（`--check` を含意）。stdout に 1 オブジェクト、終了コードは同じ |
+| `--dry-run` | 整形結果を stdout に出すだけ。書き込まない |
+| `--no-import-edit` | import 行を一切編集しない |
+
+`--json` の出力:
+
+```json
+{"checked":2,"unformatted":["src/a.almd"],"unreadable":[],"verify_failed":false,"ok":false}
+```
+
+`--json` も `--check` も書き込みは一切しない。整形の適用は `almide fmt <path>`。
+
+テスト: `tests/mcp_test.rs`（`fmt_check_json_reports_drift_and_keeps_the_gate_exit_code`）
 
 ---
 
@@ -191,6 +222,48 @@ JSON 出力の構造:
 ```
 
 `abi` フィールドは具象型（ジェネリックでない）にのみ付与。C ABI のレイアウト（size, align, field offset）。
+
+---
+
+### `almide mcp`
+
+Model Context Protocol サーバを stdio で起動する。エージェント（Claude Code 等）が
+コンパイラを **型付きツール呼び出し** として使うための口。人間向け出力を
+モデルに読み解かせる工程を挟まないことが目的で、この工程こそが精度の漏れ口。
+
+```bash
+almide mcp                              # stdio で JSON-RPC 2.0（改行区切り）を待つ
+```
+
+対応メソッド: `initialize` / `tools/list` / `tools/call` / `ping`。
+それ以外は JSON-RPC `-32601`（`capabilities` は `tools` のみを宣言する）。
+
+ツール（5 つ。すべて CLI の既存の機械可読出力を経由する）:
+
+| ツール | 実体 | 返すもの |
+|---|---|---|
+| `almide_check` | `almide check --json` | 構造化診断の配列（`try`/`try_replace` 込み） |
+| `almide_test` | `almide test --json` | ファイル単位の pass/fail + ランナー生出力 |
+| `almide_api` | `almide ide outline --json` / `stdlib-snapshot --json` | 公開宣言のシグネチャ一覧 |
+| `almide_explain` | `almide explain <CODE>` | 診断コードの解説（markdown） |
+| `almide_fmt_check` | `almide fmt --check --json` | 未整形ファイル一覧（書き込みなし） |
+
+設計上の制約:
+
+- **コンパイラへの入口は 1 本**。各ツールは `current_exe()`（= 自分自身）を
+  サブプロセスとして起動し、CLI が既に出している JSON を読む。MCP 専用の
+  出力経路を作らない（作れば必ず CLI とドリフトし、しかも誰も目で読まないので
+  ドリフトが見えない）
+- **人間向けテキストは決してパースしない**。機械可読な形が無い箇所
+  （テストの個別失敗詳細 = #1313）は `*_unstructured` という名前のフィールドに
+  そのまま入れて返す
+- **書き込みツールは無い**。`fmt` は `--check` 形のみ。適用は CLI（`almide fmt` /
+  `almide fix`）で行う — エージェント自身のトランスクリプトに編集が残る
+
+Claude Code プラグイン定義（MCP + LSP）: `tools/claude-plugin/`、
+マーケットプレイス: `.claude-plugin/marketplace.json`、導入手順: [../mcp.md](../mcp.md)
+
+テスト: `tests/mcp_test.rs`
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -69,7 +69,16 @@ almide ide outline @stdlib/string         # stdlib API listing
 almide ide doc string.to_upper            # signature + doc for a symbol
 almide ide stdlib-snapshot [--json]       # concatenated stdlib outlines for
                                           # SYSTEM_PROMPT injection (~3.5K tokens)
+almide mcp                   # MCP server on stdio: check / test / api / explain /
+                             # fmt-check as typed tools with JSON results
 ```
+
+Machine-readable output (prefer these when a program, not a person, reads it):
+`check --json` (one diagnostic per line: `{level, code, message, hint, try,
+try_replace, file, line, col}`), `test --json`, `fmt --check --json`,
+`compile --json`, `ide outline --json`, `ide stdlib-snapshot --json`.
+An MCP client (Claude Code, …) gets the same answers as tool calls via
+`almide mcp` — see [docs/mcp.md](docs/mcp.md).
 
 ## Core idioms
 

--- a/scripts/ci-test-weights.txt
+++ b/scripts/ci-test-weights.txt
@@ -28,4 +28,5 @@ fmt_test                         17
 fuzz_test                        15
 io_read_all_test                 13
 eval_test                        9
+mcp_test                         9
 diagnostic_harness_test          7

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -1,4 +1,4 @@
-use crate::{parse_file, canonicalize, check as check_mod, diagnostic, resolve, project, out, err};
+use crate::{parse_file, canonicalize, check as check_mod, diagnostic, lexer, parser, resolve, project, out, err};
 
 /// `cmd_check`'s combined parse+checker error reporting and
 /// `--deny-warnings` gate. Extracted verbatim — exits the process exactly
@@ -127,8 +127,44 @@ pub fn cmd_check(file: &str, deny_warnings: bool) {
     err(&format!("No errors found"));
 }
 
+/// `cmd_check_json`'s parse step.
+///
+/// `Parser::parse` returns `Err` when NO top-level declaration survived
+/// (`parser/entry.rs`) — a whole-file syntax error — and `parse_file` renders
+/// that in human form and exits. So `almide check --json` emitted no JSON at
+/// all for a plain syntax error: the most common thing an LLM gets wrong
+/// reached the caller as prose it had to parse back, which is the failure this
+/// flag exists to prevent. The diagnostics are still on the parser, so the JSON
+/// path takes them from there.
+///
+/// Returns `None` for the program when the file did not parse at all; the
+/// diagnostics are returned in both cases.
+fn parse_for_json(file: &str) -> (Option<almide::ast::Program>, String, Vec<diagnostic::Diagnostic>) {
+    // `.json` input is an AST dump, not source — leave it on the shared path.
+    if file.ends_with(".json") {
+        let (program, source, errors) = parse_file(file);
+        return (Some(program), source, errors);
+    }
+    let input = std::fs::read_to_string(file)
+        .unwrap_or_else(|e| { err(&format!("Error reading {}: {}", file, e)); std::process::exit(1); });
+    let tokens = lexer::Lexer::tokenize(&input);
+    let mut p = parser::Parser::new(tokens).with_file(file);
+    let program = p.parse().ok();
+    let errors = std::mem::take(&mut p.errors);
+    (program, input, errors)
+}
+
 pub fn cmd_check_json(file: &str) {
-    let (mut program, source_text, parse_errors) = parse_file(file);
+    let (parsed, source_text, parse_errors) = parse_for_json(file);
+    let Some(mut program) = parsed else {
+        for d in &parse_errors {
+            out(&format!("{}", crate::diagnostic_render::to_json(d)));
+        }
+        // The exit code is deliberately unchanged (1 = this file did not
+        // parse). A harness that gates on it must not silently flip to
+        // success just because the diagnostics got a better shape.
+        std::process::exit(1);
+    };
     let (diagnostics, checker) = resolve_and_typecheck_for_check(file, &mut program, &source_text);
 
     // Output each diagnostic as JSON (one per line)

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -858,8 +858,51 @@ pub enum FmtMode {
     Write,
     /// Compare only: report each file that is not already formatted, exit 1 if any is.
     Check,
+    /// `Check`, reported as one JSON object on stdout (`--json`). Same gate,
+    /// same exit code — the difference is who reads it. Added for the MCP
+    /// server (`almide mcp`), which must not parse the human report.
+    CheckJson,
     /// Print the formatted text; never write, never fail.
     DryRun,
+}
+
+impl FmtMode {
+    /// True for the two comparing modes — neither writes a file.
+    fn is_check(self) -> bool {
+        matches!(self, FmtMode::Check | FmtMode::CheckJson)
+    }
+}
+
+/// `cmd_fmt`'s `--check` verdict. Text mode prints it to stderr and JSON mode
+/// prints it as one object to stdout; both exit 1 on any drift, so a gate
+/// written against either spelling fails identically.
+fn report_fmt_check(mode: FmtMode, total: usize, unformatted: &[String], unreadable: &[String], verify_failed: bool) {
+    let ok = unformatted.is_empty() && unreadable.is_empty() && !verify_failed;
+    if mode == FmtMode::CheckJson {
+        let report = serde_json::json!({
+            "checked": total,
+            "unformatted": unformatted,
+            "unreadable": unreadable,
+            "verify_failed": verify_failed,
+            "ok": ok,
+        });
+        out(&format!("{}", report));
+        if !ok { std::process::exit(1); }
+        return;
+    }
+    if ok {
+        err(&format!("fmt: {} file(s) already formatted", total));
+        return;
+    }
+    for f in unformatted {
+        err(&format!("not formatted: {}", f));
+    }
+    err(&format!(
+        "fmt --check: {} of {} file(s) need formatting — run `almide fmt <path>`",
+        unformatted.len(),
+        total
+    ));
+    std::process::exit(1);
 }
 
 pub fn cmd_fmt(files: &[String], mode: FmtMode, no_import_edit: bool) {
@@ -868,7 +911,7 @@ pub fn cmd_fmt(files: &[String], mode: FmtMode, no_import_edit: bool) {
     // `--check` is a gate: a file that differs, and a file that cannot even be parsed,
     // both make the run fail. Under the other modes a parse error stays a skip.
     let mut unformatted: Vec<String> = Vec::new();
-    let mut unreadable = false;
+    let mut unreadable: Vec<String> = Vec::new();
     let mut verify_failed = false;
 
     for file in files {
@@ -881,7 +924,7 @@ pub fn cmd_fmt(files: &[String], mode: FmtMode, no_import_edit: bool) {
                 err(&format!("{}", crate::diagnostic_render::display_with_source(e, &source_text)));
             }
             err(&format!("{}: {} parse error(s), skipping", file, parse_errors.len()));
-            unreadable = true;
+            unreadable.push(file.clone());
             continue;
         }
         // Auto-manage imports: add missing, remove unused. `--no-import-edit`
@@ -912,7 +955,7 @@ pub fn cmd_fmt(files: &[String], mode: FmtMode, no_import_edit: bool) {
                     .unwrap_or_else(|e| { err(&format!("Failed to write {}: {}", file, e)); std::process::exit(1); });
                 err(&format!("Formatted {}", file));
             }
-            FmtMode::Check => {
+            FmtMode::Check | FmtMode::CheckJson => {
                 if formatted != source_text {
                     unformatted.push(file.clone());
                 }
@@ -921,25 +964,13 @@ pub fn cmd_fmt(files: &[String], mode: FmtMode, no_import_edit: bool) {
         }
     }
 
-    if verify_failed && mode != FmtMode::Check {
+    if verify_failed && !mode.is_check() {
         std::process::exit(1);
     }
-    if mode != FmtMode::Check {
+    if !mode.is_check() {
         return;
     }
-    if unformatted.is_empty() && !unreadable && !verify_failed {
-        err(&format!("fmt: {} file(s) already formatted", files.len()));
-        return;
-    }
-    for f in &unformatted {
-        err(&format!("not formatted: {}", f));
-    }
-    err(&format!(
-        "fmt --check: {} of {} file(s) need formatting — run `almide fmt <path>`",
-        unformatted.len(),
-        files.len()
-    ));
-    std::process::exit(1);
+    report_fmt_check(mode, files.len(), &unformatted, &unreadable, verify_failed);
 }
 
 pub fn cmd_clean() {

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -1,0 +1,219 @@
+//! `almide mcp` — a Model Context Protocol server over stdio.
+//!
+//! The compiler's answers reach an agent as typed calls with JSON results
+//! instead of a shell command whose human-formatted output has to be re-parsed
+//! by the model. That parsing step is where accuracy leaks, and this repo is
+//! scored on one metric: how accurately an LLM writes and modifies Almide.
+//!
+//! Transport: newline-delimited JSON-RPC 2.0 on stdin/stdout (the MCP stdio
+//! transport — no `Content-Length` framing; that is LSP, which `almide lsp`
+//! speaks). Nothing but protocol messages may be written to stdout, so every
+//! tool runs the compiler in a SUBPROCESS and captures its streams
+//! ([`super::mcp_tools`]); the in-process `out()`/`err()` writers are never
+//! used on this path.
+//!
+//! Implemented methods: `initialize`, `tools/list`, `tools/call`, `ping`.
+//! Capabilities advertise `tools` only, so an unknown method is answered with
+//! JSON-RPC `-32601` rather than a guess.
+
+use serde_json::{json, Value};
+use std::io::{BufRead, Write};
+
+/// MCP revision this server implements. A client that asks for a different one
+/// gets its own version echoed back when we can serve it — the tool surface is
+/// identical across the revisions that have `tools/*` — and this one otherwise.
+const PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// Revisions whose `tools/*` shape this server satisfies as-is.
+const SUPPORTED_VERSIONS: &[&str] = &["2024-11-05", "2025-03-26", "2025-06-18"];
+
+/// What the model is told about this server up front. Short on purpose: the
+/// per-tool descriptions carry the detail.
+const INSTRUCTIONS: &str = "\
+Almide compiler tools. Prefer these over shelling out to `almide`: they return \
+structured results, so nothing has to be parsed out of rendered text.
+
+- almide_check   type errors as {code, file, line, col, message, hint, try}
+- almide_api     exact signatures of a module or of @stdlib/<module>
+- almide_explain what a diagnostic code means and the sanctioned fix
+- almide_test    run the .almd test blocks (compiles and executes)
+- almide_fmt_check  which files are not formatted (never rewrites)
+
+Write operations are deliberately absent: run `almide fmt` / `almide fix` in a \
+shell when you intend to change files.";
+
+/// Read newline-delimited JSON-RPC from stdin until EOF, answering each
+/// request on stdout. Returns when the client closes the pipe.
+pub fn run_mcp() {
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout();
+    let mut reader = stdin.lock();
+    let mut line = String::new();
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => return,
+            Ok(_) => {}
+        }
+        let text = line.trim();
+        if text.is_empty() {
+            continue;
+        }
+        if let Some(response) = handle_message(text) {
+            if writeln!(stdout, "{}", response).is_err() || stdout.flush().is_err() {
+                return;
+            }
+        }
+    }
+}
+
+/// One inbound message → an optional response line. Notifications (no `id`)
+/// are answered with `None`, as JSON-RPC requires.
+fn handle_message(text: &str) -> Option<String> {
+    let msg: Value = match serde_json::from_str(text) {
+        Ok(v) => v,
+        Err(e) => return Some(error_response(Value::Null, -32700, &format!("parse error: {}", e))),
+    };
+    let id = msg.get("id").cloned();
+    let method = msg.get("method").and_then(|m| m.as_str()).unwrap_or("");
+    // A notification carries no id and must never be answered — not even with
+    // an error, or a client that sends `notifications/initialized` sees a
+    // spurious failure.
+    let id = id.filter(|v| !v.is_null())?;
+    if method.is_empty() {
+        return Some(error_response(id, -32600, "invalid request: no method"));
+    }
+    let params = msg.get("params").cloned().unwrap_or_else(|| json!({}));
+    Some(match dispatch(method, &params) {
+        Ok(result) => success_response(id, result),
+        Err(RpcError { code, message }) => error_response(id, code, &message),
+    })
+}
+
+struct RpcError {
+    code: i64,
+    message: String,
+}
+
+fn dispatch(method: &str, params: &Value) -> Result<Value, RpcError> {
+    match method {
+        "initialize" => Ok(initialize_result(params)),
+        "tools/list" => Ok(json!({ "tools": super::mcp_tools::catalog() })),
+        "tools/call" => tools_call(params),
+        "ping" => Ok(json!({})),
+        other => Err(RpcError {
+            code: -32601,
+            message: format!("method not found: {}", other),
+        }),
+    }
+}
+
+fn initialize_result(params: &Value) -> Value {
+    let requested = params.get("protocolVersion").and_then(|v| v.as_str());
+    let version = match requested {
+        Some(v) if SUPPORTED_VERSIONS.contains(&v) => v,
+        _ => PROTOCOL_VERSION,
+    };
+    json!({
+        "protocolVersion": version,
+        "capabilities": { "tools": { "listChanged": false } },
+        "serverInfo": {
+            "name": "almide",
+            "title": "Almide compiler",
+            "version": env!("CARGO_PKG_VERSION"),
+        },
+        "instructions": INSTRUCTIONS,
+    })
+}
+
+/// `tools/call`: a failing TOOL is a successful RPC carrying `isError: true`
+/// (the agent is meant to read it and react); only a malformed request is a
+/// JSON-RPC error.
+fn tools_call(params: &Value) -> Result<Value, RpcError> {
+    let name = params.get("name").and_then(|n| n.as_str()).ok_or(RpcError {
+        code: -32602,
+        message: "invalid params: `name` is required".to_string(),
+    })?;
+    let args = params.get("arguments").cloned().unwrap_or_else(|| json!({}));
+    Ok(match super::mcp_tools::call(name, &args) {
+        Ok(value) => text_result(&serde_json::to_string_pretty(&value).unwrap_or_default(), false),
+        Err(message) => text_result(&message, true),
+    })
+}
+
+fn text_result(text: &str, is_error: bool) -> Value {
+    json!({
+        "content": [ { "type": "text", "text": text } ],
+        "isError": is_error,
+    })
+}
+
+fn success_response(id: Value, result: Value) -> String {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result }).to_string()
+}
+
+fn error_response(id: Value, code: i64, message: &str) -> String {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } }).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn call(text: &str) -> Value {
+        serde_json::from_str(&handle_message(text).expect("a response")).unwrap()
+    }
+
+    #[test]
+    fn initialize_echoes_a_supported_protocol_version() {
+        let r = call(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}"#);
+        assert_eq!(r["result"]["protocolVersion"], "2024-11-05");
+        assert_eq!(r["result"]["serverInfo"]["name"], "almide");
+        assert!(r["result"]["capabilities"]["tools"].is_object());
+    }
+
+    #[test]
+    fn initialize_falls_back_to_our_revision_for_an_unknown_one() {
+        let r = call(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"1999-01-01"}}"#);
+        assert_eq!(r["result"]["protocolVersion"], PROTOCOL_VERSION);
+    }
+
+    #[test]
+    fn notifications_get_no_response() {
+        assert!(handle_message(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#).is_none());
+    }
+
+    #[test]
+    fn unknown_method_is_method_not_found() {
+        let r = call(r#"{"jsonrpc":"2.0","id":7,"method":"resources/list"}"#);
+        assert_eq!(r["error"]["code"], -32601);
+        assert_eq!(r["id"], 7);
+    }
+
+    #[test]
+    fn malformed_json_is_a_parse_error_with_a_null_id() {
+        let r = call("{not json");
+        assert_eq!(r["error"]["code"], -32700);
+        assert!(r["id"].is_null());
+    }
+
+    #[test]
+    fn a_failing_tool_is_a_successful_rpc_flagged_as_an_error() {
+        let r = call(r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"nope"}}"#);
+        assert_eq!(r["result"]["isError"], true);
+        assert!(r["result"]["content"][0]["text"].as_str().unwrap().contains("unknown tool"));
+    }
+
+    #[test]
+    fn tools_call_without_a_name_is_an_invalid_params_error() {
+        let r = call(r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{}}"#);
+        assert_eq!(r["error"]["code"], -32602);
+    }
+
+    #[test]
+    fn tools_list_returns_the_catalog() {
+        let r = call(r#"{"jsonrpc":"2.0","id":4,"method":"tools/list"}"#);
+        let tools = r["result"]["tools"].as_array().expect("tools array");
+        assert!(tools.iter().any(|t| t["name"] == "almide_check"));
+    }
+}

--- a/src/cli/mcp_tools.rs
+++ b/src/cli/mcp_tools.rs
@@ -1,0 +1,430 @@
+//! The `almide mcp` tool catalog: what an agent may call, and how each call
+//! reaches the compiler.
+//!
+//! **One path into the compiler.** Every tool runs THE CLI —
+//! `std::env::current_exe()` with the flags a human would type — and reads the
+//! machine-readable output the CLI already emits (`check --json`,
+//! `test --json`, `fmt --check --json`, `ide outline --json`). There is
+//! deliberately no second, MCP-only rendering of a diagnostic or a test result:
+//! a parallel formatter drifts from the CLI's, and the drift is invisible
+//! precisely because nobody reads the MCP output by eye.
+//!
+//! **Human text is never parsed.** Where a surface has no machine-readable
+//! form (the test runner's per-assertion output, #1313), the raw text is passed
+//! through verbatim in a field whose name says it is unstructured. Regex-
+//! scraping a rendered diagnostic would reintroduce exactly the parsing step
+//! this server exists to remove.
+//!
+//! **Read-only.** No tool here writes a source file. `fmt` is exposed only in
+//! its `--check` form; the writing forms (`almide fmt`, `almide fix`) stay on
+//! the CLI, where the edit is visible in the agent's own transcript.
+
+use serde_json::{json, Value};
+
+/// The captured result of one CLI invocation.
+struct CliRun {
+    exit_code: i32,
+    stdout: String,
+    stderr: String,
+}
+
+/// Run the almide binary that is serving MCP (`current_exe`) with `args`.
+///
+/// Self-invocation is what makes "no second output path" true by construction:
+/// the tool result is produced by the same build of the same compiler the user
+/// would get from the shell, and a compiler panic on a malformed input kills a
+/// subprocess instead of the session.
+fn run_cli(args: &[String], cwd: Option<&str>) -> Result<CliRun, String> {
+    let exe = std::env::current_exe()
+        .map_err(|e| format!("cannot locate the almide binary: {}", e))?;
+    let mut cmd = std::process::Command::new(exe);
+    cmd.args(args);
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+    let out = cmd
+        .output()
+        .map_err(|e| format!("failed to run `almide {}`: {}", args.join(" "), e))?;
+    Ok(CliRun {
+        exit_code: out.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    })
+}
+
+/// Split NDJSON output into (parsed objects, lines that were not JSON).
+///
+/// The non-JSON remainder is never pattern-matched — it is handed back to the
+/// caller as text so a tool can report it honestly rather than guess at it.
+fn split_json_lines(text: &str) -> (Vec<Value>, Vec<&str>) {
+    let mut parsed = Vec::new();
+    let mut other = Vec::new();
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<Value>(line) {
+            Ok(v) if v.is_object() => parsed.push(v),
+            _ => other.push(line),
+        }
+    }
+    (parsed, other)
+}
+
+fn arg_str(args: &Value, key: &str) -> Option<String> {
+    args.get(key)?.as_str().map(|s| s.to_string())
+}
+
+fn require_str(args: &Value, key: &str) -> Result<String, String> {
+    arg_str(args, key).ok_or_else(|| format!("missing required argument `{}` (string)", key))
+}
+
+fn arg_strs(args: &Value, key: &str) -> Vec<String> {
+    args.get(key)
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+        .unwrap_or_default()
+}
+
+/// Keep the TAIL of a long runner dump: failures print last, and an agent's
+/// context is the scarce resource. Returns (text, truncated).
+fn tail(text: &str, limit: usize) -> (String, bool) {
+    if text.len() <= limit {
+        return (text.to_string(), false);
+    }
+    let start = text.len() - limit;
+    let cut = text
+        .char_indices()
+        .map(|(i, _)| i)
+        .find(|i| *i >= start)
+        .unwrap_or(text.len());
+    (text[cut..].to_string(), true)
+}
+
+fn count_level(diags: &[Value], level: &str) -> usize {
+    diags
+        .iter()
+        .filter(|d| d.get("level").and_then(|l| l.as_str()) == Some(level))
+        .count()
+}
+
+/// Attach the CLI's stderr when it said something, labelled as the
+/// unstructured channel it is.
+fn with_stderr(obj: &mut Value, run: &CliRun) {
+    if !run.stderr.trim().is_empty() {
+        let (text, truncated) = tail(run.stderr.trim_end(), 4000);
+        obj["stderr_unstructured"] = json!(text);
+        if truncated {
+            obj["stderr_truncated"] = json!(true);
+        }
+    }
+}
+
+// ── tools ──
+
+/// `almide check --json` → the diagnostic list, verbatim.
+///
+/// Each element is the compiler's own JSON diagnostic:
+/// `{level, code, message, hint, here, try, try_replace, context, file, line,
+/// col, end_col, secondary}` — `try`/`try_replace` are the fix-it snippet and
+/// the span it replaces.
+fn tool_check(args: &Value) -> Result<Value, String> {
+    let file = require_str(args, "file")?;
+    let cwd = arg_str(args, "cwd");
+    let run = run_cli(&["check".into(), file.clone(), "--json".into()], cwd.as_deref())?;
+    let (diagnostics, unparsed) = split_json_lines(&run.stdout);
+    let errors = count_level(&diagnostics, "error");
+    let warnings = count_level(&diagnostics, "warning");
+    let mut obj = json!({
+        "file": file,
+        "ok": errors == 0 && run.exit_code == 0,
+        "errors": errors,
+        "warnings": warnings,
+        "diagnostics": diagnostics,
+        "exit_code": run.exit_code,
+    });
+    if !unparsed.is_empty() {
+        obj["stdout_unstructured"] = json!(unparsed.join("\n"));
+    }
+    with_stderr(&mut obj, &run);
+    Ok(obj)
+}
+
+/// `almide test --json` → per-FILE pass/fail, plus the runner's raw text.
+///
+/// Per-TEST structure (name / expected / found / diff) does not exist yet
+/// (#1313), so the runner's own output is returned verbatim under
+/// `runner_output_unstructured` rather than parsed into a shape the CLI does
+/// not actually promise.
+fn tool_test(args: &Value) -> Result<Value, String> {
+    let mut argv: Vec<String> = vec!["test".into()];
+    if let Some(path) = arg_str(args, "path") {
+        argv.push(path);
+    }
+    argv.push("--json".into());
+    if let Some(filter) = arg_str(args, "run") {
+        argv.push("--run".into());
+        argv.push(filter);
+    }
+    let cwd = arg_str(args, "cwd");
+    let run = run_cli(&argv, cwd.as_deref())?;
+    let (rows, other) = split_json_lines(&run.stdout);
+    let files: Vec<Value> = rows.into_iter().filter(|v| v.get("file").is_some()).collect();
+    let passed = files.iter().filter(|v| v.get("status").and_then(|s| s.as_str()) == Some("pass")).count();
+    let failed = files.len() - passed;
+    let raw = format!("{}\n{}", other.join("\n"), run.stderr);
+    let (raw, truncated) = tail(raw.trim(), 8000);
+    Ok(json!({
+        "ok": failed == 0 && run.exit_code == 0,
+        "files_passed": passed,
+        "files_failed": failed,
+        "files": files,
+        "exit_code": run.exit_code,
+        "runner_output_unstructured": raw,
+        "runner_output_truncated": truncated,
+        "note": "per-file status is structured; per-test expected/found is not (#1313) — read runner_output_unstructured for failure detail",
+    }))
+}
+
+/// `almide ide outline --json` / `almide ide stdlib-snapshot --json` → the API
+/// surface of a file or a stdlib module.
+fn tool_api(args: &Value) -> Result<Value, String> {
+    let target = require_str(args, "target")?;
+    let cwd = arg_str(args, "cwd");
+    let mut argv: Vec<String> = vec!["ide".into()];
+    if target == "@stdlib" {
+        argv.push("stdlib-snapshot".into());
+        if let Some(modules) = arg_str(args, "modules") {
+            argv.push("--modules".into());
+            argv.push(modules);
+        }
+    } else {
+        argv.push("outline".into());
+        argv.push(target.clone());
+        if let Some(filter) = arg_str(args, "filter") {
+            argv.push("--filter".into());
+            argv.push(filter);
+        }
+    }
+    argv.push("--json".into());
+    let run = run_cli(&argv, cwd.as_deref())?;
+    if run.exit_code != 0 {
+        return Err(format!(
+            "{}\n(hint: a file target must type-check first — call almide_check on it)",
+            run.stderr.trim()
+        ));
+    }
+    let outline: Value = serde_json::from_str(run.stdout.trim())
+        .map_err(|e| format!("almide ide emitted output this server could not parse as JSON: {}", e))?;
+    Ok(json!({ "target": target, "outline": outline }))
+}
+
+/// `almide explain <CODE>` → the diagnostic's reference page.
+///
+/// The payload is documentation, returned as the markdown the CLI prints; it is
+/// not parsed into fields, because it does not have any.
+fn tool_explain(args: &Value) -> Result<Value, String> {
+    let code = require_str(args, "code")?;
+    let run = run_cli(&["explain".into(), code.clone()], None)?;
+    if run.exit_code != 0 {
+        return Err(run.stderr.trim().to_string());
+    }
+    Ok(json!({ "code": code.to_uppercase(), "doc": run.stdout }))
+}
+
+/// `almide fmt --check --json` → which files are not formatted. Never writes.
+fn tool_fmt_check(args: &Value) -> Result<Value, String> {
+    let mut argv: Vec<String> = vec!["fmt".into(), "--check".into(), "--json".into()];
+    argv.extend(arg_strs(args, "paths"));
+    let cwd = arg_str(args, "cwd");
+    let run = run_cli(&argv, cwd.as_deref())?;
+    let report: Value = serde_json::from_str(run.stdout.trim()).map_err(|_| {
+        format!(
+            "almide fmt produced no JSON report (exit {}): {}",
+            run.exit_code,
+            run.stderr.trim()
+        )
+    })?;
+    let mut obj = json!({ "report": report, "exit_code": run.exit_code });
+    with_stderr(&mut obj, &run);
+    Ok(obj)
+}
+
+/// Dispatch a `tools/call`. `Err` becomes an MCP tool error (`isError: true`),
+/// which is what an agent should see for "the compiler said no" — as opposed to
+/// a protocol error, which means the request itself was malformed.
+pub fn call(name: &str, args: &Value) -> Result<Value, String> {
+    match name {
+        "almide_check" => tool_check(args),
+        "almide_test" => tool_test(args),
+        "almide_api" => tool_api(args),
+        "almide_explain" => tool_explain(args),
+        "almide_fmt_check" => tool_fmt_check(args),
+        _ => Err(format!(
+            "unknown tool `{}` — call tools/list for the catalog",
+            name
+        )),
+    }
+}
+
+fn obj_schema(props: Value, required: Value) -> Value {
+    json!({ "type": "object", "properties": props, "required": required })
+}
+
+/// Read-only, no network, same answer for the same input.
+fn read_only() -> Value {
+    json!({ "readOnlyHint": true, "idempotentHint": true, "openWorldHint": false })
+}
+
+fn cwd_prop() -> Value {
+    json!({ "type": "string", "description": "Directory to run in (defaults to the server's cwd). Use the project root so almide.toml is found." })
+}
+
+fn tool_check_def() -> Value {
+    json!({
+        "name": "almide_check",
+        "title": "Type-check an Almide file",
+        "description": "Type-check one .almd file and return the compiler's structured diagnostics: {level, code, message, hint, here, try, try_replace, file, line, col, end_col}. `try` is a copy-pasteable fix snippet and `try_replace` is the span it replaces. Nothing is written. Runs `almide check --json`.",
+        "inputSchema": obj_schema(
+            json!({
+                "file": { "type": "string", "description": "Path to the .almd file to check" },
+                "cwd": cwd_prop(),
+            }),
+            json!(["file"]),
+        ),
+        "annotations": read_only(),
+    })
+}
+
+fn tool_test_def() -> Value {
+    json!({
+        "name": "almide_test",
+        "title": "Run Almide tests",
+        "description": "Run the .almd test blocks under a path and return per-file pass/fail plus the runner's raw output for failures. COMPILES AND EXECUTES the tests (writes build artifacts under target/, never edits sources) and can take minutes on a cold cache. Runs `almide test --json`.",
+        "inputSchema": obj_schema(
+            json!({
+                "path": { "type": "string", "description": "File or directory (default: recursive from cwd)" },
+                "run": { "type": "string", "description": "Only run tests whose name matches this substring" },
+                "cwd": cwd_prop(),
+            }),
+            json!([]),
+        ),
+        "annotations": json!({ "readOnlyHint": false, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false }),
+    })
+}
+
+fn tool_api_def() -> Value {
+    json!({
+        "name": "almide_api",
+        "title": "List the API surface of a module",
+        "description": "List every public declaration with its exact signature — use this instead of guessing a stdlib name or grepping. `target` is a .almd path, `@stdlib/<module>` (e.g. @stdlib/string), or `@stdlib` for a snapshot of the core modules. Runs `almide ide outline --json` / `almide ide stdlib-snapshot --json`.",
+        "inputSchema": obj_schema(
+            json!({
+                "target": { "type": "string", "description": "A .almd file path, `@stdlib/<module>`, or `@stdlib`" },
+                "filter": { "type": "string", "description": "Keep only names containing this substring (file / single-module targets)" },
+                "modules": { "type": "string", "description": "Comma-separated module list for the `@stdlib` snapshot (default: string,list,int,option,result,map,set)" },
+                "cwd": cwd_prop(),
+            }),
+            json!(["target"]),
+        ),
+        "annotations": read_only(),
+    })
+}
+
+fn tool_explain_def() -> Value {
+    json!({
+        "name": "almide_explain",
+        "title": "Explain a diagnostic code",
+        "description": "Return the reference page for a diagnostic code (e.g. E042) — what it means, why it fires, and the sanctioned fix. Pair it with the `code` field of an almide_check diagnostic. Runs `almide explain <CODE>`.",
+        "inputSchema": obj_schema(
+            json!({ "code": { "type": "string", "description": "Diagnostic code, e.g. E001" } }),
+            json!(["code"]),
+        ),
+        "annotations": read_only(),
+    })
+}
+
+fn tool_fmt_check_def() -> Value {
+    json!({
+        "name": "almide_fmt_check",
+        "title": "Check formatting",
+        "description": "Report which .almd files are not canonically formatted. Read-only: it never rewrites a file — run `almide fmt <path>` in a shell to apply. Runs `almide fmt --check --json`.",
+        "inputSchema": obj_schema(
+            json!({
+                "paths": { "type": "array", "items": { "type": "string" }, "description": "Files or directories (default: src/**/*.almd)" },
+                "cwd": cwd_prop(),
+            }),
+            json!([]),
+        ),
+        "annotations": read_only(),
+    })
+}
+
+/// The `tools/list` catalog. Five tools, each one a surface the CLI already
+/// answers in a machine-readable form.
+pub fn catalog() -> Value {
+    json!([
+        tool_check_def(),
+        tool_test_def(),
+        tool_api_def(),
+        tool_explain_def(),
+        tool_fmt_check_def(),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_entries_are_well_formed() {
+        let tools = catalog();
+        let tools = tools.as_array().expect("catalog is an array");
+        assert_eq!(tools.len(), 5, "keep the tool count small and deliberate");
+        for t in tools {
+            let name = t["name"].as_str().expect("name");
+            assert!(name.starts_with("almide_"), "{} is not namespaced", name);
+            assert!(!t["description"].as_str().unwrap_or("").is_empty());
+            assert_eq!(t["inputSchema"]["type"], "object", "{}", name);
+            assert!(t["inputSchema"]["properties"].is_object(), "{}", name);
+            assert!(t["annotations"].is_object(), "{}", name);
+        }
+    }
+
+    #[test]
+    fn only_the_test_tool_declares_a_side_effect() {
+        let tools = catalog();
+        for t in tools.as_array().unwrap() {
+            let read_only = t["annotations"]["readOnlyHint"].as_bool().unwrap_or(false);
+            let expect_read_only = t["name"] != "almide_test";
+            assert_eq!(read_only, expect_read_only, "{}", t["name"]);
+        }
+    }
+
+    #[test]
+    fn unknown_tool_is_a_tool_error_not_a_panic() {
+        let e = call("almide_deploy", &json!({})).unwrap_err();
+        assert!(e.contains("unknown tool"), "{}", e);
+    }
+
+    #[test]
+    fn missing_required_argument_is_reported_by_name() {
+        let e = call("almide_check", &json!({})).unwrap_err();
+        assert!(e.contains("`file`"), "{}", e);
+    }
+
+    #[test]
+    fn non_json_lines_are_kept_apart_from_parsed_ones() {
+        let (parsed, other) = split_json_lines("{\"a\":1}\nplain text\n\n{\"b\":2}\n");
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(other, vec!["plain text"]);
+    }
+
+    #[test]
+    fn tail_keeps_the_end_and_flags_the_cut() {
+        let (text, truncated) = tail("abcdef", 3);
+        assert_eq!((text.as_str(), truncated), ("def", true));
+        let (text, truncated) = tail("ab", 3);
+        assert_eq!((text.as_str(), truncated), ("ab", false));
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -9,6 +9,8 @@ mod commands;
 mod install;
 mod selfupdate;
 pub mod lsp;
+pub mod mcp;
+mod mcp_tools;
 pub mod repl;
 mod ide;
 mod fix;

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,6 +172,11 @@ enum Commands {
     },
     /// Start the Language Server Protocol server (for editor integration)
     Lsp,
+    /// Start the Model Context Protocol server on stdio (for agent/LLM clients).
+    /// Exposes check / test / API-outline / explain / fmt-check as typed tools
+    /// with JSON results — the same answers as the CLI, minus the step where a
+    /// model has to parse human-formatted text.
+    Mcp,
     /// Explain a diagnostic code (e.g., almide explain E001)
     Explain {
         /// Diagnostic code such as E001
@@ -734,6 +739,9 @@ fn dispatch_rest(command: Commands) {
     match command {
         Commands::Lsp => {
             cli::lsp::run_lsp();
+        }
+        Commands::Mcp => {
+            cli::mcp::run_mcp();
         }
         Commands::Explain { code } => {
             print_error_explanation(&code);

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,6 +184,10 @@ enum Commands {
         /// Check formatting without writing (exit non-zero on drift)
         #[arg(long)]
         check: bool,
+        /// Machine-readable `--check`: one JSON object naming the files that
+        /// need formatting (implies --check; still exits non-zero on drift)
+        #[arg(long)]
+        json: bool,
         /// Print the formatted text to stdout without writing
         #[arg(long)]
         dry_run: bool,
@@ -600,11 +604,14 @@ fn dispatch_ide(cmd: IdeCommand) {
 /// `parse_file` as-is and report "Is a directory", which the always-zero exit then
 /// swallowed, so a CI job pointed at a tree silently checked nothing (#919). With no
 /// argument at all the `src/` sweep is unchanged.
-fn dispatch_fmt(files: Vec<String>, check: bool, dry_run: bool, no_import_edit: bool) {
-    let mode = match (check, dry_run) {
-        (true, _) => cli::FmtMode::Check,
-        (false, true) => cli::FmtMode::DryRun,
-        (false, false) => cli::FmtMode::Write,
+fn dispatch_fmt(files: Vec<String>, check: bool, json: bool, dry_run: bool, no_import_edit: bool) {
+    let mode = match (json, check, dry_run) {
+        // `--json` is the machine-readable spelling of the SAME gate: it never
+        // writes, and it exits non-zero on drift exactly like `--check`.
+        (true, _, _) => cli::FmtMode::CheckJson,
+        (false, true, _) => cli::FmtMode::Check,
+        (false, false, true) => cli::FmtMode::DryRun,
+        (false, false, false) => cli::FmtMode::Write,
     };
     let fmt_files = if files.is_empty() {
         let mut found = Vec::new();
@@ -732,7 +739,7 @@ fn dispatch_rest(command: Commands) {
             print_error_explanation(&code);
         }
         Commands::Ide { cmd } => dispatch_ide(cmd),
-        Commands::Fmt { files, check, dry_run, no_import_edit } => dispatch_fmt(files, check, dry_run, no_import_edit),
+        Commands::Fmt { files, check, json, dry_run, no_import_edit } => dispatch_fmt(files, check, json, dry_run, no_import_edit),
         Commands::Compile { module, json, dry_run, output } => {
             cli::cmd_compile(module.as_deref(), json, dry_run, output.as_deref());
         }

--- a/tests/mcp_test.rs
+++ b/tests/mcp_test.rs
@@ -1,0 +1,246 @@
+//! `almide mcp` end-to-end: drive the REAL binary over stdio and assert the
+//! shapes an agent depends on.
+//!
+//! Everything here spawns `CARGO_BIN_EXE_almide`, so a protocol regression, a
+//! stray `println!` on the protocol stream, or a tool that stops returning
+//! structured data fails the suite rather than silently degrading an agent's
+//! feedback into text it has to guess at.
+//!
+//! `almide_test` is deliberately NOT exercised here: it compiles and executes
+//! the tests through cargo, which belongs in `almide test`, not in a unit-suite
+//! gate. Its wiring (argv, parsing, counting) is covered by the unit tests in
+//! `src/cli/mcp_tools.rs`.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use serde_json::{json, Value};
+
+fn almide() -> &'static str {
+    env!("CARGO_BIN_EXE_almide")
+}
+
+/// Send every request as one line, close stdin, collect the response lines.
+///
+/// EOF is the server's exit condition, so this cannot hang on a missing
+/// response the way a framed, long-lived client can.
+fn mcp_session(requests: &[Value]) -> Vec<Value> {
+    let mut child = Command::new(almide())
+        .arg("mcp")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn almide mcp");
+    {
+        let stdin = child.stdin.as_mut().expect("stdin");
+        for r in requests {
+            writeln!(stdin, "{}", r).expect("write request");
+        }
+    }
+    let out = child.wait_with_output().expect("wait for almide mcp");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| {
+            serde_json::from_str(l).unwrap_or_else(|e| {
+                panic!("non-JSON line on the MCP stdout stream ({}): {:?}", e, l)
+            })
+        })
+        .collect()
+}
+
+fn init() -> Value {
+    json!({"jsonrpc":"2.0","id":1,"method":"initialize",
+           "params":{"protocolVersion":"2025-06-18","capabilities":{},
+                     "clientInfo":{"name":"mcp_test","version":"1"}}})
+}
+
+fn call(id: i64, name: &str, arguments: Value) -> Value {
+    json!({"jsonrpc":"2.0","id":id,"method":"tools/call",
+           "params":{"name":name,"arguments":arguments}})
+}
+
+/// The tool's payload: `content[0].text` is a JSON document by construction —
+/// that IS the structured result, and parsing it here is the same step a client
+/// takes.
+fn payload(response: &Value) -> Value {
+    assert_eq!(response["result"]["isError"], false, "tool reported an error: {}", response);
+    let text = response["result"]["content"][0]["text"].as_str().expect("text content");
+    serde_json::from_str(text).expect("tool payload is JSON")
+}
+
+fn write_temp(dir: &std::path::Path, name: &str, source: &str) -> String {
+    let path = dir.join(name);
+    std::fs::write(&path, source).expect("write fixture");
+    path.to_string_lossy().to_string()
+}
+
+#[test]
+fn initialize_reports_tools_capability_and_server_identity() {
+    let responses = mcp_session(&[init()]);
+    let r = &responses[0];
+    assert_eq!(r["jsonrpc"], "2.0");
+    assert_eq!(r["result"]["serverInfo"]["name"], "almide");
+    assert_eq!(r["result"]["serverInfo"]["version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(r["result"]["protocolVersion"], "2025-06-18");
+    assert!(r["result"]["capabilities"]["tools"].is_object());
+}
+
+#[test]
+fn tools_list_is_the_five_named_tools_and_only_test_declares_a_side_effect() {
+    let responses = mcp_session(&[init(), json!({"jsonrpc":"2.0","id":2,"method":"tools/list"})]);
+    let tools = responses[1]["result"]["tools"].as_array().expect("tools");
+    let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+    assert_eq!(
+        names,
+        vec!["almide_check", "almide_test", "almide_api", "almide_explain", "almide_fmt_check"]
+    );
+    for t in tools {
+        assert!(t["inputSchema"]["properties"].is_object(), "{}", t["name"]);
+        let read_only = t["annotations"]["readOnlyHint"].as_bool().unwrap_or(false);
+        assert_eq!(read_only, t["name"] != "almide_test", "{}", t["name"]);
+    }
+}
+
+#[test]
+fn check_returns_structured_diagnostics_with_a_fix_snippet() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = write_temp(
+        dir.path(),
+        "bad.almd",
+        "fn add(a: Int, b: Int) -> Int = a + b\n\nfn main() -> Unit = {\n  print(add(1, 2))\n}\n",
+    );
+    let responses = mcp_session(&[init(), call(2, "almide_check", json!({"file": file}))]);
+    let out = payload(&responses[1]);
+    assert_eq!(out["ok"], false);
+    assert!(out["errors"].as_u64().unwrap() >= 1, "{}", out);
+    let d = &out["diagnostics"][0];
+    // `print` is not a function in Almide; the diagnostic must arrive as
+    // fields — code, position, and an applicable suggestion — not as prose.
+    assert_eq!(d["code"], "E002");
+    assert_eq!(d["level"], "error");
+    assert_eq!(d["line"], 4);
+    assert_eq!(d["try"], "println");
+    assert!(d["try_replace"]["line"].is_number(), "{}", d);
+}
+
+#[test]
+fn check_on_a_clean_file_is_ok_with_no_diagnostics() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = write_temp(dir.path(), "ok.almd", "fn add(a: Int, b: Int) -> Int = a + b\n");
+    let responses = mcp_session(&[init(), call(2, "almide_check", json!({"file": file}))]);
+    let out = payload(&responses[1]);
+    assert_eq!(out["ok"], true, "{}", out);
+    assert_eq!(out["errors"], 0);
+    assert_eq!(out["diagnostics"].as_array().unwrap().len(), 0);
+}
+
+/// A file where no top-level declaration parses used to leave `check --json`
+/// with nothing on stdout and a human-formatted error on stderr — the most
+/// common LLM mistake was the one class the structured flag did not cover.
+#[test]
+fn json_check_reports_a_total_parse_failure_as_json() {
+    let dir = tempfile::tempdir().unwrap();
+    // Missing `=` before the body: the whole file fails to parse.
+    let file = write_temp(dir.path(), "syntax.almd", "fn greet(n: String) -> String {\n  n\n}\n");
+    let out = Command::new(almide())
+        .args(["check", &file, "--json"])
+        .output()
+        .expect("almide check --json");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert!(!lines.is_empty(), "no JSON emitted; stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let d: Value = serde_json::from_str(lines[0]).expect("diagnostic is JSON");
+    assert_eq!(d["level"], "error");
+    assert_eq!(d["line"], 1);
+    assert!(d["message"].as_str().unwrap().contains("Missing '='"), "{}", d);
+    // Unchanged gate: a file that did not parse still exits 1, so a harness
+    // that reads the exit code does not silently flip to success.
+    assert_eq!(out.status.code(), Some(1));
+
+    // Same file through MCP: structured, and honestly marked not-ok.
+    let responses = mcp_session(&[init(), call(2, "almide_check", json!({"file": file}))]);
+    let payload = payload(&responses[1]);
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["diagnostics"][0]["line"], 1);
+}
+
+#[test]
+fn api_lists_stdlib_signatures() {
+    let responses = mcp_session(&[
+        init(),
+        call(2, "almide_api", json!({"target": "@stdlib/string", "filter": "trim"})),
+    ]);
+    let out = payload(&responses[1]);
+    assert_eq!(out["outline"]["module"], "string");
+    assert_eq!(out["outline"]["source"], "stdlib");
+    let fns = out["outline"]["functions"].as_array().expect("functions");
+    let names: Vec<&str> = fns.iter().map(|f| f["name"].as_str().unwrap()).collect();
+    assert!(names.contains(&"trim"), "{:?}", names);
+    let trim = fns.iter().find(|f| f["name"] == "trim").unwrap();
+    assert_eq!(trim["ret"], "String");
+    assert_eq!(trim["params"][0]["ty"], "String");
+}
+
+#[test]
+fn api_on_a_broken_file_is_a_tool_error_that_says_what_to_do() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = write_temp(dir.path(), "broken.almd", "fn f() -> Int = \"nope\"\n");
+    let responses = mcp_session(&[init(), call(2, "almide_api", json!({"target": file}))]);
+    assert_eq!(responses[1]["result"]["isError"], true);
+    let text = responses[1]["result"]["content"][0]["text"].as_str().unwrap();
+    assert!(text.contains("almide_check"), "{}", text);
+}
+
+#[test]
+fn explain_returns_the_reference_page() {
+    let responses = mcp_session(&[init(), call(2, "almide_explain", json!({"code": "e001"}))]);
+    let out = payload(&responses[1]);
+    assert_eq!(out["code"], "E001");
+    assert!(out["doc"].as_str().unwrap().contains("E001"), "{}", out["doc"]);
+}
+
+#[test]
+fn fmt_check_json_reports_drift_and_keeps_the_gate_exit_code() {
+    let dir = tempfile::tempdir().unwrap();
+    let messy = write_temp(dir.path(), "messy.almd", "fn f(a: Int) -> Int =     a  +  1\n");
+    let tidy = write_temp(dir.path(), "tidy.almd", "fn f(a: Int) -> Int = a + 1\n");
+
+    let out = Command::new(almide()).args(["fmt", "--check", "--json", &messy]).output().unwrap();
+    let report: Value = serde_json::from_str(String::from_utf8_lossy(&out.stdout).trim()).unwrap();
+    assert_eq!(report["ok"], false);
+    assert_eq!(report["checked"], 1);
+    assert_eq!(report["unformatted"].as_array().unwrap().len(), 1);
+    assert_eq!(out.status.code(), Some(1), "--json keeps --check's gate semantics");
+    // The gate must not have rewritten the file it was only asked to inspect.
+    assert_eq!(std::fs::read_to_string(&messy).unwrap(), "fn f(a: Int) -> Int =     a  +  1\n");
+
+    let out = Command::new(almide()).args(["fmt", "--check", "--json", &tidy]).output().unwrap();
+    let report: Value = serde_json::from_str(String::from_utf8_lossy(&out.stdout).trim()).unwrap();
+    assert_eq!(report["ok"], true);
+    assert_eq!(out.status.code(), Some(0));
+
+    // Same answer through MCP.
+    let responses = mcp_session(&[init(), call(2, "almide_fmt_check", json!({"paths": [messy]}))]);
+    let out = payload(&responses[1]);
+    assert_eq!(out["report"]["ok"], false);
+    assert_eq!(out["exit_code"], 1);
+}
+
+#[test]
+fn protocol_errors_are_distinguished_from_tool_errors() {
+    let responses = mcp_session(&[
+        init(),
+        json!({"jsonrpc":"2.0","method":"notifications/initialized"}),
+        json!({"jsonrpc":"2.0","id":2,"method":"resources/list"}),
+        call(3, "almide_deploy", json!({})),
+        json!({"jsonrpc":"2.0","id":4,"method":"ping"}),
+    ]);
+    // The notification produced no response, so ids run 1, 2, 3, 4 over four
+    // response lines.
+    assert_eq!(responses.len(), 4, "{:?}", responses);
+    assert_eq!(responses[1]["error"]["code"], -32601, "unadvertised method");
+    assert_eq!(responses[2]["result"]["isError"], true, "unknown tool is a tool error");
+    assert_eq!(responses[3]["result"], json!({}), "ping");
+}

--- a/tools/claude-plugin/.claude-plugin/plugin.json
+++ b/tools/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "almide",
+  "displayName": "Almide",
+  "description": "Almide compiler tools for agents: MCP tools for check / test / API outline / explain / fmt-check, plus the Almide language server for .almd files.",
+  "version": "0.57.0",
+  "author": {
+    "name": "Almide",
+    "url": "https://github.com/almide"
+  },
+  "homepage": "https://github.com/almide/almide",
+  "repository": "https://github.com/almide/almide",
+  "license": "MIT OR Apache-2.0",
+  "keywords": ["almide", "compiler", "language-server", "mcp"],
+  "mcpServers": {
+    "compiler": {
+      "command": "almide",
+      "args": ["mcp"]
+    }
+  },
+  "lspServers": {
+    "almide": {
+      "command": "almide",
+      "args": ["lsp"],
+      "extensionToLanguage": {
+        ".almd": "almide"
+      }
+    }
+  }
+}

--- a/tools/claude-plugin/README.md
+++ b/tools/claude-plugin/README.md
@@ -1,0 +1,20 @@
+# Almide — Claude Code plugin
+
+Wires two servers that ship inside the `almide` binary into a Claude Code
+session:
+
+- **MCP** (`almide mcp`) — `almide_check`, `almide_test`, `almide_api`,
+  `almide_explain`, `almide_fmt_check`
+- **LSP** (`almide lsp`) — code intelligence for `.almd`
+
+The plugin configures the servers; it does not install the binary. Put `almide`
+on `PATH` first (`make install` from the repo root), otherwise the `/plugin`
+Errors tab reports `Executable not found in $PATH`.
+
+```bash
+/plugin marketplace add almide/almide
+/plugin install almide@almide
+```
+
+Full documentation: [docs/mcp.md](../../docs/mcp.md).
+Manifest schema check: `claude plugin validate tools/claude-plugin --strict`.


### PR DESCRIPTION
Closes #1333.

An agent reaching the compiler through a shell has to parse human-formatted text
to learn anything. That parsing step is where accuracy leaks, and this repo is
scored on one metric. `almide mcp` removes the step: `check`, `test`, the API
outline, `explain` and `fmt --check` arrive as typed tool calls with JSON
results.

## Design decisions

**One path into the compiler.** Every tool runs the CLI — `current_exe()` with
the flags a human would type — and reads the machine-readable output the CLI
already emits. There is no MCP-only rendering of a diagnostic or a test result:
a parallel formatter drifts from the CLI's, and the drift is invisible precisely
because nobody reads MCP output by eye. Self-invocation also means a compiler
panic kills a subprocess, not the session.

**Human text is never parsed.** Where a surface has no machine-readable form,
the raw text comes back verbatim in a field whose name ends in `_unstructured`,
and the tool names the issue that tracks the gap. Regex-scraping a rendered
diagnostic would reintroduce the fragility this exists to remove.

**Read-only.** No tool writes a source file. `fmt` is exposed only as
`--check`; applying it is `almide fmt <path>` in a shell, where the edit lands
in the agent's own transcript. `almide_test` is the single tool with a side
effect (it compiles and executes tests, writing under `target/`) and says so in
its description and in its MCP annotations — `readOnlyHint: false`, everything
else `true`:

```
$ almide mcp   # tools/list, summarised
{"name":"almide_check","readOnly":true}
{"name":"almide_test","readOnly":false}
{"name":"almide_api","readOnly":true}
{"name":"almide_explain","readOnly":true}
{"name":"almide_fmt_check","readOnly":true}
```

**Five tools, not fifteen.** `almide_api` covers both `ide outline` and
`ide stdlib-snapshot` because they answer one question ("what exists, with what
signature"). `almide compile --json` (module interface + ABI layout) stays
CLI-only: it serves binding generators, not code-writing agents.

## CLI surfaces extended

| Surface | Before | Now |
|---|---|---|
| `almide fmt --check` | human lines on stderr, exit 1 | **new** `--json`: one object on stdout, same gate, same exit code |
| `almide check --json` | a file where NO top-level decl parses printed human text on stderr and emitted no JSON at all | the parser's diagnostics reach the JSON stream; exit code deliberately unchanged (`1`) so a harness gating on it cannot silently flip to success |
| `almide mcp` | — | **new** subcommand: stdio MCP server |

The `check --json` gap mattered: a whole-file syntax error is the most common
thing an LLM gets wrong, and it was the one class the structured flag did not
cover.

## Transcript — every tool, actually invoked

Requests are newline-delimited JSON-RPC on stdin; responses are shown as
`result.content[0].text` (the tool payload) unless noted. Verbatim, except that
the scratch `cwd` paths are abbreviated to `/tmp/demo` and `/tmp/scratch`.

**`almide_check`** on a file with two errors:

```
→ {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"almide_check","arguments":{"file":"src/main.almd","cwd":"/tmp/demo"}}}
←
{
  "diagnostics": [
    {
      "code": "E005",
      "col": 16,
      "context": "call to add()",
      "end_col": 21,
      "file": "src/main.almd",
      "here": null,
      "hint": "Fix the argument type. Or use `int.parse(s)` to convert String to Int (returns Result[Int, String])",
      "level": "error",
      "line": 4,
      "message": "argument 'b' expects Int but got String",
      "secondary": [ { "col": 1, "label": "fn add() defined here", "line": 1 } ],
      "try": "// Try:\nint.parse(\"two\")",
      "try_replace": null
    },
    {
      "code": "E002",
      "col": 16,
      "context": "call to print()",
      "end_col": 21,
      "file": "src/main.almd",
      "here": null,
      "hint": "Did you mean `println`?",
      "level": "error",
      "line": 4,
      "message": "undefined function 'print'",
      "secondary": [],
      "try": "println",
      "try_replace": { "col": 3, "end_col": 8, "line": 4 }
    }
  ],
  "errors": 2,
  "exit_code": 0,
  "file": "src/main.almd",
  "ok": false,
  "warnings": 0
}
```

**`almide_api`** — signatures, not grep:

```
→ {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"almide_api","arguments":{"target":"@stdlib/string","filter":"trim"}}}
←
{
  "outline": {
    "functions": [
      { "effect": false, "name": "trim",       "params": [ { "name": "s", "ty": "String" } ], "ret": "String" },
      { "effect": false, "name": "trim_end",   "params": [ { "name": "s", "ty": "String" } ], "ret": "String" },
      { "effect": false, "name": "trim_start", "params": [ { "name": "s", "ty": "String" } ], "ret": "String" }
    ],
    "module": "string",
    "source": "stdlib"
  },
  "target": "@stdlib/string"
}
```

**`almide_explain`** — the reference page for a code returned by `almide_check`
(payload truncated here; the tool returns the whole page):

```
→ {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"almide_explain","arguments":{"code":"E042"}}}
←
{
  "code": "E042",
  "doc": "# E042 — this statement discards a Result (must-use)\n\nA statement-position expression whose type is `Result` throws the value —\nand with it, the error — away. ...\n\n## Fix\n\nTwo spellings, by intent:\n\n```almide\ncleanup(tmp)!             // propagate the err\nlet _ = cleanup(tmp)      // discard ON PURPOSE\n```\n..."
}
```

**`almide_fmt_check`** — two files, one adrift, nothing rewritten:

```
→ {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"almide_fmt_check","arguments":{"cwd":"/tmp/scratch","paths":["unfmt.almd","t1.almd"]}}}
←
{
  "exit_code": 1,
  "report": {
    "checked": 2,
    "ok": false,
    "unformatted": [ "unfmt.almd" ],
    "unreadable": [],
    "verify_failed": false
  }
}
```

**`almide_test`** — a failing test file. Per-file status is structured; the
failure detail is the runner's own text, returned verbatim and labelled, because
#1313 has not landed:

```
→ {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"almide_test","arguments":{"path":"src/greet_test.almd","cwd":"/tmp/demo"}}}
←
{
  "exit_code": 0,
  "files": [ { "exit_code": 101, "file": "src/greet_test.almd", "status": "fail" } ],
  "files_failed": 1,
  "files_passed": 0,
  "note": "per-file status is structured; per-test expected/found is not (#1313) — read runner_output_unstructured for failure detail",
  "ok": false,
  "runner_output_truncated": false,
  "runner_output_unstructured": "running 2 tests\ntest tests::__test_almd_greet_builds_a_sentence ... FAILED\ntest tests::__test_almd_greet_is_not_empty ... ok\nfailures:\n---- tests::__test_almd_greet_builds_a_sentence stdout ----\nthread ... panicked at ...:\nassertion `left == right` failed\n  left: \"Hello, world\"\n right: \"Hi, world\"\n..."
}
```

**Error paths** (raw envelopes) — a malformed request is a JSON-RPC error, a
failing tool is a successful RPC the agent is meant to read:

```
→ {"jsonrpc":"2.0","id":4,"method":"resources/list"}
← {"error":{"code":-32601,"message":"method not found: resources/list"},"id":4,"jsonrpc":"2.0"}

→ {"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"almide_deploy","arguments":{}}}
← {"id":5,"jsonrpc":"2.0","result":{"content":[{"text":"unknown tool `almide_deploy` — call tools/list for the catalog","type":"text"}],"isError":true}}
```

**New CLI JSON**, verified directly:

```
$ almide fmt --check --json unfmt.almd; echo "exit=$?"
{"checked":1,"ok":false,"unformatted":["unfmt.almd"],"unreadable":[],"verify_failed":false}
exit=1

$ almide check t2.almd --json; echo "exit=$?"    # whole file fails to parse
{"level":"error","code":"","message":"Missing '=' before function body at line 1:34","hint":"Almide requires '=' before the body. Write: fn greet(...) -> Type = { ... }","here":null,"try":null,"try_replace":null,"context":"","file":"t2.almd","line":1,"col":34,"end_col":null,"secondary":[]}
exit=1
```

## Plugin

`.claude-plugin/marketplace.json` (repo = its own marketplace) →
`tools/claude-plugin/.claude-plugin/plugin.json`, which declares BOTH servers
that already live in the binary:

```json
"mcpServers": { "compiler": { "command": "almide", "args": ["mcp"] } },
"lspServers": { "almide": { "command": "almide", "args": ["lsp"],
                            "extensionToLanguage": { ".almd": "almide" } } }
```

Install (the plugin configures the servers; it does not ship the binary, so
`almide` must be on `PATH` first):

```
/plugin marketplace add almide/almide
/plugin install almide@almide
```

Both manifests pass `claude plugin validate <path> --strict`.

## Left out on purpose

- **No write tools.** `almide fmt` (in place) and `almide fix` stay CLI-only.
- **`structuredContent`** on tool results — the payload is JSON inside
  `content[0].text`, which every MCP client handles.
- **Per-test structure** (#1313) and **applicability-tagged fix-its** (#1312):
  not invented here. `runner_output_unstructured` says what it is.
- **Parse-diagnostic codes**: syntax errors now reach `check --json`, but carry
  an empty `code`, so `almide_explain` has nothing to look up for them.
- **`almide ide doc <symbol>`** — no `--json` form exists, so it is not exposed
  rather than scraped; `almide_api` answers the same question for a module.
- **`almide compile --json`** (module interface + ABI layout) — CLI-only; it
  serves binding generators, not code-writing agents.

## Gates

```
cargo build --release                                  ok
cargo test --release --workspace                       ok
./target/release/almide test                           396/396 files (379 wasm, 17 native)
./target/release/almide fmt --check spec/ examples/    911 files already formatted
bash scripts/check-contracts.sh                        268 contracts, flagged=0
bash scripts/check-gate-verification.sh                33 gates
bash scripts/check-forbidden-impurities.sh             clean
bash scripts/check-tor-refs.sh                         15 instruments resolve
./target/release/almide docs-gen --check               ok
claude plugin validate (plugin + marketplace, --strict) ok
```

New gate: `tests/mcp_test.rs` (10 tests) drives the real binary over stdio — it
asserts the catalog, the diagnostic shape, the `--json` exit codes, that
`fmt_check` leaves the file it inspected byte-identical, and that no non-JSON
line ever reaches the protocol stream.
