### PR TITLE
Stand up the failure-side corpus: spec/wasm_fail asserts both legs break alike

### DIFF
--- a/spec/wasm_fail/effect_err_aborts_both_legs.almd
+++ b/spec/wasm_fail/effect_err_aborts_both_legs.almd
@@ -1,0 +1,11 @@
+// @expect-fail: invalid digit found in string
+// #1411 stage 1. The CONTROL for int_parse_err_propagates: the same erring
+// int.parse, but through a plain effect chain with no declared-Option carrier
+// in the way. Both legs abort with the same message today; this file pins the
+// termination shape #1410's broken cell must be brought back to.
+effect fn parse_it(k: String) -> Int = int.parse(k)!
+
+effect fn main() -> Unit = {
+  let n = parse_it("XYZ")!
+  println("UNREACHABLE ${int.to_string(n)}")
+}

--- a/spec/wasm_fail/int_parse_err_propagates.almd
+++ b/spec/wasm_fail/int_parse_err_propagates.almd
@@ -1,0 +1,18 @@
+// @expect-fail: invalid digit found in string
+// #1411 stage 1, seeded from #1410's minimal repro. A declared-Option effect
+// fn whose body's `!` fires must propagate the err out of main — on BOTH legs,
+// with the same message and a nonzero exit. This is the cell C-216's fixture
+// labels "can-err" but never actually errs (int.parse succeeds on every input
+// it passes). The wasm leg CURRENTLY swallows this error and continues with a
+// garbage value — #1410 — so this file enters the corpus as the KNOWN
+// divergence that gate tracks until the fix lands.
+// @xf-allow: #1410 — wasm swallows the err and continues (got=8260-class)
+effect fn boom(k: String) -> Int? = {
+  let n = int.parse(k)!
+  if n > 0 then some(n) else none
+}
+
+effect fn main() -> Unit = {
+  let used = boom("XYZ")!
+  println("UNREACHABLE got=${int.to_string(used ?? 99)}")
+}

--- a/tests/wasm_runtime_test.rs
+++ b/tests/wasm_runtime_test.rs
@@ -491,3 +491,4 @@ include!("wasm_runtime_test_parts/p2.rs");
 include!("wasm_runtime_test_parts/p3.rs");
 include!("wasm_runtime_test_parts/p4_corpus.rs");
 include!("wasm_runtime_test_parts/p5_gates.rs");
+include!("wasm_runtime_test_parts/p6_fail_corpus.rs");

--- a/tests/wasm_runtime_test_parts/p6_fail_corpus.rs
+++ b/tests/wasm_runtime_test_parts/p6_fail_corpus.rs
@@ -1,0 +1,139 @@
+// ── The failure-side corpus (#1411 stage 1) ──
+//
+// `spec/wasm_cross/` asks "do the two legs return the same VALUE"; this gate
+// asks "do the two legs BREAK the same way". The distinction exists because a
+// fixture written alongside a fix exercises the path the author just made work
+// — measured 2026-08-14, only 41 of 418 wasm_cross fixtures reach an error
+// path at all, and the three runtime bugs the fuzzer found that week (#1400,
+// #1408, #1410) all lived on the side no fixture ran. The mature compilers all
+// grew this category: Zig's `test/cases/safety/` (104 programs that PASS only
+// if the expected panic fires), rustc's `run-fail` mode + `error-pattern`.
+// Survey: ../almide-references/RESEARCH-failure-corpus.md.
+//
+// Format, one judgement per directory (Zig's compile_errors/safety split):
+//   // @expect-fail: <substring of stderr>
+//       Mandatory. The program must TERMINATE UNSUCCESSFULLY on both legs
+//       (nonzero exit), with this substring in stderr, and with the SAME
+//       stderr and exit code on both legs. Running to success is a FAILING
+//       test — the Zig rule that falling through to the end is itself the
+//       failure.
+//   // @xf-allow: <reason + tracking ref>
+//       A KNOWN cross-leg divergence in how the failure manifests (#1410:
+//       wasm swallows the err entirely). Exempt from the leg-equality half,
+//       still logged; when the legs re-agree the gate flags the entry as
+//       stale so it gets removed. Mirrors wasm_cross's @xt-allow exactly.
+
+#[test]
+fn wasm_fail_corpus() {
+    let bin = almide_bin();
+    if Command::new(&bin).arg("--version").output().is_err() {
+        return;
+    }
+    if Command::new("wasmtime").arg("--version").output().is_err() {
+        return;
+    }
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("spec/wasm_fail");
+    if !dir.exists() {
+        return;
+    }
+    let mut entries: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().map(|x| x == "almd").unwrap_or(false))
+        .collect();
+    entries.sort_by_key(|e| e.path());
+    assert!(
+        !entries.is_empty(),
+        "spec/wasm_fail exists but holds no fixtures — an empty failure corpus \
+         is the 9.8% problem this gate was built to end (#1411)"
+    );
+
+    let mut passed = 0;
+    let mut allowed: Vec<String> = Vec::new();
+    let mut stale: Vec<String> = Vec::new();
+    let mut failed: Vec<String> = Vec::new();
+
+    for e in entries {
+        let path = e.path();
+        let name = path.file_stem().unwrap().to_string_lossy().to_string();
+        let source = std::fs::read_to_string(&path).unwrap();
+
+        let Some(expect) = source
+            .lines()
+            .find_map(|l| l.trim().strip_prefix("// @expect-fail:").map(|r| r.trim().to_string()))
+        else {
+            failed.push(format!(
+                "{name}: missing `// @expect-fail:` header — a wasm_fail fixture must \
+                 declare the failure it exists to demonstrate"
+            ));
+            continue;
+        };
+        let allow = source
+            .lines()
+            .find_map(|l| l.trim().strip_prefix("// @xf-allow:").map(|r| r.trim().to_string()));
+
+        let (nc, nout, nerr) = run_native_capture(&source);
+        let wasm = match std::panic::catch_unwind(|| run_wasm_capture(&source)) {
+            Ok(Some(w)) => w,
+            Ok(None) => {
+                failed.push(format!("{name}: wasmtime could not be spawned mid-run"));
+                continue;
+            }
+            Err(_) => {
+                failed.push(format!("{name}: WASM build/run panicked"));
+                continue;
+            }
+        };
+        let (wc, wout, werr) = (wasm.0, &wasm.1, &wasm.2);
+
+        // Half 1 — the NATIVE reference must actually fail, the declared way.
+        // A fixture that runs to success is a failing test (the Zig rule): it
+        // means the failure it documents no longer fires, and the file must be
+        // updated or retired rather than passing vacuously.
+        let native_fails_right = nc != 0 && nerr.contains(&expect);
+        if !native_fails_right {
+            failed.push(format!(
+                "{name}: the native leg did not fail as declared\n  \
+                 expected: nonzero exit, stderr containing {expect:?}\n  \
+                 got: exit={nc} stdout={nout:?} stderr={nerr:?}"
+            ));
+            continue;
+        }
+
+        // Half 2 — both legs break the SAME way (exit + stdout + stderr),
+        // unless a tracked @xf-allow names the known divergence.
+        let legs_equal = nc == wc && nout == *wout && nerr == *werr;
+        match (legs_equal, allow.as_ref()) {
+            (true, None) => passed += 1,
+            (true, Some(r)) => stale.push(format!(
+                "{name}: @xf-allow now MATCHES (was: {r}) — remove the directive"
+            )),
+            (false, Some(r)) => allowed.push(format!("{name}: {r}")),
+            (false, None) => failed.push(format!(
+                "{name}: the two legs break DIFFERENTLY\n  \
+                 native: exit={nc} stdout={nout:?} stderr={nerr:?}\n  \
+                 wasm:   exit={wc} stdout={wout:?} stderr={werr:?}"
+            )),
+        }
+    }
+
+    eprintln!(
+        "\nwasm_fail_corpus (gate): {passed} fail-identically, {} tracked-divergence(s), {} stale-allow(s), {} problem(s)",
+        allowed.len(),
+        stale.len(),
+        failed.len()
+    );
+    for a in &allowed {
+        eprintln!("  ~ tracked: {a}");
+    }
+
+    let mut problems = failed;
+    problems.extend(stale);
+    if !problems.is_empty() {
+        panic!(
+            "\n{} wasm_fail gate problem(s):\n\n{}",
+            problems.len(),
+            problems.join("\n\n")
+        );
+    }
+}


