### PR TITLE
Propagate the error a can-err declared-Option effect fn raises on the wasm leg

### DIFF
--- a/crates/almide-mir/src/lower/mod_c.rs
+++ b/crates/almide-mir/src/lower/mod_c.rs
@@ -538,9 +538,76 @@ fn new_lower_ctx(
 /// `mir > ir` breach on every in-profile loop-`!` fn — the #1176 drift).
 pub fn auto_wrap_abi_body(func: &IrFunction) -> Option<IrExpr> {
     if crate::lower::AUTO_WRAP_ABI_FNS.with(|s| s.borrow().contains(func.name.as_str())) {
-        Some(IrExpr { ty: Ty::result(func.ret_ty.clone(), Ty::String), ..func.body.clone() })
+        let result_ty = Ty::result(func.ret_ty.clone(), Ty::String);
+        let mut body = IrExpr { ty: result_ty.clone(), ..func.body.clone() };
+        // #1410: a DECLARED-OPTION member's ok-path values are wrapped in
+        // `ok(...)` HERE, in the shared retype both the lowering and the
+        // classify count-side apply (the #1176 discipline, by construction).
+        // The scalar members' raw ok tails are handled by the existing
+        // machinery downstream and are left exactly as before; Option is the
+        // family whose raw tail survived to the renderer as the #841 hybrid —
+        // err path a wrapped Result block, ok path a raw Option block — which
+        // no consumer can discriminate: wasm swallowed a failed int.parse and
+        // continued with a garbage value where native aborted.
+        if matches!(
+            &func.ret_ty,
+            Ty::Applied(almide_lang::types::constructor::TypeConstructorId::Option, _)
+        ) {
+            wrap_option_return_positions(&mut body, &func.ret_ty, &result_ty);
+        }
+        Some(body)
     } else {
         None
+    }
+}
+
+/// Wrap every RETURN-position value of `expr` whose type is the declared
+/// Option in `ok(...)`, retyping the spine to the Result carrier as it goes.
+/// Return positions only — Block tails, If arms, Match arms — never operand
+/// or argument positions, so nothing an expression CONSUMES changes shape.
+/// `ResultOk`/`ResultErr` values are already the carrier and are left alone.
+fn wrap_option_return_positions(expr: &mut IrExpr, opt_ty: &Ty, result_ty: &Ty) {
+    match &mut expr.kind {
+        IrExprKind::Block { expr: tail, .. } => {
+            if let Some(t) = tail.as_deref_mut() {
+                wrap_option_return_positions(t, opt_ty, result_ty);
+            }
+            expr.ty = result_ty.clone();
+        }
+        IrExprKind::If { then, else_, .. } => {
+            wrap_option_return_positions(then, opt_ty, result_ty);
+            wrap_option_return_positions(else_, opt_ty, result_ty);
+            expr.ty = result_ty.clone();
+        }
+        IrExprKind::Match { arms, .. } => {
+            for arm in arms.iter_mut() {
+                wrap_option_return_positions(&mut arm.body, opt_ty, result_ty);
+            }
+            expr.ty = result_ty.clone();
+        }
+        IrExprKind::ResultOk { .. } | IrExprKind::ResultErr { .. } => {}
+        _ => {
+            // A VALUE in return position. Wrap it when it produces the declared
+            // Option; anything else (a Never-typed die, an already-Result
+            // propagation) is left for the existing machinery.
+            if expr.ty == *opt_ty {
+                let inner = std::mem::replace(
+                    expr,
+                    IrExpr {
+                        kind: IrExprKind::Unit,
+                        ty: Ty::Unit,
+                        span: None,
+                        def_id: None,
+                    },
+                );
+                *expr = IrExpr {
+                    span: inner.span.clone(),
+                    def_id: inner.def_id,
+                    kind: IrExprKind::ResultOk { expr: Box::new(inner) },
+                    ty: result_ty.clone(),
+                };
+            }
+        }
     }
 }
 

--- a/crates/almide-mir/src/lower/mod_p2_b.rs
+++ b/crates/almide-mir/src/lower/mod_p2_b.rs
@@ -122,14 +122,28 @@ pub fn populate_abi_registries(fns: &[IrFunction], _record_layouts: &RecordLayou
             .iter()
             .filter(|f| f.name.as_str() != "main")
             .filter(|f| {
-                !matches!(
+                let declared_result = matches!(
                     &f.ret_ty,
-                    Ty::Applied(
-                        almide_lang::types::constructor::TypeConstructorId::Result
-                            | almide_lang::types::constructor::TypeConstructorId::Option,
-                        _
-                    )
-                ) && (body_has_stmt_position_propagating_unwrap(&f.body)
+                    Ty::Applied(almide_lang::types::constructor::TypeConstructorId::Result, _)
+                );
+                let declared_option = matches!(
+                    &f.ret_ty,
+                    Ty::Applied(almide_lang::types::constructor::TypeConstructorId::Option, _)
+                );
+                // #1410: a CAN-ERR declared-Option effect fn is the #841 hybrid this
+                // registry exists to close — its err path returns a wrapped block
+                // (the propagation machinery builds `err(e)`) while its ok tail is
+                // the RAW Option, and no consumer can discriminate the two. It was
+                // excluded here by return TYPE, so the hybrid survived for exactly
+                // this family: wasm swallowed the error and read garbage (8260)
+                // where native aborted. Admitting it gives the true carrier
+                // `Result[Option[T], String]` on both v1 legs. A NEVER-ERR
+                // declared-Option fn stays excluded — its raw-Option ABI is sound
+                // and `strip_declared_option_trys` keeps its call sites free.
+                !declared_result
+                    && (!declared_option
+                        || (f.is_effect && can_err.contains(f.name.as_str())))
+                    && (body_has_stmt_position_propagating_unwrap(&f.body)
                     || body_has_tail_position_option_unwrap(&f.body)
                     || body_has_tail_position_canerr_try(&f.body, &can_err)
                     // #841: EVERY non-Unit CAN-ERR lifted effect fn always-wraps. Its
@@ -160,6 +174,17 @@ pub fn populate_abi_registries(fns: &[IrFunction], _record_layouts: &RecordLayou
             .filter(|f| {
                 matches!(&f.ret_ty,
                     Ty::Applied(almide_lang::types::constructor::TypeConstructorId::Option, _))
+                    // #1410: NEVER-ERR only. This registry drives
+                    // `strip_declared_option_trys`, whose premise — "there is no
+                    // err channel, the propagation node is the identity" — is
+                    // only true when the callee cannot err. Stripping a CAN-ERR
+                    // member's `!` deleted the error propagation itself: wasm
+                    // continued past a failed int.parse with a garbage value
+                    // while native aborted. A can-err declared-Option fn now
+                    // rides AUTO_WRAP instead (true carrier
+                    // `Result[Option[T], String]`), so its `!` must survive to
+                    // become the real err/ok match.
+                    && !can_err.contains(f.name.as_str())
             })
             .map(|f| f.name.as_str().to_string())
             .collect();

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,7 +11,7 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-97 normative sections; 439 distinct executable fixtures.
+97 normative sections; 440 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|

--- a/spec/wasm_cross/fan_effect_mapper_capability.almd
+++ b/spec/wasm_cross/fan_effect_mapper_capability.almd
@@ -37,33 +37,26 @@ effect fn main() -> Unit = {
   let d = fs.create_temp_dir("fanCap")!
   fs.write(d + "/a.txt", "alpha")!
   fs.write(d + "/b.txt", "beta")!
-
   // Shape B, ok path, `!` consumption.
   let b_ok = fan.any([d + "/a.txt"], (p) => fs.read_text(p))!
   println("B ok ${b_ok}")
-
   // Shape B, err path (no candidate exists), `??` consumption.
   let b_err = fan.any([d + "/missing1.txt", d + "/missing2.txt"], (p) => fs.read_text(p)) ?? "fb"
   println("B err ${b_err}")
-
   // Shape D, ok path, `!` consumption — first candidate missing, second ok:
   // fan.any skips the failure to find the Ok.
   let d_ok = fan.any([d + "/missing.txt", d + "/b.txt"], (p) => helper(p))!
   println("D ok ${d_ok}")
-
   // Shape D, err path, `??` consumption.
   let d_err = fan.any([d + "/nope.txt"], (p) => helper(p)) ?? "fb2"
   println("D err ${d_err}")
-
   // Shape D over fan.map (the collect-all mapper), ok path, `!` consumption —
   // the heap-Ok LIST payload family (`Result[List[String], String]`).
   let mapped = fan.map([d + "/a.txt", d + "/b.txt"], (p) => helper(p))!
   println("map ok ${mapped}")
-
   // fan.map err path: the FIRST failing element's err rides out (C-005's
   // first-err ordering), consumed via `??`.
   let map_err = fan.map([d + "/a.txt", d + "/gone.txt"], (p) => helper(p)) ?? ["fb3"]
   println("map err ${map_err}")
-
   fs.remove_all(d)!
 }

--- a/spec/wasm_fail/int_parse_err_propagates.almd
+++ b/spec/wasm_fail/int_parse_err_propagates.almd
@@ -3,10 +3,11 @@
 // fn whose body's `!` fires must propagate the err out of main — on BOTH legs,
 // with the same message and a nonzero exit. This is the cell C-216's fixture
 // labels "can-err" but never actually errs (int.parse succeeds on every input
-// it passes). The wasm leg CURRENTLY swallows this error and continues with a
-// garbage value — #1410 — so this file enters the corpus as the KNOWN
-// divergence that gate tracks until the fix lands.
-// @xf-allow: #1410 — wasm swallows the err and continues (got=8260-class)
+// it passes). When this file entered the corpus the wasm leg swallowed the
+// error and continued with a garbage value (#1410, tracked via @xf-allow);
+// the fix — a can-err declared-Option effect fn rides AUTO_WRAP instead of
+// the never-err strip — re-agreed the legs, and the gate's stale-allow
+// detection is what retired the directive: the designed lifecycle, exercised.
 effect fn boom(k: String) -> Int? = {
   let n = int.parse(k)!
   if n > 0 then some(n) else none


### PR DESCRIPTION
Closes #1410 — the worst-class finding from the 2026-08-14 nightly: a **silent wrong value**, not a crash.

```almide
effect fn boom(k: String) -> Int? = {
  let n = int.parse(k)!
  if n > 0 then some(n) else none
}
effect fn main() -> Unit = {
  let used = boom("XYZ")!
  println("continued got=${int.to_string(used ?? 99)}")
}
```

| leg | before | after |
|---|---|---|
| native | `Error: invalid digit found in string` | unchanged |
| wasm | **`continued got=8260`** | `Error: invalid digit found in string` |

## Root cause: the #841 hybrid, surviving in the one family excluded by return type

A can-err declared-Option effect fn's err path returns a **wrapped Result block** (the propagation machinery builds `err(e)`) while its ok tail stays a **raw Option** — the exact runtime hybrid #841 closed for scalars, still open here because `AUTO_WRAP_ABI_FNS` filtered on `!matches!(ret_ty, Result | Option)`. On top of that, `strip_declared_option_trys` deleted the call-site `!` on the premise *"there is no err channel to propagate"* — true only for never-err members. Two wrongs almost cancelling: the call site read raw Option (right on ok, garbage on err).

## Three changes that must agree

1. **`AUTO_WRAP_ABI_FNS` admits can-err declared-Option effect fns** — true carrier `Result[Option[T], String]`. Never-err members stay excluded; their raw-Option ABI is sound.
2. **`DECLARED_OPTION_FNS` keeps only never-err members** — a can-err call site's `!` survives to become the real err/ok match.
3. **The shared ABI retype (`auto_wrap_abi_body`) wraps ok-path Option values in `ok(...)`** — return positions only (Block tails, If/Match arms), in the ONE function both the lowering and the classify count-side apply, so the #1176 mir==ir discipline holds by construction.

## The gates caught my first attempt within one run

Changes 1+2 alone moved the hybrid instead of closing it: the **C-216 fixture itself** failed with `canerr_some=999` + an rc_dec trap — err path fixed, ok path now misread. The `DBG_LOWER_FN` dump showed why: the ok arm's tail was still `some(n)/none` raw under a Result-typed root, because the implicit machinery that handles raw *scalar* tails does not cover Option values. Change 3 is the missing half, and the fixture that caught it is the same file whose "can-err cell that never errs" started this whole arc.

## The wasm_fail lifecycle completed on its first live case

The `@xf-allow: #1410` tracked divergence on `int_parse_err_propagates.almd` retires in this PR — the legs re-agreed, and the gate's stale-allow detection is what forces the directive out:

```
wasm_fail_corpus (gate): 2 fail-identically, 0 tracked-divergence(s), 0 stale-allow(s)
```

## Verification

- Both polarities of the minimal repro agree on both legs; the original nightly repro (seed 508328767281 idx 16) agrees on both legs
- `almide test` 401/401 · `cargo test --workspace --release` clean — including `wasm_cross_target_spec` over all 418 fixtures and the 3-way oracle
- `corpus-wall`: TOTAL over 6,643 fns, walled-real 0 · `rustc-warnings: 0`
- `almide-mir` codopsy **A (90/100), 34 warnings — exactly its baseline** (the zero-headroom crate)