### PR TITLE
io.read_all links on the structural leg and the matrix-io pre-scan retires

### DIFF
--- a/crates/almide-wasm/src/host_env.rs
+++ b/crates/almide-wasm/src/host_env.rs
@@ -94,6 +94,17 @@ impl Emitter<'_> {
                 }
                 Some(SliceTy::List(self.types.intern(STR)))
             }
+            // stdin read-to-end (#1598's io half): the host's op-31 drain
+            // parks the stream, and the raw-text builder collects it. RAW
+            // String, not a Result block: the frontend absorbs the `!` on
+            // this @intrinsic effect call (the probe showed the Bind's
+            // value is the bare Call typed String), the same convention
+            // env.os / env.temp_dir ride — and op 31 cannot fail.
+            ("io", "read_all", []) => {
+                self.fs_call_0(OP_STDIN_READ)?;
+                self.fs_take_text()?;
+                Some(STR)
+            }
             ("io", "write", [b]) => {
                 self.lower(b, Some(SliceTy::Scalar(Scalar::Bytes)))?;
                 self.io_stdout_raw()?;

--- a/proofs/wasm-reachability-baseline.txt
+++ b/proofs/wasm-reachability-baseline.txt
@@ -94,7 +94,6 @@ matrix.pre_norm_linear :: COMPILER_FRONTIER :: unlinked stdlib/runtime call(s) w
 matrix.qwen3_block_f32_kv :: COMPILER_FRONTIER :: unlinked stdlib/runtime call(s) with no wasm definition: matrix.qwen3_block_f32_kv — rendering them would emit a dangling `(call $…)` (invalid wasm). Add the ca
 matrix.qwen3_block_q1_0_kv :: COMPILER_FRONTIER :: wasm build failed
 matrix.qwen3_block_q8_0_kv :: COMPILER_FRONTIER :: unlinked stdlib/runtime call(s) with no wasm definition: matrix.qwen3_block_q8_0_kv — rendering them would emit a dangling `(call $…)` (invalid wasm). Add the c
-matrix.select_rows :: COMPILER_FRONTIER :: unlinked stdlib/runtime call(s) with no wasm definition: matrix.select_rows — rendering them would emit a dangling `(call $…)` (invalid wasm). Add the callee to
 net.tcp_accept :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call net.tcp_accept needs a declared capability not in this brick
 net.tcp_available :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call net.tcp_available needs a declared capability not in this brick
 net.tcp_close :: HOST_CAPABILITY :: main is outside the MIR-lowering subset: effectful/impure stdlib Module call net.tcp_close needs a declared capability not in this brick

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -854,48 +854,14 @@ pub(crate) fn compile_to_wasm_bytes(file: &str, allow_unverified: bool, verified
             matches!(d, almide::ast::Decl::Import { path, .. }
                 if path.first().is_some_and(|r| matches!(r.as_str(), "fs" | "env" | "process")))
         });
-    // Explicit `matrix.*` / `io.*` module calls stay on the incumbent leg:
-    // the structural leg links neither the matrix intrinsics (llama_block)
-    // nor the stdin-read io surface (io.read_all — stdin programs CANNOT
-    // live in the spec corpus, so the shape is unmeasured by construction).
-    // Module-granular on purpose: bare println/print are Named calls and
-    // stay structural; the gates keep judging the structural leg directly
-    // through emit_program, so verification coverage is unchanged (#1598).
-    let uses_incumbent_stdlib = {
-        fn expr_hits(e: &almide::ir::IrExpr, hit: &mut bool) {
-            if let almide::ir::IrExprKind::Call { target, .. }
-            | almide::ir::IrExprKind::TailCall { target, .. } = &e.kind
-            {
-                if let almide::ir::CallTarget::Module { module, .. } = target {
-                    if matches!(module.as_str(), "matrix" | "io") {
-                        *hit = true;
-                    }
-                }
-            }
-            if !*hit {
-                e.clone().map_children(&mut |c| {
-                    expr_hits(&c, hit);
-                    c
-                });
-            }
-        }
-        let mut hit = false;
-        for f in ir_program.functions.iter().chain(ir_program.modules.iter().flat_map(|m| m.functions.iter())) {
-            expr_hits(&f.body, &mut hit);
-            if hit {
-                break;
-            }
-        }
-        if !hit {
-            for tl in ir_program.top_lets.iter().chain(ir_program.modules.iter().flat_map(|m| m.top_lets.iter())) {
-                expr_hits(&tl.value, &mut hit);
-                if hit {
-                    break;
-                }
-            }
-        }
-        hit
-    };
+    // #1598 CLOSED as per-fn auto-flip: the matrix/io module pre-scan is
+    // GONE. The linked surfaces (io.read_all via the host's op-31 drain
+    // joined io.print/write/write_bytes/read_n_bytes; the measured matrix
+    // arms) lower structurally; anything still unlinked (the qwen/llama
+    // matrix long tail, io.read_line/read_byte) WALLS at lowering and the
+    // tier-2 verified-to-verified reroute hands it to the incumbent — so
+    // every future linked fn flips its own route with no hand-mirrored
+    // list to drift.
     // #1596 CLOSED: `import self as m` projects run the structural leg.
     // The spaced globals machinery ((space, VarId) keys — separately-
     // lowered modules each restart VarIds at 0) fixed the top-let storage
@@ -910,7 +876,7 @@ pub(crate) fn compile_to_wasm_bytes(file: &str, allow_unverified: bool, verified
         library_ok,
         has_main,
         has_pkg_deps,
-        uses_incumbent_stdlib || has_exports,
+        has_exports,
         host_variant,
     )
 }


### PR DESCRIPTION
Closes #1598.

## The io half

`io.read_all` links: the host's op-31 stdin drain through the raw-text builder. The convention surprise (probe-settled): the frontend absorbs the `!` on this `@intrinsic` effect call — the Bind's value is the bare Call typed `String` — so the arm yields the RAW text like `env.os`/`env.temp_dir`, not a Result block. Verified with a piped-stdin run naming the leg (`structural leg emitted the module`) and `tests/io_read_all_test`.

## The matrix half — and the routing upgrade that subsumes it

The `matrix.*`/`io.*` module pre-scan is DELETED rather than refined. The router's tier-2 (a structural wall hands the program to the incumbent — both legs verified, the handover named under `ALMIDE_VERIFIED_DEBUG=1`) already owns the boundary honestly:

- linked matrix arms (`zeros`/`rows`/`cols`/... — the measured, fixture-gated set) now lower structurally;
- the unlinked long tail (the qwen/llama blocks, quantized loaders) WALLS with its named reason and reroutes — `examples_parity_test` (llama_block) 4/4 green;
- `io.read_line`/`read_byte` (which need guest-side line/byte buffering over the drain-once op — a real design increment, not linkage) decline by name and reroute correctly.

The payoff: every future linked fn flips its own route at lowering time. No hand-mirrored fn list to drift — the disease class the wrong-source family (#1087–#1094, #1597) keeps re-teaching.

## Verification

Full workspace battery 205 suites / 0 FAILED; piped-stdin structural run; matrix linked-arm structural run; llama parity 4/4; read_line named-decline reroute.