### PR TITLE
Run the fuzz nightly on both arches so arch-conditional bugs have an observer

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -54,7 +54,7 @@ env:
   # ~210 prog/min, up from ~1,000). Deep single-seed runs stay available
   # through the `minutes` dispatch input.
   FUZZ_MINUTES: "5"
-  FUZZ_SHARDS: "4"
+  FUZZ_SHARDS: "8"
   # Cold runners gain nothing from the workspace's release-incremental
   # profile (#1006) — it only bloats the caches. Opt out.
   CARGO_INCREMENTAL: "0"
@@ -68,8 +68,21 @@ jobs:
   # artifact download instead of a compile.
   build:
     if: github.server_url == 'https://github.com'
-    name: Build compiler + fuzzer
-    runs-on: ubuntu-latest
+    name: Build compiler + fuzzer (${{ matrix.arch }})
+    # HOST POLARITY (#1411 stage 2). The night runs on BOTH arches because a
+    # whole defect class is arch-conditional: #1403's raw-NaN byte write reads
+    # as the canonical pattern on aarch64 and only x86 can observe it, and the
+    # inverse blindness holds for anything keyed on x86's sign-set NaNs. One
+    # arch is not a subset of the other — each sees bugs the other cannot.
+    # ubuntu-24.04-arm is free for public repos, so the cost is runner-minutes,
+    # not money.
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, arch: x86_64 }
+          - { os: ubuntu-24.04-arm, arch: aarch64 }
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
@@ -85,8 +98,8 @@ jobs:
             ~/.cargo/git
             target
             tools/xtarget-fuzz/target
-          key: fuzz-cargo-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: fuzz-cargo-${{ env.RUST_TOOLCHAIN }}-
+          key: fuzz-cargo-${{ matrix.arch }}-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: fuzz-cargo-${{ matrix.arch }}-${{ env.RUST_TOOLCHAIN }}-
 
       # The compiler the fuzzer shells out to.
       - name: Build almide
@@ -102,7 +115,7 @@ jobs:
       - name: Upload binaries
         uses: actions/upload-artifact@v7
         with:
-          name: fuzz-binaries-${{ github.run_id }}
+          name: fuzz-binaries-${{ github.run_id }}-${{ matrix.arch }}
           path: |
             target/release/almide
             tools/xtarget-fuzz/target/release/xtarget-fuzz
@@ -110,18 +123,31 @@ jobs:
 
   fuzz:
     if: github.server_url == 'https://github.com'
-    name: Generative differential fuzz (shard ${{ matrix.shard }})
+    name: Generative differential fuzz (shard ${{ matrix.shard }}, ${{ matrix.arch }})
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     # `fail-fast: false` is load-bearing, not hygiene: the whole point of
     # sharding is that one shard dying must not take the night's other shards
     # with it. Keep the shard list and FUZZ_SHARDS in step — the verdict job
     # reads FUZZ_SHARDS to report `shards=k/N`, so a mismatch would understate
     # or overstate the night's coverage.
+    #
+    # Shards 1-4 run x86_64, 5-8 aarch64 (#1411 stage 2): shard NUMBERS are
+    # globally unique so the derived seeds (`run_id * 16 + shard`) and the
+    # per-shard artifact names never collide across arches, and the verdict
+    # job's `shards=k/N` accounting keeps meaning "of the whole night".
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        include:
+          - { shard: 1, os: ubuntu-latest, arch: x86_64 }
+          - { shard: 2, os: ubuntu-latest, arch: x86_64 }
+          - { shard: 3, os: ubuntu-latest, arch: x86_64 }
+          - { shard: 4, os: ubuntu-latest, arch: x86_64 }
+          - { shard: 5, os: ubuntu-24.04-arm, arch: aarch64 }
+          - { shard: 6, os: ubuntu-24.04-arm, arch: aarch64 }
+          - { shard: 7, os: ubuntu-24.04-arm, arch: aarch64 }
+          - { shard: 8, os: ubuntu-24.04-arm, arch: aarch64 }
     # Hard ceiling well above the fuzz budget so a hung child can never
     # wedge the runner indefinitely, with room for a dispatch run that raises
     # `minutes`.
