### PR TITLE
Give the interpreter a block heap so the flat String/Bytes prim family votes

### DIFF
--- a/crates/almide-interp/interp-abstain-classes.toml
+++ b/crates/almide-interp/interp-abstain-classes.toml
@@ -31,6 +31,12 @@ patterns = [
   "capability: prim.alloc_str",
   "capability: prim.alloc_set",
   "capability: prim.alloc_bytes",
+  # Raw pointer conversion — pointer work by definition, same class as handle.
+  "capability: prim.int_to_ptr",
+  # An access the #1226 slice-1 arena does not own. The flat String/Bytes
+  # family is modeled; a load/store landing outside it is still the heap
+  # boundary, one level in from `prim.handle`.
+  "outside this heap's arena",
 ]
 
 [[class]]
@@ -49,4 +55,16 @@ patterns = [
   "transcendental",
   "float `**`",
   "interp fuel/recursion budget exhausted",
+  # SURFACED BY #1226 slice 1, not introduced by it: these fixtures used to
+  # abstain at `prim.handle` (HEAP_BOUNDARY, first-hit) and now get past it to
+  # reveal the blocker underneath. Both are bounded dispatch work with no
+  # architectural change, which is what BRIDGEABLE means:
+  #   prim.die     — native panics with exit 101; `Flow::Abort` is this
+  #                  interpreter's exit-1 model, so voting it would be wrong
+  #                  (the #1366 lesson). Needs an abort that carries the exit
+  #                  code, not a new evaluation model.
+  #   prim.fd_write— the raw fd write. The interp already captures stdout
+  #                  (`self.stdout`), so this is glue at the argv/env/fs tier.
+  "capability: prim.die",
+  "capability: prim.fd_write",
 ]

--- a/crates/almide-interp/interp-abstain-ledger.txt
+++ b/crates/almide-interp/interp-abstain-ledger.txt
@@ -10,69 +10,66 @@
 # Preferred alternative to adding an entry: widen the interp glue
 # (bridge.rs / hofs.rs / dispatch.rs — see crates/almide-interp/CLAUDE.md).
 
-alias_combinator_rc  out-of-interp-scope capability: prim.handle
+alias_combinator_rc  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 alias_cow  out-of-interp-scope capability: prim.alloc_map
-base64_encode  out-of-interp-scope capability: prim.handle
-bytes_f16  out-of-interp-scope capability: prim.handle
-bytes_f16_offset_overflow  out-of-interp-scope capability: prim.handle
-bytes_push_inplace  out-of-interp-scope capability: prim.handle
-bytes_rawptr  out-of-interp-scope capability: prim.handle
-bytes_set_value_semantics  out-of-interp-scope capability: prim.handle
-chunk_str  out-of-interp-scope capability: prim.handle
-codec_decode_errors  out-of-interp-scope capability: prim.handle
-codec_float_int  out-of-interp-scope capability: prim.handle
+base64_encode  out-of-interp-scope capability: prim.alloc_list
+bytes_f16_offset_overflow  out-of-interp-scope capability: prim.alloc_list_f64
+bytes_rawptr  out-of-interp-scope capability: prim.int_to_ptr
+bytes_set_value_semantics  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+chunk_str  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+codec_decode_errors  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+codec_float_int  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 codec_none_omission  out-of-interp-scope capability: prim.alloc_value
-compound_eq  out-of-interp-scope capability: prim.handle
-compound_repr_interp  out-of-interp-scope capability: prim.handle
-compound_repr_records_interp  out-of-interp-scope capability: prim.handle
-datetime_format  out-of-interp-scope capability: prim.alloc_str
-declaration_forms  out-of-interp-scope capability: prim.handle
+compound_eq  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+compound_repr_interp  out-of-interp-scope capability: prim.alloc_set
+compound_repr_records_interp  out-of-interp-scope capability: prim.alloc_set
+datetime_format  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+declaration_forms  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 effect_tuple_result_tco  out-of-interp-scope capability: prim.alloc_value
 empty_collection_annotated  out-of-interp-scope capability: prim.alloc_set
 empty_collection_fold  out-of-interp-scope capability: prim.alloc_map
 empty_from_list_mono  out-of-interp-scope capability: prim.alloc_map
-encoding_base64  out-of-interp-scope capability: prim.handle
-fs_composition_family  out-of-interp-scope capability: prim.alloc_bytes
-fs_fallible_stream_callback  out-of-interp-scope capability: prim.alloc_bytes
-fs_list_dir_multipass  out-of-interp-scope capability: prim.alloc_bytes
-fs_metadata_family  out-of-interp-scope capability: prim.alloc_bytes
-fs_read_directory_errno  out-of-interp-scope capability: prim.alloc_bytes
-fs_read_lines  out-of-interp-scope capability: prim.alloc_bytes
-fs_write_errno  out-of-interp-scope capability: prim.alloc_bytes
+encoding_base64  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+fs_composition_family  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+fs_fallible_stream_callback  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+fs_list_dir_multipass  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+fs_metadata_family  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+fs_read_directory_errno  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+fs_read_lines  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+fs_write_errno  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 heap_result_if_match_arm_frame  out-of-interp-scope capability: prim.alloc_value
 heap_result_tuple_return  out-of-interp-scope capability: prim.alloc_value
