### PR TITLE
Reconcile the two stdin-isolation comments after the concurrent fixes met

### DIFF
--- a/proofs/output-parity.sh
+++ b/proofs/output-parity.sh
@@ -79,10 +79,13 @@ match=0; wall=0; mismatch=0; runerr=0; v0fail=0; skip=0; xfail=0
 # comparable when the render succeeds: the traps (div-by-zero, index-bounds,
 # unwrap-none) PROMISE identical stderr + exit 1 cross-target (C-001/C-035).
 # v1 stderr is normalized (the wasmtime trap preamble names the tmp wat path).
-# STDIN IS CLOSED for every fixture run. The corpus arrives on this script's own
-# stdin (`done < <(find spec ...)`), so a fixture that READS stdin consumes the
-# rest of the file list and the sweep stops early — silently, because the loop
-# simply runs out of input and the summary prints as if it had finished.
+# STDIN IS CLOSED for every fixture run. The corpus USED to arrive on this
+# script's own stdin (`done < <(find spec ...)`), so a fixture that READS stdin
+# consumed the rest of the file list and the sweep stopped early — silently,
+# because the loop simply ran out of input and the summary printed as if it had
+# finished. The worklist has since moved to fd 3 (see the sweep below), so the
+# two descriptors no longer overlap at all; this redirect stays because it is
+# the half that holds however the worklist is delivered.
 #
 # It cost a green build to learn: `count_domain_nonbytes.almd` calls
 # `io.read_n_bytes`, and the run that introduced it classified 547 of 932 files
@@ -148,12 +151,12 @@ declare -a suspects=()
 # baseline file past the cut looked like it had "stopped byte-matching" — a
 # REGRESSION verdict for work no one had touched (#1473).
 #
-# `spec/wasm_cross/count_domain_nonbytes.almd` is the fixture that hit it, and
-# the fixture is fine. It calls `io.read_n_bytes(i64::MAX)`; before that call
-# was brought under the count-domain rule it aborted on a capacity overflow
-# BEFORE reaching stdin, so the defect here was masked. Fixing the intrinsic is
-# what armed it — which is the shape to remember: this gate must not depend on
-# what the corpus chooses to read.
+# Belt and braces with the `< /dev/null` on the two fixture invocations inside
+# run_one: that redirect closes stdin for the commands that exist today, this
+# one puts the worklist out of reach of ANY command the loop body might grow.
+# The account of how the hazard came to be armed lives above run_one; the shape
+# to remember is that it was armed by FIXING an intrinsic, so this gate must
+# never depend on what the corpus chooses to read.
 while IFS= read -r f <&3; do
   grep -q 'fn main' "$f" || { skip=$((skip+1)); continue; }
   # `// wasm:skip` — a multi-module / harness-incompatible fixture that cannot run


### PR DESCRIPTION
`proofs/output-parity.sh` の stdin 隔離は、同じ日に**独立して 2 回**直りました:

- `ee6e47361` — `run_one` 内の 2 つの fixture 起動に `< /dev/null`、加えて `seen == corpus` の突き合わせ判定
- `e2a5e9bca` (#1473) — ワークリストを fd 3 へ退避

機構としては噛み合っています（前者が今日存在するコマンドを、後者が将来ループ本体に足されるコマンドを守る）。
壊れたのは**コメント**の方で、しかも両方が壊れました。これはその整合です。コード変更はありません。

## 1. 私が相手の記述を無効化した

`ee6e47361` のコメントはこう書いています:

> The corpus arrives on this script's own stdin (`done < <(find spec ...)`)

`#1473` がワークリストを `done 3< <(...)` に移したので、**この文はもう事実ではありません**。
読んだ人は存在しない形を探すことになります。

「かつてそうだった」形に直し、fd 3 へ移った事実と、それでもこの `< /dev/null` を残す理由
（ワークリストの配送方法に依存せず成立する側の防御だから）を書き足しました。

## 2. 私の記述の方が事実として誤っていた

`#1473` で私はこう書きました:

> It calls `io.read_n_bytes(i64::MAX)`; before that call was brought under the
> count-domain rule it aborted on a capacity overflow BEFORE reaching stdin

修正前バイナリでの実際の出力は:

```
r_ok=5
r_far=1
r_neg=10
r_empty=0
p_ok=xxxa
p_mb=aあああ
p_neg=ab

thread 'main' panicked at raw_vec/mod.rs:28:5: capacity overflow
```

`io_neg=` が印字される**前**に落ちています。`count_domain_nonbytes.almd` の該当箇所は:

```almide
println("io_neg=" + int.to_string(list.len(io.read_n_bytes(0 - 1))))          // ← ここで panic
println("io_max=" + int.to_string(list.len(io.read_n_bytes(9223372036854775807))))
```

つまり abort は 1 行前の**負の count** の呼び出しで起きており、私が原因として名指しした
`i64::MAX` の呼び出しには到達すらしていません。`ee6e47361` の

> `read_n_bytes(i64::MAX)` used to truncate to i32 and read nothing

を否定する証拠を、私は持っていませんでした。誤った帰属を削除し、経緯の説明は
`ee6e47361` の記述に一本化しています。私の側には fd 3 が二重防御である理由だけを残しました。

## 検証

コメントのみの変更ですが、3 つの修正が同居した最終状態でゲートを実走しています:

```
output-parity: match=482 wall=5 MISMATCH=2 RUNERR=11 XFAIL=0 v0fail=0 skip=435
REGRESSION: 0    exit 0
```

`ee6e47361` が入れた `seen == corpus` 判定が発火していないので、fd 3 と同居した状態で
全件がいずれかのバケットに計上されていることも同時に確認できています。
`bash -n` も通ります。
