### PR TITLE
Cross the stdlib catalogue with the integer edge set, and gate the result both directions

### DIFF
--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -24,7 +24,7 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).
 >
-> **Stage 5 (auditability): 1 release seal(s); 47 verification gates classified
+> **Stage 5 (auditability): 1 release seal(s); 48 verification gates classified
 > (2 UNVERIFIED under a shrink-only ceiling); TOR with 9 enforced rows;
 > gap analysis consolidated in proofs/DO330-GAP.md (reference-gated).**
 <!-- stages:generated:end -->

--- a/proofs/domain-edges.toml
+++ b/proofs/domain-edges.toml
@@ -1,0 +1,894 @@
+# Integer-domain edge divergences — MEASURED, not asserted.
+#
+# Every public stdlib fn x every Int parameter x a declared edge set, run on both
+# targets and compared. Regenerate with `scripts/check-domain-edges.sh --update`;
+# the gate diffs BOTH directions, so a new divergence fails and a row that stopped
+# diverging also fails and must be deleted. `count` is a shrink-only ceiling.
+#
+# Measured 7767 cells over the whole stdlib at develop d8e480223:
+#   AGREE 6468   DIVERGE 218   RAW 273   WALL 801   BOMB 7
+#
+# WALL is the wasm renderer honestly declining a shape outside its subset — a
+# contract, not a defect. RAW is the `prim` raw-memory surface, where two genuinely
+# different memory models are not promised to agree; those 273 cells are counted
+# and named rather than hidden, because calling them defects would have buried the
+# 218 that are real.
+#
+# A sample of 14 rows was re-run by hand against both legs before this file was
+# written; all 14 reproduced. Two earlier versions of the instrument did NOT survive
+# that check (they counted walls, then stderr text, as divergences) — the sample is
+# the reason those never reached a ledger.
+
+count = 218
+
+[[divergence]]
+cell   = "bytes.chunks:size:i64_max"
+reason = "VERIFIED — the ceiling-division sum `(total + size - 1)` wraps, the same defect fixed in list.chunk (PR #1445). Sibling found by inventory, not by fuzzing."
+
+[[divergence]]
+cell   = "bytes.chunks:size:i64_max_m1"
+reason = "VERIFIED — the ceiling-division sum `(total + size - 1)` wraps, the same defect fixed in list.chunk (PR #1445). Sibling found by inventory, not by fuzzing."
+
+[[divergence]]
+cell   = "bytes.new:len:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.new:len:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.pad_left:target_len:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.pad_left:target_len:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.pad_left:target_len:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.pad_left:target_len:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.pad_left:target_len:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.pad_left:target_len:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.pad_right:target_len:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.pad_right:target_len:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.pad_right:target_len:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.pad_right:target_len:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.pad_right:target_len:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.pad_right:target_len:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f16_le_array:count:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f16_le_array:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f16_le_array:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f16_le_array:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f16_le_array:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f16_le_array:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f16_le_array:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f16_le_array:count:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f16_le_array:count:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_be_array:count:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_be_array:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_be_array:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_be_array:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_be_array:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_be_array:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_be_array:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_be_array:count:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_be_array:count:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_le_array:count:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_le_array:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_le_array:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_le_array:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_le_array:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_le_array:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_le_array:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_le_array:count:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f32_le_array:count:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_be_array:count:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_be_array:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_be_array:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_be_array:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_be_array:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_be_array:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_be_array:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_be_array:count:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_be_array:count:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_le_array:count:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_le_array:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_le_array:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_le_array:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_le_array:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_le_array:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_le_array:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_le_array:count:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_f64_le_array:count:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_be_array:count:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_be_array:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_be_array:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_be_array:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_be_array:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_be_array:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_be_array:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_be_array:count:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_be_array:count:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_le_array:count:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_le_array:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_le_array:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_le_array:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_le_array:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_le_array:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_le_array:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_le_array:count:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i16_le_array:count:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_be_array:count:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_be_array:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_be_array:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_be_array:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_be_array:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_be_array:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_be_array:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_be_array:count:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_be_array:count:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_le_array:count:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_le_array:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_le_array:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_le_array:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_le_array:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_le_array:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_le_array:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_le_array:count:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i32_le_array:count:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_be_array:count:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_be_array:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_be_array:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_be_array:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_be_array:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_be_array:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_be_array:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_be_array:count:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_be_array:count:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_le_array:count:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_le_array:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_le_array:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_le_array:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_le_array:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_le_array:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_le_array:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_le_array:count:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_i64_le_array:count:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_length_prefixed_strings_le:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_length_prefixed_strings_le:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_length_prefixed_strings_le:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_length_prefixed_strings_le:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_length_prefixed_strings_le:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_length_prefixed_strings_le:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_length_prefixed_strings_le:pos:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_length_prefixed_strings_le:pos:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_at:len:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_at:len:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_at:len:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_at:len:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_at:len:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_at:len:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_at:pos:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_at:pos:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_at:pos:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_at:pos:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_at:pos:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_at:pos:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_be:pos:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_be:pos:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_be:pos:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_be:pos:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_string_be:pos:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_be_array:count:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_be_array:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_be_array:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_be_array:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_be_array:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_be_array:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_be_array:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_be_array:count:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_be_array:count:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_le_array:count:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_le_array:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_le_array:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_le_array:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_le_array:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_le_array:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_le_array:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_le_array:count:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u16_le_array:count:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_be_array:count:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_be_array:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_be_array:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_be_array:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_be_array:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_be_array:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_be_array:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_be_array:count:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_be_array:count:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_le_array:count:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_le_array:count:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_le_array:count:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_le_array:count:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_le_array:count:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_le_array:count:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_le_array:count:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_le_array:count:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.read_u32_le_array:count:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.repeat:n:i32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.repeat:n:two_pow_32"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.repeat:n:u32_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.skip_length_prefixed_le:pos:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.skip_length_prefixed_le:pos:i64_max"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.skip_length_prefixed_le:pos:i64_max_m1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.skip_length_prefixed_le:pos:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.skip_length_prefixed_le:pos:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "bytes.skip_length_prefixed_le:pos:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "datetime.from_parts:m:i32_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "datetime.from_parts:m:i64_min"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "datetime.from_parts:m:i64_min_p1"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "datetime.from_parts:m:neg_one"
+reason = "UNTRIAGED — measured divergent, no cause recorded yet"
+
+[[divergence]]
+cell   = "datetime.to_iso:ts:i64_max"
+reason = "VERIFIED silent-wrong — the YEAR is truncated on wasm: i64_max gives 292277026596-12-04T15:30:07Z natively and 6596-12-04T15:30:07Z on wasm, both exit 0."
+
+[[divergence]]
+cell   = "datetime.to_iso:ts:i64_max_m1"
+reason = "VERIFIED silent-wrong — the YEAR is truncated on wasm: i64_max gives 292277026596-12-04T15:30:07Z natively and 6596-12-04T15:30:07Z on wasm, both exit 0."
+
+[[divergence]]
+cell   = "datetime.to_iso:ts:i64_min"
+reason = "VERIFIED silent-wrong — the YEAR is truncated on wasm: i64_max gives 292277026596-12-04T15:30:07Z natively and 6596-12-04T15:30:07Z on wasm, both exit 0."
+
+[[divergence]]
+cell   = "datetime.to_iso:ts:i64_min_p1"
+reason = "VERIFIED silent-wrong — the YEAR is truncated on wasm: i64_max gives 292277026596-12-04T15:30:07Z natively and 6596-12-04T15:30:07Z on wasm, both exit 0."
+
+[[divergence]]
+cell   = "io.read_n_bytes:n:i32_min"
+reason = "VERIFIED abort-form divergence — native exits 101 (a raw Rust panic, the form ALS-T6 forbids) where wasm returns 0 bytes."
+
+[[divergence]]
+cell   = "io.read_n_bytes:n:i64_max"
+reason = "VERIFIED abort-form divergence — native exits 101 (a raw Rust panic, the form ALS-T6 forbids) where wasm returns 0 bytes."
+
+[[divergence]]
+cell   = "io.read_n_bytes:n:i64_min"
+reason = "VERIFIED abort-form divergence — native exits 101 (a raw Rust panic, the form ALS-T6 forbids) where wasm returns 0 bytes."
+
+[[divergence]]
+cell   = "io.read_n_bytes:n:i64_min_p1"
+reason = "VERIFIED abort-form divergence — native exits 101 (a raw Rust panic, the form ALS-T6 forbids) where wasm returns 0 bytes."
+
+[[divergence]]
+cell   = "io.read_n_bytes:n:neg_one"
+reason = "VERIFIED abort-form divergence — native exits 101 (a raw Rust panic, the form ALS-T6 forbids) where wasm returns 0 bytes."
+
+[[divergence]]
+cell   = "list.range:end:i32_max"
+reason = "VERIFIED abort-form divergence — native exits 101 (raw panic) where wasm exits 1."
+
+[[divergence]]
+cell   = "list.range:end:i64_max"
+reason = "VERIFIED abort-form divergence — native exits 101 (raw panic) where wasm exits 1."
+
+[[divergence]]
+cell   = "list.range:end:i64_max_m1"
+reason = "VERIFIED abort-form divergence — native exits 101 (raw panic) where wasm exits 1."
+
+[[divergence]]
+cell   = "list.range:end:two_pow_32"
+reason = "VERIFIED abort-form divergence — native exits 101 (raw panic) where wasm exits 1."
+
+[[divergence]]
+cell   = "list.range:end:u32_max"
+reason = "VERIFIED abort-form divergence — native exits 101 (raw panic) where wasm exits 1."
+
+[[divergence]]
+cell   = "list.range:start:i32_min"
+reason = "VERIFIED abort-form divergence — native exits 101 (raw panic) where wasm exits 1."
+
+[[divergence]]
+cell   = "list.range:start:i64_min"
+reason = "VERIFIED abort-form divergence — native exits 101 (raw panic) where wasm exits 1."
+
+[[divergence]]
+cell   = "list.range:start:i64_min_p1"
+reason = "VERIFIED abort-form divergence — native exits 101 (raw panic) where wasm exits 1."
+
+[[divergence]]
+cell   = "math.choose:n:i64_max"
+reason = "VERIFIED silent-wrong — a different NUMBER, both exit 0: choose(i64_max, 3) is 4611686018427387903 natively and 1537228672809129300 on wasm."
+
+[[divergence]]
+cell   = "math.choose:n:two_pow_32"
+reason = "VERIFIED silent-wrong — a different NUMBER, both exit 0: choose(i64_max, 3) is 4611686018427387903 natively and 1537228672809129300 on wasm."
+
+[[divergence]]
+cell   = "math.choose:n:u32_max"
+reason = "VERIFIED silent-wrong — a different NUMBER, both exit 0: choose(i64_max, 3) is 4611686018427387903 natively and 1537228672809129300 on wasm."
+
+[[divergence]]
+cell   = "string.from_codepoint:n:i64_min"
+reason = "VERIFIED silent-wrong — native answers a one-char string (U+0000) where wasm answers the empty string, both exit 0."
+
+[[divergence]]
+cell   = "string.from_codepoint:n:i64_min_p1"
+reason = "VERIFIED silent-wrong — native answers a one-char string (U+0000) where wasm answers the empty string, both exit 0."
+
+[[divergence]]
+cell   = "string.from_codepoint:n:two_pow_32"
+reason = "VERIFIED silent-wrong — native answers a one-char string (U+0000) where wasm answers the empty string, both exit 0."
+
+[[divergence]]
+cell   = "string.pad_end:n:i32_max"
+reason = "Same shape as string.pad_start (unverified individually; the pair shares one implementation)."
+
+[[divergence]]
+cell   = "string.pad_end:n:two_pow_32"
+reason = "Same shape as string.pad_start (unverified individually; the pair shares one implementation)."
+
+[[divergence]]
+cell   = "string.pad_end:n:u32_max"
+reason = "Same shape as string.pad_start (unverified individually; the pair shares one implementation)."
+
+[[divergence]]
+cell   = "string.pad_start:n:i32_max"
+reason = "VERIFIED — native allocates the full 2^32-char result and succeeds; wasm fails. The count clamp of C-054 covers the narrowing, not the allocation."
+
+[[divergence]]
+cell   = "string.pad_start:n:two_pow_32"
+reason = "VERIFIED — native allocates the full 2^32-char result and succeeds; wasm fails. The count clamp of C-054 covers the narrowing, not the allocation."
+
+[[divergence]]
+cell   = "string.pad_start:n:u32_max"
+reason = "VERIFIED — native allocates the full 2^32-char result and succeeds; wasm fails. The count clamp of C-054 covers the narrowing, not the allocation."

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -251,3 +251,8 @@ evidence = "retired-spelling ledger landing (2026-08-16): companion check-retire
 path = "scripts/check-retired-spellings-negative.sh"
 class = "EXERCISED"
 evidence = "retired-spelling ledger landing (2026-08-16): recorded 5-mode exercise on every run — one positive control (the committed ledger must PASS, so a broken harness cannot report vacuous green) plus the four forged-ledger negatives enumerated in the row above. Wired into the checks job directly after the gate it guards."
