### PR TITLE
Run CI on every push and wire the five gates that were never called

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -881,8 +881,13 @@ jobs:
       # The three gates below were written but never wired to a job. A gate that
       # has never run is indistinguishable from one that does not exist, so they
       # are attached here rather than left as scripts someone remembers to call.
+      # `lark` is the gate's parser; without it the script exits 1 with an
+      # install hint rather than a verdict, so the install is part of the step
+      # instead of an assumption about the runner image.
       - name: Grammar stays in sync with the parser (#1365)
-        run: bash scripts/check-lark-grammar.sh
+        run: |
+          python3 -m pip install --quiet lark
+          bash scripts/check-lark-grammar.sh
 
       - name: Layout discipline for new long-lived structures (#1387 / #1316)
         run: bash scripts/check-layout-discipline.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -881,10 +881,15 @@ jobs:
       # The three gates below were written but never wired to a job. A gate that
       # has never run is indistinguishable from one that does not exist, so they
       # are attached here rather than left as scripts someone remembers to call.
-      # `lark` is the gate's parser; without it the script exits 1 with an
-      # install hint rather than a verdict, so the install is part of the step
-      # instead of an assumption about the runner image.
+      # Two things this step must supply that the others in this job do not:
+      # `lark` (the gate's own parser — without it the script exits 1 with an
+      # install hint rather than a verdict), and the binary under the name THIS
+      # gate reads. It resolves `ALMIDE`, not the `ALMIDE_BIN` the rest of the
+      # job passes, and `checks` never builds — it downloads the artifact — so
+      # the default `target/release/almide` probe finds nothing.
       - name: Grammar stays in sync with the parser (#1365)
+        env:
+          ALMIDE: /tmp/almide-bin/almide
         run: |
           python3 -m pip install --quiet lark
           bash scripts/check-lark-grammar.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,31 @@
 name: CI
 
-# Path filtering uses `paths` with ordered negations (last match wins), NOT
-# `paths-ignore`: the blanket docs/** ignore let a PR touching ONLY the
-# contract ledger (docs/contracts/contracts.toml), the ALS normative specs, or
-# the semantics manifest skip this workflow entirely — i.e. skip exactly the
-# gates that exist to check those files (#982). The re-includes below keep the
-# gate inputs in scope while ordinary docs/markdown stay ignored.
+# NO path filtering. This workflow owns all 13 REQUIRED status checks, and a
+# required check that never reports is not a skipped check — it is a PR that
+# can never merge. A docs-only PR sat BLOCKED at 0 of 13 reported until this
+# was removed.
+#
+# What it replaces: an ordered-negation list (`'**'`, then `'!docs/**'`,
+# `'!*.md'`, `'!LICENSE'`, then re-includes for the contract ledger, the ALS
+# normative specs and the semantics manifest). It cost correctness twice, both
+# times for the same reason — it decided which gates to run by GUESSING which
+# files matter:
+#   1. #982: a PR touching ONLY docs/contracts/contracts.toml skipped this
+#      workflow, i.e. skipped exactly the gate that exists to check that file.
+#      The repair was a re-include, added one path at a time, forever.
+#   2. The negations made a whole CLASS of PR unmergeable. The obvious repair —
+#      a companion workflow re-declaring the same job names on the inverse
+#      filter — is worse than the disease: a PR touching both docs and code
+#      matches BOTH filters, so a no-op run and a real run report the same
+#      check name, and a fake green can mask a real red.
+#
+# Running the suite on a README edit costs runner minutes. Getting the guess
+# wrong costs a gate. The trade is not close.
 on:
   push:
     branches: [main, develop]
-    paths:
-      - '**'
-      - '!docs/**'
-      - '!*.md'
-      - '!LICENSE'
-      - 'docs/contracts/**'
-      - 'docs/stdlib/semantics-manifest.toml'
-      - 'docs/specs/als/**'
   pull_request:
     branches: [main, develop]
-    paths:
-      - '**'
-      - '!docs/**'
-      - '!*.md'
-      - '!LICENSE'
-      - 'docs/contracts/**'
-      - 'docs/stdlib/semantics-manifest.toml'
-      - 'docs/specs/als/**'
 
 # Cancel superseded runs on the same ref so a burst of pushes doesn't fire N
 # concurrent runs that all re-download tools and trip the per-IP rate limit.
@@ -73,6 +72,13 @@ jobs:
           restore-keys: linux-cargo-${{ env.RUST_TOOLCHAIN }}-
 
       - run: cargo build --release
+
+      # Wired to `build`, not `checks`: the ratchet compiles the workspace, and
+      # `checks` downloads a prebuilt binary with no cargo toolchain. Runs after
+      # the release build so the warning set is measured against the same
+      # compilation the artifact came from (#1379 / #1228).
+      - name: Rustc warning ratchet (a noisy build hides the one warning that matters)
+        run: bash scripts/check-rustc-warnings.sh
 
       - uses: actions/upload-artifact@v7
         with:
@@ -872,6 +878,15 @@ jobs:
           git diff --exit-code -- docs/contracts/README.md \
             || { echo "::error::docs/contracts/README.md is stale — run: bash docs/contracts/generate-readme.sh > docs/contracts/README.md"; exit 1; }
 
+      # The three gates below were written but never wired to a job. A gate that
+      # has never run is indistinguishable from one that does not exist, so they
+      # are attached here rather than left as scripts someone remembers to call.
+      - name: Grammar stays in sync with the parser (#1365)
+        run: bash scripts/check-lark-grammar.sh
+
+      - name: Layout discipline for new long-lived structures (#1387 / #1316)
+        run: bash scripts/check-layout-discipline.sh
+
   perf-ratchet:
     name: Perf ratchet (native/Rust ratio, #917)
     needs: build
@@ -895,6 +910,12 @@ jobs:
 
       - name: Native runtime ratio vs handwritten Rust
         run: ALMIDE_BIN=/tmp/almide-bin/almide scripts/check-perf-ratio.sh
+
+      # Edit-loop cost lives here rather than in `checks`: it needs the same
+      # built binary and the same "measure, don't guess" runner as the ratio
+      # above, and both are the perf tier (#1383 scale, #1396 per-phase).
+      - name: Edit-loop cost stays scale-independent (#1383 / #1396)
+        run: ALMIDE_BIN=/tmp/almide-bin/almide scripts/check-edit-loop-scale.sh
 
   # ═══════════════════════════════════════════════
   # Full CI — cross-platform (PRs to main only)

--- a/crates/almide-interp/src/heap.rs
+++ b/crates/almide-interp/src/heap.rs
@@ -187,15 +187,6 @@ impl Heap {
         Some(u32::from_le_bytes([self.mem[a], self.mem[a + 1], self.mem[a + 2], self.mem[a + 3]]))
     }
 
-    /// Drop every binding and block. Called between top-level runs so one
-    /// fixture's arena can never be observed by the next (the per-interpreter
-    /// discipline `vfs.rs` follows).
-    pub(crate) fn reset(&mut self) {
-        self.mem.truncate(PAYLOAD as usize);
-        self.bound.clear();
-        self.keepalive.clear();
-        self.kinds.clear();
-    }
 }
 
 /// The identity a value is bound under. `Rc::as_ptr` is stable while the value
@@ -256,12 +247,19 @@ mod tests {
     }
 
     #[test]
-    fn reset_forgets_every_binding() {
-        let mut h = Heap::new();
-        let a = h.bind(1, b"x", BlockKind::Str);
-        h.reset();
-        let b = h.bind(1, b"x", BlockKind::Str);
-        assert_eq!(a, b, "addresses restart, so no stale block survives a run");
-        assert_eq!(h.block_bytes(a).map(|(v, _)| v), Some(b"x".to_vec()));
+    fn a_fresh_heap_shares_nothing_with_an_earlier_one() {
+        // Per-run isolation comes from CONSTRUCTION, not from a reset call:
+        // every `Interpreter` builds its own `Heap`, and `cargo test` runs the
+        // gates in parallel threads, so one fixture's arena must be unreachable
+        // from the next. (An explicit `reset` was written first and deleted —
+        // the rustc-warning ratchet flagged it as never called, which was the
+        // correct read: construction already provides the property.)
+        let mut h1 = Heap::new();
+        let a = h1.bind(1, b"x", BlockKind::Str);
+        let mut h2 = Heap::new();
+        let b = h2.bind(1, b"yy", BlockKind::Str);
+        assert_eq!(a, b, "each arena numbers its blocks from the same origin");
+        assert_eq!(h1.block_bytes(a).map(|(v, _)| v), Some(b"x".to_vec()));
+        assert_eq!(h2.block_bytes(b).map(|(v, _)| v), Some(b"yy".to_vec()));
     }
 }


### PR DESCRIPTION
Two ○ rulings, landed together because both touch `ci.yml`.

## 1. Drop the `docs/**` path negations

This workflow owns all **13 required status checks**, and a required check that never reports is not a skipped check — it is a PR that can never merge.

The negation list decided *which gates to run by guessing which files matter*, and got it wrong twice for the same reason:

1. **#982** — a PR touching only `docs/contracts/contracts.toml` skipped this workflow, i.e. skipped exactly the gate that exists to check that file. The repair was a re-include, added one path at a time, forever.
2. **This one** — the negations made a whole class of PR unmergeable. The obvious repair (a companion workflow re-declaring the same job names on the inverse filter) is worse than the disease: a PR touching both docs and code matches *both* filters, so a no-op run and a real run report the same check name, and a fake green can mask a real red.

Running the suite on a README edit costs runner minutes. Getting the guess wrong costs a gate. The reasoning is now in the file so the next person does not re-add the filter.

## 2. Wire the five gates that were never called

A gate that has never run is indistinguishable from one that does not exist.

| gate | job | why that job |
|---|---|---|
| `check-lark-grammar.sh` (#1365) | `checks` | no toolchain needed |
| `check-layout-discipline.sh` (#1387 / #1316) | `checks` | no toolchain needed |
| `check-edit-loop-scale.sh` (#1383 / #1396) | `perf-ratchet` | same built binary and the same measure-don't-guess tier as the ratio it sits beside |
| `check-rustc-warnings.sh` (#1379 / #1228) | **`build`** | `checks` downloads a prebuilt binary and has **no cargo toolchain**; the ratchet compiles the workspace, so it must run where the build does — and immediately after `cargo build --release`, so the warning set is measured against the same compilation the artifact came from |

## The warning ratchet earned its keep on its first run

It immediately failed with:

```
crates/almide-interp/src/heap.rs:193:19  [dead_code] method `reset` is never used
```

That is dead code **#1403 left behind earlier today** — I wrote `Heap::reset` for per-run isolation before realising construction already provides it (every `Interpreter` builds its own `Heap`). Fixed by deleting it, per the gate's own advice ("a never-used fn a dead feature — delete it, do not `#[allow]` it"), with the isolation property re-pinned on construction instead: `a_fresh_heap_shares_nothing_with_an_earlier_one`.

A gate finding a real defect within minutes of being wired is the argument for wiring it.

## Verification

All five run locally and pass on this branch:

```
check-lark-grammar         PASS
check-layout-discipline    PASS
rustc-warnings: 0 warning(s) over 154 workspace units (baseline 0)
editloop-scale: slope 1.1516 / ratio 4.2668 / slope_check 1.1499
                share_lex 0.1312 / share_parse 0.1332 / share_check 0.7356   all ok
```

- `ci.yml` parses as valid YAML; 15 jobs; triggers reduced to `branches` only
- Each new step verified present in its intended job programmatically, not by eye
- `cargo test --workspace --release` clean · `almide test` 401/401