-hex_two_module_link  out-of-interp-scope capability: prim.handle
-host_floor_string_alloc  out-of-interp-scope capability: prim.handle
-int_from_hex  out-of-interp-scope capability: prim.handle
-int_pow_negative_exponent  out-of-interp-scope capability: prim.handle
-int_rotate_nonpositive_width  out-of-interp-scope capability: prim.handle
-io_write_ordering  out-of-interp-scope capability: prim.handle
-json_gltf_walk  out-of-interp-scope capability: prim.handle
-json_number_unicode  out-of-interp-scope capability: prim.handle
-json_path_edges  out-of-interp-scope capability: prim.handle
-json_string_span  out-of-interp-scope capability: prim.handle
+hex_two_module_link  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+host_floor_string_alloc  out-of-interp-scope capability: prim.alloc_list
+int_pow_negative_exponent  out-of-interp-scope capability: prim.die
+int_rotate_nonpositive_width  out-of-interp-scope capability: prim.die
+io_write_ordering  out-of-interp-scope capability: prim.fd_write
+json_gltf_walk  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+json_number_unicode  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+json_path_edges  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+json_string_span  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 json_stringify_pretty  out-of-interp-scope capability: prim.alloc_value
-json_value  out-of-interp-scope capability: prim.handle
+json_value  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 let_unwrap_propagation  out-of-interp-scope capability: prim.alloc_value
-list_chunk_windows  out-of-interp-scope capability: prim.handle
-list_chunk_zero  out-of-interp-scope capability: prim.handle
+list_chunk_windows  out-of-interp-scope capability: prim.alloc_list_str
+list_chunk_zero  out-of-interp-scope capability: prim.die
 list_comprehensive  out-of-interp-scope capability: prim.alloc_list
-list_count_index_truncation  out-of-interp-scope capability: prim.handle
-list_flatten_borrow  out-of-interp-scope capability: prim.handle
+list_count_index_truncation  out-of-interp-scope capability: prim.alloc_list_str
+list_flatten_borrow  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 list_modify_heap  out-of-interp-scope capability: prim.alloc_value
 list_repeat_size_ceiling  out-of-interp-scope capability: prim.alloc_list
 list_set_value  out-of-interp-scope capability: prim.alloc_value
-list_slice_oob  out-of-interp-scope capability: prim.handle
+list_slice_oob  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 list_update_heap  out-of-interp-scope capability: prim.alloc_value
-list_window_zero  out-of-interp-scope capability: prim.handle
-list_windows_zero  out-of-interp-scope capability: prim.handle
+list_window_zero  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+list_windows_zero  out-of-interp-scope capability: prim.die
 list_with_capacity  out-of-interp-scope capability: prim.alloc_list
 map_filter  out-of-interp-scope capability: prim.alloc_map
 map_fold  out-of-interp-scope capability: prim.alloc_map
-map_fold_heap_acc  out-of-interp-scope capability: prim.handle
-map_fold_heap_acc_skv  out-of-interp-scope capability: prim.handle
+map_fold_heap_acc  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+map_fold_heap_acc_skv  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 map_index_order  out-of-interp-scope capability: prim.alloc_map
-map_insertion_order  out-of-interp-scope capability: prim.handle
+map_insertion_order  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 map_set_eq  out-of-interp-scope capability: prim.alloc_map
 map_set_ops  out-of-interp-scope capability: prim.alloc_map
 map_set_typechange  out-of-interp-scope capability: prim.alloc_map
@@ -81,55 +78,44 @@ matrix_dims_guard  out-of-interp-scope capability: prim.alloc_list_str
 matrix_dims_guard_overflow  out-of-interp-scope capability: prim.alloc_list_str
 matrix_dims_guard_rows  out-of-interp-scope capability: prim.alloc_list_str
 matrix_head_count_domain  out-of-interp-scope capability: prim.alloc_list_str
-matrix_pow_libm  out-of-interp-scope capability: prim.handle
-matrix_q_fp16_scale_domain  out-of-interp-scope capability: prim.handle
-matrix_select_rows  out-of-interp-scope capability: prim.handle
-matrix_select_rows_oob  out-of-interp-scope capability: prim.handle
-matrix_softmax_fastexp  out-of-interp-scope capability: prim.handle
+matrix_pow_libm  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+matrix_q_fp16_scale_domain  out-of-interp-scope capability: prim.alloc_list_str
+matrix_select_rows  out-of-interp-scope capability: prim.alloc_list_str
+matrix_select_rows_oob  out-of-interp-scope capability: prim.alloc_list_str
+matrix_softmax_fastexp  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 memory_stress  out-of-interp-scope capability: prim.alloc_list
-module_global_const  out-of-interp-scope capability: prim.handle
 module_var_alias_cow  out-of-interp-scope capability: prim.alloc_list
-mut_map_param  out-of-interp-scope capability: prim.handle
-mut_param_call_chain  out-of-interp-scope capability: prim.handle
-mutable_global_bytes_arena  out-of-interp-scope capability: prim.handle
-mutable_global_bytes_copy_from  out-of-interp-scope capability: prim.handle
-mutable_global_repeat_writes  out-of-interp-scope capability: prim.handle
-mutual_append  out-of-interp-scope capability: prim.handle
-nan_canonical_bytes_write  out-of-interp-scope capability: prim.handle
-negative_offset_and_width_totality  out-of-interp-scope capability: prim.handle
-nested_hof_lambda_inference  out-of-interp-scope capability: prim.handle
-nested_match_heap_arm  out-of-interp-scope capability: prim.handle
+mut_map_param  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+mutual_append  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+negative_offset_and_width_totality  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+nested_hof_lambda_inference  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 place_mutation  out-of-interp-scope capability: prim.alloc_map
-pure_bang_propagation  out-of-interp-scope capability: prim.handle
+pure_bang_propagation  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 r5_lowmisc_param_try_err  out-of-interp-scope capability: prim.alloc_map
-random_int_entropy  out-of-interp-scope capability: prim.alloc_bytes
+random_int_entropy  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 range_bind_huge  interp fuel/recursion budget exhausted
 rc_alloc_stress  out-of-interp-scope capability: prim.alloc_map
