### PR TITLE
Feed the output-parity worklist on fd 3 so a stdin-reading fixture cannot truncate the sweep

### DIFF
--- a/proofs/output-parity.sh
+++ b/proofs/output-parity.sh
@@ -123,13 +123,30 @@ run_one() { # $1=file -> sets VERDICT to match|mismatch|wall|runerr|v0fail
   fi
 }
 declare -a suspects=()
-while IFS= read -r f; do
+# The worklist arrives on fd 3, and every fixture runs with stdin closed to
+# /dev/null. Both halves are load-bearing, and neither is a style choice:
+#
+# A fixture is free to READ stdin — `io.read_n_bytes`, `io.read_all`,
+# `io.read_line`. On the old `done < <(find …)` form that read came out of the
+# SAME descriptor the loop was reading filenames from, so one such fixture
+# swallowed the rest of the worklist and the sweep stopped there. Nothing
+# reported an error: the tail simply never ran, the counters stopped, and every
+# baseline file past the cut looked like it had "stopped byte-matching" — a
+# REGRESSION verdict for work no one had touched (#1473).
+#
+# `spec/wasm_cross/count_domain_nonbytes.almd` is the fixture that hit it, and
+# the fixture is fine. It calls `io.read_n_bytes(i64::MAX)`; before that call
+# was brought under the count-domain rule it aborted on a capacity overflow
+# BEFORE reaching stdin, so the defect here was masked. Fixing the intrinsic is
+# what armed it — which is the shape to remember: this gate must not depend on
+# what the corpus chooses to read.
+while IFS= read -r f <&3; do
   grep -q 'fn main' "$f" || { skip=$((skip+1)); continue; }
   # `// wasm:skip` — a multi-module / harness-incompatible fixture that cannot run
   # STANDALONE (its imports live in sibling files); comparing a broken standalone
   # invocation proves nothing. Same class as the no-main part files.
   head -1 "$f" | grep -q 'wasm:skip' && { skip=$((skip+1)); continue; }
-  run_one "$f" 20
+  run_one "$f" 20 < /dev/null
   case "$VERDICT" in
     match) match=$((match+1)); echo "$f" >> "$TMP/matches.txt" ;;
     # EVERY non-match goes to the solo retry — the load artifact shows up as any
@@ -137,12 +154,15 @@ while IFS= read -r f; do
     # render as wall), not just as runerr. Only the quiet re-run classifies.
     *)     suspects+=("$f:$VERDICT") ;;
   esac
-done < <(find spec -name '*.almd' | sort)
-# Solo retry pass — the machine is quiet now (the sweep is over).
+done 3< <(find spec -name '*.almd' | sort)
+# Solo retry pass — the machine is quiet now (the sweep is over). This loop
+# iterates an ARRAY, so it cannot be truncated the way the sweep was; the
+# redirect is here because a stdin-reading fixture would otherwise block on the
+# terminal when the script is run by hand.
 for sv in "${suspects[@]:-}"; do
   [ -n "$sv" ] || continue
   f="${sv%%:*}"
-  run_one "$f" 60
+  run_one "$f" 60 < /dev/null
   case "$VERDICT" in
     match)    match=$((match+1)); echo "$f" >> "$TMP/matches.txt" ;;
     v0fail)   v0fail=$((v0fail+1)) ;;


### PR DESCRIPTION
`develop` の Cross-Target CI が `60e73735a` で赤。**クロスターゲットの乖離は 1 件も起きていません** — ゲートが自分で自分を壊していました。

## 症状

```
output-parity: match=113 wall=1 MISMATCH=0 RUNERR=0 XFAIL=0 v0fail=0 skip=433
output-parity: REGRESSION — these baseline files stopped byte-matching v0:   ← 305 件
```

`MISMATCH=0` なのに baseline の 305 件が REGRESSION。前回 green と並べると、乖離ではなく**未実行**だと分かります:

| | green `67d7cbe12` | red `60e73735a` |
|---|---|---|
| match | 479 | 113 |
| wall | 5 | 1 |
| MISMATCH | 2 | 0 |
| RUNERR | 11 | 0 |
| skip | 435 | 433 |
| **合計** | **932** | **547** |

