### PR TITLE
Fix the wasm ?? call! fallback arm yielding the Result block instead of the payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The guarantee is **continuous, with an explicit, ledger-managed scope**: "byte-i
 This claim is not prose. Every observable promise is a named contract in the [behavior-contract ledger](docs/contracts/), each traceable to executable evidence, and the numbers below are regenerated from the ledger (`scripts/gen-claims.sh`, enforced by `scripts/check-contracts.sh` in CI) so this section cannot drift from what the gates actually verify:
 
 <!-- claims:generated:start — derived from docs/contracts/contracts.toml by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
-> **Ledger: 270 contracts — 270 active, 0 flagged-for-revision.**
+> **Ledger: 271 contracts — 271 active, 0 flagged-for-revision.**
 >
 > **Divergences awaiting a fix: none.** Every contract in the ledger is
 > `active`, carrying executable evidence of class >= `fixture`. The one

--- a/crates/almide-interp/interp-abstain-ledger.txt
+++ b/crates/almide-interp/interp-abstain-ledger.txt
@@ -124,6 +124,7 @@ string_split_rle_codepoint  out-of-interp-scope capability: prim.handle
 string_whitespace  out-of-interp-scope capability: prim.alloc_str
 tco_map_acc_seed  out-of-interp-scope capability: prim.alloc_map
 unwrap_or_operand  out-of-interp-scope capability: prim.handle
+unwrap_or_unwrap_fallback  out-of-interp-scope capability: prim.handle
 value_array_leak_loop  out-of-interp-scope capability: prim.alloc_value
 value_array_tuple_tco  out-of-interp-scope capability: prim.alloc_value
 value_as_array_leak_loop  out-of-interp-scope capability: prim.alloc_value

--- a/crates/almide-mir/src/lower/desugar_b.rs
+++ b/crates/almide-mir/src/lower/desugar_b.rs
@@ -624,6 +624,112 @@ pub fn desugar_tuple_unwrap_or(body: &IrExpr) -> Option<IrExpr> {
     changed.then_some(out)
 }
 
+/// `carrier ?? f(..)!` over a HEAP (handle-carrying) payload — the `??` whose FALLBACK is an
+/// INLINE propagating unwrap (#1375). The fallback arm lands in the heap arm lowering as a bare
+/// `Unwrap`, whose `e! ≡ e` pass-through is the identity ONLY in a Result-typed arm; here the arm
+/// is PAYLOAD-typed, so the pass-through yielded the fallback's whole `Result` BLOCK where the
+/// merge expects the handle — `json.parse("hi") ?? json.parse("[1,2]")!` printed `true` (the
+/// ok-discriminant read through the Json tag slot) instead of `[1,2]`.
+///
+/// Rewrite to the exact identity, which keeps the fallback CONDITIONAL (hoisting `f(..)!` into a
+/// preceding `let` would evaluate — and propagate — it on the ok path too):
+///
+///   `a ?? f(..)!`  ≡  `(match a { ok($p) => ok($p), err(_) => f(..) })!`
+///   `o ?? f(..)!`  ≡  `(match o { some($p) => ok($p), none => f(..) })!`
+///
+/// Both sides evaluate `a`/`o` once and `f(..)` only on the miss path; the `!` moved OUT of the
+/// arm now sits in the proven `let x = e!` / call-arg-hoist position, and the match itself is the
+/// Result-typed shape the arm pass-through is actually valid for. CALL-COUNT-INVARIANT (the two
+/// operand calls appear exactly once before and after), so `mir == ir` holds without re-counting.
+/// SCALAR payloads keep their own proven `??` route untouched — they never reach the heap arm.
+pub fn desugar_unwrap_or_unwrap_fallback(body: &IrExpr) -> Option<IrExpr> {
+    use almide_lang::types::constructor::TypeConstructorId;
+    /// The carrier's HIT/MISS pattern pair for a payload bound to `p`, or `None` when the
+    /// operand is neither an `Option[<payload>]` nor a `Result[<payload>, _]`.
+    fn carrier_patterns(
+        carrier: &Ty,
+        payload: &Ty,
+        p: almide_ir::VarId,
+    ) -> Option<(almide_ir::IrPattern, almide_ir::IrPattern)> {
+        use almide_ir::IrPattern;
+        let bind = IrPattern::Bind { var: p, ty: payload.clone() };
+        match carrier {
+            Ty::Applied(TypeConstructorId::Result, a) if a.len() == 2 && a[0] == *payload => Some((
+                IrPattern::Ok { inner: Box::new(bind) },
+                IrPattern::Err { inner: Box::new(IrPattern::Wildcard) },
+            )),
+            Ty::Applied(TypeConstructorId::Option, a) if a.len() == 1 && a[0] == *payload => {
+                Some((IrPattern::Some { inner: Box::new(bind) }, IrPattern::None))
+            }
+            _ => None,
+        }
+    }
+    fn rewrite(e: IrExpr, changed: &mut bool, next: &mut u32) -> IrExpr {
+        let e = e.map_children(&mut |c| rewrite(c, changed, next));
+        let IrExprKind::UnwrapOr { expr, fallback } = &e.kind else { return e };
+        // `Try` is the frontend auto-`?`; both spellings propagate the same way.
+        let (IrExprKind::Unwrap { expr: inner } | IrExprKind::Try { expr: inner }) = &fallback.kind
+        else {
+            return e;
+        };
+        // HEAP payloads only — the scalar `??` never reaches the miscompiling arm.
+        if !is_heap_ty(&e.ty) {
+            return e;
+        }
+        // The fallback's `!` must yield EXACTLY the `??`'s own payload type, so `ok($p)` in the
+        // hit arm and `f(..)` in the miss arm are the same `Result[payload, _]`.
+        if !matches!(&inner.ty,
+            Ty::Applied(TypeConstructorId::Result, a) if a.len() == 2 && a[0] == e.ty)
+        {
+            return e;
+        }
+        let p = almide_ir::VarId(*next);
+        let Some((hit, miss)) = carrier_patterns(&expr.ty, &e.ty, p) else { return e };
+        *next += 1;
+        *changed = true;
+        let payload = IrExpr {
+            kind: IrExprKind::Var { id: p },
+            ty: e.ty.clone(),
+            span: e.span.clone(),
+            def_id: None,
+        };
+        // The hit arm RE-WRAPS the payload at the fallback's Result type — the carrier's own
+        // err type never has to join with the fallback's.
+        let rewrapped = IrExpr {
+            kind: IrExprKind::ResultOk { expr: Box::new(payload) },
+            ty: inner.ty.clone(),
+            span: e.span.clone(),
+            def_id: None,
+        };
+        let merged = IrExpr {
+            kind: IrExprKind::Match {
+                subject: expr.clone(),
+                arms: vec![
+                    almide_ir::IrMatchArm { pattern: hit, guard: None, body: rewrapped },
+                    almide_ir::IrMatchArm {
+                        pattern: miss,
+                        guard: None,
+                        body: (**inner).clone(),
+                    },
+                ],
+            },
+            ty: inner.ty.clone(),
+            span: e.span.clone(),
+            def_id: e.def_id,
+        };
+        IrExpr {
+            kind: IrExprKind::Unwrap { expr: Box::new(merged) },
+            ty: e.ty.clone(),
+            span: e.span.clone(),
+            def_id: e.def_id,
+        }
+    }
+    let mut changed = false;
+    let mut next = crate::lower::max_var_id(body) + 1;
+    let out = rewrite(body.clone(), &mut changed, &mut next);
+    changed.then_some(out)
+}
+
 /// `option.unwrap_or(option.map(list.find(xs, λ1), λ2), 32)` — the C-127 PIPED
 /// generic chain. The lambda lift is statement-position-sensitive: the SAME chain
 /// written as source `let`s lowers, while the nested-call form walls its HOF