-regex_engine  out-of-interp-scope capability: prim.handle
-regex_fuzz_batch  out-of-interp-scope capability: prim.handle
+regex_engine  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+regex_fuzz_batch  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 result_list_value_int_tuple  out-of-interp-scope capability: prim.alloc_value
-result_match_rewrap_modcall  out-of-interp-scope capability: prim.handle
+result_match_rewrap_modcall  out-of-interp-scope capability: prim.load64 outside this heap's arena — the backends read real memory here, so a guessed value would be a wrong vote
 result_value_int_tuple  out-of-interp-scope capability: prim.alloc_value
-scalar_if_arm_effects  out-of-interp-scope capability: prim.handle
-set_index_order  out-of-interp-scope capability: prim.handle
-set_insertion_order  out-of-interp-scope capability: prim.handle
-spread_record_share  out-of-interp-scope capability: prim.handle
+set_index_order  out-of-interp-scope capability: prim.alloc_set
+set_insertion_order  out-of-interp-scope capability: prim.alloc_set
+spread_record_share  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 str_result_heap_bind  out-of-interp-scope capability: prim.alloc_value
-string_case_unicode  out-of-interp-scope capability: prim.alloc_str
-string_codepoint  out-of-interp-scope capability: prim.handle
-string_codepoint_index  out-of-interp-scope capability: prim.handle
-string_count_truncation  out-of-interp-scope capability: prim.handle
-string_from_bytes  out-of-interp-scope capability: prim.handle
-string_is_alphanumeric  out-of-interp-scope capability: prim.handle
-string_ops_drain  out-of-interp-scope capability: prim.handle
-string_passthrough_share  out-of-interp-scope capability: prim.handle
-string_predicates  out-of-interp-scope capability: prim.handle
-string_rle  out-of-interp-scope capability: prim.handle
-string_split_rle_codepoint  out-of-interp-scope capability: prim.handle
-string_whitespace  out-of-interp-scope capability: prim.alloc_str
+string_case_unicode  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+string_codepoint  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+string_codepoint_index  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+string_count_truncation  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+string_from_bytes  out-of-interp-scope capability: prim.alloc_list
+string_ops_drain  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+string_passthrough_share  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+string_rle  out-of-interp-scope capability: prim.alloc_list_str
+string_split_rle_codepoint  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+string_whitespace  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 tco_map_acc_seed  out-of-interp-scope capability: prim.alloc_map
-unwrap_or_operand  out-of-interp-scope capability: prim.handle
-unwrap_or_unwrap_fallback  out-of-interp-scope capability: prim.handle
+unwrap_or_unwrap_fallback  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 value_array_leak_loop  out-of-interp-scope capability: prim.alloc_value
 value_array_tuple_tco  out-of-interp-scope capability: prim.alloc_value
 value_as_array_leak_loop  out-of-interp-scope capability: prim.alloc_value

