### PR TITLE
Compare the WAT prelude audit site by file, not by line

### DIFF
--- a/scripts/check-wat-prelude-audit.sh
+++ b/scripts/check-wat-prelude-audit.sh
@@ -54,6 +54,9 @@ if cur:
     rows.append(cur)
 
 errs = []
+# Non-fatal observations (a drifted line number, #1378) — printed so the column
+# can be refreshed on the next touch, never a reason to red a gate.
+notes = []
 seen = set()
 for r in rows:
     n = r.get("name")
@@ -79,8 +82,27 @@ for r in rows:
             f"{n}: digest {r.get('digest')} != {digest} — the hand-written wasm at "
             f"{site} changed. Re-confirm its evidence and update the row; evidence "
             f"is not inherited across an edit.")
-    if r.get("site") != site:
-        errs.append(f"{n}: site moved to {site} (row says {r.get('site')})")
+    # `site` is compared by FILE ONLY, never by line (#1378).
+    #
+    # `digest` is the assurance field: a whitespace-normalized hash of the unit's
+    # text, so it changes iff the hand-written wasm changes, which is what forces
+    # the row's evidence to be re-confirmed. Comparing the LINE catches nothing
+    # the digest misses — it only detects that unrelated lines above the
+    # occurrence moved. Rows can sit in ordinary production files (the enumerator
+    # deliberately over-includes, so an inline `#[test]` in a production file is
+    # enumerated too), so any edit anywhere above one reds a gate that has nothing
+    # to do with the change. It cost a red CI run and a force-push on #1370, whose
+    # digest was unchanged, and it contradicts this repo's own convention (#1232:
+    # "Line numbers drift; anchor by function name").
+    #
+    # The FILE half is kept and still fails: a unit relocated to another file is a
+    # real move whose evidence deserves re-confirmation. A drifted line is
+    # reported so the column can be refreshed on the next touch, not enforced.
+    row_site = r.get("site") or ""
+    if row_site.rsplit(":", 1)[0] != site.rsplit(":", 1)[0]:
+        errs.append(f"{n}: site moved to {site} (row says {row_site}) — a different FILE")
+    elif row_site != site:
+        notes.append(f"{n}: line drifted, {row_site} -> {site} (not a failure; digest unchanged)")
     if cls in NEEDS_FIXTURE:
         fx = r.get("via", "")
         if not fx:
@@ -104,6 +126,8 @@ for n in sorted(units):
             f"{n}: UNCLASSIFIED — a prelude function at {units[n][0]} with no row. "
             f"Hand-written wasm the oracle cannot see needs its evidence named.")
 
+for note in notes:
+    print(f"  note: {note}")
 if errs:
     print("WAT PRELUDE AUDIT FAIL —", file=sys.stderr)
     for e in errs:


### PR DESCRIPTION
Closes #1378. The audit compared site (file:line) whole. `digest` — a whitespace-normalized content hash of the unit's text — is the assurance field: it changes iff the hand-written wasm changes, which is what forces the row's evidence to be re-confirmed. The LINE half catches nothing the digest misses; it only detects that unrelated lines ABOVE the occurrence moved. Rows can sit in ordinary production files (the enumerator deliberately over-includes, so an inline test in a production file is enumerated too), so any edit above one reds a gate with nothing to do with the change. It did exactly that on #1370, whose digest was unchanged: one red CI run plus a force-push to retype 347 to 364. It also contradicts this repo's own convention (#1232: 'Line numbers drift; anchor by function name').

What changed: the FILE half still fails — a unit relocated to a different file is a real move whose evidence deserves re-confirmation. A line drift becomes a printed note. `digest` is untouched.

Both directions demonstrated (forged, run, restored; ledger diff empty afterwards): a forged line drift 163->262 printed 'note: __die: line drifted ... (not a failure; digest unchanged)' and exited 0 with the audit OK over 61 fns; a forged file change to NOWHERE.rs produced 'WAT PRELUDE AUDIT FAIL — __die: site moved ... — a different FILE'.

Gates green: the audit itself (61 fns, structure layer), check-gate-verification.sh (36 gates, UNVERIFIED still 2 at ceiling 2).