--- a/crates/almide-mir/src/lower/desugar_unwrap_b.rs
+++ b/crates/almide-mir/src/lower/desugar_unwrap_b.rs
@@ -337,6 +337,46 @@ fn find_let_unwrap_target(stmts: &[IrStmt]) -> Option<(usize, LetUnwrapTarget, I
     })
 }
 
+/// ANF the operand of `{ …; let v = (<match …>)!; rest }` into its own bind:
+/// `{ …; let $u = <match …>; let v = $u!; rest }` (#1375). [`desugar_let_unwrap`] builds a
+/// propagation `match` over the operand, and a MATCH in that subject position walls — a `Var`
+/// there is the proven shape. `None` when the operand is not a match (every other operand kept
+/// its existing route) or the statement is not one of the two unwrap-bind spellings.
+fn anf_let_unwrap_match_operand(body: &IrExpr, i: usize, inner: &IrExpr) -> Option<IrExpr> {
+    let IrExprKind::Block { stmts, expr: tail } = &body.kind else { return None };
+    if !matches!(inner.kind, IrExprKind::Match { .. }) {
+        return None;
+    }
+    let u = VarId(max_var_id(body) + 1);
+    let mut anf_stmt = stmts.get(i)?.clone();
+    let value = match &mut anf_stmt.kind {
+        IrStmtKind::Bind { value, .. } | IrStmtKind::BindDestructure { value, .. } => value,
+        _ => return None,
+    };
+    // Only the SPELLED unwrap forms — `find_let_unwrap_target` also admits a bare Result-typed
+    // destructure value, which has no `!` to re-point at the lifted bind.
+    match &mut value.kind {
+        IrExprKind::Unwrap { expr } | IrExprKind::Try { expr } => {
+            *expr = Box::new(mk_at(body, IrExprKind::Var { id: u }, inner.ty.clone()));
+        }
+        _ => return None,
+    }
+    let lift = IrStmt {
+        kind: IrStmtKind::Bind {
+            var: u,
+            mutability: almide_ir::Mutability::Let,
+            ty: inner.ty.clone(),
+            value: inner.clone(),
+        },
+        span: stmts[i].span.clone(),
+    };
+    let mut out: Vec<IrStmt> = stmts[..i].to_vec();
+    out.push(lift);
+    out.push(anf_stmt);
+    out.extend(stmts[i + 1..].iter().cloned());
+    Some(mk_at(body, IrExprKind::Block { stmts: out, expr: tail.clone() }, body.ty.clone()))
+}
+
 /// Build an `IrExpr` carrying `body`'s span and def_id — every node
 /// [`desugar_let_unwrap`] and its helpers synthesize.
 fn mk_at(body: &IrExpr, kind: IrExprKind, ty: Ty) -> IrExpr {
@@ -541,6 +581,16 @@ pub fn desugar_let_unwrap(body: &IrExpr) -> Option<IrExpr> {
         return None;
     };
     let (i, target, inner) = find_let_unwrap_target(stmts)?;
+    // A MATCH operand (`let v = (match a { ok($p) => ok($p), err(_) => f(..) })!` — what
+    // `desugar_unwrap_or_unwrap_fallback` rewrites `a ?? f(..)!` into, #1375) is NOT a
+    // materializable match SUBJECT: the propagation match built below would carry a match
+    // in its subject position, which the subject lowering walls. ANF it into its own bind
+    // first, so the propagation match dispatches on a `Var` — the proven subject shape.
+    // ONE extra statement, the SAME single evaluation of the operand, so the rewrite is
+    // call-count-invariant (`mir == ir`) and the fixpoint re-enters on `let v = $u!`.
+    if let Some(anf) = anf_let_unwrap_match_operand(body, i, &inner) {
+        return Some(anf);
+    }
     // The unwrapped expr must be a `Result[T, E]` — `!` early-returns its `Err(E)`, binds `Ok(T)`.
     let (ok_ty, err_ty) = match &inner.ty {
         Ty::Applied(TypeConstructorId::Result, a) if a.len() == 2 => (a[0].clone(), a[1].clone()),

--- a/crates/almide-mir/src/lower/heap_result_arm.rs
+++ b/crates/almide-mir/src/lower/heap_result_arm.rs
@@ -115,6 +115,25 @@ impl LowerCtx {
             // `!` and lower `e` as the arm (the same identity the tail-position `e!` uses).
             // `Try` is the frontend auto-`?` — in a Result-typed arm both it and a spelled
             // `!` propagate the inner call's same-repr Result verbatim (the pass-through).
+            // …but ONLY in a RESULT-typed arm. When the arm must yield the PAYLOAD (`result_ty`
+            // IS the arm's own type while `e` is the wrapping Result — the `??`-with-inline-`!`
+            // fallback, #1375) `e! ≡ e` is NOT the identity: passing `e` through leaves the whole
+            // Result BLOCK where the merge expects the payload handle, and the reader picks the
+            // ok-discriminant out of it (`json.parse("hi") ?? json.parse("[1,2]")!` printed
+            // `true`). DECLINE — a silent wrong value is never an acceptable arm value; the
+            // caller rolls back to its own wall, and `desugar_unwrap_or_unwrap_fallback` has
+            // already rewritten the `??` spelling to the `(match … )!` form that DOES execute.
+            IrExprKind::Unwrap { expr } | IrExprKind::Try { expr }
+                if *result_ty == arm.ty && expr.ty != arm.ty =>
+            {
+                crate::trace::trace("ALMIDE_DBG_ELEM", || {
+                    format!(
+                        "[heap-if-arm] declined payload-typed `e!` arm (arm ty {:?}, inner ty {:?})",
+                        arm.ty, expr.ty
+                    )
+                });
+                None
+            }
             IrExprKind::Unwrap { expr } | IrExprKind::Try { expr } => {
                 self.lower_heap_result_arm(expr, result_ty)
             }

--- a/crates/almide-mir/src/lower/mod_c.rs
+++ b/crates/almide-mir/src/lower/mod_c.rs
@@ -446,6 +446,7 @@ fn wrap_unit_body_in_ok(body: &IrExpr, result_ty: Ty) -> IrExpr {
 /// - `desugar_heap_if_call_args` — a HEAP-result `if` in argument position → let-decomposed (#881).
 /// - `desugar_mutable_global_projection_args` / `desugar_bytes_index_assign` —
 ///   the two that need the fn's PARAMS to decide.
+/// - `desugar_unwrap_or_unwrap_fallback` — `a ?? f(..)!` over a heap payload → `(match a { … })!` (#1375).
 /// - `desugar_list_slice_calls`, `desugar_optional_chain` — the remaining surface forms.
 fn apply_pre_lower_desugars(body: &IrExpr, params: &[almide_ir::IrParam]) -> Option<IrExpr> {
     type Pass = fn(&IrExpr) -> Option<IrExpr>;
@@ -457,6 +458,9 @@ fn apply_pre_lower_desugars(body: &IrExpr, params: &[almide_ir::IrParam]) -> Opt
         desugar_hof_chain_anf,
         desugar_heap_if_call_args,
         desugar_mutable_global_projection_args,
+        // BEFORE the branch/unwrap desugars: the rewrite moves the fallback's `!` OUT of the
+        // conditional arm into the `let x = e!` position `desugar_let_unwrap` then handles.
+        desugar_unwrap_or_unwrap_fallback,
     ];
     let mut cur: Option<IrExpr> = None;
     for pass in PASSES {

--- a/crates/almide-optimize/src/optimize/branch_lift.rs
+++ b/crates/almide-optimize/src/optimize/branch_lift.rs
@@ -215,7 +215,11 @@ impl<'a> IrMutVisitor for BranchLifter<'a> {
             }),
             _ => false,
         };
-        if self.dense_depth > 0 && heap_branch_kind && is_heap_ty(&expr.ty) {
+        if self.dense_depth > 0
+            && heap_branch_kind
+            && is_heap_ty(&expr.ty)
+            && !holds_error_op(expr)
+        {
             let ty = expr.ty.clone();
             self.lift_bind_value(ty, expr);
         }
@@ -259,11 +263,42 @@ impl<'a> IrMutVisitor for BranchLifter<'a> {
                 IrExprKind::If { .. } => self.loop_depth > 0 || self.dense_depth > 0,
                 _ => false,
             };
-            if fire {
+            if fire && !holds_error_op(value) {
                 self.lift_bind_value(ty.clone(), value);
             }
         }
     }
+}
+
+/// Does this branch carry an error-PROPAGATING `!`/`?` (`IrExprKind::Unwrap`/`Try`) that
+/// belongs to the ENCLOSING function? The helper this pass synthesizes is a plain
+/// `fn … -> <payload>` — non-effect, payload-returning — so a propagation lifted into it
+/// has NO channel out: the native backend emitted `?` in a non-`Result` fn (rustc
+/// E0277) and the wasm side always-wrapped the helper's body in `ok(..)` while the call
+/// site bound it as the bare payload, printing the ok-discriminant (`match json.parse("hi")
+/// { ok(p) => p, err(_) => json.parse("[1,2]")! }` → `true`). DECLINE the lift; the branch
+/// keeps its in-place route, where the `!` still sits in the fn that owns it. A `Lambda`
+/// body is NOT descended — a `!` there propagates to the lambda's own result, which the
+/// lift carries along unchanged.
+fn holds_error_op(e: &IrExpr) -> bool {
+    struct V {
+        found: bool,
+    }
+    impl visit::IrVisitor for V {
+        fn visit_expr(&mut self, e: &IrExpr) {
+            if self.found || matches!(e.kind, IrExprKind::Lambda { .. }) {
+                return;
+            }
+            if matches!(e.kind, IrExprKind::Unwrap { .. } | IrExprKind::Try { .. }) {
+                self.found = true;
+                return;
+            }
+            visit::walk_expr(self, e);
+        }
+    }
+    let mut v = V { found: false };
+    visit::IrVisitor::visit_expr(&mut v, e);
+    v.found
 }
 
 impl<'a> BranchLifter<'a> {

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-270 contracts
+271 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -298,4 +298,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-268 | A `_` in call-argument position is a check-time E046, identically on both targets | 0.57.1 | active | fixture | 0 |
 | C-269 | A nested variant match bound to a let executes identically on both targets; a constructor pattern the subject lacks is a check-time E048 on both | 0.57.1 | active | fixture | 1 |
 | C-270 | The shared fp16 block scale decodes the whole fp16 domain identically on both targets | 0.57.1 | active | fixture | 1 |
+| C-271 | `carrier ?? call!` yields the fallback's PAYLOAD, never its Result block, for a handle-carrying payload on both targets | 0.57.1 | active | fixture | 1 |
 

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,7 +11,7 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-96 normative sections; 424 distinct executable fixtures.
+96 normative sections; 425 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|
@@ -56,7 +56,7 @@
 | ALS-E22 | C-254 | `spec/wasm_cross/place_assign_ascription.almd` (byte-compare) |
 | ALS-E23 | C-255 | `spec/wasm_cross/record_forms.almd` (byte-compare) |
 | ALS-E24 | C-256 | `spec/wasm_cross/loop_break_continue.almd` (byte-compare) |
-| ALS-E25 | C-257 | `spec/wasm_cross/error_operators.almd` (byte-compare) |
+| ALS-E25 | C-257, C-271 | `spec/wasm_cross/error_operators.almd` (byte-compare)<br>`spec/wasm_cross/unwrap_or_unwrap_fallback.almd` (byte-compare) |
 | ALS-E26 | C-258 | `spec/wasm_cross/call_lambda_ctor.almd` (byte-compare) |
 | ALS-E27 | C-259 | `spec/wasm_cross/call_lambda_ctor.almd` (byte-compare) |
 | ALS-E28 | C-264 | `spec/wasm_cross/optional_chain_scalar.almd` (byte-compare) |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -3325,3 +3325,15 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/matrix_q_fp16_scale_domain.almd", class = "fixture" },
 ]
+
+# ── `??` WITH AN INLINE-`!` FALLBACK OVER A HANDLE PAYLOAD ─────────────
+[[contract]]
+id        = "C-271"
+spec      = "ALS-E25"
+title     = "`carrier ?? call!` yields the fallback's PAYLOAD, never its Result block, for a handle-carrying payload on both targets"
+statement = "A `??` whose FALLBACK is an inline propagating unwrap (`a ?? f(..)!`) produces byte-identical observables native <-> wasm when the FALLBACK ARM RUNS and the payload is heap/handle-carrying (a json `Value`, `String`, `List[Int]`, `Bytes`). Thirteen cells: the three reported json payloads (array, object, number), the ok path (the carrier holds a value, so a fallback that would itself fail is never evaluated — `??` stays lazy in its fallback), the `match { ok(p) => p, err(_) => f(..)! }` spelling that reaches the same arm, an Option carrier, `?`-to-Option followed by `??`, a nested `??` supplying the outer fallback, the String / List / Bytes carriers, the BOTH-fail path (the fallback's own error is the enclosing fn's error), and the scalar (Int) control that never took the handle path. Found by `tools/xtarget-fuzz` (--family all --seed 13322026081302 --index 297) as #1375, a SILENT WRONG VALUE on wasm: `json.parse(\"hi\") ?? json.parse(\"[1,2]\")!` printed `true`, which is `stringify` reading the ok DISCRIMINANT `1` out of the fallback's Result block. The heap-arm lowering applied the `e! = e` pass-through — the identity in a RESULT-typed arm, which propagates the Result verbatim — to a PAYLOAD-typed arm, so the whole Result block landed where the merge expects the payload handle. The `match` spelling detonated a second way, via `branch_lift` hoisting a `!`-bearing arm into a non-effect payload-returning helper: rustc E0277 on native, an always-wrapped body read as the bare payload on wasm. `spec/wasm_cross/declaration_forms.almd` carried the shape only on the OK path, where the fallback arm never runs — the fixture that tests what someone already thought of."
+since     = "0.57.1"
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/unwrap_or_unwrap_fallback.almd", class = "fixture" },
+]

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -7,7 +7,7 @@
 
 ## Active
 
-81 items
+82 items
 
 | Item | Description |
 |------|-------------|
@@ -34,6 +34,7 @@
 | [Fan v2 — reference examples](active/fan-v2-examples.md) | Reference examples for the fan v2 surface: every head, edge semantics, diagnostics |
 | [Fan v2 — one execution-policy grammar](active/fan-v2.md) | Fan v2: the execution-policy grammar — heads x forms, thunk-free, typed budgets |
 | [Flight Evidence Gaps — 実地監査所見台帳](active/flight-evidence-gaps.md) | Hands-on internal audit findings (2026-07-03) — the measured distance between DAL-A philosophy and DAL-A evidence, as 7 findings with corrective work items and acceptance criteria |
+| [Flight-grade: the organization and track-record rungs](active/flight-organization.md) |  |
 | [Flight Profile — 航空品質への接地分析と2つのキーストーン](active/flight-profile.md) | DO-178C flight-grade gap analysis: 6 pillars status + 2 engineering keystones |
 | [Flight Qualification — DO-178C/DO-330/DO-333 マッピング + 資格化キット(G-F5 + G-F6)](active/flight-qualification.md) | Flight gates G-F5 + G-F6 — how the PCC certificate/receipt maps to DO-178C Table A objectives, the DO-330 "prove-the-checker" tool-qualification argument (compiler→TQL-5 output-verified, checker→qualified-by-proof), the DO-333 formal-methods credit per proven property, and the G-F6 qualification kit as a product (AbsInt/SCADE-KCG model): what's in the kit, the boundary (kit provides vs customer's domain process), and the customer integration story. |
 | [Flight Reference App — PID 制御則カーネル + make verify + receipt(G-F4)](active/flight-reference-app.md) | Flight gate G-F4 — the reference application (a fixed-point Q16.16 PID control-law kernel over a counted sim loop) that passes `make verify` end-to-end, the 7-stage verify pipeline (exist vs gated on keystones), the receipt it emits (C-SAFE/C-PROVEN green, C-WCET/C-FAITHFUL pending), and the de-risking order (Slice 0 scalar-no-print green now → Slice 1 print=G-F0 frontier → Slice 2 keystone-あ unlocks C-WCET → Slice 3 keystone-い unlocks Ferrocene). |

