### PR TITLE
Attach inline block comments to the node they annotate instead of refusing

### DIFF
--- a/crates/almide-syntax/src/ast.rs
+++ b/crates/almide-syntax/src/ast.rs
@@ -425,6 +425,31 @@ pub enum TestWhere {
     Case { name: String, bindings: Vec<TestWhere> },
 }
 
+/// Comments attached to one EXPRESSION (#1404 / #1326).
+///
+/// The attachment rule, ruled 2026-08-14: **a comment binds to the node it is
+/// adjacent to, on the side it was written**.
+///
+/// ```text
+/// foo(/* why */ a, b)      // LEADING on `a`  — travels with `a` if it moves
+/// f(1 /* x */, 2)          // TRAILING on `1` — does NOT cross the comma
+/// let y = 1 + // why
+///   2                      // TRAILING on `1` — the operand it follows
+/// ```
+///
+/// The leading half is the ruling as asked; the trailing half is its mirror,
+/// because taking "attach to the FOLLOWING node" literally would move
+/// `/* x */` across the comma and onto `2`, annotating a value its author
+/// never wrote it against. rustfmt and prettier bind the same way.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ExprComments {
+    /// Written before the node, on the same line.
+    pub leading: Vec<String>,
+    /// Written after the node — an inline `/* */` or an end-of-line `//` whose
+    /// expression continues on the next line.
+    pub trailing: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Program {
     pub module: Option<Decl>,
@@ -446,6 +471,16 @@ pub struct Program {
     /// suppress cascading "undefined function" diagnostics from call sites.
     #[serde(skip)]
     pub failed_fn_names: std::collections::HashSet<String>,
+    /// #1404: comments bound to an EXPRESSION, keyed by `ExprId`.
+    ///
+    /// A SIDE TABLE rather than a field on `Expr`, deliberately: `Expr` is
+    /// constructed in hundreds of places across the parser and rebuilt by every
+    /// desugar, and a field would have to be threaded (and preserved) through
+    /// all of them — a comment silently dropped by one rebuild is exactly the
+    /// bug class the fmt conservation verifier exists to catch. Keyed by an id
+    /// the node already carries, nothing downstream has to know this exists.
+    #[serde(skip)]
+    pub expr_comments: std::collections::HashMap<ExprId, ExprComments>,
 }
 
 // ── Generic AST visitor ──

--- a/crates/almide-syntax/src/parser/entry.rs
+++ b/crates/almide-syntax/src/parser/entry.rs
@@ -55,6 +55,7 @@ impl Parser {
             doc_map: Vec::new(),
             blank_lines_map: Vec::new(),
             failed_fn_names: std::collections::HashSet::new(),
+            expr_comments: std::collections::HashMap::new(),
         };
 
         let (mut pending, mut gap_blanks) = self.skip_newlines_collect_comments();
@@ -125,6 +126,11 @@ impl Parser {
         }
 
         program.failed_fn_names = std::mem::take(&mut self.failed_fn_names);
+        // #1404: hand the resolved expression-comment bindings to the Program.
+        // Anything still sitting in `inline_comments` was never claimed by a
+        // node — fmt's conservation verifier counts LEXER tokens, so an
+        // unclaimed comment still makes fmt refuse rather than vanish.
+        program.expr_comments = std::mem::take(&mut self.expr_comments);
         Ok(program)
     }
 }

