### PR TITLE
Stop the contract gate racing SIGPIPE against its own membership tests

### DIFF
--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -22,7 +22,7 @@
 [[gate]]
 path = "scripts/check-contracts.sh"
 class = "MUTATION_TESTED"
-evidence = "flight-evidence-gaps.md F1 progress-2 (2026-07-04): spec-resolution mutation test (nonexistent ALS section reference => FAIL)"
+evidence = "flight-evidence-gaps.md F1 progress-2 (2026-07-04): spec-resolution mutation test (nonexistent ALS section reference => FAIL) SIGPIPE FLAKE FIXED (2026-08-16): seven membership tests were `printf '%s\\n' \"$SET\" | grep -q \"$x\"`, which is a RACE under this script's `set -o pipefail` — `grep -q` exits the instant it matches and closes the pipe, so a `printf` still writing dies of SIGPIPE and the PIPELINE reports failure even though the element WAS found. The gate then declared a contract \"not in the ledger\", naming whichever id lost the race, so it accused a DIFFERENT contract every time (observed: C-084, C-059, C-087). Measured on the 286-id ledger: an EARLY match false-failed 1 run in 400 and a LATE match never did — exactly the shape the race predicts, since a late match leaves nothing left to write. Locally the gate was red about 1 run in 6. All seven now read from a here-string via a single `has()` helper, so there is no pipe to break: 25 consecutive runs green, 0 red. This is not cosmetic — a verdict-bearing gate that is randomly red teaches everyone to re-run until green, which is also what you do to a real failure, and CI's green history on this gate was therefore luck rather than evidence."
 
 [[gate]]
 path = "scripts/check-scalar-read-audit.sh"

--- a/scripts/check-contracts.sh
+++ b/scripts/check-contracts.sh
@@ -78,6 +78,29 @@ err() { fail=1; echo "::error::$*"; }
 #   EV<TAB>id<TAB>path<TAB>class<TAB>name<TAB>n
 # (empty name/n render as the literal "-"; title/statement are presence flags
 # 0|1, since is the literal value or "" when the key is absent)
+# ── SIGPIPE-SAFE MEMBERSHIP ─────────────────────────────────────────────────
+# `printf '%s\n' "$SET" | grep -q "$x"` is a RACE under `set -o pipefail`.
+# `grep -q` exits the instant it matches, closing the pipe; if `printf` has not
+# finished writing, it dies of SIGPIPE and the PIPELINE's status is non-zero even
+# though the element WAS found. The gate then reports a contract as "not in the
+# ledger" — a false failure whose victim is whichever id happened to lose the
+# race, so it names a different contract every time.
+#
+# Measured on this repo's 286-id ledger: an EARLY match (C-001) false-failed
+# 1 run in 400, a LATE match (C-286) never did — exactly the shape the race
+# predicts, since a late match leaves nothing left to write. In practice the gate
+# failed about 1 local run in 6, each time naming a different contract.
+#
+# A gate that is red 15% of the time for no reason is worse than no gate: it
+# teaches everyone to re-run until green, which is also what you do to a REAL
+# failure. `has()` reads from a here-string, so there is no pipe to break.
+has() { # $1=needle  $2=haystack (newline-separated)  [$3=-E for regex]
+  case "${3:-}" in
+    -E) grep -qE -- "$1" <<<"$2" ;;
+    *)  grep -qxF -- "$1" <<<"$2" ;;
+  esac
+}
+
 parse_ledger() {
   awk '
     # Empty optional scalars render as "-": TAB is IFS whitespace, so bash `read`
@@ -128,7 +151,7 @@ while IFS=$'\t' read -r _tag id status doc title stmt since; do
   [ -z "$id" ] && continue
   [ "$doc" = "-" ] && doc=""
   [ "$since" = "-" ] && since=""
-  printf '%s\n' "$id" | grep -qE '^C-[0-9]{3}$' || err "bad contract id '$id' (must match ^C-[0-9]{3}\$)"
+  has '^C-[0-9]{3}$' "$id" -E || err "bad contract id '$id' (must match ^C-[0-9]{3}\$)"
   case "$status" in
     active|flagged-for-revision) ;;
     *) err "$id: status '$status' is not one of {active, flagged-for-revision}" ;;
@@ -137,7 +160,7 @@ while IFS=$'\t' read -r _tag id status doc title stmt since; do
   [ "$stmt"  = "1" ] || err "$id: REQUIRED key 'statement' is missing"
   if [ -z "$since" ]; then
     err "$id: REQUIRED key 'since' is missing (the version the contract became normative)"
