### PR TITLE
Stop the synthesized unwrap_or match from freeing a named binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The guarantee is **continuous, with an explicit, ledger-managed scope**: "byte-i
 This claim is not prose. Every observable promise is a named contract in the [behavior-contract ledger](docs/contracts/), each traceable to executable evidence, and the numbers below are regenerated from the ledger (`scripts/gen-claims.sh`, enforced by `scripts/check-contracts.sh` in CI) so this section cannot drift from what the gates actually verify:
 
 <!-- claims:generated:start — derived from docs/contracts/contracts.toml by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
-> **Ledger: 285 contracts — 285 active, 0 flagged-for-revision.**
+> **Ledger: 286 contracts — 286 active, 0 flagged-for-revision.**
 >
 > **Divergences awaiting a fix: none.** Every contract in the ledger is
 > `active`, carrying executable evidence of class >= `fixture`. The one

--- a/crates/almide-mir/src/lower/control_p2.rs
+++ b/crates/almide-mir/src/lower/control_p2.rs
@@ -490,7 +490,8 @@ impl LowerCtx {
         // route (`str_heap_bind`/`opt_tuple_bind`/`result_heap_err_bind`) is the exception: its
         // payload BORROWS slot-0, so the subject must stay live THROUGH the arms — its drop is
         // deferred to AFTER the branch-join below.
-        if route.heap_res && !route.subject_drops_after() {
+        let subject_is_borrowed = self.subject_is_named_binding(subject, subj);
+        if route.heap_res && !route.subject_drops_after() && !subject_is_borrowed {
             self.drop_owned_subject(subj);
         }
         self.ops.push(Op::IfThen { cond: tag, dst: Some(dst) });
@@ -506,14 +507,38 @@ impl LowerCtx {
         // call result), independent of the freed subject, so freeing the subject's slot-0 String is
         // sound (a bare-Var arm already Dup'd it; a call arm only borrowed it). A BORROWED subject
         // (param / tracked var, not in `live_heap_handles`) is owned elsewhere → left untouched.
-        if route.subject_drops_after() {
+        if route.subject_drops_after() && !subject_is_borrowed {
             self.drop_owned_subject(subj);
         }
         Some(dst)
     }
 
+    /// Is this match READING someone else's named binding rather than owning a
+    /// temporary? `live_heap_handles` cannot answer that: its own doc calls it
+    /// "heap handles in binding order, FOR SCOPE-END DROPS", so every `let`-bound
+    /// heap local is in it, and membership alone reads a still-live variable as an
+    /// owned temp.
+    ///
+    /// That is how `sv ?? "z"` twice returned `abc,z` on the wasm leg: the first
+    /// `??` lowers to a synthesized `match sv { some(p) => p, none => d }`
+    /// (#1270), the match dropped its subject, and the drop freed the user's `sv`
+    /// while the second `??` still had to read it. Native was silent because it
+    /// renders `Drop`/`DropListStr` as a comment and lets Rust free at real scope
+    /// end; wasm emits `rc_dec`, so only one leg lost the value — a wrong answer at
+    /// exit 0, on `xs ?? default`, which is the idiom the language reference
+    /// recommends. Every heap payload was affected: `String?` gave `abc,z`,
+    /// `List[Int]?` gave `3,0`, `Option[Option[Int]]` gave `5,9`
+    /// (differential fuzz, seed 510754018596 index 189).
+    ///
+    /// The scope-end pass still drops the binding exactly once, because a subject
+    /// left alone stays in `live_heap_handles`.
+    fn subject_is_named_binding(&self, subject: &IrExpr, subj: ValueId) -> bool {
+        matches!(&subject.kind, IrExprKind::Var { id }
+            if self.value_for(*id).ok() == Some(subj))
+    }
+
     /// Drop the OWNED subject once, if this scope owns it — a BORROWED subject
-    /// (param / tracked var, not in `live_heap_handles`) is owned elsewhere and
+    /// (param, or a named binding the scope end will drop) is owned elsewhere and
     /// left untouched.
     fn drop_owned_subject(&mut self, subj: ValueId) {
         if let Some(pos) = self.live_heap_handles.iter().rposition(|&v| v == subj) {

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -24,7 +24,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-285 contracts
+286 contracts
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |
 |----|----------|-------|--------|--------------------|-----------:|
@@ -313,4 +313,5 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-283 | A call through a Fn-typed local resolves that local, never a same-named top-level fn | 0.57.1 | active | fixture | 1 |
 | C-284 | A fallible list HOF driven by a user effect fn callback runs identically on both targets | 0.57.1 | active | fixture | 1 |
 | C-285 | regex.captures answers the whole match at index 0, and `none` means only that nothing matched | 0.57.1 | active | fixture | 1 |
+| C-286 | `??` reads its source; the Option survives the elimination and stays readable | 0.57.1 | active | fixture | 1 |
 

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -11,7 +11,7 @@
 > (spec-coverage + evidence-class >= fixture for every active contract), so this
 > page cannot legitimately contain an empty Fixtures cell.
 
-97 normative sections; 454 distinct executable fixtures.
+97 normative sections; 455 distinct executable fixtures.
 
 | Section | Contracts | Fixtures (how CI runs each) |
 |---------|-----------|------------------------------|
@@ -40,7 +40,7 @@
 | ALS-E6 | C-234 | `spec/wasm_cross/grouping_unary.almd` (byte-compare)<br>`spec/wasm_cross/tuple_single.almd` (byte-compare) |
 | ALS-E7 | C-235 | `spec/wasm_cross/grouping_unary.almd` (byte-compare) |
 | ALS-E8 | C-236 | `spec/wasm_cross/tuple_ops.almd` (byte-compare) |
-| ALS-E9 | C-237 | `spec/wasm_cross/option_result_ctors.almd` (byte-compare) |
+| ALS-E9 | C-237, C-286 | `spec/wasm_cross/option_result_ctors.almd` (byte-compare)<br>`spec/wasm_cross/unwrap_or_source_survives.almd` (byte-compare) |
 | ALS-E10 | C-238 | `spec/wasm_cross/range_first_class.almd` (byte-compare)<br>`spec/wasm_cross/range_bind_no_materialize.almd` (byte-compare)<br>`spec/wasm_cross/range_bind_huge.almd` (byte-compare) |
 | ALS-E11 | C-239 | `spec/wasm_cross/collection_literals.almd` (byte-compare) |
 | ALS-E12 | C-240 | `spec/wasm_cross/collection_literals.almd` (byte-compare) |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -3522,3 +3522,14 @@ status    = "active"
 evidence  = [
   { path = "spec/wasm_cross/regex_engine.almd", class = "fixture" },
 ]
+
+[[contract]]
+id        = "C-286"
+spec      = "ALS-E9"
+title     = "`??` reads its source; the Option survives the elimination and stays readable"
+statement = "`xs ?? default` READS the Option it eliminates. The source is not consumed, so the same binding may be eliminated any number of times, and remains readable afterwards by any other spelling (`match`, a further `??`), with identical results on both targets. It used to be consumed on the wasm leg for every HEAP payload. A heap `??` lowers to a synthesized `match e { some(p) => p, none => d }` (#1270), and `try_lower_variant_value_match` dropped its subject; the ownership test was membership in `live_heap_handles`, whose own documentation calls it `heap handles in binding order, FOR SCOPE-END DROPS` — so every `let`-bound heap local is in it, and a still-live user variable was read as an owned temporary. The first `??` therefore FREED the binding while later readers still needed it. The payload arm was never the problem: it already emitted `Op::Dup`. Only one leg lost the value, which is why it went unseen: the native renderer emits `Drop`/`DropListStr` as a COMMENT and leaves the free to Rust's own scope end, while the wasm renderer emits `rc_dec` and the free is real — so both legs exited 0 and printed different answers. Measured across the family: `String?` gave `abc,z` against `abc,abc`, `List[Int]?` gave `3,0` against `3,3`, `Option[Option[Int]]` gave `5,9,9` against `5,5,5`, and a `match` reading the source after one `??` saw the payload already freed. This is `xs ?? default` — the fallback idiom docs/CHEATSHEET.md recommends — so the blast radius was every heap Option in the language, not a corner. Found by the differential fuzz (seed 510754018596 index 189, a mutation of spec/wasm_cross/option_result_ctors.almd) in its nested-Option cell only; the fixture pins the whole family because the defect lived in the match's subject handling and never cared which payload type it carried. A HAND-WRITTEN two-arm `match` over the same binding was always correct — that asymmetry is what localized the defect to the synthesized rewrite rather than to matching, and it is pinned here as a counter-cell. The scope-end pass still drops the binding exactly once: a subject left alone stays in `live_heap_handles`, so the single-use shape neither double-frees nor leaks, and that cell is pinned too."
+since     = "0.57.1"
+status    = "active"
+evidence  = [
+  { path = "spec/wasm_cross/unwrap_or_source_survives.almd", class = "fixture" },
+]

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -15,10 +15,10 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > scalar-read 61 arms / 0 UNGUARDED; WAT prelude 63 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 322/431 fixtures cast a real 3-way vote (74%)** —
+> **Stage 2 (translation validation): 323/432 fixtures cast a real 3-way vote (74%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
-> **Stage 3 (semantics freeze): 286/285 contracts spec-keyed; syntax-element coverage
+> **Stage 3 (semantics freeze): 287/286 contracts spec-keyed; syntax-element coverage
 > 72/72 sectioned (0 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;

--- a/spec/wasm_cross/unwrap_or_source_survives.almd
+++ b/spec/wasm_cross/unwrap_or_source_survives.almd
@@ -1,0 +1,67 @@
+// @contract: C-286
+// `xs ?? default` READS its source. It does not consume it, so the same Option
+// may be eliminated twice, three times, or read afterwards by any other
+// spelling — identically on both targets.
+//
+// It used to consume it on the wasm leg. A heap `??` lowers to a synthesized
+// `match e { some(p) => p, none => d }` (#1270), and that match dropped its
+// subject. The ownership test was membership in `live_heap_handles`, whose own
+// doc calls it "heap handles in binding order, FOR SCOPE-END DROPS" — so every
+// `let`-bound heap local is in it, and a still-live variable read as an owned
+// temp. The first `??` therefore freed the user's binding while later readers
+// still needed it.
+//
+// Only one leg lost the value: native renders `Drop`/`DropListStr` as a comment
+// and lets Rust free at real scope end, while wasm emits `rc_dec` and the free
+// is real. So both legs exited 0 and printed different answers — on
+// `xs ?? default`, the idiom docs/CHEATSHEET.md recommends. Found by the
+// differential fuzz (seed 510754018596 index 189, a mutation of
+// spec/wasm_cross/option_result_ctors.almd) as the nested-Option cell; the
+// matrix below is the whole family, because the defect was in the match's
+// subject handling and never cared which payload type it was.
+//
+// The counter-cell matters as much as the repeats: a HAND-WRITTEN
+// `match sv { some(x) => x, none => .. }` twice was always correct, which is
+// what localized the defect to the synthesized rewrite rather than to matching.
+effect fn main() -> Unit = {
+  // String payload — was "abc,z": the second read took the fallback.
+  let s: String? = some("abc")
+  let s1: String = s ?? "z"
+  let s2: String = s ?? "z"
+  println("str=" + s1 + "," + s2)
+  // List payload — was "3,0": the second read saw an emptied block.
+  let l: List[Int]? = some([1, 2, 3])
+  let l1: List[Int] = l ?? []
+  let l2: List[Int] = l ?? []
+  println("list=" + int.to_string(list.len(l1)) + "," + int.to_string(list.len(l2)))
+  // Nested Option — the shape the fuzzer hit; was "5,9,9".
+  let n = some(some(5))
+  let n1: Int? = n ?? none
+  let n2: Int? = n ?? none
+  let n3: Int? = n ?? none
+  println("nested=" + int.to_string(n1 ?? 9) + "," + int.to_string(n2 ?? 9) + "," + int.to_string(n3 ?? 9))
+  // The source is still readable by ANOTHER spelling after an elimination —
+  // the container survived before, but its payload had been freed out from
+  // under it, so this printed the fallback on wasm.
+  let m: String? = some("keep")
+  let m1: String = m ?? "z"
+  match m {
+    some(inner) => println("after=" + m1 + "," + inner),
+    none => println("after=" + m1 + ",SOURCE-CONSUMED"),
+  }
+  // Counter-cell: the hand-written match was never affected, and must stay so.
+  let h: String? = some("hw")
+  let h1: String = match h {
+    some(x) => x,
+    none => "z",
+  }
+  let h2: String = match h {
+    some(x) => x,
+    none => "z",
+  }
+  println("handwritten=" + h1 + "," + h2)
+  // A single use must still free exactly once — the fix removes a drop, so the
+  // shape that was already correct has to stay correct rather than leak.
+  let o: String? = some("once")
+  println("single=" + (o ?? "z"))
+}


### PR DESCRIPTION
`xs ?? default` was **consuming** its source on the wasm leg for every heap payload. Use the
same Option twice and the second read got the fallback — exit 0 on both legs, no diagnostic.

```almide
let sv: String? = some("abc")
let a: String = sv ?? "z"
let b: String = sv ?? "z"
println(a + "," + b)          // native "abc,abc"   wasm "abc,z"
```

| payload | native | wasm (before) |
|---|---|---|
| `String?` | `abc,abc` | `abc,z` |
| `List[Int]?` | `3,3` | `3,0` |
| `Option[Option[Int]]` ×3 | `5,5,5` | `5,9,9` |
| read the source by `match` after one `??` | `keep,keep` | `keep,SOURCE-CONSUMED` |

`xs ?? default` is the fallback idiom `docs/CHEATSHEET.md` recommends, so the blast radius
was every heap Option in the language.

## Root cause — the subject drop, not the payload

The payload was never the problem: `some(p) => p` already emits `Op::Dup`
(`lower/heap_result_arm.rs:185`). A heap `??` lowers to a synthesized
`match e { some(p) => p, none => d }` (#1270), and `try_lower_variant_value_match`
**dropped its subject**. The ownership test was membership in `live_heap_handles` — whose
own doc (`lower/mod_p2_b.rs:377-378`) calls it *"heap handles in binding order, **for
scope-end drops**"*. Every `let`-bound heap local is in it, so a still-live user variable
read as an owned temporary, and the first `??` freed it while later readers still needed it.

The comment above the drop site stated the assumption that is false here — *"A BORROWED
subject (param / **tracked var**, not in `live_heap_handles`) is owned elsewhere → left
untouched"*. A tracked var **is** in it.

**Why only one leg lost the value**, and why it went unseen: the native renderer emits
`Drop`/`DropListStr` as a *comment* (`render_native.rs:711-728`) and lets Rust free at real
scope end, while the wasm renderer emits `rc_dec` (`render_wasm_p2.rs:388`) and the free is
real. Both legs exited 0 and printed different answers.

## The fix

Both drop sites now skip a subject that is a **named binding** — the match is a *reader* of
someone else's local, not the owner of a temporary. The scope-end pass still drops it
exactly once, because a subject left alone stays in `live_heap_handles`.

## Verified by probe, not by reading

I was wrong twice before measuring. First I read it as a shadowing bug — refuted by using
two *distinct* names and still diverging. Then as a missing payload `Dup` — refuted by the
`Dup` being unconditional in the source. What settled it:
`ALMIDE_DBG_QQ=1` shows `[qq] match took Applied(Option, [String]) ?? (heap)` twice, and the
emitted WAT carries an `rc_dec` + element-free sequence **mid-function**, separate from the
scope-end drops.

## Evidence

- `spec/wasm_cross/unwrap_or_source_survives.almd` (new, C-286): String / List / nested
  Option repeats, a `match` reading the source after an elimination, and two cells that
  exist to keep the fix honest — a **counter-cell** pinning that the hand-written two-arm
  `match` was never affected (the asymmetry that localized the defect), and a **single-use**
  cell so removing a drop cannot turn into a leak.
- **A/B against v0.57.0**: the fixture diverges there (`abc,z` / `3,0` / `5,9,9` /
  `SOURCE-CONSUMED`) and is identical here.
- Original fuzz repro (seed 510754018596 index 189) now identical on both legs.
- `cargo test --workspace --release`: 150 suites, 0 failures — `wasm_cross_target_spec`,
  `interp_cross_target_spec`, `interp_abstain_ledger` all ok.
- `almide test`: 403/403. `almide fmt --check spec/ examples/`: clean.
- `check-contracts.sh`: 286 contracts, 432/432 fixtures, links symmetric.
- codopsy `almide-mir` A/B with the repo config: A(91) before and after.