### PR TITLE
Decline a backtick escape that encloses no identifier character instead of minting an empty name

### DIFF
--- a/crates/almide-syntax/src/lexer.rs
+++ b/crates/almide-syntax/src/lexer.rs
@@ -213,7 +213,15 @@ fn lex_word(chars: &[char], cur: &mut Cursor, tokens: &mut Vec<Token>) -> bool {
         return false;
     }
     let (tok, new_pos) = if is_backtick {
-        lex_backtick_ident(chars, cur.pos, cur.line, cur.col)
+        // A malformed escape (empty body) must NOT become a zero-length Ident:
+        // that token reached the checker as `undefined variable ''` (#1457).
+        // Decline instead, so the main loop lexes the backtick through
+        // `lex_operator` → Unknown and the parser reports it like any other
+        // stray character.
+        match lex_backtick_ident(chars, cur.pos, cur.line, cur.col) {
+            Some(pair) => pair,
+            None => return false,
+        }
     } else {
         lex_ident(chars, cur.pos, cur.line, cur.col)
     };
@@ -921,11 +929,21 @@ fn lex_ident(chars: &[char], start: usize, line: usize, col: usize) -> (Token, u
 /// Lex a backtick-escaped identifier: `protocol`, `type`, etc.
 /// The backticks are consumed but not included in the token value.
 /// The result is always TokenType::Ident regardless of keyword status.
-fn lex_backtick_ident(chars: &[char], start: usize, line: usize, col: usize) -> (Token, usize) {
+///
+/// `None` when the escape encloses no identifier character at all — an empty
+/// pair of backticks, or a body the identifier rule cannot start on (a
+/// non-ASCII name). The body is the SAME ASCII set `lex_ident` accepts, so a
+/// non-ASCII name is no more writable escaped than bare; the escape only buys
+/// keyword-ness. An empty name is not a token any later stage can use, so it is
+/// never built (#1457).
+fn lex_backtick_ident(chars: &[char], start: usize, line: usize, col: usize) -> Option<(Token, usize)> {
     let mut pos = start + 1; // skip opening backtick
     let ident_start = pos;
     while pos < chars.len() && (chars[pos].is_ascii_alphanumeric() || chars[pos] == '_') {
         pos += 1;
+    }
+    if pos == ident_start {
+        return None;
     }
     let value: String = chars[ident_start..pos].iter().collect();
     // Consume closing backtick if present
@@ -938,7 +956,7 @@ fn lex_backtick_ident(chars: &[char], start: usize, line: usize, col: usize) -> 
         TokenType::Ident
     };
     let end_col = col + (pos - start);
-    (Token { token_type, value, line, col, end_col, raw: None }, pos)
+    Some((Token { token_type, value, line, col, end_col, raw: None }, pos))
 }
 
 /// The keyword table — data, not control flow: one row per spelling
@@ -1027,6 +1045,47 @@ fn peek(chars: &[char], pos: usize) -> Option<char> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Regression (#1457): a backtick escape enclosing no identifier character
+    // used to lex to a ZERO-LENGTH Ident. That token survived every later stage
+    // and surfaced in the checker as `undefined variable ''` — a name no source
+    // text can spell. The lexer must never mint an empty-named identifier; the
+    // malformed escape falls through to Unknown like any other stray character.
+    #[test]
+    fn malformed_backtick_escape_never_yields_an_empty_ident() {
+        // Non-ASCII body, empty body, and an unterminated escape at EOF.
+        for src in ["let `日本語` = 1", "let `` = 1", "let `"] {
+            let tokens = Lexer::tokenize(src);
+            assert!(
+                !tokens.iter().any(|t| {
+                    matches!(t.token_type, TokenType::Ident | TokenType::TypeName)
+                        && t.value.is_empty()
+                }),
+                "empty-named identifier token minted for {src:?}: {:?}",
+                tokens.iter().map(|t| (t.token_type, &t.value)).collect::<Vec<_>>()
+            );
+            assert!(
+                tokens.iter().any(|t| t.token_type == TokenType::Unknown && t.value == "`"),
+                "malformed escape should surface the backtick as Unknown for {src:?}"
+            );
+        }
+    }
+
+    // The escape itself still works — the fix must not cost `type`/`protocol`
+    // their keyword-escaping, which is the whole reason backticks exist.
+    #[test]
+    fn well_formed_backtick_escape_still_lexes_as_a_name() {
+        let tokens = Lexer::tokenize("let `type` = 1");
+        let t = tokens
+            .iter()
+            .find(|t| t.value == "type")
+            .expect("`type` should lex to a name token");
+        assert_eq!(t.token_type, TokenType::Ident, "backtick escape defeats keyword-ness");
+        // An uppercase escaped name keeps its TypeName classification.
+        let tokens = Lexer::tokenize("let `Protocol` = 1");
+        let t = tokens.iter().find(|t| t.value == "Protocol").expect("escaped TypeName");
+        assert_eq!(t.token_type, TokenType::TypeName);
+    }
 
     // Regression: a heredoc whose blank line holds multi-byte Unicode whitespace
     // (U+3000) used to panic in strip_heredoc_indent — the byte-offset dedent

--- a/crates/almide-syntax/src/parser/diagnostics.rs
+++ b/crates/almide-syntax/src/parser/diagnostics.rs
@@ -40,9 +40,20 @@ impl Parser {
     pub(crate) fn unknown_char_error(&mut self, value: &str, line: usize, col: usize) -> String {
         let ch = value.chars().next().unwrap_or('\u{FFFD}');
         let msg = format!("Unexpected character '{}' (U+{:04X})", ch, ch as u32);
-        let hint = "This character is not Almide syntax. Full-width or invisible Unicode \
-                    characters often sneak in from copy-paste — delete it, or move it into \
-                    a string or comment.";
+        // A backtick reaches this arm only as a MALFORMED escape: the lexer
+        // declines an escape enclosing no identifier character, rather than
+        // building a zero-length Ident (#1457). The generic copy-paste hint
+        // would send the reader looking for an invisible character, so name the
+        // construct that actually failed.
+        let hint = if ch == '`' {
+            "A backtick escape wraps a name that would otherwise be a keyword — \
+             `type`, `protocol`. It takes ASCII letters, digits and '_', and cannot \
+             be empty, so it does not make a non-ASCII name writable either."
+        } else {
+            "This character is not Almide syntax. Full-width or invisible Unicode \
+             characters often sneak in from copy-paste — delete it, or move it into \
+             a string or comment."
+        };
         let diag = self.diag_error(msg.clone(), hint, "unknown-char");
         self.errors.push(diag);
         format!("{} at line {}:{}", msg, line, col)

--- a/crates/almide-syntax/src/parser/helpers.rs
+++ b/crates/almide-syntax/src/parser/helpers.rs
@@ -221,6 +221,12 @@ impl Parser {
         let hint = match (&tok.token_type, tok.value.as_str()) {
             (TokenType::Underscore, _) => "\n  Hint: '_' can only be used in match patterns, not as a variable name.",
             (TokenType::Test, _) => "\n  Hint: `test \"...\"` is a top-level form. Got here mid-declaration — either the previous fn/type/impl is missing a closing `}`, or the test block shouldn't be in this file at all (harness-submitted code).",
+            // A backtick lands here only as a MALFORMED escape — the lexer
+            // declines one enclosing no identifier character (#1457). Binding
+            // position never reaches `unknown_char_error`, so the hint that
+            // names the construct has to be repeated here.
+            (TokenType::Unknown, "`") => "\n  Hint: A backtick escape takes ASCII letters, digits and '_', and cannot be empty. It makes a KEYWORD usable as a name (`type`, `protocol`) — it does not make a non-ASCII name writable.",
+            (TokenType::Unknown, _) => "\n  Hint: This character is not Almide syntax. Full-width or invisible Unicode characters often sneak in from copy-paste — delete it, or move it into a string or comment.",
             _ => "",
         };
         Err(format!(


### PR DESCRIPTION
Fixes #1457.

## Repro (v0.57.0)

```almide
let `日本語` = 1
```

```
error: Expected Eq at line 4:8 (got Unknown '日')
error[E003]: undefined variable ''
  hint: Check the variable name
```

`undefined variable ''` — 空文字列の変数名。そんな名前はどんなソーステキストからも綴れません。

バッククォートを外すと診断は的確です:

```
error: Unexpected character '日' (U+65E5)
  hint: This character is not Almide syntax. Full-width or invisible Unicode
        characters often sneak in from copy-paste — delete it, or move it into
        a string or comment.
```

つまり**囲むと診断が劣化していました**。

## Root cause

`lex_backtick_ident` は開きバッククォートの次から ASCII 識別子文字を舐めますが、
0 文字しか進めなかった場合を扱っていませんでした。`value` が空文字列のまま
`TokenType::Ident` のトークンが作られ、字句層の不変条件（識別子は空でない）が破れます。
そのトークンは以降の全ステージを素通りして型検査器に届きます。

トークン列を実際に取ると、空 `Ident` は **1 つではなく 2 つ**出ていました
（開きと閉じ、それぞれのバッククォートが 1 つずつ生む）:

```
[(Let,"let"), (Ident,""), (Unknown,"日"), (Unknown,"本"), (Unknown,"語"),
 (Ident,""), (Eq,"="), (Int,"1"), (EOF,"")]
```

## 修正

`lex_backtick_ident` は 0 文字消費なら `Option::None` を返し、`lex_word` はそこで宣言を降ります。
main ループが `lex_operator` 経由でバッククォートを `Unknown` にするので、
他のはぐれ文字とまったく同じ扱いに合流します。**空名トークンは生成されません** — 型で保証されます。

診断は 2 経路あり、片方だけでは不足でした:

- 式位置 → `unknown_char_error`（`parser/diagnostics.rs`）
- 束縛位置 → `expect_ident`（`parser/helpers.rs`）— こちらは `Unknown` の arm を持っていなかった

両方にバッククォート固有のヒントを入れました。ついでに `expect_ident` に `Unknown` 一般の arm も
足したので、束縛位置に紛れ込んだ全角・不可視文字も今後は理由が出ます。

結果:

```
error: Expected identifier at line 4:7 (got Unknown '`')
  hint: A backtick escape takes ASCII letters, digits and '_', and cannot be empty.
        It makes a KEYWORD usable as a name (`type`, `protocol`) — it does not make
        a non-ASCII name writable.
```

## 検証

**A/B** — ガードを `if false &&` で無効化すると新テストは FAIL:

```
empty-named identifier token minted for "let `日本語` = 1":
[(Let,"let"), (Ident,""), (Unknown,"日"), …]
```

正常系テストは A/B 両方で pass するので、空振りテストではありません。

**正常系（end-to-end）** — バッククォート脱出の本来の用途は無傷:

```almide
let `type` = 5
let `match` = `type` + 1
println("${`match`}")   // → 6
```

**スイート** — `origin/develop` (`60e73735a`) に rebase 済みで、その上で:

| | 結果 |
|---|---|
| `cargo test -p almide-syntax --lib` | 70 passed |
| `almide test` | 403 files, 0 failed (391 WASM / 12 native) |
| `cargo check -p almide-syntax` | 警告ゼロ |
| `scripts/check-lark-grammar.sh` | corpus superset 1260/1260 |
| `scripts/check-contracts.sh` | 286 contracts, flagged=0 |

テストは 2 本 — 異常系（非 ASCII 本体 / 空 `` `` `` / EOF での未終端）と、
正常系（`` `type` `` → `Ident`、`` `Protocol` `` → `TypeName`）。

## スコープ外

非 ASCII 識別子そのものを書けるようにする件は #1456 で別途扱います。
このPRは**今日存在する字句層の不変条件の破れ**だけを直すもので、
`lex_backtick_ident` が受理する文字集合は変えていません（ASCII のまま）。
