### PR TITLE
Populate the dependency cache atomically and honor --tag in almide add

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -656,11 +656,7 @@ fn dispatch_fmt(files: Vec<String>, check: bool, json: bool, dry_run: bool, no_i
 
 /// `dispatch`'s `Commands::Add` arm. Extracted verbatim.
 fn dispatch_add(pkg: String, git: Option<String>, tag: Option<String>) {
-    let (name, git_url, tag) = if let Some(git_url) = git {
-        (pkg, git_url, tag)
-    } else {
-        project_fetch::resolve_package_spec(&pkg)
-    };
+    let (name, git_url, tag) = project_fetch::resolve_add_target(pkg, git, tag);
     project_fetch::add_dep_to_toml(&name, &git_url, tag.as_deref())
         .unwrap_or_else(|e| { err(&format!("{}", e)); std::process::exit(1); });
     let dep = project::Dependency {

--- a/src/project_fetch.rs
+++ b/src/project_fetch.rs
@@ -22,40 +22,77 @@ pub fn fetch_dep(dep: &Dependency) -> Result<PathBuf, String> {
     fetch_dep_with_lock(dep, None)
 }
 
+/// Populate cache dir `dir` atomically: run `clone` against a fresh sibling
+/// temp dir, then rename it into place. Callers may race — `almide test`
+/// compiles test files on parallel threads and every thread resolves deps,
+/// and two `almide` processes can share `~/.almide` — so the old
+/// "`dir.exists()` then clone into `dir`" let several clones write into the
+/// same directory (`fatal: cannot copy ... File exists`) and left a
+/// half-populated dir that later runs took for a finished cache. With the
+/// rename, `dir` exists only when it is complete; the first rename wins and
+/// the losers discard their own copy.
+fn populate_cache_dir(dir: &Path, clone: impl FnOnce(&Path) -> Result<(), String>) -> Result<(), String> {
+    if dir.exists() {
+        return Ok(());
+    }
+    let parent = dir.parent().ok_or_else(|| "cache dir has no parent".to_string())?;
+    std::fs::create_dir_all(parent)
+        .map_err(|e| format!("Failed to create cache dir: {}", e))?;
+    let leaf = dir.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_default();
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = parent.join(format!(".{}.tmp-{}-{}", leaf, std::process::id(), seq));
+    let _ = std::fs::remove_dir_all(&tmp);
+    if let Err(e) = clone(&tmp) {
+        let _ = std::fs::remove_dir_all(&tmp);
+        return Err(e);
+    }
+    match std::fs::rename(&tmp, dir) {
+        Ok(()) => Ok(()),
+        Err(_) if dir.exists() => {
+            // Another clone finished first; ours is redundant.
+            let _ = std::fs::remove_dir_all(&tmp);
+            Ok(())
+        }
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&tmp);
+            Err(format!("Failed to move fetched dependency into cache: {}", e))
+        }
+    }
+}
+
 /// `fetch_dep_with_lock`'s locked-commit path: clone into a commit-keyed
-/// cache dir and checkout the exact commit. Extracted verbatim.
+/// cache dir and checkout the exact commit.
 fn fetch_dep_at_commit(dep: &Dependency, commit: &str) -> Result<PathBuf, String> {
     let cache = cache_dir();
     let dir = cache.join(&dep.name).join(&commit[..12.min(commit.len())]);
     if dir.exists() {
         return Ok(dir);
     }
-    // Clone and checkout exact commit
-    std::fs::create_dir_all(&dir)
-        .map_err(|e| format!("Failed to create cache dir: {}", e))?;
     err(&format!("Fetching {} from {} (locked: {})", dep.name, dep.git, &commit[..8.min(commit.len())]));
-    let output = Command::new("git")
-        .arg("clone").arg(&dep.git).arg(&dir)
-        .output()
-        .map_err(|e| format!("Failed to run git: {}", e))?;
-    if !output.status.success() {
-        let _ = std::fs::remove_dir_all(&dir);
-        return Err(format!("Failed to fetch {}: {}", dep.name, String::from_utf8_lossy(&output.stderr)));
-    }
-    let checkout = Command::new("git")
-        .arg("-C").arg(&dir)
-        .arg("checkout").arg(commit)
-        .output()
-        .map_err(|e| format!("Failed to checkout commit: {}", e))?;
-    if !checkout.status.success() {
-        let _ = std::fs::remove_dir_all(&dir);
-        return Err(format!("Failed to checkout {} at {}: {}", dep.name, commit, String::from_utf8_lossy(&checkout.stderr)));
-    }
+    populate_cache_dir(&dir, |tmp| {
+        let output = Command::new("git")
+            .arg("clone").arg(&dep.git).arg(tmp)
+            .output()
+            .map_err(|e| format!("Failed to run git: {}", e))?;
+        if !output.status.success() {
+            return Err(format!("Failed to fetch {}: {}", dep.name, String::from_utf8_lossy(&output.stderr)));
+        }
+        let checkout = Command::new("git")
+            .arg("-C").arg(tmp)
+            .arg("checkout").arg(commit)
+            .output()
+            .map_err(|e| format!("Failed to checkout commit: {}", e))?;
+        if !checkout.status.success() {
+            return Err(format!("Failed to checkout {} at {}: {}", dep.name, commit, String::from_utf8_lossy(&checkout.stderr)));
+        }
+        Ok(())
+    })?;
     Ok(dir)
 }
 
 /// `fetch_dep_with_lock`'s ref-based path (tag/branch, no lock pin): clone
-/// into a ref-keyed cache dir. Extracted verbatim.
+/// into a ref-keyed cache dir.
 fn fetch_dep_at_ref(dep: &Dependency, ref_name: &str) -> Result<PathBuf, String> {
     let cache = cache_dir();
     let dep_dir = cache.join(&dep.name).join(ref_name);
@@ -64,31 +101,30 @@ fn fetch_dep_at_ref(dep: &Dependency, ref_name: &str) -> Result<PathBuf, String>
         return Ok(dep_dir);
     }
 
-    std::fs::create_dir_all(&dep_dir)
-        .map_err(|e| format!("Failed to create cache dir: {}", e))?;
-
     err(&format!("Fetching {} from {} ({})", dep.name, dep.git, ref_name));
 
-    let mut cmd = Command::new("git");
-    cmd.arg("clone")
-        .arg("--depth").arg("1")
-        .arg(&dep.git)
-        .arg(&dep_dir);
+    populate_cache_dir(&dep_dir, |tmp| {
+        let mut cmd = Command::new("git");
+        cmd.arg("clone")
+            .arg("--depth").arg("1")
+            .arg(&dep.git)
+            .arg(tmp);
 
-    if let Some(ref tag) = dep.tag {
-        cmd.arg("--branch").arg(tag);
-    } else if let Some(ref branch) = dep.branch {
-        cmd.arg("--branch").arg(branch);
-    }
+        if let Some(ref tag) = dep.tag {
+            cmd.arg("--branch").arg(tag);
+        } else if let Some(ref branch) = dep.branch {
+            cmd.arg("--branch").arg(branch);
+        }
 
-    let output = cmd.output()
-        .map_err(|e| format!("Failed to run git: {}", e))?;
+        let output = cmd.output()
+            .map_err(|e| format!("Failed to run git: {}", e))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let _ = std::fs::remove_dir_all(&dep_dir);
-        return Err(format!("Failed to fetch {}: {}", dep.name, stderr));
-    }
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!("Failed to fetch {}: {}", dep.name, stderr));
+        }
+        Ok(())
+    })?;
 
     Ok(dep_dir)
 }