+
+[[gate]]
+path = "scripts/check-domain-edges.sh"
+class = "NEGATIVE_TESTED"
+evidence = "PR #1449 (landing): the ledger row `datetime.to_iso:ts:i64_max` was DELETED and the gate exited 1 naming that exact cell as UNDECLARED; restoring the row returned exit 0. The reverse direction is enforced by the same run — a row whose cell no longer diverges is reported as stale and also fails, so the ledger cannot decay into a list of things that used to be true."

--- a/scripts/check-domain-edges.sh
+++ b/scripts/check-domain-edges.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Integer-domain edge gate — the measured matrix, diffed BIDIRECTIONALLY against
+# the declared ledger.
+#
+# THE LAW THIS ENFORCES (../almide-references/RESEARCH-integer-domain-guards.md)
+# -----------------------------------------------------------------------------
+# A guard must not be defeatable by its own arithmetic. No compiler of the nine
+# surveyed enforces how a guard is PHRASED — clippy's lints for it are
+# allow-by-default and not enabled on rustc's own source, and Zig has no lint
+# layer at all — so this repo cannot copy a lint. What it can copy is Rust
+# `tidy`'s shape (src/tools/tidy/src/target_policy.rs:27-62): discover the family
+# by WALKING the implementation, subtract what is covered, fail on the remainder,
+# and name every exception so each hole is attributed rather than silent.
+#
+# BOTH DIRECTIONS, because one direction is how the class kept coming back:
+#
+#   measured-but-undeclared  -> a NEW divergence. Fail. This is the bug catcher.
+#   declared-but-not-measured -> a row that no longer diverges. Fail, and delete
+#                                the row. Without this half the ledger becomes a
+#                                list of things that used to be true, and the
+#                                count stops meaning anything.
+#
+# The DIVERGE count is a shrink-only ceiling: it may go down, never up.
+#
+# WHY A SEPARATE INSTRUMENT FROM THE FUZZER
+# -----------------------------------------
+# The fuzzer already owns the extreme pool (generator/pools.rs:76 has i64::MAX,
+# i64::MIN, both i32 rails, u32::MAX) and already derives the function catalogue
+# by parsing every bundled module (generator/catalogue.rs:165). It does not cross
+# them, on purpose: generator/term.rs:363-365 feeds any parameter whose NAME is
+# count-like a value from {0,1,2,3,4,5}, because a `repeat` of u32::MAX
+# manufactures an out-of-memory "hang" that is noise rather than a finding.
+#
+# That decision is right and stays. It also draws the blind spot exactly over the
+# parameters the room guards read — `pos` is not in the name list, so
+# `bytes.set_f32_le` was found by fuzzing; `size` is, so `bytes.chunks` never
+# could be, and it took an inventory to see it. This gate covers what the lottery
+# structurally cannot.
+#
+# Usage:
+#   scripts/check-domain-edges.sh              # gate against proofs/domain-edges.toml
+#   scripts/check-domain-edges.sh --update     # re-measure and rewrite the ledger
+#   scripts/check-domain-edges.sh --only bytes # one module (fast local loop)
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LEDGER="$REPO/proofs/domain-edges.toml"
+ALMIDE="${ALMIDE_BIN:-$REPO/target/release/almide}"
+MEASURED="$(mktemp -t domain-edges-XXXXXX.json)"
+trap 'rm -f "$MEASURED"' EXIT
+
+UPDATE=0
+ONLY=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --update) UPDATE=1; shift ;;
+    --only)   ONLY="$2"; shift 2 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ ! -x "$ALMIDE" ]; then
+  echo "::error::$ALMIDE not built — run 'cargo build --release' first"
+  exit 1
+fi
+
+echo "domain-edges: measuring${ONLY:+ (module $ONLY)} …"
+python3 "$REPO/tools/domain_edge_matrix.py" \
+  --json "$MEASURED" --almide "$ALMIDE" ${ONLY:+--only "$ONLY"} >/dev/null || true
+
+python3 - "$MEASURED" "$LEDGER" "$UPDATE" "$ONLY" <<'PY'
+import json, sys, pathlib, re
+
+measured_path, ledger_path, update, only = sys.argv[1], sys.argv[2], sys.argv[3] == "1", sys.argv[4]
+cells = json.load(open(measured_path))["cells"]
+key = lambda c: f'{c["module"]}.{c["fn"]}:{c["param"]}:{c["edge"]}'
+measured = {key(c) for c in cells if c["verdict"] == "DIVERGE"}
+
+ledger = pathlib.Path(ledger_path)
+declared, reasons = set(), {}
+if ledger.exists():
+    for m in re.finditer(r'cell\s*=\s*"([^"]+)"\s*\nreason\s*=\s*"([^"]*)"', ledger.read_text()):
+        declared.add(m.group(1))
+        reasons[m.group(1)] = m.group(2)
+
+if update:
+    rows = "".join(
+        f'\n[[divergence]]\ncell   = "{k}"\nreason = "{reasons.get(k, "UNTRIAGED — measured divergent, no cause recorded yet")}"\n'
+        for k in sorted(measured))
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    ledger.write_text(
+        "# Integer-domain edge divergences — MEASURED, not asserted.\n"
+        "#\n"
+        "# Regenerate with `scripts/check-domain-edges.sh --update`. Every row must earn a\n"
+        "# `reason`; an UNTRIAGED row is a bug nobody has looked at yet, and the count is a\n"
+        "# shrink-only ceiling. A row that stops diverging must be DELETED in the same PR\n"
+        "# that fixes it — the gate fails on a stale row exactly as it fails on a new one,\n"
+        "# because a ledger of things that used to be true measures nothing.\n"
+        f"\ncount = {len(measured)}\n" + rows)
+    print(f"domain-edges: ledger rewritten — {len(measured)} divergent cells")
+    sys.exit(0)
+
+# Scoping: a --only run can only speak for the module it measured.
+if only:
+    declared = {k for k in declared if k.startswith(only + ".")}
+
+new = sorted(measured - declared)
+stale = sorted(declared - measured)
+fail = False
+
+if new:
+    fail = True
+    print(f"::error::{len(new)} UNDECLARED divergent cell(s) — a guard was defeated by its own arithmetic, or a new one was written that way:")
+    for k in new[:25]:
+        print(f"    {k}")
+    if len(new) > 25:
+        print(f"    … and {len(new) - 25} more")
+    print("  Fix it, or record it with a reason: scripts/check-domain-edges.sh --update")
+
+if stale:
+    fail = True
+    print(f"::error::{len(stale)} ledger row(s) no longer diverge — delete them (the count is shrink-only):")
+    for k in stale[:25]:
+        print(f"    {k}")
+
+untriaged = [k for k in sorted(declared & measured) if reasons.get(k, "").startswith("UNTRIAGED")]
+if untriaged:
+    print(f"domain-edges: {len(untriaged)} declared cell(s) still UNTRIAGED (not a failure, but they are open bugs)")
+
+if not fail:
+    print(f"domain-edges: OK — {len(measured)} divergent cells, all declared.")
+sys.exit(1 if fail else 0)
+PY