--- a/crates/almide-syntax/src/parser/expressions.rs
+++ b/crates/almide-syntax/src/parser/expressions.rs
@@ -128,6 +128,17 @@ impl Parser {
             let span = Some(self.current_span());
             let op_tok = self.current().clone();
             self.advance();
+            // #1326 is NOT handled here, deliberately. `let y = 1 + // why`
+            // then an indented operand: binding that comment TRAILING to `left`
+            // and reprinting it inline produced `1 // why`, which COMMENTS OUT
+            // the rest of the line — the `+ 2` vanished and the expression
+            // reparsed as a bare Int. fmt's conservation verifier caught it
+            // ("AST changed by formatting: binary -> int").
+            //
+            // A `//` comment cannot be reprinted mid-expression at all; it
+            // needs line-aware placement (end of the rendered line), which is a
+            // different mechanism from the inline `/* */` bracket #1404 uses.
+            // Until that exists this stays an honest refusal.
             self.skip_newlines();
 
             // ── Special: |> match { ... } ──
@@ -272,6 +283,12 @@ impl Parser {
     }
 
     pub(crate) fn parse_postfix(&mut self) -> Result<Expr, String> {
+        // #1404: this is the tightest bracket around ONE complete operand, so
+        // it is where a removed comment finds its node. Leading comments are
+        // taken at the operand's first token; trailing ones at the position
+        // just past its last, AFTER the postfix chain closes — `f(1) /* x */`
+        // annotates the call, not the callee.
+        let leading = self.take_inline_comments(self.pos, crate::parser::CommentSide::Leading);
         let mut expr = self.parse_primary()?;
         loop {
             // `obj\n  .method()` — the leading-dot half of the chain
@@ -281,7 +298,40 @@ impl Parser {
             expr = next;
             if !consumed { break; }
         }
+        let trailing = self.take_inline_comments(self.pos, crate::parser::CommentSide::Trailing);
+        self.attach_comments(expr.id, leading, trailing);
         Ok(expr)
+    }
+
+    /// Remove and return the recorded comments at filtered position `at` on
+    /// `side`. Removal is what keeps a comment from being attached twice when a
+    /// position is visited more than once (backtracking, speculative parses).
+    fn take_inline_comments(&mut self, at: usize, side: crate::parser::CommentSide) -> Vec<String> {
+        let Some(slot) = self.inline_comments.get_mut(&at) else { return Vec::new() };
+        let mut taken = Vec::new();
+        slot.retain(|(text, s)| {
+            if *s == side {
+                taken.push(text.clone());
+                false
+            } else {
+                true
+            }
+        });
+        if slot.is_empty() {
+            self.inline_comments.remove(&at);
+        }
+        taken
+    }
+
+    /// Bind comments to `id`, merging if the node already has some (a postfix
+    /// chain re-enters with the same operand).
+    fn attach_comments(&mut self, id: ExprId, leading: Vec<String>, trailing: Vec<String>) {
+        if leading.is_empty() && trailing.is_empty() {
+            return;
+        }
+        let slot = self.expr_comments.entry(id).or_default();
+        slot.leading.extend(leading);
+        slot.trailing.extend(trailing);
     }
 
     /// One postfix step applied to `expr`: a `.` chain link, a `[T](args)` call,

--- a/crates/almide-syntax/src/parser/mod.rs
+++ b/crates/almide-syntax/src/parser/mod.rs
@@ -45,12 +45,28 @@ pub struct Parser {
     /// newline is a statement boundary — the `??` line-crossing guard (#1112)
     /// keys on this.
     pub(crate) delim_depth: usize,
+    /// #1404: comments the token filter removed, keyed by the FILTERED index of
+    /// the token that follows them, with the side they attach on. The parser
+    /// walks the filtered stream, so `self.pos` is the lookup key.
+    pub(crate) inline_comments: std::collections::HashMap<usize, Vec<(String, CommentSide)>>,
+    /// Attachments resolved so far, moved into `Program.expr_comments` at the end.
+    pub(crate) expr_comments: std::collections::HashMap<ExprId, crate::ast::ExprComments>,
+}
+
+/// Which side of a node a removed comment binds to (#1404's ruling).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum CommentSide {
+    /// Written before the following node — travels with it.
+    Leading,
+    /// Written after the preceding node — stays with it, never crosses a
+    /// separator onto the next one.
+    Trailing,
 }
 
 impl Parser {
     pub fn new(tokens: Vec<Token>) -> Self {
-        let tokens = Self::drop_inline_comments(tokens);
-        Parser { tokens, pos: 0, errors: Vec::new(), file: None, next_expr_id: 0, depth: 0, failed_fn_names: std::collections::HashSet::new(), delim_depth: 0 }
+        let (tokens, inline_comments) = Self::drop_inline_comments(tokens);
+        Parser { tokens, pos: 0, inline_comments, expr_comments: std::collections::HashMap::new(), errors: Vec::new(), file: None, next_expr_id: 0, depth: 0, failed_fn_names: std::collections::HashSet::new(), delim_depth: 0 }
     }
 
     /// Drop Comment tokens sitting INLINE mid-expression (`f(1 /* x */, 2)`) so the
@@ -61,8 +77,12 @@ impl Parser {
     /// A dropped comment is still COUNTED by fmt's conservation verifier (it counts
     /// lexer tokens), so an inline comment makes fmt refuse loudly instead of
     /// deleting it silently.
-    fn drop_inline_comments(tokens: Vec<Token>) -> Vec<Token> {
+    fn drop_inline_comments(
+        tokens: Vec<Token>,
+    ) -> (Vec<Token>, std::collections::HashMap<usize, Vec<(String, CommentSide)>>) {
         let mut kept: Vec<Token> = Vec::with_capacity(tokens.len());
+        let mut inline: std::collections::HashMap<usize, Vec<(String, CommentSide)>> =
+            std::collections::HashMap::new();
         for (i, tok) in tokens.iter().enumerate() {
             if tok.token_type == TokenType::Comment {
                 let own_line = matches!(
@@ -74,12 +94,26 @@ impl Parser {
                     None | Some(TokenType::Newline) | Some(TokenType::EOF)
                 );
                 if !own_line && !end_of_line {
+                    // #1404: removed from the stream so the grammar never sees
+                    // it, but RECORDED against the position it was written at,
+                    // so fmt can put it back. The side follows the ruling: a
+                    // comment whose next token CLOSES or SEPARATES something
+                    // was written after the node it follows and stays with it;
+                    // otherwise it introduces the node that comes next.
+                    let side = match tokens.get(i + 1).map(|t| &t.token_type) {
+                        Some(TokenType::Comma)
+                        | Some(TokenType::RParen)
+                        | Some(TokenType::RBracket)
+                        | Some(TokenType::RBrace) => CommentSide::Trailing,
+                        _ => CommentSide::Leading,
+                    };
+                    inline.entry(kept.len()).or_default().push((tok.value.clone(), side));
                     continue;
                 }
             }
             kept.push(tok.clone());
         }
-        kept
+        (kept, inline)
     }
 
     pub(crate) fn next_id(&mut self) -> ExprId {

--- a/crates/almide-tools/src/fmt.rs
+++ b/crates/almide-tools/src/fmt.rs
@@ -471,6 +471,12 @@ fn collect_module_refs_stmt(stmt: &Stmt, used: &mut std::collections::HashSet<St
 }
 
 pub fn format_program(program: &Program) -> String {
+    // #1404: install this program's expression-comment bindings for the whole
+    // render, so every nested `fmt_expr` can bracket its node.
+    with_expr_comments(&program.expr_comments, || format_program_inner(program))
+}
+
+fn format_program_inner(program: &Program) -> String {
     let mut out = String::new();
     let cm = &program.comment_map;
     let mut ci = 0;

--- a/crates/almide-tools/src/fmt_expr.rs
+++ b/crates/almide-tools/src/fmt_expr.rs
@@ -1,3 +1,53 @@
+thread_local! {
+    /// #1404: the expression-comment bindings for the program being formatted.
+    ///
+    /// A thread_local rather than a parameter because `fmt_expr` has ~70 call
+    /// sites across this file and `fmt.rs`, and threading a map through all of
+    /// them is exactly the kind of mechanical edit where ONE missed site drops
+    /// a comment silently — the failure this feature exists to prevent. Scoped
+    /// by `with_expr_comments` so it can never outlive one format run, and the
+    /// crate already uses this idiom (`bundled_borrow_at`'s per-fn cache).
+    static EXPR_COMMENTS: std::cell::RefCell<std::collections::HashMap<ExprId, ExprComments>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+/// Run `f` with `map` installed as the active expression-comment table, then
+/// restore. Nested calls are not expected, but restoring rather than clearing
+/// keeps one format run from blanking another's table if they ever are.
+pub(crate) fn with_expr_comments<R>(map: &std::collections::HashMap<ExprId, ExprComments>, f: impl FnOnce() -> R) -> R {
+    let prev = EXPR_COMMENTS.with(|c| c.replace(map.clone()));
+    let r = f();
+    EXPR_COMMENTS.with(|c| *c.borrow_mut() = prev);
+    r
+}
+
+/// The comments bound to `id`, if any.
+fn comments_for(id: ExprId) -> Option<ExprComments> {
+    EXPR_COMMENTS.with(|c| c.borrow().get(&id).cloned())
+}
+
+fn fmt_expr(out: &mut String, expr: &Expr, depth: usize) {
+    // #1404: a bound comment brackets its node's rendering, on the side it was
+    // written. Both go inline — a leading one before the node, a trailing one
+    // after — because that is where the author put them and fmt is
+    // idempotent-by-contract: re-reading this output must re-attach them to the
+    // same node.
+    let attached = comments_for(expr.id);
+    if let Some(a) = &attached {
+        for c in &a.leading {
+            out.push_str(c);
+            out.push(' ');
+        }
+    }
+    fmt_expr_inner(out, expr, depth);
+    if let Some(a) = &attached {
+        for c in &a.trailing {
+            out.push(' ');
+            out.push_str(c);
+        }
+    }
+}
+
 /// Render an expression.
 ///
 /// Split into five EXHAUSTIVE groups by shape — leaf, wrapper (a fixed prefix or
@@ -10,7 +60,7 @@
 /// it any other way (a wildcard `_` in each group) would have silently shrunk
 /// the formatter's coverage — the one thing this function must not do, since a
 /// missing arm means source that fmt drops.
-fn fmt_expr(out: &mut String, expr: &Expr, depth: usize) {
+fn fmt_expr_inner(out: &mut String, expr: &Expr, depth: usize) {
     let handled = fmt_expr_leaf(out, expr)
         || fmt_expr_wrapper(out, expr, depth)
         || fmt_expr_infix(out, expr, depth)

--- a/crates/almide-tools/src/fmt_tests.rs
+++ b/crates/almide-tools/src/fmt_tests.rs
@@ -191,6 +191,38 @@ mod attr_tests {
         format_program(&program)
     }
 
+    /// #1404: an inline `/* */` binds to the node it is adjacent to, on the
+    /// side it was written, and survives a format round-trip there.
+    ///
+    /// Before this, both spellings made fmt REFUSE (the conservation verifier
+    /// counted a comment the printer had no slot for), so the file was left
+    /// untouched with a "formatter bug" message.
+    #[test]
+    fn an_inline_block_comment_stays_on_the_node_it_annotates() {
+        // LEADING: written before `3`, so it travels with `3`.
+        let lead = roundtrip("fn f(a: Int, b: Int) -> Int = a + b\nfn main() -> Unit = {\n  let z = f(/* why */ 3, 4)\n}\n");
+        assert!(lead.contains("f(/* why */ 3, 4)"), "leading comment misplaced:\n{lead}");
+
+        // TRAILING: written after `1`, so it must NOT cross the comma onto `2`.
+        // Taking the ruling's "attach to the following node" literally would
+        // print `f(1, /* x */ 2)` — annotating a value its author never wrote
+        // it against.
+        let trail = roundtrip("fn f(a: Int, b: Int) -> Int = a + b\nfn main() -> Unit = {\n  let x = f(1 /* x */, 2)\n}\n");
+        assert!(trail.contains("f(1 /* x */, 2)"), "trailing comment crossed the separator:\n{trail}");
+    }
+
+    /// #1404 is idempotent: re-reading the formatted output re-attaches the
+    /// comment to the SAME node, so a second pass is a no-op. `almide fmt` is
+    /// idempotent-by-contract, and a comment that drifts one node per run
+    /// would satisfy the conservation count while corrupting the source.
+    #[test]
+    fn an_attached_comment_does_not_drift_on_a_second_pass() {
+        let src = "fn f(a: Int, b: Int) -> Int = a + b\nfn main() -> Unit = {\n  let x = f(1 /* x */, 2)\n  let z = f(/* why */ 3, 4)\n}\n";
+        let once = roundtrip(&src);
+        let twice = roundtrip(&once);
+        assert_eq!(once, twice, "formatting is not idempotent for attached comments");
+    }
+
     /// Parse → format → parse round-trip: the second parse must
     /// produce the same attribute structure as the first. This is
     /// the formatter's idempotency contract, stricter than matching

--- a/crates/almide-tools/tests/fmt_corpus_test.rs
+++ b/crates/almide-tools/tests/fmt_corpus_test.rs
@@ -153,12 +153,38 @@ fn own_line_block_comments_survive_fmt() {
     assert_eq!(format_program(&second), formatted, "fmt must be idempotent");
 }
 
+/// SUPERSEDED BEHAVIOUR (#1404): this used to assert that an inline block
+/// comment made the verifier REFUSE, because the printer had no slot for it.
+/// It now attaches to the node it annotates and round-trips, so the assertion
+/// is inverted — kept rather than deleted so the change of contract is visible
+/// in the history at the place that pinned the old one.
 #[test]
-fn inline_block_comment_makes_the_verifier_refuse_not_delete() {
+fn inline_block_comment_is_attached_and_conserved() {
     let src = "fn f(a: Int, b: Int) -> Int = a + b\n\nfn main() -> Unit = {\n  let x = f(1 /* inline */, 2)\n  println(\"ok\")\n}\n";
     let program = parse(src).expect("inline block comments stay legal to parse");
     let formatted = format_program(&program);
+    verify_format(src, &program, &formatted)
+        .expect("an attached inline comment is conserved, not refused");
+    // TRAILING on `1`: it must not cross the comma onto `2`.
+    assert!(
+        formatted.contains("f(1 /* inline */, 2)"),
+        "inline comment moved off the node it annotates:\n{formatted}"
+    );
+    let second = parse(&formatted).expect("formatted parses");
+    assert_eq!(format_program(&second), formatted, "fmt must stay idempotent");
+}
+
+/// The half #1404 does NOT close, pinned so the boundary is explicit: a `//`
+/// comment before a continuation line still refuses. Reprinting it inline
+/// would comment out the rest of the line — an early attempt did exactly that
+/// and the verifier caught `binary -> int`, i.e. the `+ 2` had vanished. It
+/// needs line-aware placement, which the inline bracket is not.
+#[test]
+fn a_line_comment_before_a_continuation_still_refuses() {
+    let src = "fn main() -> Unit = {\n  let y = 1 + // why\n    2\n  println(\"ok\")\n}\n";
+    let program = parse(src).expect("parses");
+    let formatted = format_program(&program);
     let why = verify_format(src, &program, &formatted)
-        .expect_err("an unattachable inline comment must refuse, never silently drop");
+        .expect_err("an unattachable line comment must refuse, never silently drop");
     assert!(why.contains("comment"), "got: {why}");
 }

--- a/src/cli/lsp_code_actions.rs
+++ b/src/cli/lsp_code_actions.rs
@@ -393,6 +393,7 @@ fn empty_program() -> crate::ast::Program {
         module: None, imports: vec![], decls: vec![],
         comment_map: vec![], doc_map: vec![], blank_lines_map: vec![],
         failed_fn_names: std::collections::HashSet::new(),
+        expr_comments: Default::default(),
     }
 }
 


### PR DESCRIPTION
Closes #1404. Half of #1326 (the other half is pinned below as still-refusing, with the reason).

## The ruling, and its mirror

Ruled: **a comment binds to the node it is adjacent to, on the side it was written.**

```almide
foo(/* why */ a, b)     // LEADING on `a`  — travels with `a`
f(1 /* x */, 2)         // TRAILING on `1` — does NOT cross the comma
```

The leading half is the ruling as given. The trailing half is its mirror, and it matters: taking "attach to the FOLLOWING node" literally would move `/* x */` across the comma onto `2`, annotating a value its author never wrote it against. rustfmt and prettier bind the same way.

## Design: a side table, not a field on `Expr`

`Program.expr_comments: HashMap<ExprId, ExprComments>`, keyed by an id the node already carries.

A field on `Expr` was the obvious move and is the wrong one: `Expr` is built in hundreds of places and rebuilt by every desugar, so the field would have to be threaded and *preserved* through all of them — and one missed rebuild silently drops a comment, which is precisely the bug class fmt's conservation verifier exists to catch. As a side table, nothing downstream needs to know it exists; the whole change adds one field to `Program` and touched exactly **two** construction sites.

The parser's token filter still removes inline comments so the grammar never sees them (unchanged), but now *records* each one against the filtered position it was written at, with its side. `parse_postfix` is the bracket — the tightest scope around one complete operand — taking leading comments at the operand's first token and trailing ones after the postfix chain closes, so `f(1) /* x */` annotates the call rather than the callee.

`fmt_expr` brackets each node's rendering with its attached comments. The map reaches it via a `thread_local` scoped by `with_expr_comments`, because `fmt_expr` has ~70 call sites and threading a parameter through all of them is the same one-missed-site hazard the side table avoids.

## The half this does NOT close, and why

`let y = 1 + // why` followed by an indented operand still refuses. I implemented it, and the conservation verifier caught the result:

```
AST changed by formatting at $.decls[0].body.stmts[0].value.kind: "binary" → "int"
```

A `//` comment reprinted inline **comments out the rest of the line** — `1 // why` swallowed the `+ 2`, and the expression reparsed as a bare `Int`. That is a source-destroying bug, not a cosmetic one. It needs line-aware placement, which the inline bracket is not, so it stays an honest refusal with `a_line_comment_before_a_continuation_still_refuses` pinning the boundary.

## Verification

- `an_inline_block_comment_stays_on_the_node_it_annotates` — both sides, and asserts the trailing one does not cross the separator
- `an_attached_comment_does_not_drift_on_a_second_pass` — idempotency; a comment drifting one node per run would satisfy the conservation count while corrupting source
- `inline_block_comment_makes_the_verifier_refuse_not_delete` → `inline_block_comment_is_attached_and_conserved`: the test that pinned the old refusal is **inverted, not deleted**, so the contract change is visible where it was previously asserted
- `cargo test --workspace --release` clean · `almide test` 401/401
- `rustc-warnings: 0 over 154 units` (baseline 0) — the ratchet #1405 just wired
- codopsy: `almide-syntax` A (96), `almide-tools` A (97)
- **fmt drift A/B against the pre-change binary**: `spec/` 908 formatted on both; `stdlib/`+`examples/` 235-need-formatting on both — identical, so this change is drift-neutral (that 235 is fmt's import insertion without `--no-import-edit`, pre-existing)