### PR TITLE
Split the two densest mir functions so almide-mir scores A

### DIFF
--- a/crates/almide-mir/examples/classify_corpus_parts/classify_corpus_c.rs
+++ b/crates/almide-mir/examples/classify_corpus_parts/classify_corpus_c.rs
@@ -44,6 +44,56 @@ fn classify_check_unlinkable_call(ctx: &FileCtx, t: &mut Tally, mir: &MirFunctio
     }
 }
 
+/// The per-MIR witness emission of [`classify_lowered_fn`]: the borrow-by-default
+/// backing gate, then one ownership-certificate + name-witness pair per function.
+///
+/// Split out because it is the only phase of that function that LOOPS with a
+/// `continue` and writes three streams — the shape that carried most of its
+/// cognitive complexity. Everything here is a LOCAL property (ownership is one
+/// heap object per line, names are one line per function; no transitivity), so
+/// the phase is genuinely independent of the caps count that follows it.
+fn emit_cert_witnesses(
+    ctx: &FileCtx,
+    mirs: &[MirFunction],
+    t: &mut Tally,
+    s: &mut CertStreams,
+) {
+for mir in mirs {
+        // The borrow-by-default soundness gate: every `+1` event must
+        // be backed by a real runtime op (no synthetic param `+1`).
+        if !plus_one_events_backed(mir) {
+            t.cert_backing_breaches
+                .push(format!("{}::{}", ctx.file.display(), mir.name));
+        }
+        // Ownership is one heap object per line; names are one line per
+        // function. Both are LOCAL properties — no transitivity.
+        let (cert, poisoned) = almide_mir::certificate::ownership_certificate_with_poison(mir);
+        // A POISONED certificate (a nested-region arm flushed as the
+        // always-rejecting `{i|}`) is kernel-UNREPRESENTABLE by its own
+        // declaration — shipping it in the witness would fail the gate
+        // by design, not by finding a bug (#1146: the C-220 test fns
+        // were the first in-profile poisoned certs; every earlier
+        // poisoned fn sat outside the witness). EXCLUDE it, COUNTED —
+        // the render is still covered by the executable verifier.
+        if poisoned {
+            t.cert_poisoned_excluded += 1;
+            s.names.push_str(&name_witness_string(mir));
+            s.names.push('\n');
+            continue;
+        }
+        // Parallel name index (ownership.names): one `<file>::<fn>` line per
+        // cert line, so a checker REJECT bisects straight to its function
+        // (the anonymous 20k-line cert made a reject a needle hunt).
+        for _ in cert.lines() {
+            s.ownership_names
+                .push_str(&format!("{}::{}\n", ctx.file.display(), mir.name));
+        }
+        s.ownership.push_str(&cert);
+        s.names.push_str(&name_witness_string(mir));
+        s.names.push('\n');
+    }
+}
+
 /// The LOWERED arm of [`classify_lower_one_fn`], verbatim (codopsy
 /// A-maintenance split): witness emission, interp/link coverage, and the
 /// two-sided call-count gate for a function the lowering accepted.
@@ -122,40 +172,7 @@ fn classify_lowered_fn(
             }
         }
     }
-    for mir in &mirs {
-        // The borrow-by-default soundness gate: every `+1` event must
-        // be backed by a real runtime op (no synthetic param `+1`).
-        if !plus_one_events_backed(mir) {
-            t.cert_backing_breaches
-                .push(format!("{}::{}", ctx.file.display(), mir.name));
-        }
-        // Ownership is one heap object per line; names are one line per
-        // function. Both are LOCAL properties — no transitivity.
-        let (cert, poisoned) = almide_mir::certificate::ownership_certificate_with_poison(mir);
-        // A POISONED certificate (a nested-region arm flushed as the
-        // always-rejecting `{i|}`) is kernel-UNREPRESENTABLE by its own
-        // declaration — shipping it in the witness would fail the gate
-        // by design, not by finding a bug (#1146: the C-220 test fns
-        // were the first in-profile poisoned certs; every earlier
-        // poisoned fn sat outside the witness). EXCLUDE it, COUNTED —
-        // the render is still covered by the executable verifier.
-        if poisoned {
-            t.cert_poisoned_excluded += 1;
-            s.names.push_str(&name_witness_string(mir));
-            s.names.push('\n');
-            continue;
-        }
-        // Parallel name index (ownership.names): one `<file>::<fn>` line per
-        // cert line, so a checker REJECT bisects straight to its function
-        // (the anonymous 20k-line cert made a reject a needle hunt).
-        for _ in cert.lines() {
-            s.ownership_names
-                .push_str(&format!("{}::{}\n", ctx.file.display(), mir.name));
-        }
-        s.ownership.push_str(&cert);
-        s.names.push_str(&name_witness_string(mir));
-        s.names.push('\n');
-    }
+    emit_cert_witnesses(ctx, &mirs, t, s);
     // CAPS SOUNDNESS: count the source's call nodes. A call ELIDED by
     // Opaque lowering (a list element, ctor payload, BinOp operand, …) is
     // absent from the MIR ops, so the transitive caps fold over CallFn /