全カウンタの合計が 932 → 547。385 件がどのカウンタにも入っていない = ループが途中で終わっている。

## 原因

`proofs/output-parity.sh` はファイル一覧を **stdin** から読んでいました:

```bash
while IFS= read -r f; do
  ...
  run_one "$f" 20
done < <(find spec -name '*.almd' | sort)
```

ループ内の `almide` / `wasmtime` に stdin のリダイレクトがありません。fixture は stdin を読んでよい —
`io.read_n_bytes` / `io.read_all` / `io.read_line` — ので、そういう fixture が来ると
**ループが読んでいるのと同じ記述子から読み**、残りのファイル名を全部飲みます。

踏んだのは `d646a463b` が追加した `spec/wasm_cross/count_domain_nonbytes.almd`:

```almide
println("io_max=" + int.to_string(list.len(io.read_n_bytes(9223372036854775807))))
```

ソート順で **550 番目**。赤の集計は 547 で一致します。

**fixture に非はありません。** むしろ `io.read_n_bytes` を count-domain 規則の下に入れた修正**そのもの**が
この地雷を起爆しました。修正前は stdin に到達する前に capacity overflow で落ちていたので、欠陥が隠れていた:

```
$ almide run spec/wasm_cross/count_domain_nonbytes.almd   # 修正前バイナリ
thread 'main' panicked at raw_vec/mod.rs:28:5: capacity overflow
```

そして誰も気づけません。エラーは出ず、末尾が黙って実行されないだけで、
切れ目より後ろの baseline 全部が「誰も触っていない作業の REGRESSION」に見える。

## 修正

```bash
while IFS= read -r f <&3; do
  ...
  run_one "$f" 20 < /dev/null
done 3< <(find spec -name '*.almd' | sort)
```

両方が必要です。fd 3 だけだと内側が端末/CI の stdin を読みに行き、`< /dev/null` だけだと
`run_one` 内の他プロセスが残ります。solo retry の `run_one "$f" 60` にも付けました —
そちらは配列反復なので切り詰めは起きませんが、手動実行時にハングするためです。

## 検証

プローブ（修正後バイナリ + 実 fixture + 実際のループ形）:

| | 処理件数 |
|---|---|
| 現状のパターン | **2 / 5** |
| `fd3` + `< /dev/null` | **5 / 5** |

ゲート本体:

```
output-parity: match=481 wall=5 MISMATCH=2 RUNERR=11 XFAIL=0 v0fail=0 skip=435
REGRESSION: 0    exit 0
```

合計 **934** = `spec/**/*.almd` の実ファイル数と完全一致（全件処理）。
green の数値（match=479 / MISMATCH=2 / RUNERR=11）をそのまま再現し、
増えた 2 件は 16 コミットが追加した新規 fixture 分です。

## 族の確認

コーパスのプログラムを実行するスクリプトは 3 本 — `proofs/diff-fuzz.sh`、
`proofs/output-parity.sh`、`scripts/check-edit-loop-scale.sh`。
このうち一覧を stdin から取るのは **`output-parity.sh` だけ**なので、他 2 本は同じ壊れ方をしません。

`while read` を持つ他のゲート（`scripts/check-embedded-size.sh`、`scripts/org-byte-verify.sh`、
`proofs/corpus-wall.sh` ほか）は、ループ本体が `awk` / `wc` にファイル名を**引数で**渡すか、
配列に詰めるだけで stdin を読みません。族は閉じています。

## 副次的な確認

最初のゲート実行はツールチェーン・スタンプが自衛して停止しました:

```
FATAL: PATH almide (30e6599…) != workspace build (bb992d0…).
The evidence this gate produces would not describe the tree under test.
```

無関係なローカルビルドが PATH にいたためです。証拠と測定対象の木の食い違いを検出して止まるのは
正しい挙動で、この防御は効いていることを確認できました。

なお `NEW matches not yet in baseline` が 72 件出ますが、これは green の時点でも出ていた既存の状態で、
ゲートは REGRESSION でのみ落ちるため exit 0 です。ratchet (`--update`) はインフラ修正とは別判断なので
このPRには含めていません。