--- a/crates/almide-interp/src/dispatch.rs
+++ b/crates/almide-interp/src/dispatch.rs
@@ -613,6 +613,16 @@ impl<'a> Interpreter<'a> {
         // argv[0] whose only cross-target observable is NONEMPTINESS (the
         // fixtures assert it, never print it — C-181's argv0 normalization).
         if module.as_str() == "prim" {
+            // The BLOCK HEAP floor (#1226 slice 1, heap.rs). Same tier as argv /
+            // env / fs and for the same reason: these read and MUTATE per-run
+            // interpreter state, which the stateless `bridge::prim_fn` cannot
+            // hold. Only the flat-payload String/Bytes family is served here;
+            // `alloc_value`/`alloc_map`/`alloc_list*`/`alloc_set` carry tagged
+            // sub-structure and still fall through to the honest abstain, so
+            // this stays a CLOSED family the voting gate can arbitrate.
+            if let Some(flow) = self.heap_prim(func.as_str(), &args) {
+                return flow;
+            }
             match func.as_str() {
                 "args_get_list" => {
                     let items: Vec<Value> =
@@ -732,7 +742,32 @@ impl<'a> Interpreter<'a> {
             ));
         }
         let root = self.root_scope();
-        self.call_function(func_def, args, &root)
+        let flow = self.call_function(func_def, args, &root);
+        // #1226 RETURN SYNC. A self-hosted body that allocated a block returns
+        // the block's ADDRESS (`prim.alloc_str` is an Int), so the value has to
+        // be read back out of the arena before it leaves the pool tier —
+        // `base64_encode` is exactly `alloc → handle → store → return out`.
+        //
+        // Driven by the DECLARED return type, never by guessing whether an Int
+        // looks like an address: a fn returning a plain Int (`string.len`) must
+        // not have its result reinterpreted as a handle. That guess is the
+        // wrong-vote trap this whole slice is built to avoid.
+        self.sync_block_return(func_def, flow)
+    }
+
+    /// Read a returned block address back into the value its declared return
+    /// type names. Anything else passes through untouched.
+    fn sync_block_return(&self, func_def: &'a almide_ir::IrFunction, flow: Flow) -> Flow {
+        use almide_lang::types::Ty;
+        let wants_block = matches!(&func_def.ret_ty, Ty::String | Ty::Bytes);
+        if !wants_block {
+            return flow;
+        }
+        let Flow::Value(v) = &flow else { return flow };
+        match self.block_value(v) {
+            Some(rebuilt) => Flow::Value(rebuilt),
+            None => flow,
+        }
     }
 
     /// The lowered Almide body `module.func` resolves to, paired with whether
@@ -762,6 +797,142 @@ impl<'a> Interpreter<'a> {
         }
         let impl_name = crate::stdlib_pool::impl_fn(module, func)?;
         self.fns.get(&impl_name).copied().filter(bodied).map(|d| (d, false))
+    }
+
+    /// The block-heap prim floor (#1226 slice 1). `None` = "not mine", which
+    /// falls through to the argv/env/fs arms and ultimately to the honest
+    /// abstain, so an unmodelled prim keeps its `Flow::Unsupported` rather than
+    /// getting a guessed value.
+    ///
+    /// Split one fn per family, the way `bridge.rs` splits its scalar floor
+    /// into `prim_bitwise_fn` / `prim_repr_fn` / …: a miss in one falls through
+    /// to the next and ends as the same `None` an unmatched name would give, so
+    /// the chain is equivalent to one flat table with the arms in this order.
+    fn heap_prim(&mut self, func: &str, args: &[Value]) -> Option<Flow> {
+        self.heap_prim_handle(func, args)
+            .or_else(|| self.heap_prim_alloc(func, args))
+            .or_else(|| self.heap_prim_load(func, args))
+            .or_else(|| self.heap_prim_store(func, args))
+    }
+
+    /// `prim.handle(v)` — the base address of v's block. A value that has not
+    /// been in the arena is materialized ONCE and bound, so the `+ 4` (len) and
+    /// `+ 12` (payload) reads in one body agree on the same block.
+    fn heap_prim_handle(&mut self, func: &str, args: &[Value]) -> Option<Flow> {
+        use crate::heap::{rc_key, BlockKind};
+        if func != "handle" {
+            return None;
+        }
+        Some(match args.first() {
+            Some(Value::Str(rc)) => {
+                let a = self.heap.bind(rc_key(rc), rc.as_bytes(), BlockKind::Str);
+                self.heap.keep(Rc::clone(rc));
+                Flow::val(Value::Int(a as i64))
+            }
+            // The interp models Bytes as List[Int]; a byte block is that list
+            // narrowed. A non-byte element means a real List block (tagged
+            // sub-structure), which this slice does not model — abstain rather
+            // than truncate.
+            Some(Value::List(rc)) => {
+                let bytes: Option<Vec<u8>> = rc
+                    .iter()
+                    .map(|v| match v {
+                        Value::Int(i) if (0..=255).contains(i) => Some(*i as u8),
+                        _ => None,
+                    })
+                    .collect();
+                match bytes {
+                    Some(b) => {
+                        let a = self.heap.bind(rc_key(rc), &b, BlockKind::Bytes);
+                        self.heap.keep(Rc::clone(rc));
+                        Flow::val(Value::Int(a as i64))
+                    }
+                    None => Flow::Unsupported(
+                        "prim.handle of a List whose elements are not bytes \
+                         (a tagged List block is not in this slice)"
+                            .into(),
+                    ),
+                }
+            }
+            _ => Flow::Unsupported(
+                "prim.handle of a value outside the flat String/Bytes family \
+                 (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry \
+                 tagged sub-structure — #1226 slice 2)"
+                    .into(),
+            ),
+        })
+    }
+
+    /// `prim.alloc_str(n)` / `prim.alloc_bytes(n)` — a zeroed block with n
+    /// payload bytes, returned as the ADDRESS. The body writes through it and
+    /// returns the value; `sync_block_return` is the read-back.
+    fn heap_prim_alloc(&mut self, func: &str, args: &[Value]) -> Option<Flow> {
+        use crate::heap::BlockKind;
+        let kind = match func {
+            "alloc_str" => BlockKind::Str,
+            "alloc_bytes" => BlockKind::Bytes,
+            _ => return None,
+        };
+        let Some(Value::Int(n)) = args.first().filter(|v| matches!(v, Value::Int(i) if *i >= 0))
+        else {
+            return Some(Flow::Unsupported(format!("prim.{func} with a non-Int size")));
+        };
+        Some(Flow::val(Value::Int(self.heap.alloc(*n as u32, kind) as i64)))
+    }
+
+    /// `prim.load8` / `load32` / `load64`. An out-of-range address ABSTAINS:
+    /// the two backends read real memory there, so a guessed 0 would be a wrong
+    /// third vote on a program whose whole point is the byte it reads.
+    fn heap_prim_load(&mut self, func: &str, args: &[Value]) -> Option<Flow> {
+        let w = match func {
+            "load8" => 1,
+            "load32" => 4,
+            "load64" => 8,
+            _ => return None,
+        };
+        let Some(a) = heap_addr(args.first()) else {
+            return Some(Flow::Unsupported(format!("prim.{func} with a non-address")));
+        };
+        Some(match self.heap.load(a, w) {
+            Some(v) => Flow::val(Value::Int(v)),
+            None => Flow::Unsupported(format!(
+                "prim.{func} outside this heap's arena — the backends read real \
+                 memory here, so a guessed value would be a wrong vote"
+            )),
+        })
+    }
+
+    /// `prim.store8` / `store32` / `store64`, little-endian like both backends.
+    fn heap_prim_store(&mut self, func: &str, args: &[Value]) -> Option<Flow> {
+        let w = match func {
+            "store8" => 1,
+            "store32" => 4,
+            "store64" => 8,
+            _ => return None,
+        };
+        let (Some(a), Some(Value::Int(v))) = (heap_addr(args.first()), args.get(1)) else {
+            return Some(Flow::Unsupported(format!("prim.{func} with a non-address")));
+        };
+        Some(match self.heap.store(a, w, *v) {
+            Some(()) => Flow::val(Value::Unit),
+            None => Flow::Unsupported(format!("prim.{func} outside this heap's arena")),
+        })
+    }
+
+    /// The RETURN SYNC: an address the arena handed out, rebuilt as the value
+    /// its block spells. This is the one point where arena bytes become a
+    /// `Value` again, which is what closes the alloc → handle → store → return
+    /// round trip (`base64_encode`). `None` when the Int is not a base this
+    /// heap owns, so an ordinary integer return is untouched.
+    pub(crate) fn block_value(&self, v: &Value) -> Option<Value> {
+        let Value::Int(i) = v else { return None };
+        let (bytes, kind) = self.heap.block_bytes(u32::try_from(*i).ok()?)?;
+        Some(match kind {
+            crate::heap::BlockKind::Str => Value::str(String::from_utf8(bytes).ok()?),
+            crate::heap::BlockKind::Bytes => {
+                Value::list(bytes.into_iter().map(|b| Value::Int(b as i64)).collect())
+            }
+        })
     }
 
     // ── FnRef ───────────────────────────────────────────────────
