### PR TITLE
Pin checker-resolved types on return-only-generic runtime ctors (#1416)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The guarantee is **continuous, with an explicit, ledger-managed scope**: "byte-i
 This claim is not prose. Every observable promise is a named contract in the [behavior-contract ledger](docs/contracts/), each traceable to executable evidence, and the numbers below are regenerated from the ledger (`scripts/gen-claims.sh`, enforced by `scripts/check-contracts.sh` in CI) so this section cannot drift from what the gates actually verify:
 
 <!-- claims:generated:start — derived from docs/contracts/contracts.toml by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
-> **Ledger: 276 contracts — 276 active, 0 flagged-for-revision.**
+> **Ledger: 277 contracts — 277 active, 0 flagged-for-revision.**
 >
 > **Divergences awaiting a fix: none.** Every contract in the ledger is
 > `active`, carrying executable evidence of class >= `fixture`. The one

--- a/crates/almide-codegen/src/walker/expressions.rs
+++ b/crates/almide-codegen/src/walker/expressions.rs
@@ -350,27 +350,31 @@ fn render_expr_empty_map(ctx: &RenderContext, ty: &Ty) -> String {
         .unwrap_or_else(|| format!("AlmideMap::<{}, {}>::new()", key_ty, value_ty))
 }
 
-/// `map.new()` / `set.new()` reaching Rust as a bare generic runtime call can
-/// leave rustc with an uninferrable type parameter when nothing downstream
-/// pins it: const-folding `if true then map.new() else <typed literal>`
-/// collapses the typing context away, and `map.contains` leaves `V` free —
-/// E0282 after `check` accepted (nightly-fuzz seed 1785045556318379299,
-/// index 867). The checker resolved the full container type on the node, so
-/// pin it with a turbofish — the same recipe as the `[:]` EmptyMap literal.
-/// Only a fully concrete type is pinned; anything unresolved falls back to
-/// plain rendering (inference handles it exactly as before).
+/// A runtime constructor whose generic appears in NO parameter type
+/// (`map.new()` / `set.new()` / `list.with_capacity(n)`) reaching Rust as a
+/// bare call can leave rustc with an uninferrable type parameter when nothing
+/// downstream pins it: const-folding `if true then map.new() else <typed
+/// literal>` collapses the typing context away, and an element-agnostic
+/// consumer (`map.contains`, `list.is_empty`) leaves it free — E0282 after
+/// `check` accepted (nightly-fuzz seed 1785045556318379299 index 867 for
+/// `map.new`; #1416, seed 508666777783, for `with_capacity`). The checker
+/// resolved the full container type on the node, so pin it with a turbofish —
+/// the same recipe as the `[:]` EmptyMap literal. Only a fully concrete type
+/// is pinned; anything unresolved falls back to plain rendering (inference
+/// handles it exactly as before).
+///
+/// Family rule (C-277): an arm here for EVERY runtime fn with a return-only
+/// generic — `runtime_ctor_turbofish_family_gate_test.rs` measures both sides
+/// from source and fails on any mismatch.
 fn render_runtime_ctor_turbofish(
     ctx: &RenderContext,
     symbol: &str,
     args: &[IrExpr],
     ty: &Ty,
 ) -> Option<String> {
-    if !args.is_empty() {
-        return None;
-    }
     match (symbol, ty) {
         ("almide_rt_map_new", Ty::Applied(TypeConstructorId::Map, targs))
-            if targs.len() == 2 && targs.iter().all(|t| !t.is_unresolved()) =>
+            if args.is_empty() && targs.len() == 2 && targs.iter().all(|t| !t.is_unresolved()) =>
         {
             Some(format!(
                 "almide_rt_map_new::<{}, {}>()",
@@ -379,11 +383,20 @@ fn render_runtime_ctor_turbofish(
             ))
         }
         ("almide_rt_set_new", Ty::Applied(TypeConstructorId::Set, targs))
-            if targs.len() == 1 && !targs[0].is_unresolved() =>
+            if args.is_empty() && targs.len() == 1 && !targs[0].is_unresolved() =>
         {
             Some(format!(
                 "almide_rt_set_new::<{}>()",
                 render_map_type_arg(ctx, &targs[0])
+            ))
+        }
+        ("almide_rt_list_with_capacity", Ty::Applied(TypeConstructorId::List, targs))
+            if args.len() == 1 && targs.len() == 1 && !targs[0].is_unresolved() =>
+        {
+            Some(format!(
+                "almide_rt_list_with_capacity::<{}>({})",
+                render_map_type_arg(ctx, &targs[0]),
+                render_expr_owned(ctx, &args[0])
             ))
         }
         _ => None,

--- a/crates/almide-interp/interp-abstain-classes.toml
+++ b/crates/almide-interp/interp-abstain-classes.toml
@@ -43,6 +43,13 @@ patterns = [
 name = "BRIDGEABLE"
 patterns = [
   "capability: HOF map.fold",
+  # SURFACED BY the #1416 ctor glue (map.new/set.new/with_capacity), not
+  # introduced by it: map_filter / map_set_typechange used to abstain at
+  # `prim.alloc_map` (HEAP_BOUNDARY, first-hit) and now get past the
+  # constructor to reveal the missing HOF arm underneath — dispatch glue,
+  # the textbook BRIDGEABLE shape.
+  "capability: HOF map.filter",
+  "capability: HOF map.map",
   "capability: HOF list.update",
   "capability: list.min/max on non-comparable elements",
   "capability: prim.args_get_list_full",

--- a/crates/almide-interp/interp-abstain-ledger.txt
+++ b/crates/almide-interp/interp-abstain-ledger.txt
@@ -11,7 +11,6 @@
 # (bridge.rs / hofs.rs / dispatch.rs — see crates/almide-interp/CLAUDE.md).
 
 alias_combinator_rc  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
-alias_cow  out-of-interp-scope capability: prim.alloc_map
 base64_encode  out-of-interp-scope capability: prim.alloc_list
 bytes_f16_offset_overflow  out-of-interp-scope capability: prim.alloc_list_f64
 bytes_rawptr  out-of-interp-scope capability: prim.int_to_ptr
@@ -21,14 +20,9 @@ codec_decode_errors  out-of-interp-scope capability: prim.handle of a value outs
 codec_float_int  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 codec_none_omission  out-of-interp-scope capability: prim.alloc_value
 compound_eq  out-of-interp-scope capability: prim.handle of a List whose elements are not bytes (a tagged List block is not in this slice)
-compound_repr_interp  out-of-interp-scope capability: prim.alloc_set
-compound_repr_records_interp  out-of-interp-scope capability: prim.alloc_set
 datetime_format  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 declaration_forms  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 effect_tuple_result_tco  out-of-interp-scope capability: prim.alloc_value
-empty_collection_annotated  out-of-interp-scope capability: prim.alloc_set
-empty_collection_fold  out-of-interp-scope capability: prim.alloc_map
-empty_from_list_mono  out-of-interp-scope capability: prim.alloc_map
 encoding_base64  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 fan_effect_mapper_capability  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 fs_composition_family  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
@@ -64,17 +58,13 @@ list_slice_oob  out-of-interp-scope capability: prim.handle of a List whose elem
 list_update_heap  out-of-interp-scope capability: prim.alloc_value
 list_window_zero  out-of-interp-scope capability: prim.handle of a List whose elements are not bytes (a tagged List block is not in this slice)
 list_windows_zero  out-of-interp-scope capability: prim.die
-list_with_capacity  out-of-interp-scope capability: prim.alloc_list
-map_filter  out-of-interp-scope capability: prim.alloc_map
-map_fold  out-of-interp-scope capability: prim.alloc_map
+map_filter  out-of-interp-scope capability: HOF map.filter
 map_fold_heap_acc  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
-map_fold_heap_acc_skv  out-of-interp-scope capability: prim.handle of a List whose elements are not bytes (a tagged List block is not in this slice)
-map_index_order  out-of-interp-scope capability: prim.alloc_map
+map_index_order  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 map_insertion_order  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
-map_set_eq  out-of-interp-scope capability: prim.alloc_map
-map_set_ops  out-of-interp-scope capability: prim.alloc_map
-map_set_typechange  out-of-interp-scope capability: prim.alloc_map
-map_wide_int_key  out-of-interp-scope capability: prim.alloc_map
+map_set_ops  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+map_set_typechange  out-of-interp-scope capability: HOF map.map
+map_wide_int_key  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 matrix_dims_guard  out-of-interp-scope capability: prim.alloc_list_str
 matrix_dims_guard_overflow  out-of-interp-scope capability: prim.alloc_list_str
 matrix_dims_guard_rows  out-of-interp-scope capability: prim.alloc_list_str
@@ -90,19 +80,17 @@ mut_map_param  out-of-interp-scope capability: prim.handle of a value outside th
 mutual_append  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 negative_offset_and_width_totality  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 nested_hof_lambda_inference  out-of-interp-scope capability: prim.handle of a List whose elements are not bytes (a tagged List block is not in this slice)
-place_mutation  out-of-interp-scope capability: prim.alloc_map
 pure_bang_propagation  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
-r5_lowmisc_param_try_err  out-of-interp-scope capability: prim.alloc_map
 random_int_entropy  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 range_bind_huge  interp fuel/recursion budget exhausted
-rc_alloc_stress  out-of-interp-scope capability: prim.alloc_map
+rc_alloc_stress  out-of-interp-scope capability: prim.alloc_list
 regex_engine  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 regex_fuzz_batch  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 result_list_value_int_tuple  out-of-interp-scope capability: prim.alloc_value
 result_match_rewrap_modcall  out-of-interp-scope capability: prim.load64 outside this heap's arena — the backends read real memory here, so a guessed value would be a wrong vote
 result_value_int_tuple  out-of-interp-scope capability: prim.alloc_value
-set_index_order  out-of-interp-scope capability: prim.alloc_set
-set_insertion_order  out-of-interp-scope capability: prim.alloc_set
+set_index_order  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
+set_insertion_order  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 spread_record_share  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 str_result_heap_bind  out-of-interp-scope capability: prim.alloc_value
 string_case_unicode  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
@@ -115,7 +103,7 @@ string_passthrough_share  out-of-interp-scope capability: prim.handle of a value
 string_rle  out-of-interp-scope capability: prim.alloc_list_str
 string_split_rle_codepoint  out-of-interp-scope capability: prim.handle of a List whose elements are not bytes (a tagged List block is not in this slice)
 string_whitespace  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
-tco_map_acc_seed  out-of-interp-scope capability: prim.alloc_map
+tco_map_acc_seed  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 unwrap_or_unwrap_fallback  out-of-interp-scope capability: prim.handle of a value outside the flat String/Bytes family (alloc_value/alloc_map/alloc_list*/alloc_set blocks carry tagged sub-structure — #1226 slice 2)
 value_array_leak_loop  out-of-interp-scope capability: prim.alloc_value
 value_array_tuple_tco  out-of-interp-scope capability: prim.alloc_value

--- a/crates/almide-interp/src/hofs_list_ops.rs
+++ b/crates/almide-interp/src/hofs_list_ops.rs
@@ -72,6 +72,14 @@ impl<'a> Interpreter<'a> {
             // mutating `list.push` is intercepted by the in-place-mutation guard
             // above and never reaches here.
             "append" => Some(self.list_append(args)),
+            // A fresh EMPTY list on every leg: native clamps and reserves
+            // (runtime/rs/src/list.rs::almide_rt_list_with_capacity) and the
+            // wasm self-host ignores `cap` outright (stdlib/list_make.almd) —
+            // the reservation is unobservable (C-034), so the cap value never
+            // matters here either. Without this arm the interp descended into
+            // the self-host body and abstained on `prim.alloc_list` (C-277's
+            // fixture, #1416).
+            "with_capacity" => Some(Flow::val(Value::list(Vec::new()))),
             "concat" => Some(self.list_concat(args)),
             // The aggregate/ordering ops are a second-tier sub-router — purely
             // to keep this router's own arm count (and cyclomatic weight)
@@ -333,9 +341,17 @@ impl<'a> Interpreter<'a> {
     // ── map ──
     fn eval_container_op_map(&mut self, func: &str, args: &[Value]) -> Option<Flow> {
         match func {
+            // The empty constructor — same value the `[:]` literal evaluates
+            // to (eval.rs::EmptyMap). Without this arm the interp descended
+            // into the self-host body and abstained on `prim.alloc_map`
+            // (C-277's fixture, #1416; `with_capacity`/`set.new` likewise).
+            "new" if args.is_empty() => Some(Flow::val(Value::Map(Rc::new(Vec::new())))),
             "len" | "size" => Some(self.map_len(args)),
             "get" => Some(self.map_get(args)),
-            "contains_key" | "has" => Some(self.map_contains_key(args)),
+            // `map.contains` is the stdlib's KEY-membership name
+            // (stdlib/map.almd: `fn contains[K, V](m, key) -> Bool`) —
+            // same op as the `contains_key`/`has` aliases.
+            "contains" | "contains_key" | "has" => Some(self.map_contains_key(args)),
             // `map.set` is FUNCTIONAL (`-> Map`, returns a new map); the
             // mutating `map.insert` (`mut m, .. -> Unit`) is intercepted by the
             // in-place-mutation guard above.
@@ -397,6 +413,14 @@ impl<'a> Interpreter<'a> {
     // ── set ──
     fn eval_container_op_set(&mut self, func: &str, args: &[Value]) -> Option<Flow> {
         match func {
+            // The empty constructor — see the `map.new` arm above.
+            "new" if args.is_empty() => Some(Flow::val(Value::Set(Rc::new(Vec::new())))),
+            // Dedup preserving FIRST-occurrence insertion order — the same
+            // order both backends print (spec/wasm_cross/compound_repr_interp
+            // pins `set.from_list([3, 1, 2, 1, 3])` as `{3, 1, 2}`), and the
+            // same rule `set_insert` below already implements one element at
+            // a time.
+            "from_list" => Some(self.set_from_list(args)),
             "len" | "size" => Some(self.set_len(args)),
             "contains" | "has" => Some(self.set_contains(args)),
             "insert" | "add" => Some(self.set_insert(args)),
@@ -409,6 +433,21 @@ impl<'a> Interpreter<'a> {
         match args.first() {
             Some(Value::Set(e)) => Flow::val(Value::Int(e.len() as i64)),
             _ => Flow::Abort("internal: set.len on non-set".into()),
+        }
+    }
+
+    fn set_from_list(&mut self, args: &[Value]) -> Flow {
+        match args.first().and_then(|v| v.as_iter_items()) {
+            Some(items) => {
+                let mut out: Vec<Value> = Vec::new();
+                for x in items {
+                    if !out.contains(&x) {
+                        out.push(x);
+                    }
+                }
+                Flow::val(Value::Set(Rc::new(out)))
+            }
+            None => Flow::Abort("internal: set.from_list on non-list".into()),
         }
     }
 

--- a/crates/almide-interp/src/value.rs
+++ b/crates/almide-interp/src/value.rs
@@ -377,7 +377,12 @@ impl Value {
                 repr_seq("[", "]", &items)
             }
             Value::Tuple(xs) => repr_seq("(", ")", xs),
-            Value::Set(xs) => repr_seq("[", "]", xs),
+            // Set: the CONSTRUCTOR form `set.from_list([...])`, empty included
+            // (runtime/rs/src/set.rs:108 — element order = insertion order).
+            // The bare `[...]` this arm previously produced was unobservable
+            // until the `set.new`/`set.from_list` glue made Set-repr fixtures
+            // evaluate, and the 3-way harness caught the dissent (#1416 PR).
+            Value::Set(xs) => repr_seq("set.from_list([", "])", xs),
             Value::Map(entries) => {
                 // Map: `["k": v]` insertion order (runtime/rs/src/map.rs:74),
                 // empty map `[:]`.

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-276 contracts
+277 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -304,4 +304,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-274 | A fallible callback makes an fs streaming walk fallible, stopping at the first err | 0.57.1 | active | fixture | 1 |
 | C-275 | Each test starts from re-initialized mutable module globals, on both targets | 0.57.1 | active | fixture | 1 |
 | C-276 | A String-key `list.sort_by` over HEAP elements orders and co-owns identically on both targets | 0.57.1 | active | fixture | 1 |
+| C-277 | A return-only-generic constructor pinned by unification builds and runs identically on both targets even when const-folding erases the pinning context | 0.57.1 | active | fixture | 1 |
 

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,7 +11,7 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-97 normative sections; 440 distinct executable fixtures.
+97 normative sections; 441 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|
@@ -24,7 +24,7 @@
 | ALS-C7 | C-036, C-224, C-226 | `spec/wasm_cross/records_variants.almd` (byte-compare)<br>`spec/wasm_cross/match_result.almd` (byte-compare)<br>`spec/wasm_cross/closures_and_variants.almd` (byte-compare)<br>`spec/wasm_cross/playground_default.almd` (byte-compare)<br>`spec/wasm_cross/match_container_literal.almd` (byte-compare)<br>`spec/wasm_cross/match_payload_string_literal.almd` (byte-compare)<br>`spec/wasm_cross/if_let_guard_let.almd` (byte-compare)<br>`spec/wasm_cross/mut_param_call_chain.almd` (byte-compare) |
 | ALS-C8 | C-038 | `spec/wasm_cross/sized_int_record_fields.almd` (byte-compare)<br>`spec/wasm_cross/sized_numeric_literals.almd` (byte-compare) |
 | ALS-C9 | C-053, C-055, C-276 | `spec/wasm_cross/list_total_order.almd` (byte-compare)<br>`spec/wasm_cross/list_float_total_order.almd` (byte-compare)<br>`spec/wasm_cross/sort_by_call_count.almd` (byte-compare)<br>`spec/wasm_cross/sort_by_str_key_heap.almd` (byte-compare) |
-| ALS-C10 | C-052, C-058 | `spec/wasm_cross/empty_collection_fold.almd` (byte-compare)<br>`spec/wasm_cross/empty_collection_annotated.almd` (byte-compare)<br>`tests/diagnostics/e018-empty-collection-element/broken.almd` (checker) |
+| ALS-C10 | C-052, C-058, C-277 | `spec/wasm_cross/empty_collection_fold.almd` (byte-compare)<br>`spec/wasm_cross/empty_collection_annotated.almd` (byte-compare)<br>`tests/diagnostics/e018-empty-collection-element/broken.almd` (checker)<br>`spec/wasm_cross/ctor_turbofish_family.almd` (byte-compare) |
 | ALS-D1 | C-031, C-202, C-203, C-260 | `spec/wasm_cross/json_path_edges.almd` (byte-compare)<br>`spec/wasm_cross/json_value.almd` (byte-compare)<br>`spec/wasm_cross/time_negative_trap.almd` (byte-compare)<br>`spec/wasm_cross/time_negative_scale.almd` (byte-compare)<br>`spec/wasm_cross/time_saturate.almd` (byte-compare)<br>`spec/wasm_cross/time_ops_algebra.almd` (byte-compare)<br>`spec/wasm_cross/declaration_forms.almd` (byte-compare) |
 | ALS-D2 | C-060, C-204, C-207, C-263 | `spec/wasm_cross/value_repr.almd` (byte-compare)<br>`spec/wasm_cross/fuel_bounded_boundary.almd` (byte-compare)<br>`spec/wasm_cross/fuel_block_body.almd` (byte-compare)<br>`spec/wasm_cross/fuel_bare_result.almd` (byte-compare)<br>`spec/wasm_cross/fuel_divergence_cut.almd` (byte-compare)<br>`spec/wasm_cross/fuel_dyn_charge.almd` (byte-compare)<br>`spec/wasm_cross/fuel_var_budget.almd` (byte-compare)<br>`spec/wasm_cross/declaration_forms.almd` (byte-compare) |
 | ALS-D3 | C-063, C-205 | `spec/wasm_cross/json_gltf_walk.almd` (byte-compare)<br>`spec/wasm_cross/fuel_race_boundary.almd` (byte-compare)<br>`spec/wasm_cross/fuel_race_err_skip.almd` (byte-compare)<br>`spec/wasm_cross/fuel_bare_result.almd` (byte-compare)<br>`spec/wasm_cross/fuel_trap_cut.almd` (byte-compare)<br>`spec/wasm_cross/fuel_trap_window.almd` (byte-compare)<br>`spec/wasm_cross/fan_race_mapper.almd` (byte-compare) |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -3416,3 +3416,15 @@ evidence  = [
   { path = "spec/wasm_cross/sort_by_str_key_heap.almd", class = "fixture" },
   { path = "crates/almide-mir/src/coown_names.rs", name = "coown_names_documented", class = "by-construction" },
 ]
+
+[[contract]]
+id        = "C-277"
+spec      = "ALS-C10"
+title     = "A return-only-generic constructor pinned by unification builds and runs identically on both targets even when const-folding erases the pinning context"
+statement = "A runtime constructor whose type parameter appears in NO argument — `list.with_capacity(n)`, `map.new()`, `set.new()` — that `almide check` ACCEPTED because unification pinned the element from the surrounding context (the other arm of an `if`, a later use) builds and runs identically on native and wasm even when that context is erased before emit (const-folding `if true then list.with_capacity(4) else [1, 2]` deletes the pinning arm) and the consumer is element-agnostic (`list.is_empty`, `map.contains`). The dual of C-058: there the UNDECIDABLE empty collection is a frontend error on both targets; here the DECIDED one must never die at the native build. The native emitter carries the checker's resolved type on the call as a turbofish (`almide_rt_list_with_capacity::<i64>(4)`), because after folding, the call site is the only place the resolution can survive; the wasm leg carries no element type and was never affected. Previously `check` accepted and rustc E0282'd behind the codegen wall (`cannot infer type of the type parameter A`) while wasm built and ran — a build-success asymmetry in the acceptance-gap class (#809, #1416; found by the first both-arch fuzz dispatch, run 31791673611, seed 508666777783, and for map/set by nightly-fuzz seed 1785045556318379299). The family is closed by measurement, not by hand: runtime_ctor_turbofish_family_gate_test.rs recomputes the return-only-generic set from runtime signatures and fails on any member without its emit arm, or any stale arm."
+since     = "0.57.1"
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/ctor_turbofish_family.almd", class = "fixture" },
+  { path = "tests/runtime_ctor_turbofish_family_gate_test.rs", name = "every_return_only_generic_ctor_has_a_turbofish_arm", class = "by-construction" },
+]

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,10 +15,10 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 63 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 302/419 fixtures cast a real 3-way vote (72%)** —
+> **Stage 2 (translation validation): 303/420 fixtures cast a real 3-way vote (72%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
-> **Stage 3 (semantics freeze): 277/276 contracts spec-keyed; syntax-element coverage
+> **Stage 3 (semantics freeze): 278/277 contracts spec-keyed; syntax-element coverage
 > 72/72 sectioned (0 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,7 +15,7 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 63 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 303/420 fixtures cast a real 3-way vote (72%)** —
+> **Stage 2 (translation validation): 315/420 fixtures cast a real 3-way vote (75%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
 > **Stage 3 (semantics freeze): 278/277 contracts spec-keyed; syntax-element coverage

--- a/spec/lang/unwrap_or_unit_test.almd
+++ b/spec/lang/unwrap_or_unit_test.almd
@@ -2,9 +2,7 @@
 // until the scalar-value lowering learned the Unit-is-0 arm (result-family-
 // from-type follow-up, 2026-08-14): the fallback `()` had no lowering, so the
 // whole `??` declined and the desugared match walled as an untracked subject.
-
-fn check(flag: Bool) -> Result[Unit, String] =
-  if flag then ok(()) else err("boom")
+fn check(flag: Bool) -> Result[Unit, String] = if flag then ok(()) else err("boom")
 
 fn swallow_err() -> Int = {
   let _ = check(false) ?? ()

--- a/spec/wasm_cross/ctor_turbofish_family.almd
+++ b/spec/wasm_cross/ctor_turbofish_family.almd
@@ -1,0 +1,57 @@
+// @contract: C-277
+// #1416: a runtime constructor whose generic appears in NO parameter —
+// `list.with_capacity(n)`, `map.new()`, `set.new()` — pinned by unification
+// but consumed by an element-agnostic op, in a const-foldable if-arm ARGUMENT
+// position. The checker resolves the element from the other arm; const-folding
+// then deletes that arm, and the emitted call is the only place the type can
+// survive. Emit used to drop it: `almide check` accepted every line below and
+// the native build died with rustc E0282 (`cannot infer type of the type
+// parameter A declared on the function almide_rt_list_with_capacity`) while
+// the wasm leg, carrying no element type, built and ran — a build-success
+// asymmetry (the acceptance-gap class; same shape as closed #809).
+//
+// Found by the first both-arch fuzz dispatch (run 31791673611, seed
+// 508666777783 — x86 shard 3 and aarch64 shard 7 independently). The map/set
+// cells pin the SAME defect fixed earlier from nightly-fuzz seed
+// 1785045556318379299 index 867; this file is the family matrix CLAUDE.md
+// requires — every return-only-generic runtime ctor, both fold polarities for
+// the new member — so a point regression in any cell is caught here, not by
+// the next fuzz seed. The family's completeness (an emit arm for every such
+// ctor) is measured from source by runtime_ctor_turbofish_family_gate_test.rs.
+//
+// The let-bound spelling always worked (the binding's annotation pins the
+// type); probe_let holds that as the control.
+fn probe_with_capacity() -> String = {
+  // then-polarity: `if true` folds to the with_capacity arm.
+  let a = list.is_empty(if true then list.with_capacity(4)
+  else [1, 2])
+  // else-polarity: `if false` folds the SAME way from the other side.
+  let b = list.is_empty(if false then [1, 2]
+  else list.with_capacity(4))
+  // non-scalar element: the turbofish renders a nested type.
+  let c = list.is_empty(if true then list.with_capacity(2)
+  else [
+    ["x", "y"]
+  ])
+  "wc=${a}/${b}/${c}"
+}
+
+fn probe_map_set() -> String = {
+  let m = map.contains(if true then map.new()
+  else ["a": 1], "a")
+  let s = set.contains(if true then set.new()
+  else set.from_list([1, 2]), 1)
+  "map=${m} set=${s}"
+}
+
+fn probe_let() -> String = {
+  let xs = if true then list.with_capacity(4)
+  else [1, 2]
+  "let=${list.is_empty(xs)}"
+}
+
+fn main() -> Unit = {
+  println(probe_with_capacity())
+  println(probe_map_set())
+  println(probe_let())
+}

--- a/tests/runtime_ctor_turbofish_family_gate_test.rs
+++ b/tests/runtime_ctor_turbofish_family_gate_test.rs
@@ -1,0 +1,236 @@
+//! C-277 family gate (#1416): every native-runtime fn with a RETURN-ONLY
+//! generic — a type parameter appearing in no parameter type — must have a
+//! turbofish arm in the walker's `render_runtime_ctor_turbofish`.
+//!
+//! Why: such a fn ships its type in the return position only, so the emitted
+//! call site is the one place the checker's resolution can survive. Whenever
+//! the surrounding context is erased (const-folding `if true then
+//! list.with_capacity(4) else [1, 2]` in argument position) and the consumer
+//! is element-agnostic (`list.is_empty`), a bare call leaves rustc nothing to
+//! infer from: E0282 AFTER `almide check` accepted — the acceptance-gap class
+//! (#809, #1416). The family so far: `almide_rt_map_new`, `almide_rt_set_new`
+//! (nightly-fuzz seed 1785045556318379299), `almide_rt_list_with_capacity`
+//! (#1416, both-arch dispatch seed 508666777783).
+//!
+//! Both sides are MEASURED from source at test time — the family from
+//! `runtime/rs/src/*.rs` signatures, the arms from the walker — so adding a
+//! new return-only-generic runtime fn without its emit arm (or leaving a
+//! stale arm behind a removed fn) fails here, in the same PR, not in the next
+//! fuzz night.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Split a Rust type/param string into identifier tokens.
+fn ident_tokens(s: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let mut cur = String::new();
+    for c in s.chars() {
+        if c.is_alphanumeric() || c == '_' {
+            cur.push(c);
+        } else if !cur.is_empty() {
+            out.insert(std::mem::take(&mut cur));
+        }
+    }
+    if !cur.is_empty() {
+        out.insert(cur);
+    }
+    out
+}
+
+/// Split a generic list on TOP-LEVEL commas only (`F: Fn(A, B) -> C` is one
+/// entry; the comma inside `Fn(A, B)` must not split it).
+fn split_generic_entries(generics: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut depth = 0i32;
+    let mut cur = String::new();
+    let mut prev = '\0';
+    for c in generics.chars() {
+        match c {
+            '<' | '(' | '[' => depth += 1,
+            // `->` in an Fn bound is an arrow, not a closer.
+            '>' if prev != '-' => depth -= 1,
+            ')' | ']' => depth -= 1,
+            ',' if depth == 0 => {
+                out.push(std::mem::take(&mut cur));
+                prev = c;
+                continue;
+            }
+            _ => {}
+        }
+        cur.push(c);
+        prev = c;
+    }
+    if !cur.trim().is_empty() {
+        out.push(cur);
+    }
+    out
+}
+
+/// Scan `runtime/rs/src/*.rs` for `pub fn almide_rt_*<G, ...>(params...)`
+/// signatures and return the names whose generic list has at least one
+/// parameter that occurs in NO function parameter type (return-only).
+fn return_only_generic_runtime_fns() -> BTreeSet<String> {
+    let dir = repo_root().join("runtime/rs/src");
+    let mut family = BTreeSet::new();
+    for entry in fs::read_dir(&dir).expect("runtime/rs/src must exist") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let src = fs::read_to_string(&path).expect("readable runtime source");
+        let bytes = src.as_bytes();
+        let mut from = 0;
+        while let Some(rel) = src[from..].find("pub fn almide_rt_") {
+            let fn_start = from + rel + "pub fn ".len();
+            from = fn_start;
+            // Name runs to `<` (generic fn) or `(` (monomorphic — skip).
+            let rest = &src[fn_start..];
+            let name_end = match rest.find(|c: char| c == '<' || c == '(') {
+                Some(i) => i,
+                None => continue,
+            };
+            if rest.as_bytes()[name_end] != b'<' {
+                continue;
+            }
+            let name = rest[..name_end].trim().to_string();
+            // Generic list: balance `<...>` (bounds can nest, e.g. `F: Fn(A) -> B`).
+            let gen_open = fn_start + name_end;
+            let mut depth = 0usize;
+            let mut i = gen_open;
+            let gen_close = loop {
+                match bytes[i] {
+                    b'<' => depth += 1,
+                    // `->` in an Fn bound is an arrow, not a closer.
+                    b'>' if bytes[i - 1] != b'-' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            break i;
+                        }
+                    }
+                    _ => {}
+                }
+                i += 1;
+            };
+            let generics = &src[gen_open + 1..gen_close];
+            // Param list: balance `(...)` right after the generics.
+            let par_open = gen_close + src[gen_close..].find('(').expect("param list");
+            let mut depth = 0usize;
+            let mut i = par_open;
+            let par_close = loop {
+                match bytes[i] {
+                    b'(' => depth += 1,
+                    b')' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            break i;
+                        }
+                    }
+                    _ => {}
+                }
+                i += 1;
+            };
+            let params = &src[par_open + 1..par_close];
+            // A generic is PINNED by the arguments if it appears in a
+            // parameter type, or transitively through another pinned generic's
+            // bound: in `<A, F: Fn(A) -> A>(xs: Vec<X>, f: F)` the closure
+            // argument's concrete type carries `A`, so rustc infers it —
+            // that is not the E0282 family. Split each generic entry into
+            // (name, bound idents), seed the pinned set from the param list,
+            // and close over bounds to fixpoint.
+            let entries: Vec<(String, BTreeSet<String>)> = split_generic_entries(generics)
+                .into_iter()
+                .filter_map(|e| {
+                    let (name_part, bound) = match e.split_once(':') {
+                        Some((n, b)) => (n, ident_tokens(b)),
+                        None => (e.as_str(), BTreeSet::new()),
+                    };
+                    let n = name_part.trim().trim_start_matches("const ").trim();
+                    (!n.is_empty()).then(|| (n.to_string(), bound))
+                })
+                .collect();
+            let mut pinned = ident_tokens(params);
+            loop {
+                let before = pinned.len();
+                for (n, bound) in &entries {
+                    if pinned.contains(n) {
+                        pinned.extend(bound.iter().cloned());
+                    }
+                }
+                if pinned.len() == before {
+                    break;
+                }
+            }
+            if entries.iter().any(|(n, _)| !pinned.contains(n)) {
+                family.insert(name.clone());
+            }
+        }
+    }
+    assert!(
+        !family.is_empty(),
+        "signature scan found no return-only-generic runtime fns — the parser \
+         broke, not the family"
+    );
+    family
+}
+
+/// Extract the `almide_rt_*` symbols matched inside the walker's
+/// `render_runtime_ctor_turbofish`.
+fn turbofish_arm_symbols() -> BTreeSet<String> {
+    let path = repo_root().join("crates/almide-codegen/src/walker/expressions.rs");
+    let src = fs::read_to_string(&path).expect("walker source");
+    let start = src
+        .find("fn render_runtime_ctor_turbofish")
+        .expect("render_runtime_ctor_turbofish must exist in the walker");
+    // The next top-level `fn ` ends the function — string-literal scan only
+    // needs a window that covers the whole body.
+    let end = src[start + 1..]
+        .find("\nfn ")
+        .map(|i| start + 1 + i)
+        .unwrap_or(src.len());
+    let body = &src[start..end];
+    let mut arms = BTreeSet::new();
+    let mut from = 0;
+    while let Some(rel) = body[from..].find("\"almide_rt_") {
+        let lit_start = from + rel + 1;
+        // Both the match-pattern literal (`"almide_rt_map_new"`) and the
+        // format string (`"almide_rt_map_new::<{}, {}>()"`) begin with the
+        // symbol — take the identifier prefix so they normalize to one name.
+        let name: String = body[lit_start..]
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        from = lit_start + name.len();
+        arms.insert(name);
+    }
+    arms
+}
+
+#[test]
+fn every_return_only_generic_ctor_has_a_turbofish_arm() {
+    let family = return_only_generic_runtime_fns();
+    let arms = turbofish_arm_symbols();
+
+    let missing: Vec<_> = family.difference(&arms).collect();
+    assert!(
+        missing.is_empty(),
+        "runtime fns with a return-only generic but NO turbofish arm in \
+         render_runtime_ctor_turbofish: {missing:?}\n\
+         A bare call to these can E0282 after `check` accepted whenever \
+         const-folding erases the typing context (#1416). Add an arm that pins \
+         the node's resolved type — see the almide_rt_list_with_capacity arm."
+    );
+
+    let stale: Vec<_> = arms.difference(&family).collect();
+    assert!(
+        stale.is_empty(),
+        "turbofish arms in render_runtime_ctor_turbofish for symbols that are \
+         no longer return-only-generic runtime fns: {stale:?}\n\
+         Remove the arm (or the signature scan in this test broke)."
+    );
+}


### PR DESCRIPTION
Closes #1416.

The first both-arch fuzz dispatch (run 31791673611, seed 508666777783 — found independently by x86 shard 3 and aarch64 shard 7) surfaced an acceptance gap: `almide check` accepts

```almide
let e = list.is_empty(if true then list.with_capacity(4) else [1, 2])
```

but the native build dies behind the codegen wall with rustc E0282. The checker's unification is right (the else arm pins the element to `Int`); what loses it is emit — const-folding deletes the pinning arm, and in argument position there is no binding annotation, so the emitted `almide_rt_list_with_capacity(4i64)` leaves `A` free. The wasm leg carries no element type and always built: a build-success asymmetry, same class as closed #809.

## The fix

`render_runtime_ctor_turbofish` already existed for exactly this defect in `map.new()` / `set.new()` (nightly-fuzz seed 1785045556318379299). `list.with_capacity` is the third member of the same family — a runtime fn whose generic appears in **no parameter type** — and was excluded only by the function's `args.is_empty()` guard. The arm added here pins the node's checker-resolved element type: `almide_rt_list_with_capacity::<i64>(4i64)`.

## The family, closed by measurement

Per CLAUDE.md ("API families are extended by matrix, never point-wise"):

- **`tests/runtime_ctor_turbofish_family_gate_test.rs`** recomputes the return-only-generic set from `runtime/rs/src/*.rs` signatures (generic-bound transitive closure: `F: Fn(A) -> A` pins `A` through the closure argument, so HOFs are correctly excluded) and the turbofish arms from the walker source, and fails on any member without an arm or any stale arm. The scan's first run flagged 6 candidates that turned out to be bound-pinned false positives — the transitive-closure rule is measured, not assumed. A/B'd: neutering the with_capacity arm turns the gate red.
- **`spec/wasm_cross/ctor_turbofish_family.almd`** (contract **C-277**, the dual of C-058's undecidable-empty-collection error): all three family members in const-folded if-arm argument position, both fold polarities, a nested element type, and the let-bound control. A/B'd against the pre-fix binary: E0282 before, both legs green after.

## Verification

- minimal repro + family fixture: native == wasm, byte-identical
- `almide test`: 401/401
- `cargo test --workspace --release`: green
- contract ledger: 277 contracts, flagged 0; derived docs regenerated
- codopsy: almide-codegen A(92); almide-mir untouched, warnings 34 = baseline