@@ -134,7 +160,7 @@ jobs:
       - name: Download binaries
         uses: actions/download-artifact@v8
         with:
-          name: fuzz-binaries-${{ github.run_id }}
+          name: fuzz-binaries-${{ github.run_id }}-${{ matrix.arch }}
 
       - name: Restore the executable bit
         # `upload-artifact` does not preserve the mode.
@@ -145,8 +171,8 @@ jobs:
       - name: Cache wasmtime tarball
         uses: actions/cache@v6
         with:
-          path: wasmtime-v47.0.3-x86_64-linux.tar.xz
-          key: wasmtime-v47.0.3-x86_64-linux
+          path: wasmtime-v47.0.3-${{ matrix.arch }}-linux.tar.xz
+          key: wasmtime-v47.0.3-${{ matrix.arch }}-linux
       - name: Install wasmtime
         # Pinned + cached + retried (matches develop's ci.yml): the exact-release
         # asset download is per-IP rate-limited (a 429 storm burned all retries
@@ -155,7 +181,7 @@ jobs:
         # and the cache key together.
         run: |
           VERSION=v47.0.3
-          TARBALL="wasmtime-${VERSION}-x86_64-linux.tar.xz"
+          TARBALL="wasmtime-${VERSION}-${{ matrix.arch }}-linux.tar.xz"
           if [ ! -s "$TARBALL" ]; then
             for i in 1 2 3 4 5; do
               curl -fLO "https://github.com/bytecodealliance/wasmtime/releases/download/${VERSION}/${TARBALL}" && break


### PR DESCRIPTION
#1411 Stage 2 — host polarity. Survey: `../almide-references/RESEARCH-failure-corpus.md`.

## Why this jumps ahead of the corpus inventory

#1403 (the raw-NaN byte write) was **unobservable on aarch64** — the raw pattern there happens to equal the canonical one, so every local run in that session was structurally blind to it, and only CI's x86 could see it. The inverse holds too: anything keyed on x86's sign-set NaNs is invisible to an x86-only nightly. One arch is not a subset of the other — **each sees bugs the other cannot** — and until this lands, a whole class is unobservable *today* on every machine in use.

## What

The nightly's `build` and `fuzz` jobs gain an arch axis:

| shards | runner | arch |
|---|---|---|
| 1–4 | `ubuntu-latest` | x86_64 |
| 5–8 | `ubuntu-24.04-arm` | aarch64 |

- **Shard numbers are globally unique**, so the derived seeds (`run_id * 16 + shard`) and per-shard artifact names never collide across arches, and the verdict job's `shards=k/N` keeps meaning "of the whole night". `FUZZ_SHARDS` → 8.
- Per-arch binary artifacts (`fuzz-binaries-<run>-<arch>`) and per-arch cargo cache keys.
- The wasmtime tarball is parametrized by arch — and `wasmtime-v47.0.3-aarch64-linux.tar.xz` was **verified to exist in the release assets** before wiring, since a wrong asset name would kill every ARM shard at install.
- `ubuntu-24.04-arm` is free for public repos (this repo is public), so the cost is runner-minutes, not money.

Night coverage doubles at constant wall clock (~8,000 programs/night at the measured ~210 prog/min), and the ARM half explores with different seeds rather than repeating the x86 campaign.

## Verification

- YAML parses; every remaining `x86_64` literal audited (matrix values only)
- Seed/artifact uniqueness checked across all 8 shards
- The scheduled run is the real test — after merge I will fire a short `workflow_dispatch` (`minutes=5`) to validate the ARM path end-to-end rather than waiting for tonight