--- a/docs/roadmap/active/fuzz-findings-triage.md
+++ b/docs/roadmap/active/fuzz-findings-triage.md
@@ -733,3 +733,29 @@ divergence was a sign bit. A fixture for a bit-pattern claim has to observe the 
 the zeros are now spelled through `float.to_string`, which prints `-0.0`. The new C-269 fixture
 pins the whole fp16 scale domain through BOTH q1_0 entry points, so the twin decoders cannot
 drift apart again. Verified A/B: on the pre-fix binary both fixtures are red.
+
+## #1375 — one source shape, TWO independent wrong-value mechanisms (2026-08-13)
+
+`json.parse("hi") ?? json.parse("[1,2]")!` printed `true` on wasm and `[1,2]` on native. The
+emitted WAT settled the mechanism in one read: the `??` lowered to the right skeleton (tag at
+`+16`, payload at `+12`, `tag != 0` picks the fallback), but the fallback arm ended
+`(local.set $v13 (call $json.parse …)) (local.get $v13)` — the whole `Result` block handed to
+the merge, with no tag read and no propagation. The heap-arm lowering applies `e! == e`, which
+is the identity in a RESULT-typed arm and NOT in a payload-typed one.
+
+The rule this entry adds: **narrow to the mechanism, then re-run the whole neighbourhood, because
+one surface shape can have more than one.** Rewriting `a ?? f(..)!` to `(match a { ok($p) =>
+ok($p), err(_) => f(..) })!` fixed eleven cells; the twelfth — the same arm spelled as a
+literal `match` — still printed `true`, and the emitted code showed why: that spelling reaches
+`branch_lift`, which hoists the branch into a synthesized NON-effect `fn … -> <payload>`. A `!`
+inside a lifted helper has no channel out, so native emitted `?` in a non-`Result` fn (rustc
+E0277 — loud) while wasm always-wrapped the helper body and the call site bound the wrapper as
+the bare payload (silent). Two mechanisms, one shape, and the second was only visible because
+the neighbourhood was re-measured after the first fix rather than at the start.
+
+Also worth keeping: the ANF that made the fix executable. `(match a { … })!` walls, because
+`desugar_let_unwrap` builds a propagation match whose SUBJECT would then be a match. Binding it
+first (`let $u = match a { … }; let v = $u!`) puts a `Var` in the subject position, which is the
+proven shape — one extra statement, the same single evaluation, call-count invariant. Hoisting
+the fallback itself would have been the wrong ANF: `??` must not evaluate its fallback on the ok
+path, and the fixture pins that with a cell whose unused fallback would fail.

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,10 +15,10 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 61 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 282/406 fixtures cast a real 3-way vote (69%)** —
+> **Stage 2 (translation validation): 282/407 fixtures cast a real 3-way vote (69%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
-> **Stage 3 (semantics freeze): 270/270 contracts spec-keyed; syntax-element coverage
+> **Stage 3 (semantics freeze): 271/271 contracts spec-keyed; syntax-element coverage
 > 72/72 sectioned (0 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;

--- a/spec/wasm_cross/unwrap_or_unwrap_fallback.almd
+++ b/spec/wasm_cross/unwrap_or_unwrap_fallback.almd
@@ -1,0 +1,135 @@
+// @contract: C-271
+// #1375: `<carrier> ?? <call>!` — a `??` whose FALLBACK is an inline
+// propagating unwrap — taking the FALLBACK arm, for a HANDLE-carrying payload.
+//
+// `spec/wasm_cross/declaration_forms.almd` already carried this shape, but only
+// on the OK path, where the fallback arm never runs. The generative fuzzer
+// perturbed the parsed literal into something unparseable and the err arm
+// finally executed: wasm printed `true` for
+// `json.parse("hi") ?? json.parse("[1,2]")!` — `stringify` reading the ok
+// DISCRIMINANT `1` out of the `Result` block the arm yielded instead of the
+// parsed handle. A silent wrong value on one leg, on a program that compiled,
+// ran and exited 0.
+//
+// Mechanism: the heap-arm lowering treats an `e!` arm as the identity `e`
+// (true in a Result-typed arm, which propagates the Result verbatim). Here the
+// arm is PAYLOAD-typed, so the whole `Result` block landed where the merge
+// expects the payload handle. Both spellings are pinned below — the `??` one
+// AND the `match` one that reaches the same arm.
+//
+// Every non-json carrier is a PURE Result-returning fn (`!` in a pure fn is
+// C-247) rather than an effect fn: the interp returns an effect call's success
+// value bare, so a `match` over one cannot vote. One cell per fn — a body with
+// several heap-branch binds is the bounded-duplication region, an orthogonal
+// concern this fixture deliberately does not ride on.
+import json
+
+fn take_bytes(n: Int) -> Result[Bytes, String] = if n > 0 then ok(bytes.from_list([65, 66, 67 + n]))
+else err("no bytes")
+
+fn take_list(n: Int) -> Result[List[Int], String] = if n > 0 then ok([n, n + 1])
+else err("no list")
+
+fn take_word(n: Int) -> Result[String, String] = if n > 0 then ok("word${n}")
+else err("no word")
+
+// The reported shape: the fallback arm runs and must yield the PARSED handle.
+fn miss_json(text: String) -> Result[String, String] = {
+  let a = json.parse("hi") ?? json.parse(text)!
+  ok(json.stringify(a))
+}
+
+// The OK path: the carrier holds a value, so the fallback (which would fail) is
+// never evaluated — `??` stays lazy in its fallback.
+fn hit_json() -> Result[String, String] = {
+  let a = json.parse("[3,4]") ?? json.parse("nope")!
+  ok(json.stringify(a))
+}
+
+// The `match` spelling of the same arm.
+fn miss_json_match() -> Result[String, String] = {
+  let a = match json.parse("hi") {
+    ok(p) => p,
+    err(_) => json.parse("[8,9]")!,
+  }
+  ok(json.stringify(a))
+}
+
+// An OPTION carrier over the same handle payload.
+fn miss_option() -> Result[String, String] = {
+  let vs: List[Value] = [value.int(1)]
+  let a = list.get(vs, 9) ?? json.parse("[5]")!
+  ok(json.stringify(a))
+}
+
+// `?` (Result -> Option) followed by `??`.
+fn miss_via_option() -> Result[String, String] = {
+  let a = json.parse("hi")? ?? json.parse("[6]")!
+  ok(json.stringify(a))
+}
+
+// Nested `??`: the inner one supplies the outer one's fallback.
+fn miss_nested() -> Result[String, String] = {
+  let a = json.parse("hi") ?? (json.parse("also bad") ?? json.parse("[7]")!)
+  ok(json.stringify(a))
+}
+
+// The other heap carriers: String, List and Bytes payloads.
+fn pick_word(n: Int) -> Result[String, String] = {
+  let w = take_word(0) ?? take_word(n)!
+  ok("picked ${w}")
+}
+
+fn pick_list() -> Result[String, String] = {
+  let xs = take_list(0) ?? take_list(5)!
+  ok(xs |> list.map((x) => int.to_string(x)) |> list.join(","))
+}
+
+fn pick_bytes() -> Result[String, String] = {
+  let bs = take_bytes(0) ?? take_bytes(1)!
+  ok("${bytes.len(bs)}:${bytes.to_string(bs)!}")
+}
+
+// SCALAR control: the same shape over an Int payload, which never took the
+// handle path and must keep its own route.
+fn pick_int() -> Result[String, String] = {
+  let n = int.parse("x") ?? int.parse("7")!
+  ok(int.to_string(n))
+}
+
+// The Result is bound to an ANNOTATED `let` before it is rendered: a
+// Result-returning call passed straight as an argument is propagated at the
+// call site, which would take the whole cell out of the fixture.
+fn show(label: String, r: Result[String, String]) -> String = match r {
+  ok(v) => "${label}: ${v}",
+  err(e) => "${label}: propagated ${e}",
+}
+
+effect fn main() -> Unit = {
+  let r_array: Result[String, String] = miss_json("[1,2]")
+  println(show("array", r_array))
+  let r_object: Result[String, String] = miss_json("{\"k\":1}")
+  println(show("object", r_object))
+  let r_number: Result[String, String] = miss_json("7")
+  println(show("number", r_number))
+  let r_hit: Result[String, String] = hit_json()
+  println(show("hit", r_hit))
+  let r_match: Result[String, String] = miss_json_match()
+  println(show("match", r_match))
+  let r_option: Result[String, String] = miss_option()
+  println(show("option", r_option))
+  let r_via: Result[String, String] = miss_via_option()
+  println(show("via-option", r_via))
+  let r_nested: Result[String, String] = miss_nested()
+  println(show("nested", r_nested))
+  let r_word: Result[String, String] = pick_word(3)
+  println(show("word", r_word))
+  let r_word_err: Result[String, String] = pick_word(0)
+  println(show("word-both-err", r_word_err))
+  let r_list: Result[String, String] = pick_list()
+  println(show("list", r_list))
+  let r_bytes: Result[String, String] = pick_bytes()
+  println(show("bytes", r_bytes))
+  let r_int: Result[String, String] = pick_int()
+  println(show("int", r_int))
+}


### PR DESCRIPTION
Closes #1375.

## What the emitted wasm actually did

`ALMIDE_DBG_WAT=main` on the reporter's repro, before any change:

```wat
(local.set $v1 (call $json.parse (local.get $v0)))       ;; the carrier
(local.set $v6 (i32.load … (+ $v1 16)))                  ;; tag   @16
(local.set $v9 (i32.load … (+ $v1 12)))                  ;; payload @12
(local.set $v2 (if (result i32) (i64.ne $v6 (i64.const 0))
  (then
    (local.set $v11 (call $json.parse (local.get $v10)))  ;; the FALLBACK
    (local.get $v11))                                     ;; ← the whole Result BLOCK
  (else
    (call $rc_inc $v9) (local.get $v9))))                 ;; ← the payload handle
```

The skeleton is right — tag at `+16`, payload at `+12`, `tag != 0` picks the fallback. The
fallback arm is not: it yields `json.parse`'s **`Result` block**, with no tag read and no
propagation, where the merge expects a payload handle. `json.stringify` then reads that block
through the json tag slot, which holds the ok-discriminant `1` → `true`.

**Mechanism.** `lower_heap_result_arm_literal_a` applies the pass-through `e! ≡ e`. That is the
identity in a **Result-typed** arm (`e!` propagates `e`'s Result verbatim) and is *not* the
identity in a **payload-typed** arm, which is what the `??` fallback is. Scalars never reached
that arm, which is why `int.parse("x") ?? int.parse("7")!` was always fine.

A second, independent mechanism turned up only after the first fix, on the `match` spelling of
the same arm: `branch_lift` hoists the branch into a synthesized **non-effect**
`fn … -> <payload>` helper. A `!` inside it has no channel out — native emitted `?` in a
non-`Result` fn (rustc E0277, loud) and wasm always-wrapped the helper body while the call site
bound the wrapper as the bare payload (silent `true`).

## The fix

1. **`desugar_unwrap_or_unwrap_fallback`** (new pre-lower desugar, heap payloads only) rewrites
   to the exact identity, keeping the fallback conditional:
   `a ?? f(..)!` → `(match a { ok($p) => ok($p), err(_) => f(..) })!`
   (Option carrier: `some/none`.) Hoisting `f(..)!` into a preceding `let` would have been the
   *wrong* ANF — `??` must not evaluate its fallback on the ok path.
2. **`anf_let_unwrap_match_operand`** binds a match operand of `let v = (…)!` first
   (`let $u = match …; let v = $u!`), so the propagation match dispatches on a `Var` — the proven
   subject shape. One extra statement, same single evaluation, call-count invariant.
3. **The arm pass-through now DECLINES** when the arm is payload-typed and its operand is the
   wrapping Result. The root cause is closed at the source: any other route into that arm gets an
   honest wall instead of a wrong value.
4. **`branch_lift` no longer lifts a branch that propagates `!`** into a non-effect helper.

## Before / after, both legs

| cell | native | wasm before | wasm after |
|---|---|---|---|
| `json.parse("hi") ?? json.parse("[1,2]")!` | `[1,2]` | **`true`** | `[1,2]` |
| …`?? json.parse("{\"k\":1}")!` | `{"k":1}` | **`true`** | `{"k":1}` |
| …`?? json.parse("7")!` | `7` | **`true`** | `7` |
| in a call arg / in a `"${…}"` interp | `[1,2]` | **`true`** | `[1,2]` |
| `match r { ok(p) => p, err(_) => f()! }` | **rustc E0277** | **`true`** | `[8,9]` (both legs) |
| Option carrier (`list.get(vs,9) ?? …!`) | `[1,2]` | **`true`** | `[5]` |
| `?`-to-Option then `??` | `[1,2]` | **`true`** | `[6]` |
| nested `??` | `[1,2]` | **`true`** | `[7]` |
| `String` carrier | `hello` | **`4`** | `hello` |
| `List[Int]` carrier | `5,6` | **`8232`** | `5,6` |
| `Bytes` carrier | `3` | **`1`** | `3` |
| both sides fail (propagation) | `Error: …` | **`true`** (error swallowed) | `Error: …` |
| ok path, fallback unused | `[3,4]` | `[3,4]` | `[3,4]` |
| scalar `int.parse("x") ?? int.parse("7")!` | `7` | `7` | `7` |
| `let p = …!` then `r ?? p` (hoisted) | `[1,2]` | `[1,2]` | `[1,2]` |
| `?? <call>` without `!` | `9` | `9` | `9` |
| `if c then f()! else g()!` | `[1,2]` | `[1,2]` | `[1,2]` |
| scalar Option carrier (`list.get ?? int.parse!`) | `7` | `7` | `7` |

A/B verified against the released `almide 0.57.0`: the new fixture prints `true` / garbage on 10
of its 13 cells there, and is byte-identical on both legs here.

## Neighbourhood sweep — cells checked and found CLEAN

`?? <non-call>` (hoisted `let` fallback), `?? <call>` without `!`, the ok path (incl. an ok path
whose *unused* fallback would fail — laziness is pinned), scalar carriers (Result and Option),
`if`-arm `!` in payload position, and the `match`-on-the-same-Result baseline. Two cells still
wall on wasm, both **pre-existing and unrelated** (reproduced without any `??`):
a user `effect fn` returning a heap Result via a bare `Try`, and `map.get` over
`Map[String, Value]` (`map.get_hval_wall` is unlinked). Honest build-time walls, not divergences.

## Contract

**C-271** (`ALS-E25`), evidenced by `spec/wasm_cross/unwrap_or_unwrap_fallback.almd` — thirteen
cells, `// @contract:` header on both sides of the link. The interpreter abstains on it
(`prim.handle`, as it does on every `json.parse` fixture), ledgered in
`crates/almide-interp/interp-abstain-ledger.txt` in this PR.

## Gates

`cargo build --release` · `cargo test --release` (all green) · `almide test` (0 failed, native
fallback still 17, ratchet OK) · `almide fmt --check spec/ examples/` · `scripts/check-contracts.sh`
· `cargo test --release --test wasm_runtime_test` · `check-rustc-warnings` (0) ·
`check-scalar-read-audit` · `check-abstain-classes` · `check-wasm-fallback` ·
`check-wasm-reachability` · `check-gate-verification` · `check-frees-churn` ·
`check-embedded-size` · `check-wat-prelude-audit`.