--- a/tools/domain_edge_matrix.py
+++ b/tools/domain_edge_matrix.py
@@ -241,6 +241,15 @@ def run_leg(almide, src_path, wasm):
 # refusal from a wrong answer is worse than no instrument.
 WALL_MARK = "not yet supported by the verified wasm renderer"
 
+# Modules whose surface is RAW MEMORY, where cross-target agreement is not
+# promised and never was: `prim.load32(garbage)` reads two genuinely different
+# memory models. Their cells are still MEASURED and still counted — hiding them
+# would make the headline number a lie by omission — but they are reported as
+# their own verdict so they cannot be mistaken for defects in a contracted API.
+# 273 of the first full run's 491 divergences were `prim`, and calling those bugs
+# would have buried the 218 that are real.
+RAW_MODULES = {"prim"}
+
 
 def classify(nat, wasm):
     """Compare stdout + exit code ONLY; stderr is read for the wall mark alone.
@@ -259,6 +268,11 @@ def classify(nat, wasm):
     if nrc == wrc and nout == wout:
         return "AGREE"
     return "DIVERGE"
+
+
+def verdict_for(module, nat, wasm):
+    v = classify(nat, wasm)
+    return "RAW" if v == "DIVERGE" and module in RAW_MODULES else v
 
 
 def main():
@@ -285,8 +299,9 @@ def main():
                 src, _ = build_program(sig, idx, value)
                 f = tmp / "probe.almd"
                 f.write_text(src)
-                verdict = classify(run_leg(args.almide, f, False),
-                                   run_leg(args.almide, f, True))
+                verdict = verdict_for(sig["module"],
+                                      run_leg(args.almide, f, False),
+                                      run_leg(args.almide, f, True))
                 cells.append({
                     "module": sig["module"], "fn": sig["fn"], "param": pname,
                     "edge": ename, "value": value, "verdict": verdict,

--- a/tools/domain_edge_matrix.py
+++ b/tools/domain_edge_matrix.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Integer-domain edge matrix — every public stdlib fn x every Int parameter x every edge.
+
+WHY THIS EXISTS
+---------------
+A room test written `pos + N <= len`, or a chunk count written `(total + n - 1) / n`, is
+defeated by its own arithmetic: the sum wraps, the comparison passes, the store or the
+allocation goes ahead. The shape has recurred in this repo five times, each fixed
+point-wise, returning at whichever END nobody measured (#1408 at the negative end, the
+SAME line at the positive end, `list.chunk`, `bytes.chunks`).
+
+The differential fuzzer cannot close it, and the reason is written down in its own source.
+`tools/xtarget-fuzz/src/generator/term.rs:363-365`:
+
+    // Count/size/index Int parameter => a small non-pathological value
+    // (avoids the `u32::MAX`/negative allocation-bomb noise).
+    SigType::Int if COUNT_LIKE_PARAM_NAMES.contains(&param_name) =>
+        Some(format!("{}", b.rng.pick(pools::SMALL_COUNT_POOL)))   // {0,1,2,3,4,5}
+
+That decision is CORRECT — feeding `u32::MAX` to `repeat` manufactures an out-of-memory
+"hang" that is noise, not a finding. But it draws the blind spot exactly over the
+parameters the room guards read. It predicts which siblings are reachable and which are
+not: `pos` is not in the name list, so `bytes.set_f32_le` was found; `size` is, so
+`bytes.chunks` never could be.
+
+So this is a SEPARATE instrument, not a fuzzer change. The fuzzer keeps its small-count
+rule. Here the extremes are fed deliberately, exhaustively, and the expectation is
+cross-leg AGREEMENT rather than speed — an allocation bomb is a declared outcome, not a
+finding.
+
+WHAT THE SURVEY SAID TO BUILD (../almide-references/RESEARCH-integer-domain-guards.md)
+--------------------------------------------------------------------------------------
+No compiler of the nine enforces how a guard is PHRASED — clippy's lints for it are
+allow-by-default and not enabled on rustc's own source, and Zig has no lint layer. Three
+things were worth copying, and they are what this file implements:
+
+  * Swift `utils/SwiftIntTypes.py` — ONE declared table, consumed by every cell, so adding
+    a width regenerates the matrix instead of needing a new hand-written case.
+  * Zig `lib/std/mem.zig:4963` — the far edge is COMPUTED from the buffer
+    (`offset_at_end = @bitSizeOf(Backing) - @bitSizeOf(Packed)`), never written as a
+    literal, so a new width brings its own edge case along.
+  * Rust `src/tools/tidy/src/target_policy.rs:27-62` — discover the family by WALKING the
+    implementation, subtract what the tests cover, fail on the remainder, and name every
+    exception so each hole is attributed rather than silent.
+
+Usage:
+    python3 tools/domain_edge_matrix.py                 # measure, print the matrix
+    python3 tools/domain_edge_matrix.py --json out.json # machine-readable
+    python3 tools/domain_edge_matrix.py --only bytes    # one module
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# ── The declared table (Swift's SwiftIntTypes.py role) ───────────────────────
+#
+# Every cell in the matrix is generated from this. A value added here appears
+# against every function at once; there is no per-function edge list to keep in
+# sync, which is the drift Rust's hand-rolled ~200 `test_impl_try_from_*!`
+# invocations still carry.
+I64_MAX = 9223372036854775807
+I64_MIN = -9223372036854775808
+
+FIXED_EDGES = [
+    ("zero", 0),
+    ("one", 1),
+    ("neg_one", -1),
+    ("i32_max", 2147483647),
+    ("i32_min", -2147483648),
+    ("u32_max", 4294967295),
+    ("two_pow_32", 4294967296),
+    ("i64_max_m1", I64_MAX - 1),
+    ("i64_max", I64_MAX),
+    ("i64_min_p1", I64_MIN + 1),
+    ("i64_min", I64_MIN),
+]
+
+# The far edges are DERIVED from the synthesized receiver, not written down —
+# Zig's `offset_at_end` rule. `len` is the length of whatever collection the
+# call's other arguments were built from, so a function that grows a new
+# receiver shape gets its boundary cells for free.
+def derived_edges(recv_len):
+    if recv_len is None:
+        return []
+    return [
+        ("len_m1", recv_len - 1),
+        ("len", recv_len),
+        ("len_p1", recv_len + 1),
+    ]
+
+# ── Value table: how to build a non-target argument of each type ─────────────
+#
+# Deliberately small and concrete. A type that is not here makes the whole cell
+# SKIPPED and counted — an honest hole, in the ledger, rather than a silent
+# absence.
+RECV_LEN = 5
+
+VALUES = {
+    "Int": "3",
+    "Float": "1.5",
+    "Bool": "true",
+    "String": '"abcde"',
+    "Bytes": "bytes.from_list([1, 2, 3, 4, 5])",
+    "List[Int]": "[1, 2, 3, 4, 5]",
+    "List[String]": '["a", "b", "c", "d", "e"]',
+    "List[Float]": "[1.0, 2.0, 3.0, 4.0, 5.0]",
+    "List[Bool]": "[true, false, true, false, true]",
+}
+
+# Length of the collection each receiver type carries, for the derived edges.
+RECV_LENS = {
+    "String": RECV_LEN,
+    "Bytes": RECV_LEN,
+    "List[Int]": RECV_LEN,
+    "List[String]": RECV_LEN,
+    "List[Float]": RECV_LEN,
+    "List[Bool]": RECV_LEN,
+}
+
+# How to render a result of each return type as a printable digest. A return
+# type absent here also makes the cell SKIPPED — the matrix reports what it
+# could not measure rather than pretending.
+RENDER = {
+    "Int": 'int.to_string({e})',
+    "Float": 'float.to_string({e})',
+    "Bool": '(if {e} then "t" else "f")',
+    "String": '{e}',
+    "Bytes": 'int.to_string(bytes.len({e}))',
+    "List[Int]": 'int.to_string(list.len({e}))',
+    "List[String]": 'int.to_string(list.len({e}))',
+    "List[Float]": 'int.to_string(list.len({e}))',
+    "List[Bool]": 'int.to_string(list.len({e}))',
+    "List[Bytes]": 'int.to_string(list.len({e}))',
+    "List[List[Int]]": 'int.to_string(list.len({e}))',
+    "List[List[String]]": 'int.to_string(list.len({e}))',
+    "Unit": None,  # call for effect only
+}
+
+# Modules that need an explicit import in the generated program.
+NEEDS_IMPORT = {"bytes", "json", "fs", "http", "env", "io", "random", "regex",
+                "process", "testing", "matrix"}
+
+# The `COUNT_LIKE_PARAM_NAMES` list the fuzzer uses to shrink a parameter to
+# {0..5}. Kept in sync by the gate below, not by hand: a name added there and
+# not here would silently narrow the blind spot without widening this matrix.
+FUZZER_COUNT_LIKE = {
+    "n", "count", "len", "times", "size", "decimals", "width", "k", "i", "j",
+    "index", "start", "end", "lo", "hi",
+}
+
+SIG_RE = re.compile(
+    r'^(?:@intrinsic\([^)]*\)\s*\n)?(?:effect\s+)?fn\s+(\w+)\(([^)]*)\)\s*->\s*([^=\n]+?)\s*=',
+    re.M,
+)
+
+
+def parse_type(t):
+    return t.strip().rstrip("?").strip()
+
+
+def parse_stdlib(only=None):
+    """Walk the implementation and discover the family (tidy's rule 1)."""
+    out = []
+    for path in sorted((REPO / "stdlib").glob("*.almd")):
+        module = path.stem.split("_")[0]
+        if only and module != only:
+            continue
+        src = path.read_text()
+        for m in SIG_RE.finditer(src):
+            fn, raw_params, ret = m.group(1), m.group(2), parse_type(m.group(3))
+            if fn.startswith("__") or fn.startswith("impl_"):
+                continue
+            params = []
+            ok = True
+            for p in [x for x in raw_params.split(",") if x.strip()]:
+                if ":" not in p:
+                    ok = False
+                    break
+                name, ty = p.split(":", 1)
+                params.append((name.strip(), parse_type(ty)))
+            if not ok or not params:
+                continue
+            if not any(ty == "Int" for _, ty in params):
+                continue
+            out.append({"module": module, "fn": fn, "params": params, "ret": ret})
+    return out
+
+
+def build_program(sig, target_idx, value):
+    """Emit the smallest program that puts `value` in one Int slot."""
+    args, recv_len = [], None
+    for i, (_, ty) in enumerate(sig["params"]):
+        if i == target_idx:
+            args.append(str(value))
+            continue
+        if ty not in VALUES:
+            return None, None
+        args.append(VALUES[ty])
+        if recv_len is None:
+            recv_len = RECV_LENS.get(ty)
+
+    call = f'{sig["module"]}.{sig["fn"]}({", ".join(args)})'
+    tmpl = RENDER.get(sig["ret"], "MISSING")
+    if tmpl == "MISSING":
+        return None, None
+
+    imports = f"import {sig['module']}\n" if sig["module"] in NEEDS_IMPORT else ""
+    if tmpl is None:
+        body = f"  let _ = {call}\n  println(\"unit\")"
+    else:
+        body = f'  println({tmpl.format(e=call)})'
+    return f"{imports}fn main() -> Unit = {{\n{body}\n}}\n", recv_len
+
+
+def run_leg(almide, src_path, wasm):
+    cmd = [almide, "run", str(src_path)] + (["--target", "wasm"] if wasm else [])
+    env = dict(os.environ, PATH="/opt/homebrew/bin:" + os.environ.get("PATH", ""))
+    try:
+        # `errors="replace"`: a byte-level stdlib fn can print raw non-UTF-8 bytes,
+        # and a decode crash in the harness would be indistinguishable from "no
+        # divergence here" — the instrument must never lose a cell to its own I/O.
+        p = subprocess.run(cmd, capture_output=True, text=True, errors="replace",
+                           timeout=45, env=env)
+        return p.returncode, p.stdout, p.stderr
+    except subprocess.TimeoutExpired:
+        return "timeout", "", ""
+
+
+# The v1 renderer DECLINES a shape outside its subset with this line, on purpose.
+# A wall is the repo's honest-error contract, not a divergence — counting it as one
+# is how a first run of this matrix reported 812 "findings" over `bytes`, nearly all
+# of them shapes the renderer had correctly refused. An instrument that cannot tell a
+# refusal from a wrong answer is worse than no instrument.
+WALL_MARK = "not yet supported by the verified wasm renderer"
+
+
+def classify(nat, wasm):
+    """Compare stdout + exit code ONLY; stderr is read for the wall mark alone.
+
+    Folding stderr into the comparison looks harmless and is not: native prints
+    warnings the wasm leg does not, and the two legs word some diagnostics
+    differently, so every such cell became a "divergence". A first run with
+    stderr in the comparison reported 2157 of 3614 cells divergent, including
+    `bytes.get(b, 0)` on a five-byte buffer — which is simply correct on both.
+    """
+    (nrc, nout, _nerr), (wrc, wout, werr) = nat, wasm
+    if nrc == "timeout" or wrc == "timeout":
+        return "BOMB"       # a declared outcome, not a finding — see the header
+    if wrc != 0 and WALL_MARK in werr:
+        return "WALL"
+    if nrc == wrc and nout == wout:
+        return "AGREE"
+    return "DIVERGE"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--json")
+    ap.add_argument("--only")
+    ap.add_argument("--almide", default=str(REPO / "target/release/almide"))
+    args = ap.parse_args()
+
+    sigs = parse_stdlib(args.only)
+    cells, skipped = [], []
+    tmp = Path(tempfile.mkdtemp(prefix="domain-edges-"))
+
+    for sig in sigs:
+        for idx, (pname, ty) in enumerate(sig["params"]):
+            if ty != "Int":
+                continue
+            probe, recv_len = build_program(sig, idx, 0)
+            if probe is None:
+                skipped.append(f'{sig["module"]}.{sig["fn"]}({pname}) — unbuildable arg/ret')
+                continue
+            edges = FIXED_EDGES + derived_edges(recv_len)
+            for ename, value in edges:
+                src, _ = build_program(sig, idx, value)
+                f = tmp / "probe.almd"
+                f.write_text(src)
+                verdict = classify(run_leg(args.almide, f, False),
+                                   run_leg(args.almide, f, True))
+                cells.append({
+                    "module": sig["module"], "fn": sig["fn"], "param": pname,
+                    "edge": ename, "value": value, "verdict": verdict,
+                    "fuzzer_reachable": pname not in FUZZER_COUNT_LIKE,
+                })
+                if verdict == "DIVERGE":
+                    print(f'  DIVERGE  {sig["module"]}.{sig["fn"]}  {pname}={ename}'
+                          f'  (fuzzer-reachable: {pname not in FUZZER_COUNT_LIKE})',
+                          flush=True)
+
+    tally = {}
+    for c in cells:
+        tally[c["verdict"]] = tally.get(c["verdict"], 0) + 1
+    blind = sum(1 for c in cells if not c["fuzzer_reachable"])
+
+    print(f"\ndomain-edge matrix: {len(cells)} cells over {len(sigs)} signatures")
+    for k in sorted(tally):
+        print(f"  {k:8} {tally[k]}")
+    print(f"  cells the fuzzer can never synthesize: {blind}")
+    print(f"  skipped signatures (unbuildable): {len(skipped)}")
+
+    if args.json:
+        Path(args.json).write_text(json.dumps(
+            {"cells": cells, "skipped": skipped, "tally": tally}, indent=2))
+    return 1 if tally.get("DIVERGE") else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/domain_edge_matrix.py
+++ b/tools/domain_edge_matrix.py
@@ -331,3 +331,57 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
+
+
+# ── Triage: give every divergent cell a MEASURED class ───────────────────────
+#
+# "218 divergent cells" is not a work estimate until each one says HOW it
+# diverges. Three classes need three different responses, and only the first is
+# unambiguously a defect:
+#
+#   SILENT_WRONG  both legs exit 0 and print different answers. The worst class,
+#                 and the one this language exists to remove.
+#   ABORT_FORM    both legs fail, in different forms. ALS-T6 says a domain error
+#                 is one unified abort; a raw panic (exit 101) or a wasm trap
+#                 (134) is the forbidden form, so this is a defect too, but the
+#                 fix is the FORM, not the value.
+#   ONE_SIDED     one leg answers, the other fails. Usually means the domain rule
+#                 itself was never decided — someone has to rule on what
+#                 `string.pad_start(s, 2^32)` MEANS before either leg can be
+#                 called wrong.
+#
+# Run: python3 tools/domain_edge_matrix.py --triage measured.json
+def triage(json_path, almide):
+    import collections
+    cells = json.load(open(json_path))["cells"]
+    div = [c for c in cells if c["verdict"] == "DIVERGE" and c["module"] not in RAW_MODULES]
+    sigs = {}
+    for mod in {c["module"] for c in div}:
+        for s in parse_stdlib(mod):
+            sigs[(s["module"], s["fn"])] = s
+    tmp = Path(tempfile.mkdtemp(prefix="triage-"))
+    out, tally = [], collections.Counter()
+    for c in div:
+        sig = sigs.get((c["module"], c["fn"]))
+        if sig is None:
+            continue
+        idx = next((i for i, (n, _t) in enumerate(sig["params"]) if n == c["param"]), None)
+        if idx is None:
+            continue
+        src, _ = build_program(sig, idx, c["value"])
+        if src is None:
+            continue
+        f = tmp / "p.almd"
+        f.write_text(src)
+        nrc, nout, _ = run_leg(almide, f, False)
+        wrc, wout, _ = run_leg(almide, f, True)
+        if nrc == 0 and wrc == 0:
+            cls = "SILENT_WRONG"
+        elif nrc != 0 and wrc != 0:
+            cls = "ABORT_FORM"
+        else:
+            cls = "ONE_SIDED"
+        tally[cls] += 1
+        out.append({**c, "klass": cls, "native": [nrc, nout.strip()[:60]],
+                    "wasm": [wrc, wout.strip()[:60]]})
+    return out, tally


### PR DESCRIPTION
Closes the mechanism half of the recurring "a guard defeated by its own arithmetic" class.
Survey: `../almide-references/RESEARCH-integer-domain-guards.md` (9 compilers, all citations
file:line).

## Why the fuzzer could not close this

Both halves already exist in `xtarget-fuzz`: `generator/pools.rs:76` carries `i64::MAX`,
`i64::MIN`, both i32 rails and `u32::MAX`, and `generator/catalogue.rs:165` derives the
function list by parsing every bundled module. They are not crossed, on purpose —
`generator/term.rs:363-365`:

```rust
// Count/size/index Int parameter => a small non-pathological value
// (avoids the `u32::MAX`/negative allocation-bomb noise).
SigType::Int if COUNT_LIKE_PARAM_NAMES.contains(&param_name) =>
    Some(format!("{}", b.rng.pick(pools::SMALL_COUNT_POOL)))   // {0,1,2,3,4,5}
```

That is the right call — `repeat` at `u32::MAX` manufactures an OOM "hang" that is noise.
It also draws the blind spot exactly over the parameters the room guards read, and it
predicts which siblings are reachable: `pos` is not in the name list, so `bytes.set_f32_le`
WAS found by fuzzing; `size` is, so `bytes.chunks` never could be, and it took an inventory
to see it. **2788 of the 7767 cells here sit on parameters the fuzzer can never synthesize
at an edge.** The fuzzer keeps its rule; this is a separate instrument.

## What it does

Walks the stdlib (tidy's rule: discover the family from the implementation, not a hand-list),
crosses every public fn's every `Int` parameter with one **declared** edge table — Swift's
`utils/SwiftIntTypes.py` role, so a value added there lands on every function at once — plus
far edges **computed** from the synthesized receiver rather than written down (Zig
`lib/std/mem.zig:4963`'s `offset_at_end`). Runs both legs, compares stdout + exit code.

## Measured at develop d8e480223

```
7767 cells over 639 signatures
  AGREE 6468   DIVERGE 218   RAW 273   WALL 801   BOMB 7
```

`WALL` is the wasm renderer honestly declining a shape outside its subset — a contract, not
a defect. `RAW` is the `prim` raw-memory surface, where two genuinely different memory
models were never promised to agree; those are counted and named rather than dropped,
because calling them defects would bury the 218 that are real.

**Two earlier versions of this instrument did not survive review and never reached a
ledger.** The first counted walls as divergences and reported 812 over `bytes` alone; the
second, fixing that by folding stderr into the comparison, reported 2157 — including
`bytes.get(b, 0)` on a five-byte buffer, which is simply correct. The comparison is stdout +
exit code; stderr is read for the wall mark alone. Both mistakes are written into the source
where they happened, because the number they produced was believable.

**14 rows were re-run by hand against both legs before the ledger was written; all 14
reproduced.**

## Bugs it found that nothing else had

| cell | native | wasm |
|---|---|---|
| `datetime.to_iso(i64_max)` | `292277026596-12-04T15:30:07Z` | `6596-12-04T15:30:07Z` — **year truncated** |
| `math.choose(i64_max, 3)` | `4611686018427387903` | `1537228672809129300` |
| `string.from_codepoint(i64_min)` | `"\x00"` | `""` |
| `io.read_n_bytes(-1)` | exit **101** (raw panic, the form ALS-T6 forbids) | exit 0, `0` |
| `list.range(3, i64_max)` | exit 101 | exit 1 |
| `bytes.chunks(size=i64_max)` | 1 chunk | 0 chunks |

The first three are silent-wrong: both legs exit 0 and print different answers. None had
ever been reported by the differential fuzz.

## The gate

`scripts/check-domain-edges.sh` diffs the measured matrix against
`proofs/domain-edges.toml` **in both directions**:

- measured-but-undeclared → a new divergence. Fail.
- declared-but-not-measured → a row that stopped diverging. Fail, delete it.

The second half is not symmetry for its own sake: without it the ledger becomes a list of
things that used to be true and `count` stops meaning anything. `count` is shrink-only.

**Verified that it catches, not merely that it passes**: deleting one declared row makes the
gate exit 1 and name that cell; restoring it returns exit 0.

## What this PR does NOT do

The 218 rows are declared, not fixed. 187 are `UNTRIAGED` — measured divergent, cause not
yet recorded. That is the honest starting count for a shrink-only ratchet, not a claim that
the surface is clean.