-  elif ! printf '%s\n' "$since" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  elif ! has '^[0-9]+\.[0-9]+\.[0-9]+$' "$since" -E; then
     err "$id: since='$since' is not a MAJOR.MINOR.PATCH version"
   fi
   if [ "$doc" != "" ] && [ ! -f "$DOC_DIR/$doc" ]; then
@@ -154,10 +177,10 @@ fi
 while IFS=$'\t' read -r _tag id path class name n; do
   [ -z "$id" ] && continue
   # class enum
-  printf '%s\n' "$class" | grep -qxE "$CLASS_ALT" || err "$id: class '$class' not one of {$(printf '%s' "$CLASSES" | paste -sd, -)}"
+  has "^(${CLASS_ALT})$" "$class" -E || err "$id: class '$class' not one of {$(printf '%s' "$CLASSES" | paste -sd, -)}"
   # fuzz requires n>=1
   if [ "$class" = "fuzz" ]; then
-    if ! printf '%s' "$n" | grep -qE '^[0-9]+$' || [ "${n:-0}" -lt 1 ]; then
+    if ! has '^[0-9]+$' "$n" -E || [ "${n:-0}" -lt 1 ]; then
       err "$id: class='fuzz' evidence ($path) requires n=<int >= 1> (got '$n')"
     fi
   fi
@@ -231,7 +254,7 @@ for f in "$FIXTURE_DIR"/*.almd; do
   for cid in $(printf '%s' "$ids" | tr ',' ' '); do
     cid="$(printf '%s' "$cid" | tr -d '[:space:]')"
     [ -z "$cid" ] && continue
-    if ! printf '%s\n' "$ALL_IDS" | grep -qxF "$cid"; then
+    if ! has "$cid" "$ALL_IDS"; then
       err "$base references $cid which is not in the ledger"
       continue
     fi
@@ -292,7 +315,7 @@ maxnum="$((10#${maxnum:-0}))"
 i=1
 while [ "$i" -le "$maxnum" ]; do
   want="$(printf 'C-%03d' "$i")"
-  printf '%s\n' "$sorted_ids" | grep -qxF "$want" || err "coverage gap: $want is missing (C-001..C-$(printf '%03d' "$maxnum") must be contiguous)"
+  has "$want" "$sorted_ids" || err "coverage gap: $want is missing (C-001..C-$(printf '%03d' "$maxnum") must be contiguous)"
   i=$((i + 1))
 done
 
@@ -364,7 +387,7 @@ if [ -d "$ALS_DIR" ]; then
   # uncited section is exactly where a spec↔implementation divergence hides.
   n_orphan=0
   for sec in $(grep -hoE '^## ALS-[A-Z0-9]+' "$ALS_DIR"/*.md | sed 's/^## //' | sort -u); do
-    if ! printf '%s\n' "$specd" | grep -qxF "$sec"; then
+    if ! has "$sec" "$specd"; then
       echo "::error::ALS section '$sec' is cited by NO contract — every normative section needs >=1 [[contract]] with spec = \"$sec\" (see #565)"
       n_orphan=$((n_orphan + 1))
       fail=1


### PR DESCRIPTION
`scripts/check-contracts.sh` is **red about 1 local run in 6**, and it accuses a
different contract every time.

```
run 1: OK — 286 contracts
run 2: ::error::wide_function_body.almd references C-059 which is not in the ledger
run 3: OK — 286 contracts
run 4: ::error::json_number_unicode.almd references C-087 which is not in the ledger
```

Every one of those contracts **is** in the ledger.

## The race

Seven membership tests are written

```sh
printf '%s\n' "$SET" | grep -qxF "$x"
```

and the script runs under `set -uo pipefail`. `grep -q` exits the *instant* it
matches and closes the pipe; if `printf` has not finished writing, it dies of
SIGPIPE — and with `pipefail` the **pipeline** reports failure even though the
element was found.

Measured on this repo's 286-id ledger:

| match position | false failures |
|---|---|
| early (`C-001`) | **1 in 400** |
| late (`C-286`) | 0 in 400 |

Exactly the shape the race predicts: a late match leaves nothing left to write, so
there is no pipe to break. With 286 ids checked per fixture across ~430 fixtures,
the per-run probability compounds to roughly 1 in 6.

## The fix

All seven now read from a here-string through one `has()` helper. No pipe, no race.

**25 consecutive runs green, 0 red** (was ~1 red in 6).

## Why this is not cosmetic

A verdict-bearing gate that is randomly red teaches everyone to **re-run until
green** — which is also exactly what you do to a real failure. This gate's green
history in CI was luck, not evidence, and the next genuine contract-link break
would have been indistinguishable from the noise.

Found while chasing an unrelated red on #1454: the gate failed, passed on re-run,
then failed differently. "Passes on re-run" was the symptom worth stopping for.