@@ -299,6 +335,18 @@ pub fn resolve_package_spec(spec: &str) -> (String, String, Option<String>) {
     (name, git_url, tag)
 }
 
+/// Resolve the `almide add` arguments to `(name, git_url, tag)`. `--tag`
+/// applies to both spellings; a `pkg@tag` suffix in the spec is the fallback
+/// when `--tag` is absent. (Previously the spec's tag silently replaced
+/// `--tag`, so `almide add almide/svg --tag v0.1.0` pinned to `main`.)
+pub fn resolve_add_target(pkg: String, git: Option<String>, tag: Option<String>) -> (String, String, Option<String>) {
+    if let Some(git_url) = git {
+        return (pkg, git_url, tag);
+    }
+    let (name, git_url, spec_tag) = resolve_package_spec(&pkg);
+    (name, git_url, tag.or(spec_tag))
+}
+
 /// Add a dependency to almide.toml
 pub fn add_dep_to_toml(name: &str, git: &str, tag: Option<&str>) -> Result<(), String> {
     // Package names must be valid Almide identifiers (no hyphens).
@@ -430,4 +478,68 @@ fn git_remote_head(git_url: &str, ref_name: &str) -> Result<String, String> {
         return Err(format!("no ref '{}' at {}", ref_name, git_url));
     }
     Ok(hash)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_tag_flag_is_kept_for_short_specs() {
+        let (name, git, tag) = resolve_add_target("almide/svg".into(), None, Some("v0.1.0".into()));
+        assert_eq!(name, "svg");
+        assert_eq!(git, "https://github.com/almide/svg");
+        assert_eq!(tag.as_deref(), Some("v0.1.0"));
+    }
+
+    #[test]
+    fn add_tag_flag_wins_over_spec_suffix_and_suffix_is_fallback() {
+        let (_, _, tag) = resolve_add_target("svg@v0.2.0".into(), None, Some("v0.1.0".into()));
+        assert_eq!(tag.as_deref(), Some("v0.1.0"));
+        let (_, _, tag) = resolve_add_target("svg@v0.2.0".into(), None, None);
+        assert_eq!(tag.as_deref(), Some("v0.2.0"));
+    }
+
+    #[test]
+    fn populate_cache_dir_survives_concurrent_callers() {
+        let root = std::env::temp_dir().join(format!("almide-populate-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let dir = root.join("dep").join("abcdef123456");
+        let handles: Vec<_> = (0..8).map(|i| {
+            let dir = dir.clone();
+            std::thread::spawn(move || {
+                populate_cache_dir(&dir, |tmp| {
+                    std::fs::create_dir_all(tmp).map_err(|e| e.to_string())?;
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                    std::fs::write(tmp.join("marker"), format!("{}", i)).map_err(|e| e.to_string())
+                })
+            })
+        }).collect();
+        for h in handles {
+            h.join().unwrap().unwrap();
+        }
+        // Exactly one complete copy is in place and no temp dirs are left behind.
+        assert!(dir.join("marker").is_file());
+        let leftovers: Vec<_> = std::fs::read_dir(dir.parent().unwrap()).unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|n| n != "abcdef123456")
+            .collect();
+        assert!(leftovers.is_empty(), "leftover temp dirs: {:?}", leftovers);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn populate_cache_dir_leaves_nothing_when_clone_fails() {
+        let root = std::env::temp_dir().join(format!("almide-populate-fail-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let dir = root.join("dep").join("deadbeef0000");
+        let r = populate_cache_dir(&dir, |tmp| {
+            std::fs::create_dir_all(tmp).map_err(|e| e.to_string())?;
+            Err("boom".to_string())
+        });
+        assert_eq!(r, Err("boom".to_string()));
+        assert!(!dir.exists());
+        assert!(std::fs::read_dir(dir.parent().unwrap()).unwrap().next().is_none());
+        let _ = std::fs::remove_dir_all(&root);
+    }
 }


### PR DESCRIPTION
Two dependency-management defects found while setting up a project on 0.57.0 (both reproduce with the released binary; both fixed here with unit tests).

## 1. `almide test` with a cold `~/.almide/cache` corrupts the cache

`cmd_test` compiles test files on parallel threads and every thread resolves the project's deps. `fetch_dep_at_commit` / `fetch_dep_at_ref` did "`dir.exists()` → `create_dir_all(dir)` → `git clone <url> <dir>`", so concurrent threads (or two `almide` processes sharing the cache) cloned into the same directory:

```
Failed to fetch svg: Cloning into '~/.almide/cache/svg/dee89e341b05'...
fatal: cannot copy '.../templates/info/exclude' to '.../.git/info/exclude': File exists
```

and the loser's `remove_dir_all` left a half-populated dir that the next run took for a finished cache (so the *warm* run failed too). On a 2-file project with one git dep: 2/3 cold runs failed with the released 0.57.0.

Fix: `populate_cache_dir` clones into a fresh sibling temp dir and `rename`s it into place; the first rename wins, losers discard their copy, and a failed clone leaves nothing behind. `dir` now exists only when complete. Same project, 5/5 cold runs pass with this build; no temp dirs left.

## 2. `almide add <pkg> --tag <tag>` ignores `--tag`

`dispatch_add` took the tag from `resolve_package_spec` (the `pkg@tag` suffix) and dropped the `--tag` argument whenever `--git` was absent, so `almide add almide/svg --tag v0.1.0` wrote `svg = { git = ... }` and pinned `ref = "main"`. Extracted `resolve_add_target` (`--tag` wins, `@tag` suffix is the fallback) and wired `dispatch_add` to it. Verified: `almide add almide/svg --tag v0.1.0` now writes `tag = "v0.1.0"` and the lock records `ref = "v0.1.0"`.

## Verification

- `cargo test --lib project_fetch`: 4 new tests (tag precedence ×2, concurrent populate ×8 threads leaves one copy and no temps, failed clone leaves nothing)
- `scripts/check-rustc-warnings.sh`: 0 warnings (baseline 0)
- `almide test spec/lang` with the patched release build: 197/197 files pass
- Manual: cold-cache `almide test` 5/5 on a project with a git dep (released binary: 2/3 failed)