### PR DESCRIPTION
#1411 Stage 1. Survey: `../almide-references/RESEARCH-failure-corpus.md`.

## Why

Measured 2026-08-14: **41 of 418** `wasm_cross` fixtures reach an error path (9.8%), and the three runtime bugs the fuzzer found this week (#1400, #1408, #1410) all lived on the side no fixture ran. The clarifying case is #1410: the 2-way gate is **sound** (`native exit=1 / wasm exit=0` — it catches the divergence the moment the input exists), but C-216's "can-err" cell never actually errs, so the input never existed. The gap is corpus, not gate.

Every mature compiler surveyed grew this category: Zig's `test/cases/safety/` (104 programs that pass **only if the expected panic fires** — falling through to the end is itself `error.TestFailed`), rustc's `run-fail` mode + `error-pattern` (189 tests), Lean4's `elab_fail` (631).

## What

`spec/wasm_fail/` — where `wasm_cross` asks *"do the two legs return the same value"*, this asks *"do the two legs **break the same way**"*. Separate directory per Zig's split: one judgement per directory.

Each fixture declares its failure:

```
// @expect-fail: invalid digit found in string     ← mandatory: substring of stderr
// @xf-allow: #1410 — …                            ← optional: tracked cross-leg divergence
```

The gate (`wasm_fail_corpus`, in the same shared-corpus harness as `wasm_cross_target_spec`) asserts **two halves**:

1. the native reference **actually fails as declared** — nonzero exit, stderr contains the pattern. A fixture that runs to success is a *failing test*, which makes the C-216 vacuity class (a can-err cell that never errs) unrepresentable in this directory.
2. both legs terminate **identically** (exit + stdout + stderr), with `@xf-allow` giving the same tracked/stale lifecycle as `wasm_cross`'s `@xt-allow` — a fixed divergence flags the stale directive for removal.

## Seeds

- `int_parse_err_propagates.almd` — the #1410 minimal repro, entering as the **tracked divergence** (wasm swallows the err and continues with garbage). The gate report shows it: `1 fail-identically, 1 tracked-divergence(s)`.
- `effect_err_aborts_both_legs.almd` — the control: same erring `int.parse` through a plain effect chain, which agrees on both legs today and pins the termination shape the #1410 fix must reach.

## Verified, including the negative

- **A/B on the gate itself**: planted a vacuous fixture (`@expect-fail` + a program that succeeds) → the gate fails with `the native leg did not fail as declared`; removed → green. The gate demonstrably rejects the class it was built for.
- An empty `spec/wasm_fail/` also fails loudly (the 9.8% problem must not silently return).
- `cargo test --workspace --release` clean · `rustc-warnings: 0` · fmt clean · fixtures carry no `test` blocks so `almide test` does not double-run them.