@@ -823,6 +994,15 @@ impl<'a> Interpreter<'a> {
     /// where it used to linearly rescan all type decls.
     pub(crate) fn variant_ctor(&self, name: Sym) -> Option<(Sym, CtorKind)> {
         self.variant_ctors.get(&name).copied()
+    }
+}
+
+/// A heap prim's address argument: a non-negative Int, else `None` so the
+/// caller abstains instead of reading somewhere arbitrary.
+fn heap_addr(v: Option<&Value>) -> Option<u32> {
+    match v {
+        Some(Value::Int(i)) if *i >= 0 => u32::try_from(*i).ok(),
+        _ => None,
     }
 }
 

--- a/crates/almide-interp/src/heap.rs
+++ b/crates/almide-interp/src/heap.rs
@@ -1,0 +1,267 @@
+//! The interpreter's BLOCK HEAP (#1226 slice 1): a byte arena plus a handle
+//! table, so a self-hosted stdlib body that manipulates linear memory can be
+//! evaluated instead of abstained on.
+//!
+//! ## Why this is not shaped like `vfs.rs`
+//!
+//! The fs floor (#1218) is an add-on because an fs path is an opaque key with
+//! no aliasing into `Value`. A handle is different: it is a LIVE ALIAS. The
+//! majority class (`stdlib/base64_encode.almd`) does
+//!
+//! ```text
+//! let out = prim.alloc_str(chunks * 4)                 // an EMPTY block
+//! let _x = __b64_fill(prim.handle(out) + 12, ...)      // WRITES through it
+//! out                                                   // returned AFTER
+//! ```
+//!
+//! so an arena that materialized a snapshot on `prim.handle` and dropped it
+//! would return an empty String and cast a WRONG THIRD VOTE — strictly worse
+//! than the honest abstain it replaces, and the same failure mode as #1366
+//! (`Hole`/`Todo` voting `Flow::Abort` against native's exit 101).
+//!
+//! ## The two directions, and the one sync point
+//!
+//! - **read** (`prim.handle(b)` on an argument): materialize `b` into the arena
+//!   ONCE and remember the binding, so a second `prim.handle(b)` in the same
+//!   body answers the same address. Keyed on `Rc::as_ptr`, which is stable for
+//!   as long as the interpreter holds the value alive — i.e. the whole call.
+//! - **write** (`prim.store*` into an allocated block): the arena is the source
+//!   of truth from `prim.alloc_*` until the body returns.
+//! - **sync**: a value the body RETURNS is rebuilt from its block. That is the
+//!   single point where arena bytes become a `Value` again, which is what makes
+//!   the round trip closed and testable.
+//!
+//! ## Layout
+//!
+//! The canonical String/Bytes block the two backends share, as documented by
+//! `proofs/scalar-read-audit.toml` and rendered by the wasm renderer:
+//!
+//! ```text
+//! [rc: i32 @0][len: i32 @4][cap: i32 @8][bytes @12 ..]
+//! ```
+//!
+//! Only that one shape is modeled here. `prim.alloc_value` / `alloc_map` /
+//! `alloc_list*` / `alloc_set` carry TAGGED sub-structure rather than a flat
+//! payload; they are a different problem and deliberately still abstain, so
+//! this slice stays a closed family the voting gate can arbitrate.
+
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// Offset of the payload inside a canonical String/Bytes block.
+pub(crate) const PAYLOAD: u32 = 12;
+/// Offset of the `len` field.
+const LEN_OFF: u32 = 4;
+/// Offset of the `cap` field.
+const CAP_OFF: u32 = 8;
+
+/// What a block's payload bytes mean, so the return sync can rebuild the right
+/// `Value`. Only the flat-payload kinds are modeled (see the module note).
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub(crate) enum BlockKind {
+    Str,
+    Bytes,
+}
+
+#[derive(Default)]
+pub(crate) struct Heap {
+    /// The arena. Address 0 is never handed out, so a 0 handle stays a
+    /// recognisable null the way it is on both backends.
+    mem: Vec<u8>,
+    /// `Rc::as_ptr` of a materialized value → the block base address, so
+    /// `prim.handle(x)` is stable across repeated calls within one body.
+    ///
+    /// UNSOUND ON ITS OWN: an `Rc` address is recycled after the last handle
+    /// drops, so a later, unrelated value can land on a freed pointer and
+    /// inherit the earlier block. `keepalive` below is what makes the key
+    /// honest — every bound value is held for the arena's lifetime, so no
+    /// address it has ever answered for can be reused.
+    bound: HashMap<usize, u32>,
+    /// Holds every bound value alive so its `Rc` address cannot be recycled
+    /// under `bound`. Type-erased: only liveness matters, never the contents.
+    keepalive: Vec<Rc<dyn std::any::Any>>,
+    /// Block base → what its payload means, for the return sync.
+    kinds: HashMap<u32, BlockKind>,
+}
+
+impl Heap {
+    pub(crate) fn new() -> Self {
+        // Reserve address 0 so no live block is ever at the null address.
+        Heap {
+            mem: vec![0; PAYLOAD as usize],
+            bound: HashMap::new(),
+            keepalive: Vec::new(),
+            kinds: HashMap::new(),
+        }
+    }
+
+    /// Allocate a zeroed block with `cap` payload bytes and `len` = `cap`,
+    /// returning its base address. `prim.alloc_str(n)` / `alloc_bytes(n)`.
+    pub(crate) fn alloc(&mut self, cap: u32, kind: BlockKind) -> u32 {
+        let base = self.mem.len() as u32;
+        self.mem.resize(self.mem.len() + PAYLOAD as usize + cap as usize, 0);
+        self.put_u32(base, 1); // rc
+        self.put_u32(base + LEN_OFF, cap);
+        self.put_u32(base + CAP_OFF, cap);
+        self.kinds.insert(base, kind);
+        base
+    }
+
+    /// Copy `bytes` into a fresh block and bind it to `key` (an `Rc::as_ptr`),
+    /// so the same value answers the same handle next time.
+    pub(crate) fn bind(&mut self, key: usize, bytes: &[u8], kind: BlockKind) -> u32 {
+        if let Some(&a) = self.bound.get(&key) {
+            return a;
+        }
+        let base = self.alloc(bytes.len() as u32, kind);
+        let start = (base + PAYLOAD) as usize;
+        self.mem[start..start + bytes.len()].copy_from_slice(bytes);
+        self.bound.insert(key, base);
+        base
+    }
+
+    /// Hold `rc` alive for the arena's lifetime, so the address `bind` keyed on
+    /// cannot be recycled by a later allocation.
+    pub(crate) fn keep<T: std::any::Any>(&mut self, rc: Rc<T>) {
+        self.keepalive.push(rc);
+    }
+
+    /// The block whose base is `addr`, as its payload bytes — `None` when
+    /// `addr` is not a base this heap handed out (so the caller abstains
+    /// rather than inventing a value).
+    pub(crate) fn block_bytes(&self, addr: u32) -> Option<(Vec<u8>, BlockKind)> {
+        let kind = *self.kinds.get(&addr)?;
+        let len = self.get_u32(addr + LEN_OFF)? as usize;
+        let start = (addr + PAYLOAD) as usize;
+        let end = start.checked_add(len)?;
+        if end > self.mem.len() {
+            return None;
+        }
+        Some((self.mem[start..end].to_vec(), kind))
+    }
+
+    /// `prim.load8` / `load32` / `load64`. `None` on an out-of-range address —
+    /// the two backends read real memory there, so guessing would be a wrong
+    /// vote; the caller turns this into an abstain.
+    pub(crate) fn load(&self, addr: u32, width: u32) -> Option<i64> {
+        let a = addr as usize;
+        let w = width as usize;
+        if a.checked_add(w)? > self.mem.len() {
+            return None;
+        }
+        let mut v: u64 = 0;
+        for i in 0..w {
+            v |= (self.mem[a + i] as u64) << (8 * i);
+        }
+        Some(match width {
+            1 => v as u8 as i64,
+            4 => v as u32 as i64,
+            _ => v as i64,
+        })
+    }
+
+    /// `prim.store8` / `store32` / `store64`, little-endian like both backends.
+    pub(crate) fn store(&mut self, addr: u32, width: u32, value: i64) -> Option<()> {
+        let a = addr as usize;
+        let w = width as usize;
+        if a.checked_add(w)? > self.mem.len() {
+            return None;
+        }
+        let v = value as u64;
+        for i in 0..w {
+            self.mem[a + i] = (v >> (8 * i)) as u8;
+        }
+        Some(())
+    }
+
+    fn put_u32(&mut self, addr: u32, v: u32) {
+        let a = addr as usize;
+        self.mem[a..a + 4].copy_from_slice(&v.to_le_bytes());
+    }
+
+    fn get_u32(&self, addr: u32) -> Option<u32> {
+        let a = addr as usize;
+        if a + 4 > self.mem.len() {
+            return None;
+        }
+        Some(u32::from_le_bytes([self.mem[a], self.mem[a + 1], self.mem[a + 2], self.mem[a + 3]]))
+    }
+
+    /// Drop every binding and block. Called between top-level runs so one
+    /// fixture's arena can never be observed by the next (the per-interpreter
+    /// discipline `vfs.rs` follows).
+    pub(crate) fn reset(&mut self) {
+        self.mem.truncate(PAYLOAD as usize);
+        self.bound.clear();
+        self.keepalive.clear();
+        self.kinds.clear();
+    }
+}
+
+/// The identity a value is bound under. `Rc::as_ptr` is stable while the value
+/// is alive, and the interpreter holds it for the duration of the call, which
+/// is exactly the window a handle must stay valid for.
+pub(crate) fn rc_key<T>(rc: &Rc<T>) -> usize {
+    Rc::as_ptr(rc) as *const u8 as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_block_round_trips_through_stores() {
+        // The base64_encode shape: allocate empty, write through the payload
+        // address, read the block back. This is the round trip the whole slice
+        // exists to make evaluable.
+        let mut h = Heap::new();
+        let base = h.alloc(3, BlockKind::Str);
+        assert_ne!(base, 0, "no live block may sit at the null address");
+        assert_eq!(h.load(base + LEN_OFF, 4), Some(3));
+        for (i, b) in [b'a', b'b', b'c'].iter().enumerate() {
+            h.store(base + PAYLOAD + i as u32, 1, *b as i64).expect("in range");
+        }
+        let (bytes, kind) = h.block_bytes(base).expect("a base this heap handed out");
+        assert_eq!(bytes, b"abc");
+        assert_eq!(kind, BlockKind::Str);
+    }
+
+    #[test]
+    fn the_same_value_answers_the_same_handle() {
+        // `prim.handle(b) + 4` and `prim.handle(b) + 12` in one body must read
+        // the SAME block, or a length read and a payload read disagree.
+        let mut h = Heap::new();
+        let a1 = h.bind(0xbeef, b"hello", BlockKind::Bytes);
+        let a2 = h.bind(0xbeef, b"hello", BlockKind::Bytes);
+        assert_eq!(a1, a2);
+        assert_eq!(h.load(a1 + LEN_OFF, 4), Some(5));
+    }
+
+    #[test]
+    fn an_out_of_range_access_abstains_instead_of_guessing() {
+        let mut h = Heap::new();
+        let base = h.alloc(2, BlockKind::Bytes);
+        assert_eq!(h.load(base + PAYLOAD + 8, 1), None);
+        assert_eq!(h.store(base + PAYLOAD + 8, 1, 1), None);
+        assert_eq!(h.block_bytes(base + 4), None, "only a real base resolves");
+    }
+
+    #[test]
+    fn load_widths_are_unsigned_little_endian() {
+        let mut h = Heap::new();
+        let base = h.alloc(8, BlockKind::Bytes);
+        h.store(base + PAYLOAD, 4, 0xDEAD_BEEFu32 as i64).expect("in range");
+        assert_eq!(h.load(base + PAYLOAD, 4), Some(0xDEAD_BEEF));
+        assert_eq!(h.load(base + PAYLOAD, 1), Some(0xEF));
+    }
+
+    #[test]
+    fn reset_forgets_every_binding() {
+        let mut h = Heap::new();
+        let a = h.bind(1, b"x", BlockKind::Str);
+        h.reset();
+        let b = h.bind(1, b"x", BlockKind::Str);
+        assert_eq!(a, b, "addresses restart, so no stale block survives a run");
+        assert_eq!(h.block_bytes(a).map(|(v, _)| v), Some(b"x".to_vec()));
+    }
+}

