### PR TITLE
A value else on guard always returns from the fn

### DIFF
--- a/crates/almide-codegen/src/walker/statements.rs
+++ b/crates/almide-codegen/src/walker/statements.rs
@@ -475,21 +475,20 @@ fn render_stmt_assign(ctx: &RenderContext, stmt: &IrStmt) -> String {
 /// expression type (for LICM-hoisted vars whose kind is Var but type is
 /// Result[Unit,_]). Extracted verbatim (cog>25 decomposition).
 fn stmt_guard_is_loop_control(else_: &IrExpr) -> bool {
-    matches!(&else_.kind, IrExprKind::Unit | IrExprKind::Break | IrExprKind::Continue)
-        || (matches!(&else_.kind, IrExprKind::ResultOk { .. }) && {
-            if let IrExprKind::ResultOk { expr: inner } = &else_.kind {
-                matches!(&inner.kind, IrExprKind::Unit)
-            } else { false }
-        })
+    // ONLY an actual Break/Continue expression (bare, or as a block's single
+    // statement) is loop control. A VALUE else — `ok(())` included — is a
+    // FUNCTION return, per the interp's normative semantics (exec_stmt_guard:
+    // Flow::Value → Flow::Return). The retired arms here (Unit, ResultOk(Unit),
+    // the LICM-hoisted Result[Unit,_] Var) classified `guard c else ok(())` in
+    // an effect fn as `break` — E0268 outside a loop (#1593), and inside one a
+    // silent semantic split from the interp/wasm legs, which return.
+    matches!(&else_.kind, IrExprKind::Break | IrExprKind::Continue)
         // Block wrapping Continue/Break: { continue } has ty=Unit but action=continue
         || (matches!(&else_.kind, IrExprKind::Block { .. }) && {
             if let IrExprKind::Block { stmts, expr: None } = &else_.kind {
                 stmts.len() == 1 && matches!(&stmts[0].kind, IrStmtKind::Expr { expr } if matches!(&expr.kind, IrExprKind::Continue | IrExprKind::Break))
             } else { false }
         })
-        // LICM-hoisted ok(()) → Var with Result[Unit,_] type
-        || (matches!(&else_.kind, IrExprKind::Var { .. }) &&
-            matches!(&else_.ty, Ty::Applied(TypeConstructorId::Result, args) if args.first().is_some_and(|t| matches!(t, Ty::Unit))))
 }
 
 /// `render_stmt_guard` step: within a loop-control guard, is the action

--- a/tests/guard_else_value_test.rs
+++ b/tests/guard_else_value_test.rs
@@ -1,0 +1,95 @@
+//! #1593: a VALUE else on `guard` is a FUNCTION return — never loop control.
+//!
+//! The Rust walker's `stmt_guard_is_loop_control` classified `ok(())` (and
+//! any hoisted `Result[Unit,_]` else) as a loop `break`: at fn level that
+//! emitted `break` outside a loop (rustc E0268), and inside a loop it
+//! silently diverged from the interp/wasm legs, which RETURN from the fn
+//! (the interp's `exec_stmt_guard`: `Flow::Value → Flow::Return` — the
+//! normative reading). Only a literal `break`/`continue` else is loop
+//! control. Lives as a native-leg test (not a spec fixture) because the
+//! effect-fn guard shape sits on the v1 wasm leg's linearization frontier —
+//! a spec file would land in the fallback set the coverage ratchet freezes.
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn tools_available() -> bool {
+    Command::new(almide_bin()).arg("--version").output().is_ok()
+}
+
+const SRC: &str = r#"import int
+
+effect fn check(n: Int) -> Unit = {
+  guard n > 0 else ok(())
+  println("positive ${int.to_string(n)}")
+  ok(())
+}
+
+effect fn scan_until_gap(xs: List[Int]) -> Unit = {
+  for x in xs {
+    guard x > 0 else ok(())
+    println("saw ${int.to_string(x)}")
+  }
+  println("no gap")
+  ok(())
+}
+
+fn keep_positive(xs: List[Int]) -> Int = {
+  var total = 0
+  for x in xs {
+    guard x > 0 else continue
+    total = total + x
+  }
+  total
+}
+
+effect fn main() -> Unit = {
+  check(1)!
+  check(-1)!
+  scan_until_gap([1, 2])!
+  scan_until_gap([3, -1, 9])!
+  println(int.to_string(keep_positive([1, -2, 3])))
+}
+"#;
+
+#[test]
+fn guard_else_value_returns_from_the_fn_on_the_native_leg() {
+    if !tools_available() {
+        return;
+    }
+    let dir = std::env::temp_dir().join("almide-issue1593");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let src = dir.join("main.almd");
+    std::fs::write(&src, SRC).expect("write");
+    let out = Command::new(almide_bin())
+        .args(["run", src.to_str().unwrap()])
+        .current_dir(&dir)
+        .output()
+        .expect("spawn almide");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("E0268"),
+        "guard's value else rendered as a loop break again (#1593):\n{stderr}"
+    );
+    assert!(out.status.success(), "run failed:\nstdout: {stdout}\nstderr: {stderr}");
+    // check(-1) returns silently; scan_until_gap([3,-1,9]) exits the FN at
+    // -1 — no "saw 9", no "no gap".
+    assert_eq!(
+        stdout,
+        "positive 1\nsaw 1\nsaw 2\nno gap\nsaw 3\n4\n",
+        "wrong output: {stdout}"
+    );
+}


### PR DESCRIPTION
Closes #1593.

`stmt_guard_is_loop_control` classified `ok(())` — and any hoisted `Result[Unit,_]` else — as a loop `break`. At fn level that emitted `break` outside a loop (rustc E0268, the issue's repro); inside a loop it silently diverged from the interp and wasm legs, which RETURN from the fn (the interp's `exec_stmt_guard` is the normative reading: `Flow::Value → Flow::Return`; the wasm leg already agreed).

The classifier now keeps only a literal `break`/`continue` (bare or as a block's single statement) as loop control. The retired arms — `Unit`, `ResultOk(Unit)`, the LICM-hoisted `Result[Unit,_]` Var — were load-bearing nowhere: the full workspace battery (205 suites) is green without them.

Regression pin: `tests/guard_else_value_test.rs` — fn-level both branches, the in-loop `guard c else ok(())` exiting the FN (not the loop), and `guard c else continue` staying loop control. It lives as a native-leg test rather than a spec fixture because the effect-fn guard shape sits on the v1 wasm leg's if-linearization frontier — a spec file would land in the fallback set the coverage ratchet freezes (reason documented in the test header).