--- a/crates/almide-mir/src/lower/control_p3_c.rs
+++ b/crates/almide-mir/src/lower/control_p3_c.rs
@@ -293,45 +293,12 @@ impl LowerCtx {
         depth: u32,
     ) -> Option<ValueId> {
         use almide_lang::types::constructor::TypeConstructorId as TC;
-        // A `List[<record>]` — the synthesized loop-helper route (#1134 Shape 1, the
-        // codec `many: List[Inner]` cell): per-element record eq via the record
-        // helper, the identical branchless loop as List[variant] (Tier 2 already
-        // passed — a record is never in `variant_layouts`, so this is the first
-        // tier that can serve it). Gated to a NON-GENERIC Named record with a
-        // resolvable field layout; a field outside the engine fails the ensure and
-        // the site walls (None — honest, never wrong bytes).
-        if let Ty::Applied(TC::List, es) = ty {
-            if es.len() == 1 {
-                if let Ty::Named(n, args) = &es[0] {
-                    if args.is_empty() {
-                        if let Some((_names, ftys)) = self.aggregate_field_tys(&es[0]) {
-                            let key = n.as_str().to_string();
-                            if self.ensure_list_record_eq_helper(&key, &ftys) {
-                                let name = self.list_record_eq_helper_name(&key);
-                                return Some(self.emit_eq_helper_call(name, lv, rv));
-                            }
-                            return None;
-                        }
-                    }
-                }
-                // `List[Option[<record>]]` (the codec `lc: List[Inner?]` eq cell,
-                // #1134): the synthesized loop over the option-element helper —
-                // tag eq per element, the record compare guarded to both-Some.
-                if let Ty::Applied(TC::Option, oa) = &es[0] {
-                    if let [Ty::Named(n, args)] = &oa[..] {
-                        if args.is_empty() && self.custom_variant_type_name(&oa[0]).is_none() {
-                            if let Some((_names, ftys)) = self.aggregate_field_tys(&oa[0]) {
-                                let key = n.as_str().to_string();
-                                if self.ensure_list_opt_record_eq_helper(&key, &ftys) {
-                                    let name = self.list_opt_record_eq_helper_name(&key);
-                                    return Some(self.emit_eq_helper_call(name, lv, rv));
-                                }
-                                return None;
-                            }
-                        }
-                    }
-                }
-            }
+        // The two `List[...]` synthesized-loop routes come first and carry all of
+        // this tier's nesting, so they live in their own helper (same
+        // `Option<Option<_>>` convention the tiers above use: outer None = "not my
+        // shape, keep going", inner None = "mine, and it WALLS").
+        if let Some(done) = self.list_element_eq_helper(lv, rv, ty) {
+            return done;
         }
         if let Ty::Applied(TC::Option, oa) = ty {
             if oa.len() == 1 {
@@ -354,6 +321,61 @@ impl LowerCtx {
             return self.aggregate_eq_from_handles(lv, rv, &ftys, depth);
         }
         None
+    }
+
+    /// The `List[<record>]` and `List[Option[<record>]]` routes of
+    /// [`Self::container_slot_eq`] — per-element eq through a SYNTHESIZED loop
+    /// helper (#1134 Shape 1: the codec `many: List[Inner]` and `lc: List[Inner?]`
+    /// cells). The same branchless loop `List[variant]` uses; Tier 2 has already
+    /// passed by here because a record is never in `variant_layouts`, so this is
+    /// the first tier that can serve it.
+    ///
+    /// Both routes are gated to a NON-GENERIC `Named` record with a resolvable
+    /// field layout. A field the engine cannot compare fails the `ensure` and the
+    /// SITE WALLS — honest refusal, never wrong bytes.
+    ///
+    /// Returns `None` for "not one of these shapes, keep walking the tier";
+    /// `Some(Some(v))` for the emitted call; `Some(None)` for the wall. Split out
+    /// of `container_slot_eq` because these two routes carried all of its nesting
+    /// (depth 7) and most of its cognitive complexity — the Option/Result/aggregate
+    /// arms that remain there are flat.
+    fn list_element_eq_helper(
+        &mut self,
+        lv: ValueId,
+        rv: ValueId,
+        ty: &Ty,
+    ) -> Option<Option<ValueId>> {
+        use almide_lang::types::constructor::TypeConstructorId as TC;
+        let Ty::Applied(TC::List, es) = ty else { return None };
+        let [elem] = &es[..] else { return None };
+
+        if let Ty::Named(n, args) = elem {
+            if args.is_empty() {
+                if let Some((_names, ftys)) = self.aggregate_field_tys(elem) {
+                    let key = n.as_str().to_string();
+                    if !self.ensure_list_record_eq_helper(&key, &ftys) {
+                        return Some(None);
+                    }
+                    let name = self.list_record_eq_helper_name(&key);
+                    return Some(Some(self.emit_eq_helper_call(name, lv, rv)));
+                }
+            }
+        }
+
+        // `List[Option[<record>]]`: the loop runs over the option-element helper —
+        // tag eq per element, with the record compare guarded to both-Some.
+        let Ty::Applied(TC::Option, oa) = elem else { return None };
+        let [Ty::Named(n, args)] = &oa[..] else { return None };
+        if !args.is_empty() || self.custom_variant_type_name(&oa[0]).is_some() {
+            return None;
+        }
+        let (_names, ftys) = self.aggregate_field_tys(&oa[0])?;
+        let key = n.as_str().to_string();
+        if !self.ensure_list_opt_record_eq_helper(&key, &ftys) {
+            return Some(None);
+        }
+        let name = self.list_opt_record_eq_helper_name(&key);
+        Some(Some(self.emit_eq_helper_call(name, lv, rv)))
     }
 
     /// Tuple/record `==` over two materialized block HANDLES: load each declaration-order


### PR DESCRIPTION
`almide-mir` was the one crate of seventeen still scoring **B (89)** on `codopsy`; every other crate is A. This takes it to **A (90)** by splitting the two functions carrying the most complexity, with no behaviour change.

## What moved

**`container_slot_eq` → `list_element_eq_helper`** (`crates/almide-mir/src/lower/control_p3_c.rs`). The two `List[<record>]` / `List[Option[<record>]]` synthesized-loop routes carried *all* of that function's nesting — three warnings at once: cyclomatic 21, **cognitive 61**, and a depth-7 nesting flag. They now sit in their own helper using the same `Option<Option<_>>` convention the tiers above it already use (outer `None` = "not my shape, keep walking"; inner `None` = "mine, and it WALLS"). What remains in `container_slot_eq` — the Option, Result and aggregate arms — is flat.

**`classify_lowered_fn` → `emit_cert_witnesses`** (`crates/almide-mir/examples/classify_corpus_parts/classify_corpus_c.rs`). The per-MIR witness phase — the borrow-by-default backing gate plus one ownership-certificate + name-witness pair per function — is the only phase of that function that loops with a `continue` and writes three streams. It is also genuinely independent: ownership is one heap object per line and names are one line per function, both LOCAL properties with no transitivity, so the split is along a real seam rather than a line count.

## Semantics preserved, checked case by case

The `List` extraction changes control flow shape, so each fall-through was walked rather than assumed:

- element is `Named` with generic args → before: skipped the Named branch, tried Option, fell out of the `List` block. After: inner `args.is_empty()` is false, falls to the Option check, element is `Named` not `Option`, returns `None`. Same.
- element is `Named`, no args, but `aggregate_field_tys` yields `None` → both versions fall through to the Option check and then out. Same.
- `ensure_*_eq_helper` returning false still WALLS the site (`Some(None)`) rather than falling through — that is the "honest refusal, never wrong bytes" path and it is the one a careless flattening would have turned into a fall-through.

## Gates

`proofs/corpus-wall.sh`: **TOTAL over 6550 corpus functions**, zero panics, zero undetected refusals, every in-profile `+1` backed by a real runtime op; walled-real ratchet 0. That is the check that matters here — `classify_corpus` is what feeds the trust-spine's `mir == ir` credit rule, so a behaviour change in it would show up as a wall or a breach.

Also green: `cargo test --release -p almide-mir`, `almide test` (399 files, 0 failed, native fallback 17 — unchanged), `almide fmt --check spec/ examples/` (917), `check-contracts.sh` (269 contracts, 405/405 linked).

`codopsy analyze crates/almide-mir`: **B (89) → A (90)**, warnings 34 → 32. The remaining top offender is `is_admitted_effectful_fs` (cyclomatic 34, `lower/calls.rs`) — left alone deliberately, since it is a flat dispatch table whose complexity IS its enumeration, and splitting it would hide the surface rather than simplify it.