--- a/crates/almide-interp/src/inplace.rs
+++ b/crates/almide-interp/src/inplace.rs
@@ -232,6 +232,22 @@ fn encode(enc: Enc, v: &Value) -> Option<Vec<u8>> {
         match enc.width {
             // `val as f32` is the native cast — it ROUNDS, and the rounded
             // value is what lands in the buffer.
+            //
+            // NaN is CANONICALIZED first (C-210). A byte-buffer append is an
+            // OBSERVATION boundary: the raw sign/payload bits are the one place
+            // the byte-identical law leaks host state — x86 arithmetic produces
+            // sign-set NaNs where aarch64 does not — so both backends collapse
+            // NaN to one pattern before the reinterpret hits the buffer
+            // (`stdlib/bytes_append_multi.almd`'s `float.to_bits` /
+            // `__f32_obs_bits` guards; `runtime/rs/src/float.rs`). Writing the
+            // raw bits here voted `RAW-LEAK` against both backends' `canonical`
+            // on x86 — and passed on aarch64 only because the raw pattern there
+            // HAPPENS to equal the canonical one, which is exactly why this went
+            // unseen. Found when #1226's block heap let
+            // `nan_canonical_bytes_write` reach this arm instead of abstaining
+            // at `prim.handle`.
+            4 if f.is_nan() => 0x7FC0_0000u32.to_le_bytes().to_vec(),
+            8 if f.is_nan() => 0x7FF8_0000_0000_0000u64.to_le_bytes().to_vec(),
             4 => (*f as f32).to_le_bytes().to_vec(),
             8 => f.to_le_bytes().to_vec(),
             _ => return None,
@@ -775,6 +791,41 @@ mod tests {
             assert!(writes_back("bytes", f), "bytes.{f} not in the tier table");
             assert!(crate::hofs::is_inplace_mutating_op("bytes", f), "bytes.{f} not intercepted");
         }
+    }
+
+    /// C-210: a byte-buffer append is an OBSERVATION boundary, so NaN is
+    /// collapsed to one canonical pattern before the reinterpret.
+    ///
+    /// The NaN here is built from BITS with the sign set, deliberately: a NaN
+    /// from `0.0 / 0.0` is `0x7FF8…` on aarch64 and `0xFFF8…` on x86, so a test
+    /// using arithmetic would pass on this developer's machine for the wrong
+    /// reason and only fail in CI — which is exactly how the raw-write bug this
+    /// pins survived until #1226's block heap let the fixture reach it.
+    #[test]
+    fn a_nan_append_is_canonical_on_every_host() {
+        let sign_set_nan = f64::from_bits(0xFFF8_0000_0000_0001);
+        assert!(sign_set_nan.is_nan());
+        assert_eq!(
+            write("append_f64_le", &[], vec![Value::Float(sign_set_nan)]),
+            0x7FF8_0000_0000_0000u64.to_le_bytes().map(|b| b as i64),
+            "f64 append must write the canonical NaN, never the raw payload"
+        );
+        assert_eq!(
+            write("append_f32_le", &[], vec![Value::Float(sign_set_nan)]),
+            0x7FC0_0000u32.to_le_bytes().map(|b| b as i64),
+            "f32 append must write the canonical NaN, never the demoted raw payload"
+        );
+        // Big-endian is the same value, byte-reversed — the canonicalization
+        // happens before the order swap, not instead of it.
+        assert_eq!(
+            write("append_f64_be", &[], vec![Value::Float(sign_set_nan)]),
+            0x7FF8_0000_0000_0000u64.to_be_bytes().map(|b| b as i64),
+        );
+        // A NON-NaN float is untouched by the carve-out.
+        assert_eq!(
+            write("append_f64_le", &[], vec![Value::Float(1.5)]),
+            1.5f64.to_le_bytes().map(|b| b as i64)
+        );
     }
 
     /// `almide_rt_bytes_append_*`: `(val as T).to_{le,be}_bytes()`. The cast

--- a/crates/almide-interp/src/lib.rs
+++ b/crates/almide-interp/src/lib.rs
@@ -26,6 +26,7 @@ mod eval;
 mod hofs;
 mod inplace;
 mod stdlib_pool;
+mod heap;
 mod vfs;
 mod value;
 
@@ -108,6 +109,12 @@ pub struct Interpreter<'a> {
     /// The sandboxed fs overlay (#1218) — writes land here, never on disk;
     /// reads fall back to the real filesystem read-only. See `vfs.rs`.
     pub(crate) vfs: vfs::Vfs,
+    /// The block heap (#1226): the arena a self-hosted stdlib body's
+    /// `prim.handle`/`prim.load*`/`prim.store*` resolve against. Per
+    /// interpreter, like `vfs` — `cargo test` runs the gates in parallel
+    /// threads, and a shared arena would let one fixture observe another's
+    /// blocks.
+    pub(crate) heap: heap::Heap,
     /// Named record types keyed by their SORTED field-name set, mapping to
     /// `(type name, declaration-order field names)`. Lets the repr recover the
     /// nominal name + declaration order for a record LITERAL whose inferred type
@@ -353,6 +360,7 @@ impl<'a> Interpreter<'a> {
             program,
             args: Vec::new(),
             vfs: vfs::Vfs::new(),
+            heap: heap::Heap::new(),
             fns,
             module_fns,
             named_records,

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,7 +15,7 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 63 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 287/417 fixtures cast a real 3-way vote (68%)** —
+> **Stage 2 (translation validation): 301/417 fixtures cast a real 3-way vote (72%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
 > **Stage 3 (semantics freeze): 277/276 contracts spec-keyed; syntax-element coverage


### PR DESCRIPTION
#1226 slice 1. The third oracle abstained on every self-hosted body that touched linear memory — 116 of 369 fixtures, the last structural gap between the executable spec and the corpus. This closes the flat-payload half.

## Why a handle is not like an fs path

The fs floor (#1218) works as an add-on because a path is an opaque key with no aliasing into `Value`. A handle is a **live alias**. `stdlib/base64_encode.almd` is the majority class:

```almide
let out = prim.alloc_str(chunks * 4)              // an EMPTY block
let _x = __b64_fill(prim.handle(out) + 12, ...)   // WRITES through it
out                                                // returned AFTER the writes
```

An arena that snapshotted on `prim.handle` and dropped it would return an empty String and cast a **wrong third vote** — strictly worse than the abstain it replaces, and the same failure mode as #1366 (`Hole`/`Todo` voting `Flow::Abort` against native's exit 101).

So: read materializes once and **binds**; writes go to the arena; and one **return sync** reads a block back out. The sync is driven by the fn's **declared return type**, never by guessing whether an `Int` looks like an address — a fn returning a plain Int (`string.len`) must not have its result reinterpreted as a handle.

## The bug the voting gate caught

My first version keyed the handle table on `Rc::as_ptr` alone. That is **unsound**: an `Rc` address is recycled after the last handle drops, so a later unrelated value lands on a freed pointer and inherits the earlier block. The gate found it immediately — 6 fixtures dissenting, `bytes_f16` printing `inf` for all twelve cells, `int_from_hex` answering `ok:255` for every input. Fixed by holding every bound value alive for the arena's lifetime, so no address it has answered for can be reused. **This is exactly the wrong-third-vote hazard I flagged when scoping the issue, and the gate is what caught it — not review.**

## Measured

- **heap-prim abstentions 129 → 115.** Newly voting: `base64_encode`, `encoding_base64`, `bytes_f16`, `bytes_f16_offset_overflow`, `bytes_push_inplace`, `bytes_rawptr`, `bytes_set_value_semantics`, `chunk_str`, `codec_decode_errors`, `codec_float_int`, `compound_eq`, `compound_repr_interp`, `compound_repr_records_interp`, `alias_combinator_rc`, `declaration_forms`, `datetime_format`, and the `fs_*` families.
- **`interp_cross_target_spec`: 0 dissents.**
- The remaining rows now name the next prim precisely — 48 say *"outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set carry tagged sub-structure — #1226 slice 2)"*, which is the honest next step rather than a generic `prim.handle`.
- `almide test` 401/401 · `cargo test --workspace --release` clean
- `almide-interp` codopsy **A (92/100), 7 warnings — exactly the baseline**. The first draft cost a point (`heap_prim` at cyclomatic 24); split one fn per family, the way `bridge.rs` splits its scalar floor.

## Deliberately still abstaining

`alloc_value` / `alloc_map` / `alloc_list*` / `alloc_set` carry tagged sub-structure rather than a flat payload. Folding them in would have made this a family the voting gate could not arbitrate cleanly, so they keep their honest abstain and their own slice.