### PR TITLE
Spaced global identities put import-self projects on the structural leg

### DIFF
--- a/ci/mutations/018-init-decl-order.patch
+++ b/ci/mutations/018-init-decl-order.patch
@@ -1,19 +1,16 @@
 diff --git a/crates/almide-wasm/src/lib.rs b/crates/almide-wasm/src/lib.rs
-index cd70046b3..f820c338e 100644
+index cde211f7a..08cfed973 100644
 --- a/crates/almide-wasm/src/lib.rs
 +++ b/crates/almide-wasm/src/lib.rs
-@@ -660,8 +660,12 @@ pub fn emit_program(ir: &IrProgram) -> Result<Vec<u8>, EmitError> {
-                 inputs.push(top_let_inputs(tl));
-             }
+@@ -578,7 +578,10 @@ fn build_globals(
+             global_map.insert(use_g, slot);
          }
--        let (_info, alias, _off) = build_global_tables(&inputs, &ir.var_table);
--        dependency_init_order(ir, &alias)
-+        let (_info, _alias, _off) = build_global_tables(&inputs, &ir.var_table);
-+        let mut decl: Vec<VarId> = ir.top_lets.iter().map(|t| t.var).collect();
-+        for m in &ir.modules {
-+            decl.extend(m.top_lets.iter().map(|t| t.var));
-+        }
-+        decl
-     };
-     let mut init_by_var: HashMap<VarId, &IrTopLet> = HashMap::new();
+     }
+-    let init_order = dependency_init_order_spaced(ir, &alias);
++    let mut init_order: Vec<GVar> = ir.top_lets.iter().map(|t| (0, t.var)).collect(); // [MUTANT: decl order]
++    for (i, m) in ir.modules.iter().enumerate() {
++        init_order.extend(m.top_lets.iter().map(|t| (i as u32 + 1, t.var)));
++    }
+     let mut init_by_var: HashMap<GVar, InitLet> = HashMap::new();
      for tl in &ir.top_lets {
+         init_by_var.insert((0, tl.var), InitLet { space: 0, module: None, tl: tl.clone() });

--- a/crates/almide-ir/src/top_let_storage.rs
+++ b/crates/almide-ir/src/top_let_storage.rs
@@ -289,6 +289,173 @@ pub fn dependency_init_order(
     topo_sort_emit(&decl_order, &deps)
 }
 
+/// Space-aware [`dependency_init_order`]: the same six steps with every
+/// variable identity a `GVar` and every scanned body tagged with the space
+/// its `VarId`s index. Returns the init order as `GVar`s (the consumer
+/// emits each initializer in its own space).
+pub fn dependency_init_order_spaced(
+    program: &IrProgram,
+    alias: &HashMap<GVar, GVar>,
+) -> Vec<GVar> {
+    // Step 1: legacy emission order — (decl, owning module, initializer).
+    let mut decl_order: Vec<(GVar, Option<&str>, &IrExpr)> = Vec::new();
+    for tl in &program.top_lets {
+        decl_order.push(((0, tl.var), None, &tl.value));
+    }
+    for (i, m) in program.modules.iter().enumerate() {
+        for tl in &m.top_lets {
+            decl_order.push(((i as SpaceId + 1, tl.var), Some(m.name.as_str()), &tl.value));
+        }
+    }
+    let decls: HashSet<GVar> = decl_order.iter().map(|(g, _, _)| *g).collect();
+
+    // Scan one body whose `VarId`s live in `space`.
+    let scan = |space: SpaceId, expr: &IrExpr| -> (Vec<GVar>, Vec<FnKey>) {
+        use crate::visit::{walk_expr, IrVisitor};
+        struct Collector<'a> {
+            space: SpaceId,
+            alias: &'a HashMap<GVar, GVar>,
+            decls: &'a HashSet<GVar>,
+            reads: Vec<GVar>,
+            calls: Vec<FnKey>,
+        }
+        impl IrVisitor for Collector<'_> {
+            fn visit_expr(&mut self, e: &IrExpr) {
+                match &e.kind {
+                    IrExprKind::Var { id } => {
+                        let g = (self.space, *id);
+                        let decl = self.alias.get(&g).copied().unwrap_or(g);
+                        if self.decls.contains(&decl) && !self.reads.contains(&decl) {
+                            self.reads.push(decl);
+                        }
+                    }
+                    IrExprKind::Call { target, .. } => {
+                        if let Some(k) = fn_key_of_target(target) {
+                            if !self.calls.contains(&k) {
+                                self.calls.push(k);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+                walk_expr(self, e);
+            }
+        }
+        let mut c = Collector { space, alias, decls: &decls, reads: Vec::new(), calls: Vec::new() };
+        c.visit_expr(expr);
+        (c.reads, c.calls)
+    };
+
+    // Step 2: index every user function (with its space) by identity.
+    let mut fn_reads: HashMap<FnKey, Vec<GVar>> = HashMap::new();
+    let mut fn_calls: HashMap<FnKey, Vec<FnKey>> = HashMap::new();
+    let mut index_fn = |space: SpaceId, f: &IrFunction| {
+        let (reads, calls) = scan(space, &f.body);
+        let key = fn_key_of_function(f);
+        fn_reads.entry(key.clone()).or_default().extend(reads);
+        fn_calls.entry(key).or_default().extend(calls);
+    };
+    for f in &program.functions {
+        index_fn(0, f);
+    }
+    for (i, m) in program.modules.iter().enumerate() {
+        for f in &m.functions {
+            index_fn(i as SpaceId + 1, f);
+        }
+    }
+
+    // Step 3: transitive global read-set per function.
+    fn reads_of(
+        key: &FnKey,
+        fn_reads: &HashMap<FnKey, Vec<GVar>>,
+        fn_calls: &HashMap<FnKey, Vec<FnKey>>,
+        seen: &mut HashSet<FnKey>,
+        out: &mut Vec<GVar>,
+    ) {
+        if !seen.insert(key.clone()) {
+            return;
+        }
+        if let Some(rs) = fn_reads.get(key) {
+            for &r in rs {
+                if !out.contains(&r) {
+                    out.push(r);
+                }
+            }
+        }
+        if let Some(cs) = fn_calls.get(key) {
+            for c in cs {
+                reads_of(c, fn_reads, fn_calls, seen, out);
+            }
+        }
+    }
+
+    // Step 4: module → its top-let global decls (coarse safety net).
+    let mut module_globals: HashMap<&str, Vec<GVar>> = HashMap::new();
+    for &(g, m, _) in &decl_order {
+        if let Some(mn) = m {
+            module_globals.entry(mn).or_default().push(g);
+        }
+    }
+
+    // Step 5: per-top-let dependency set.
+    let mut deps: HashMap<GVar, Vec<GVar>> = HashMap::new();
+    for &(g, owner, expr) in &decl_order {
+        let (direct, calls) = scan(g.0, expr);
+        let mut dep: Vec<GVar> = direct;
+        for c in &calls {
+            let mut seen = HashSet::new();
+            let mut reads = Vec::new();
+            reads_of(c, &fn_reads, &fn_calls, &mut seen, &mut reads);
+            for r in reads {
+                if !dep.contains(&r) {
+                    dep.push(r);
+                }
+            }
+        }
+        if owner.is_none() {
+            for gs in module_globals.values() {
+                for &mg in gs {
+                    if !dep.contains(&mg) {
+                        dep.push(mg);
+                    }
+                }
+            }
+        }
+        dep.retain(|d| *d != g);
+        deps.insert(g, dep);
+    }
+
+    // Step 6: stable topological emit.
+    fn visit(
+        g: GVar,
+        deps: &HashMap<GVar, Vec<GVar>>,
+        done: &mut HashSet<GVar>,
+        on_stack: &mut HashSet<GVar>,
+        emitted: &mut Vec<GVar>,
+    ) {
+        if done.contains(&g) || on_stack.contains(&g) {
+            return;
+        }
+        on_stack.insert(g);
+        if let Some(ds) = deps.get(&g) {
+            for &d in ds {
+                visit(d, deps, done, on_stack, emitted);
+            }
+        }
+        on_stack.remove(&g);
+        if done.insert(g) {
+            emitted.push(g);
+        }
+    }
+    let mut emitted: Vec<GVar> = Vec::with_capacity(decl_order.len());
+    let mut done: HashSet<GVar> = HashSet::new();
+    let mut on_stack: HashSet<GVar> = HashSet::new();
+    for &(g, _, _) in &decl_order {
+        visit(g, &deps, &mut done, &mut on_stack, &mut emitted);
+    }
+    emitted
+}
+
 /// Step 1: the legacy emission order — (decl VarId, owning module, &initializer).
 /// `None` module = root.
 fn build_decl_order(program: &IrProgram) -> Vec<(VarId, Option<&str>, &IrExpr)> {
@@ -458,6 +625,91 @@ fn alias_key(vi: &VarInfo) -> (String, String) {
         vi.module_origin.as_deref().unwrap_or("").to_uppercase().replace('.', "_"),
         vi.name.as_str().to_uppercase(),
     )
+}
+
+// ── Space-aware form (#1596) ────────────────────────────────────────────
+//
+// Separately-lowered modules carry their OWN `VarTable` (each starting at
+// VarId 0), so a bare-VarId key collides across module tables and with the
+// program's — the panic/wrong-slot class the structural wasm leg hit on
+// `import self` packages. `SpaceId` names the table a VarId belongs to;
+// every global-machinery identity below is the (space, var) pair. The flat
+// forms above stay for the single-space callers (the Rust-target pass,
+// where module vars share the program counter by construction).
+
+/// Which `VarTable` a `VarId` indexes: 0 = the program root,
+/// i+1 = `program.modules[i]`.
+pub type SpaceId = u32;
+/// A globally-unambiguous variable identity.
+pub type GVar = (SpaceId, VarId);
+
+/// The `VarInfo` a `GVar` names. Panics on an out-of-range id — by the time
+/// the global machinery runs, every top-let var is in its own table by
+/// construction.
+pub fn spaced_var<'a>(program: &'a IrProgram, g: GVar) -> &'a VarInfo {
+    let (space, var) = g;
+    if space == 0 {
+        program.var_table.get(var)
+    } else {
+        program.modules[(space - 1) as usize].var_table.get(var)
+    }
+}
+
+/// Space-aware [`GlobalInfo`]: the decl is a `GVar`.
+#[derive(Debug, Clone)]
+pub struct SpacedGlobalInfo {
+    pub storage: TopLetStorage,
+    pub static_name: String,
+    pub decl: GVar,
+}
+
+/// Space-aware [`build_global_tables`]: derives the spaces from the program
+/// itself. The alias map resolves EVERY table's module-origin use-site vars
+/// to their declaration `GVar` (cross-space reads: the entry reading
+/// `m.SYSTEM`, one module reading another's global).
+pub fn build_global_tables_spaced(
+    program: &IrProgram,
+) -> (HashMap<GVar, SpacedGlobalInfo>, HashMap<GVar, GVar>, Vec<String>) {
+    let mut globals: HashMap<GVar, SpacedGlobalInfo> = HashMap::new();
+    let mut by_key: HashMap<(String, String), GVar> = HashMap::new();
+    let mut each_top_let = |space: SpaceId, tls: &[IrTopLet], table: &VarTable| {
+        for tl in tls {
+            let (mutable, kind, var, init_aborts) = top_let_inputs(tl);
+            let g = (space, var);
+            let vi = table.get(var);
+            let storage = classify_storage(mutable, kind, &vi.ty, init_aborts);
+            globals.insert(g, SpacedGlobalInfo { storage, static_name: static_name(vi), decl: g });
+            by_key.insert(alias_key(vi), g);
+        }
+    };
+    each_top_let(0, &program.top_lets, &program.var_table);
+    for (i, m) in program.modules.iter().enumerate() {
+        each_top_let(i as SpaceId + 1, &m.top_lets, &m.var_table);
+    }
+    let mut alias: HashMap<GVar, GVar> = HashMap::new();
+    let mut offenders: Vec<String> = Vec::new();
+    let mut each_table = |space: SpaceId, table: &VarTable| {
+        for (i, vi) in table.entries.iter().enumerate() {
+            let g = (space, VarId(i as u32));
+            if vi.module_origin.is_none() || globals.contains_key(&g) {
+                continue;
+            }
+            match by_key.get(&alias_key(vi)) {
+                Some(&decl) => {
+                    alias.insert(g, decl);
+                }
+                None => offenders.push(format!(
+                    "space {} var #{} `{}` (origin {:?})",
+                    space, i, vi.name.as_str(), vi.module_origin
+                )),
+            }
+        }
+    };
+    each_table(0, &program.var_table);
+    for (i, m) in program.modules.iter().enumerate() {
+        each_table(i as SpaceId + 1, &m.var_table);
+    }
+    (globals, alias, offenders)
 }
 
 /// Build the decl table + resolve every module-origin use-site VarId to its

--- a/crates/almide-wasm/src/display.rs
+++ b/crates/almide-wasm/src/display.rs
@@ -486,6 +486,7 @@ fn build_one_scan_helper(
     let empty_cells = std::collections::HashSet::new();
     {
         let mut em = Emitter {
+            var_space: 0,
             pool,
             locals: &empty_locals,
             rc_param_ceiling: 0,
@@ -579,6 +580,7 @@ fn build_one_eq_helper(
     let empty_cells = std::collections::HashSet::new();
     {
         let mut em = Emitter {
+            var_space: 0,
             pool,
             locals: &empty_locals,
             rc_param_ceiling: 0,
@@ -646,6 +648,7 @@ fn build_one_display_helper(
     let empty_cells = std::collections::HashSet::new();
     {
         let mut em = Emitter {
+            var_space: 0,
             pool,
             locals: &empty_locals,
             rc_param_ceiling: 0,

--- a/crates/almide-wasm/src/emit.rs
+++ b/crates/almide-wasm/src/emit.rs
@@ -54,7 +54,7 @@ fn emit_program_pass(
 
     let mut table =
         FnTable { by_name: HashMap::new(), impl_index: HashMap::new(), infos: Vec::new() };
-    for (i, (f, qual)) in program_fns.iter().enumerate() {
+    for (i, (f, qual, _space)) in program_fns.iter().enumerate() {
         let (params, ret, refuse) = match fn_signature(f, &types) {
             Ok((p, r)) => (p, r, None),
             Err(reason) => (Vec::new(), None, Some(reason)),
@@ -90,7 +90,7 @@ fn emit_program_pass(
     // Lower every callable function; a body that doesn't lower yet is
     // recorded (not fatal) — fatal only if `main` can reach it.
     let mut lowered: Vec<Result<(Function, HashSet<usize>), String>> = Vec::new();
-    for (i, (f, qual)) in program_fns.iter().enumerate() {
+    for (i, (f, qual, space)) in program_fns.iter().enumerate() {
         if let Some(r) = &table.infos[i].refuse {
             lowered.push(Err(r.clone()));
             continue;
@@ -122,6 +122,7 @@ fn emit_program_pass(
             metered: meter.user.contains(f.name.as_str()),
             charge_entry: meter.user.contains(f.name.as_str())
                 && !meter.exempt.contains(f.name.as_str()),
+            var_space: *space,
         };
         match lower_fn(&params, plan, &f.body, &[], &ctx, &mut pool) {
             Ok(ok) => {
@@ -158,6 +159,7 @@ fn emit_program_pass(
     let main_plan = FnPlan {
         ret: None,
         cur_module: None,
+        var_space: 0,
         effect_raw: None,
         in_main: true,
         env_captures: None,
@@ -185,6 +187,7 @@ fn emit_program_pass(
             let plan = FnPlan {
                 ret: ll.ret,
                 cur_module: None,
+                var_space: ll.var_space,
                 effect_raw: ll.effect_raw,
                 in_main: false,
                 env_captures: Some(ll.captures.clone()),
@@ -245,7 +248,7 @@ fn emit_program_pass(
     // lowers; one that (transitively) hits an unlowered body is simply not
     // exported — main-reachable strictness above is untouched.
     let mut export_fns: Vec<(String, u32)> = Vec::new();
-    for (i, (f, qual)) in program_fns.iter().enumerate() {
+    for (i, (f, qual, _space)) in program_fns.iter().enumerate() {
         let name = f.name.as_str();
         if qual.is_some()
             || name == "main"

--- a/crates/almide-wasm/src/emitter.rs
+++ b/crates/almide-wasm/src/emitter.rs
@@ -49,9 +49,14 @@ pub(crate) struct Emitter<'a> {
     /// Function-value work: funcref-table entries, call_indirect types,
     /// lifted lambdas (W-1/W-2).
     pub(crate) work: &'a FnWork,
-    /// Top-let globals (VarId → wasm global index + type): the fallback
-    /// when a Var/Assign misses the locals map.
-    pub(crate) globals: &'a HashMap<VarId, (u32, SliceTy)>,
+    /// Top-let globals ((space, VarId) → wasm global index + type): the
+    /// fallback when a Var/Assign misses the locals map. Spaced (#1596):
+    /// separately-lowered modules each restart VarIds at 0, so the bare
+    /// id is ambiguous — lookups pair it with `var_space`.
+    pub(crate) globals: &'a HashMap<crate::GVar, (u32, SliceTy)>,
+    /// Which VarTable this function's VarIds index (0 = the entry
+    /// program, i+1 = `ir.modules[i]`).
+    pub(crate) var_space: u32,
     /// Deferred head-only range binds (C-238): VarId → (start local,
     /// end local, inclusive). No block exists for these vars.
     pub(crate) deferred_ranges: &'a HashMap<VarId, (u32, u32, bool)>,
@@ -312,7 +317,7 @@ impl Emitter<'_> {
                         self.load_ty_slot(ty, 0);
                     }
                     ty
-                } else if let Some(&(gidx, ty)) = self.globals.get(id) {
+                } else if let Some(&(gidx, ty)) = self.globals.get(&(self.var_space, *id)) {
                     self.f.instructions().global_get(gidx);
                     ty
                 } else {
@@ -708,6 +713,7 @@ impl Emitter<'_> {
                     effect_raw,
                     body: body.clone(),
                     captures: captures.clone(),
+                    var_space: self.var_space,
                 });
                 let slot = self.work.slot(TableEntry::Lambda(j));
                 if captures.is_empty() {

--- a/crates/almide-wasm/src/emitter_vars.rs
+++ b/crates/almide-wasm/src/emitter_vars.rs
@@ -34,7 +34,7 @@ impl Emitter<'_> {
         self.locals
             .get(id)
             .map(|&(i, t)| (i, t, false))
-            .or_else(|| self.globals.get(id).map(|&(i, t)| (i, t, true)))
+            .or_else(|| self.globals.get(&(self.var_space, *id)).map(|&(i, t)| (i, t, true)))
     }
 
     /// Push the mut var's current VALUE (cells deref for locals).

--- a/crates/almide-wasm/src/func.rs
+++ b/crates/almide-wasm/src/func.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use almide_ir::{IrFunction, IrTopLet, VarId};
+use almide_ir::{IrFunction, VarId};
 use almide_types::types::Ty;
 use wasm_encoder::{Function, ValType};
 
@@ -83,17 +83,21 @@ pub(crate) struct FnPlan {
     /// Lifted lambda: raw wasm param 0 is the closure ENV block; the
     /// prelude loads each capture into a fresh local (value snapshot).
     pub(crate) env_captures: Option<Vec<(VarId, SliceTy, u32, bool)>>,
+    /// Which VarTable this body's VarIds index (0 = entry program,
+    /// i+1 = `ir.modules[i]`) — the global-lookup space (#1596).
+    pub(crate) var_space: u32,
 }
 
 pub(crate) fn lower_fn(
     params: &[(VarId, SliceTy)],
     plan: FnPlan,
     body: &IrExpr,
-    top_lets: &[IrTopLet],
+    top_lets: &[crate::InitLet],
     ctx: &Ctx,
     pool: &mut Pool,
 ) -> Result<(Function, HashSet<usize>), EmitError> {
-    let FnPlan { ret, effect_raw, in_main, env_captures, cur_module, metered, charge_entry } = plan;
+    let FnPlan { ret, effect_raw, in_main, env_captures, cur_module, metered, charge_entry, var_space } =
+        plan;
     let cur_module = cur_module.as_deref();
     let env_shift: u32 = u32::from(env_captures.is_some());
     let mut locals: HashMap<VarId, (u32, SliceTy)> = HashMap::new();
@@ -117,14 +121,29 @@ pub(crate) fn lower_fn(
             }
         }
     }
-    for tl in top_lets {
+    for il in top_lets {
+        let tl = &il.tl;
         if slice_ty_of(&tl.ty, ctx.types).is_none() {
             return unsup(&format!("bind-ty:{}", ty_name(&tl.ty)));
         };
-        // The top-let var itself is a GLOBAL; only its initializer's
-        // inner binds need main locals.
-        seen.insert(tl.var);
-        collect_binds(&tl.value, &mut binds, &mut seen, ctx.types)?;
+        if il.space == 0 {
+            // The top-let var itself is a GLOBAL; only its initializer's
+            // inner binds need main locals.
+            seen.insert(tl.var);
+            collect_binds(&tl.value, &mut binds, &mut seen, ctx.types)?;
+        } else {
+            // A MODULE-space initializer (#1596): its inner binds would
+            // index a different VarTable than main's locals map, so
+            // increment 1 admits only bind-free initializers (literals,
+            // ctor/fn-call values). The rest wall honestly — and the
+            // routing rerroutes the program to the incumbent leg.
+            let mut probe: Vec<(VarId, SliceTy)> = Vec::new();
+            let mut probe_seen: HashSet<VarId> = HashSet::new();
+            collect_binds(&tl.value, &mut probe, &mut probe_seen, ctx.types)?;
+            if !probe.is_empty() {
+                return unsup("modinit:inner-binds");
+            }
+        }
     }
     collect_binds(body, &mut binds, &mut seen, ctx.types)?;
 
@@ -217,6 +236,7 @@ pub(crate) fn lower_fn(
             loop_ctl: None,
             in_tail: false,
             cur_module,
+            var_space,
             in_main,
             work: ctx.work,
             globals: ctx.globals,
@@ -247,11 +267,22 @@ pub(crate) fn lower_fn(
                 em.f.instructions().local_set(idx);
             }
         }
-        for tl in top_lets {
-            let Some(&(gidx, declared)) = ctx.globals.get(&tl.var) else {
+        for il in top_lets {
+            let tl = &il.tl;
+            let Some(&(gidx, declared)) = ctx.globals.get(&(il.space, tl.var)) else {
                 return unsup(&format!("bind-ty:{}", ty_name(&tl.ty)));
             };
-            em.lower(&tl.value, Some(declared))?;
+            // A module initializer lowers in ITS OWN space: its Var reads
+            // index that module's table and its bare Named calls resolve
+            // module-qualified first (#1596).
+            let saved_space = em.var_space;
+            let saved_module = em.cur_module;
+            em.var_space = il.space;
+            em.cur_module = il.module.as_deref();
+            let lowered = em.lower(&tl.value, Some(declared));
+            em.var_space = saved_space;
+            em.cur_module = saved_module;
+            lowered?;
             if matches!(
                 declared,
                 SliceTy::List(_)

--- a/crates/almide-wasm/src/lib.rs
+++ b/crates/almide-wasm/src/lib.rs
@@ -443,10 +443,10 @@ pub(crate) struct Ctx<'a> {
     pub(crate) table: &'a FnTable,
     pub(crate) types: &'a TypeTable,
     pub(crate) work: &'a FnWork,
-    /// Top-let vars (root + module) as WASM GLOBALS: VarId → (global
-    /// index, slice type). Functions read them across function
+    /// Top-let vars (root + module) as WASM GLOBALS: (space, VarId) →
+    /// (global index, slice type). Functions read them across function
     /// boundaries — the class main-local top-lets could never serve.
-    pub(crate) globals: &'a HashMap<VarId, (u32, SliceTy)>,
+    pub(crate) globals: &'a HashMap<GVar, (u32, SliceTy)>,
 }
 
 /// Function-VALUE work discovered during lowering: funcref-table entries
@@ -475,6 +475,9 @@ pub(crate) struct LiftedLambda {
     /// The lifted fn's prelude loads each from the env param (raw param
     /// slot 0) into a fresh local — by-value snapshot semantics.
     pub(crate) captures: Vec<(VarId, SliceTy, u32, bool)>,
+    /// The variable space the body's VarIds index (the lifting fn's own
+    /// space — a lambda inside a module fn reads module-space globals).
+    pub(crate) var_space: u32,
 }
 
 /// A call_indirect signature at the wasm value-type level.
@@ -513,26 +516,45 @@ fn pattern_irrefutable(p: &IrPattern) -> bool {
     }
 }
 
+pub(crate) use almide_ir::top_let_storage::GVar;
+
+/// One top-let initializer for main's prelude: the space its body's VarIds
+/// index and the module whose fns it may call by bare name (None = root).
+#[derive(Clone)]
+pub(crate) struct InitLet {
+    pub(crate) space: u32,
+    pub(crate) module: Option<String>,
+    pub(crate) tl: IrTopLet,
+}
+
 /// Top-lets (root + module) as wasm globals + the dependency init order
 /// (split from emit_program for the complexity budget).
 #[allow(clippy::type_complexity)]
 fn build_globals(
     ir: &IrProgram,
     types: &TypeTable,
-) -> (HashMap<VarId, (u32, SliceTy)>, Vec<(VarId, SliceTy)>, Vec<IrTopLet>) {
+) -> (HashMap<GVar, (u32, SliceTy)>, Vec<(VarId, SliceTy)>, Vec<InitLet>) {
     // Top-lets (root + module) become wasm globals — zero-initialized,
     // then set by main's prelude in DEPENDENCY order (C-077: the same
     // `dependency_init_order` the interp uses, so the order matches by
-    // construction).
-    let mut global_map: HashMap<VarId, (u32, SliceTy)> = HashMap::new();
+    // construction). Identities are SPACED (#1596): separately-lowered
+    // modules each carry their own VarTable starting at VarId 0, so a
+    // bare-VarId key collides across tables — the (space, var) pair is
+    // the unambiguous name, and every use-site alias (the entry reading
+    // `m.SYSTEM`) maps to its declaration's slot.
+    use almide_ir::top_let_storage::{
+        build_global_tables_spaced, dependency_init_order_spaced,
+    };
+    let mut global_map: HashMap<GVar, (u32, SliceTy)> = HashMap::new();
     let mut global_decls: Vec<(VarId, SliceTy)> = Vec::new();
     {
         let mut next = G_FIXED_COUNT;
-        let mut add = |tl: &IrTopLet,
-                       map: &mut HashMap<VarId, (u32, SliceTy)>,
+        let mut add = |space: u32,
+                       tl: &IrTopLet,
+                       map: &mut HashMap<GVar, (u32, SliceTy)>,
                        decls: &mut Vec<(VarId, SliceTy)>| {
             if let Some(sty) = slice_ty_of(&tl.ty, types) {
-                map.insert(tl.var, (next, sty));
+                map.insert((space, tl.var), (next, sty));
                 decls.push((tl.var, sty));
                 next += 1;
             }
@@ -540,55 +562,53 @@ fn build_globals(
             // refuses at the var site with its own honest reason.
         };
         for tl in &ir.top_lets {
-            add(tl, &mut global_map, &mut global_decls);
+            add(0, tl, &mut global_map, &mut global_decls);
         }
-        for m in &ir.modules {
+        for (i, m) in ir.modules.iter().enumerate() {
             for tl in &m.top_lets {
-                add(tl, &mut global_map, &mut global_decls);
+                add(i as u32 + 1, tl, &mut global_map, &mut global_decls);
             }
         }
     }
-    let init_order: Vec<VarId> = {
-        use almide_ir::top_let_storage::{
-            build_global_tables, dependency_init_order, top_let_inputs,
-        };
-        let mut inputs = Vec::new();
-        for tl in &ir.top_lets {
-            inputs.push(top_let_inputs(tl));
+    let (_info, alias, _off) = build_global_tables_spaced(ir);
+    // Use-site aliases resolve to the declaration's slot — one lookup at
+    // the Var site whatever space the read happens in.
+    for (&use_g, &decl_g) in &alias {
+        if let Some(&slot) = global_map.get(&decl_g) {
+            global_map.insert(use_g, slot);
         }
-        for m in &ir.modules {
-            for tl in &m.top_lets {
-                inputs.push(top_let_inputs(tl));
-            }
-        }
-        let (_info, alias, _off) = build_global_tables(&inputs, &ir.var_table);
-        dependency_init_order(ir, &alias)
-    };
-    let mut init_by_var: HashMap<VarId, &IrTopLet> = HashMap::new();
+    }
+    let init_order = dependency_init_order_spaced(ir, &alias);
+    let mut init_by_var: HashMap<GVar, InitLet> = HashMap::new();
     for tl in &ir.top_lets {
-        init_by_var.insert(tl.var, tl);
+        init_by_var.insert((0, tl.var), InitLet { space: 0, module: None, tl: tl.clone() });
     }
-    for m in &ir.modules {
+    for (i, m) in ir.modules.iter().enumerate() {
         for tl in &m.top_lets {
-            init_by_var.insert(tl.var, tl);
+            init_by_var.insert(
+                (i as u32 + 1, tl.var),
+                InitLet { space: i as u32 + 1, module: Some(m.name.as_str().to_string()), tl: tl.clone() },
+            );
         }
     }
-    let init_lets: Vec<IrTopLet> =
-        init_order.iter().filter_map(|v| init_by_var.get(v).map(|tl| (*tl).clone())).collect();
+    let init_lets: Vec<InitLet> =
+        init_order.iter().filter_map(|g| init_by_var.get(g).cloned()).collect();
     (global_map, global_decls, init_lets)
 }
 
 
 /// The callable-fn flattening (entry fns + module fns under qualified
-/// names, Hole-bodied surfaces excluded) — split from emit_program.
-fn collect_program_fns(ir: &IrProgram) -> Vec<(&IrFunction, Option<String>)> {
-    let mut program_fns: Vec<(&IrFunction, Option<String>)> = ir
+/// names, Hole-bodied surfaces excluded) — split from emit_program. The
+/// third field is the fn's variable SPACE (0 = entry program, i+1 =
+/// `ir.modules[i]` — #1596): module fn bodies index their own VarTable.
+fn collect_program_fns(ir: &IrProgram) -> Vec<(&IrFunction, Option<String>, u32)> {
+    let mut program_fns: Vec<(&IrFunction, Option<String>, u32)> = ir
         .functions
         .iter()
         .filter(|f| !f.is_test && f.name.as_str() != "main")
-        .map(|f| (f, None))
+        .map(|f| (f, None, 0))
         .collect();
-    for m in &ir.modules {
+    for (i, m) in ir.modules.iter().enumerate() {
         for f in &m.functions {
             // A Hole body is a bodyless SURFACE decl (`= _`) — a bridge
             // boundary, not an implementation. Registering it would
@@ -596,8 +616,11 @@ fn collect_program_fns(ir: &IrProgram) -> Vec<(&IrFunction, Option<String>)> {
             // an unlowersble stub (found by the burn-up: expr:Hole ×70).
             let is_surface = matches!(f.body.kind, IrExprKind::Hole);
             if !f.is_test && !is_surface {
-                program_fns
-                    .push((f, Some(format!("{}.{}", m.name.as_str(), f.name.as_str()))));
+                program_fns.push((
+                    f,
+                    Some(format!("{}.{}", m.name.as_str(), f.name.as_str())),
+                    i as u32 + 1,
+                ));
             }
         }
     }

--- a/crates/almide-wasm/src/stmts.rs
+++ b/crates/almide-wasm/src/stmts.rs
@@ -495,7 +495,7 @@ impl Emitter<'_> {
 
                 let (is_local, declared) = match self.locals.get(target) {
                     Some(&(_, d)) => (true, d),
-                    None => match self.globals.get(target) {
+                    None => match self.globals.get(&(self.var_space, *target)) {
                         Some(&(_, d)) => (false, d),
                         None => return unsup("index-assign:unmapped"),
                     },
@@ -513,11 +513,12 @@ impl Emitter<'_> {
                 let hv = self.hold_val(el)?;
                 let hb = self.hold_i32()?;
                 self.f.instructions().local_set(hv);
-                let get_target = |f: &mut wasm_encoder::Function, locals: &HashMap<VarId, (u32, SliceTy)>, globals: &HashMap<VarId, (u32, SliceTy)>| {
+                let var_space = self.var_space;
+                let get_target = |f: &mut wasm_encoder::Function, locals: &HashMap<VarId, (u32, SliceTy)>, globals: &HashMap<GVar, (u32, SliceTy)>| {
                     if is_local {
                         f.instructions().local_get(locals[target].0);
                     } else {
-                        f.instructions().global_get(globals[target].0);
+                        f.instructions().global_get(globals[&(var_space, *target)].0);
                     }
                 };
                 // OOB → the exact native frame + exit 1.
@@ -543,7 +544,7 @@ impl Emitter<'_> {
                     let idx = self.locals[target].0;
                     self.f.instructions().local_get(hb).local_set(idx);
                 } else {
-                    let g = self.globals[target].0;
+                    let g = self.globals[&(self.var_space, *target)].0;
                     self.f.instructions().local_get(hb).global_set(g);
                 }
                 {
@@ -612,7 +613,7 @@ impl Emitter<'_> {
                 }
                 let (local, declared) = match self.locals.get(var) {
                     Some(&(idx, d)) => (Some(idx), d),
-                    None => match self.globals.get(var) {
+                    None => match self.globals.get(&(self.var_space, *var)) {
                         Some(&(gidx, d)) => (None, {
                             let _ = gidx;
                             d
@@ -651,7 +652,7 @@ impl Emitter<'_> {
                 match local {
                     Some(idx) => self.emit_store_var(*var, idx, declared)?,
                     None => {
-                        let gidx = self.globals[var].0;
+                        let gidx = self.globals[&(self.var_space, *var)].0;
                         self.f.instructions().global_set(gidx);
                     }
                 }
@@ -677,7 +678,7 @@ impl Emitter<'_> {
                 }
                 let (slot, declared) = match self.locals.get(target) {
                     Some(&(idx, d)) => (Ok(idx), d),
-                    None => match self.globals.get(target) {
+                    None => match self.globals.get(&(self.var_space, *target)) {
                         Some(&(gidx, d)) => (Err(gidx), d),
                         None => return unsup("field-assign:unmapped"),
                     },

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -373,10 +373,16 @@ fn cmd_build_wasm_direct(file: &str, output: Option<&str>, _no_check: bool, allo
     // an explicit, default-off opt-in (`--wasm-opt`) rather than automatic —
     // see the wasm-opt parity leg (`tests/wasm_runtime_test.rs::wasm_opt_parity_spec`) for the
     // differential-testing evidence backing this tier's own guarantee.
+    // Name the LEG in the one line every build prints: "which renderer
+    // produced these bytes" was invisible by default (the line said
+    // v1-verified even for structural output), and that opacity cost real
+    // diagnosis time — a "wasm doesn't work" report cannot be split
+    // between legs without it.
+    let leg = if structural { "structural leg" } else { "incumbent v1 leg" };
     if !wasm_opt {
         err(&format!(
-            "Built {} ({} bytes, v1-verified — wasm-opt skipped; pass --wasm-opt for a smaller, non-verified build)",
-            output, pre_size
+            "Built {} ({} bytes, {}, verified — wasm-opt skipped; pass --wasm-opt for a smaller, non-verified build)",
+            output, pre_size, leg
         ));
         return;
     }
@@ -589,8 +595,14 @@ fn check_no_native_only_matrix(ir_program: &almide::ir::IrProgram) -> Result<(),
 /// the greenfield engine — measured 610/610 byte-identical to native on
 /// the full wasm_cross corpus) and the incumbent WAT trust-spine.
 ///
-/// Routing is by PROJECT SHAPE, never by failure fallback (a wall stays an
-/// honest hard error on whichever leg owns the program):
+/// Routing has TWO tiers. Tier 1 is by PROJECT SHAPE (the enumerated
+/// conditions below). Tier 2: a program the shape routing gives to the
+/// structural leg whose lowering then WALLS is re-rendered by the incumbent
+/// — a verified-to-verified handover, NOT the retired v0 fallback (#782's
+/// sin was falling into UNVERIFIED codegen). A program NEITHER leg lowers
+/// still fails hard with the incumbent's wall diagnostics. The handover is
+/// named on stderr under `ALMIDE_VERIFIED_DEBUG=1`, and the leg that
+/// produced the bytes is named in the `Built …` line / `--time-report`:
 ///   - `ALMIDE_WASM_INCUMBENT=1`     → incumbent (the reversible switch,
 ///                                      kept for one release)
 ///   - main-less library module      → incumbent (#881 export mode — the
@@ -664,6 +676,15 @@ fn render_wasm_module_routed(
             // never ship bytes wasmtime would refuse at load.
             if let Err(e) = wasmparser::validate(&bytes) {
                 return reroute(&format!("validation: {}", e.message()));
+            }
+            // With the debug env, ALWAYS name the winning leg — the
+            // incumbent path and the reroute already speak, so a silent
+            // structural success made the env an incomplete oracle.
+            if std::env::var_os("ALMIDE_VERIFIED_DEBUG").is_some() {
+                err(&format!(
+                    "[almide] structural leg emitted the module ({} bytes)",
+                    bytes.len()
+                ));
             }
             Ok((bytes, true))
         }

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -613,19 +613,28 @@ fn render_wasm_module_routed(
     library_ok: bool,
     has_main: bool,
     has_pkg_deps: bool,
-    has_self_import: bool,
+    uses_incumbent_features: bool,
     host_variant: bool,
 ) -> Result<(Vec<u8>, bool), ()> {
     //   - `ALMIDE_FUEL_PROBE` set         → incumbent (the charge-trace
     //     probe line is that leg's Σ-probe instrumentation — contract
     //     evidence keeps its measured meaning; the structural leg's C-320
     //     conformance has its own gates in crates/almide-wasm)
-    let incumbent = std::env::var_os("ALMIDE_WASM_INCUMBENT").is_some()
-        || std::env::var_os("ALMIDE_FUEL_PROBE").is_some()
-        || !has_main
-        || has_pkg_deps
-        || has_self_import
-        || (library_ok && host_variant);
+    // `ALMIDE_WASM_STRUCTURAL=1` — the frontier-development probe switch:
+    // force the STRUCTURAL leg on shapes the routing would send to the
+    // incumbent, and turn every wall/decline into a hard error instead of
+    // the reroute (a probe that silently rerouted would measure nothing).
+    // This is how a routed-away shape (#1596 self-import, #1598 matrix/io)
+    // is exercised while its structural support is built, and the lever the
+    // eventual route flip is verified with.
+    let force_structural = std::env::var_os("ALMIDE_WASM_STRUCTURAL").is_some();
+    let incumbent = !force_structural
+        && (std::env::var_os("ALMIDE_WASM_INCUMBENT").is_some()
+            || std::env::var_os("ALMIDE_FUEL_PROBE").is_some()
+            || !has_main
+            || has_pkg_deps
+            || uses_incumbent_features
+            || (library_ok && host_variant));
     if incumbent {
         return render_wasm_module(source_text, v1_self_modules, library_ok).map(|(b, _)| (b, false));
     }
@@ -636,6 +645,10 @@ fn render_wasm_module_routed(
     // lower still fails hard with the incumbent's rich wall diagnostics.
     // ALMIDE_VERIFIED_DEBUG=1 names the wall that rerouted.
     let reroute = |why: &str| {
+        if force_structural {
+            err(&format!("error: structural leg walled under ALMIDE_WASM_STRUCTURAL ({why})"));
+            return Err(());
+        }
         if std::env::var_os("ALMIDE_VERIFIED_DEBUG").is_some() {
             err(&format!("[almide] structural leg declined ({why}) — incumbent renderer"));
         }
@@ -862,17 +875,12 @@ pub(crate) fn compile_to_wasm_bytes(file: &str, allow_unverified: bool, verified
         }
         hit
     };
-    // `import self as m` projects stay on the incumbent leg: the structural
-    // driver misaligns self-package top-let storage (#1596 — the crossmod
-    // matrix walls/panics there), and the shape sits outside the measured
-    // corpus (the run manifest sweeps wasm_cross/wasm_fail only).
-    let has_self_import = std::iter::once(&program)
-        .chain(resolved.modules.iter().map(|(_, p, _, _)| p))
-        .flat_map(|p| p.imports.iter())
-        .any(|d| {
-            matches!(d, almide::ast::Decl::Import { path, .. }
-                if path.first().is_some_and(|r| r.as_str() == "self"))
-        });
+    // #1596 CLOSED: `import self as m` projects run the structural leg.
+    // The spaced globals machinery ((space, VarId) keys — separately-
+    // lowered modules each restart VarIds at 0) fixed the top-let storage
+    // misalignment; the full crossmod matrix passes on the forced
+    // structural leg, and a shape it still cannot lower (a module
+    // initializer with inner binds) walls honestly and reroutes.
     let _ = (&mut ir_program, allow_unverified, verified);
     render_wasm_module_routed(
         file,
@@ -881,7 +889,7 @@ pub(crate) fn compile_to_wasm_bytes(file: &str, allow_unverified: bool, verified
         library_ok,
         has_main,
         has_pkg_deps,
-        has_self_import || uses_incumbent_stdlib || has_exports,
+        uses_incumbent_stdlib || has_exports,
         host_variant,
     )
 }


### PR DESCRIPTION
Closes #1596.

## What

Separately-lowered modules each carry their own `VarTable` (every one restarting at `VarId(0)`), but the global-storage machinery keyed module top-lets by bare `VarId` against the PROGRAM's table — an out-of-range id panicked at `VarTable::get`, an in-range one read ANOTHER binding's storage (`m.SYSTEM` answering with `WORDS`' slot). The crossmod matrix walled/panicked on 37 `import self` cells; the commissioning routed the shape to the incumbent leg and #1596 tracked the fix.

- **`almide-ir::top_let_storage` grows the spaced form**: `GVar = (SpaceId, VarId)` names the table a VarId indexes (0 = program, i+1 = `modules[i]`); `build_global_tables_spaced` / `dependency_init_order_spaced` are the (space-threaded) twins of the flat machinery, which stays for the single-space Rust-target pass.
- **The structural emitter goes spaced**: `global_map` keys by `GVar` (alias entries point use-site vars at their declaration's slot), every Var/Assign/mut-var site pairs the id with the emitter's `var_space`, module fns lower in their module's space, and each module top-let initializer lowers in ITS OWN space with its module's name-resolution context. A module initializer with inner binds walls honestly (`modinit:inner-binds` — increment 1's boundary) and reroutes.
- **The route flips**: `import self` projects run the structural leg. `ALMIDE_WASM_STRUCTURAL=1` joins as the frontier probe switch — force-structural with HARD walls (no reroute), the lever this fix was developed and verified with.
- **Leg visibility**: the `Built …` line names the leg that produced the bytes (it said "v1-verified" even for structural output), and `ALMIDE_VERIFIED_DEBUG=1` now speaks on every outcome (structural success was silent — an incomplete oracle).
- Mutant 018 (init decl-order) refreshed against the spaced call and verified CAUGHT.

## Verification

- Full workspace battery: 0 FAILED. crossmod matrix: all cells pass on the FORCED structural leg (hard walls) and under production routing. wasm_runtime_test 79/79; `almide test spec/` 421/421 (413 via WASM).
- codopsy: almide-wasm A(93) held, almide-ir A(95).
- The interp's same-class latent hole is filed as #1602 (its env binds by bare VarId; not reachable through today's gates).