### PR TITLE
Bare-name audit round 1: four wrong-source sites in the fn-identity family

### DIFF
--- a/crates/almide-codegen/src/pass_auto_parallel.rs
+++ b/crates/almide-codegen/src/pass_auto_parallel.rs
@@ -24,10 +24,25 @@ fn collect_effect_fn_names(program: &IrProgram) -> std::collections::HashSet<Sym
         }
     }
     for module in &program.modules {
+        let mod_ident = module.versioned_name
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| module.name.to_string())
+            .replace('.', "_");
         for func in &module.functions {
             if func.is_effect {
+                // Module-QUALIFIED plus the mangled runtime symbol
+                // StdlibLowering renames call targets to — never the bare
+                // name, which could only ever collide with a root fn or
+                // another module's fn (#1597's wrong-source family). The
+                // Named-call purity check sees the MANGLED spelling by
+                // this point in the pipeline, so the old bare insert was
+                // checking a name no call site carries.
                 effect_fns.insert(sym(&format!("{}.{}", module.name, func.name)));
-                effect_fns.insert(func.name);
+                effect_fns.insert(sym(&format!(
+                    "almide_rt_{}_{}",
+                    mod_ident,
+                    func.name.as_str().replace('.', "_")
+                )));
             }
         }
     }
@@ -133,8 +148,14 @@ fn is_pure_call(
                 }
             }
         }
-        CallTarget::Module { module, .. } => {
+        CallTarget::Module { module, func, .. } => {
             if matches!(&**module, "fs" | "http" | "env" | "process" | "time") {
+                return false;
+            }
+            // A USER module's effect fn is impure too — the old arm never
+            // consulted effect_fns for Module targets, so only the five
+            // stdlib modules were screened.
+            if effect_fns.contains(&sym(&format!("{}.{}", module, func))) {
                 return false;
             }
         }

--- a/crates/almide-frontend/src/canonicalize/registration.rs
+++ b/crates/almide-frontend/src/canonicalize/registration.rs
@@ -328,7 +328,6 @@ pub fn register_fn_sig(env: &mut TypeEnv, decl: &FnSigToRegister<'_>) {
     }
     let is_effect = effect.unwrap_or(false);
     let key = prefixed_key(prefix, name);
-    if prefix.is_none() && is_effect { env.effect_fns.insert(sym(name)); }
     let min_p = params.iter().take_while(|p| p.default.is_none()).count();
     env.functions.insert(sym(&key), FnSig { params: ptys, ret, is_effect, generics: gnames, structural_bounds: sb, protocol_bounds: pb, mut_params });
     match crate::deprecation::parse(attrs) {

--- a/crates/almide-frontend/src/lower/module_lowering.rs
+++ b/crates/almide-frontend/src/lower/module_lowering.rs
@@ -544,10 +544,15 @@ fn lower_fn_value_params(ctx: &mut LowerCtx, name: &str, params: &[ast::Param], 
 // "option.unwrap_or") to avoid picking up a user function with the same
 // bare name.
 fn resolve_fn_ret_ty(ctx: &LowerCtx, name: &str, module_prefix: Option<&str>, body: &ast::Expr) -> Ty {
-    let prefixed = module_prefix.map(|p| format!("{}.{}", p, name));
-    let sig = prefixed.as_ref()
-        .and_then(|pn| ctx.env.functions.get(&sym(pn)))
-        .or_else(|| ctx.env.functions.get(&sym(name)));
+    // Scope-aware (#1597's wrong-source family): `env.functions` keys module
+    // fns PREFIXED and root fns bare, so a MODULE fn whose prefixed lookup
+    // misses must fall to the body's inferred type — the bare key can only
+    // name a ROOT fn, and grabbing it here would type this fn's return from
+    // an unrelated same-named function.
+    let sig = match module_prefix {
+        Some(p) => ctx.env.functions.get(&sym(&format!("{}.{}", p, name))),
+        None => ctx.env.functions.get(&sym(name)),
+    };
     if let Some(sig) = sig {
         sig.ret.clone()
     } else {

--- a/crates/almide-frontend/src/type_env.rs
+++ b/crates/almide-frontend/src/type_env.rs
@@ -52,8 +52,6 @@ pub struct TypeEnv {
     /// diagnostic can say "move the effect out of the region" instead of
     /// the misleading "mark the caller as effect fn" (the caller already is).
     pub metered_region: Option<&'static str>,
-    /// Set of effect function names
-    pub effect_fns: std::collections::HashSet<Sym>,
     /// Variant constructor name -> candidate (variant type name, case info) list.
     /// Usually one entry; MORE than one when the same constructor name is declared
     /// in multiple variant types (e.g. a local type and a dependency's) — an
@@ -190,7 +188,6 @@ impl TypeEnv {
             auto_unwrap: false,
             can_call_effect: false,
             metered_region: None,
-            effect_fns: std::collections::HashSet::new(),
             constructors: std::collections::HashMap::new(),
             user_modules: std::collections::HashSet::new(),
             dep_root_modules: std::collections::HashSet::new(),

--- a/crates/almide-mir/src/lower/newtype_erase.rs
+++ b/crates/almide-mir/src/lower/newtype_erase.rs
@@ -370,11 +370,15 @@ fn build_purity_registry(
     }
     for m in &program.modules {
         for f in &m.functions {
+            // QUALIFIED only (#1597's wrong-source family): the bare insert
+            // let a module fn's BODY shadow a root fn of the same name in
+            // `fns_by_name` — the purity recursion (and any inline decided
+            // from it) then read ANOTHER function's body. A Named call can
+            // only mean a root fn; a Module call looks up its qualified
+            // spelling (the consumer already does).
             let qualified = format!("{}.{}", m.name.as_str(), f.name.as_str());
-            fns_by_name.insert(f.name.as_str().to_string(), f.body.clone());
             fns_by_name.insert(qualified.clone(), f.body.clone());
             if f.is_effect {
-                effect_fns.insert(f.name.as_str().to_string());
                 effect_fns.insert(qualified);
             }
         }


### PR DESCRIPTION
The systematic sweep #1597 opened: every place a function's identity was a bare name that a cross-package collision could claim (the #1087–#1094 wrong-source family, fn axis). Four sites fixed, one exonerated, one already filed:

- **env.effect_fns (canonicalize) — DELETED.** One writer, zero readers; the compiler proves the table dead. A bare-name set that LOOKS load-bearing is exactly how the next #1597 gets written against it.
- **resolve_fn_ret_ty (module lowering) — scope-aware.** The bare fallback could type a MODULE fn's return from a same-named ROOT fn's signature (env.functions keys module fns prefixed, so bare keys can only be root fns). A prefixed miss now falls to the body's inferred type, never the bare grab.
- **AutoParallel's effect screen — qualified + mangled.** Module effect fns registered bare (a name no call site carries at that pipeline stage) and Module-target calls were never screened at all beyond five hardcoded stdlib modules — a user module's effect fn could pass the purity check feeding par_map conversion. Now: qualified + mangled runtime symbols in the set; Module calls screened by qualified spelling.
- **mir purity registry (newtype_erase) — qualified only.** Module fn BODIES were also registered under bare names, SHADOWING root fns of the same name in fns_by_name — the purity recursion (and any inline decided from it) could read another function's body. Named lookups can only mean root fns now.
- pass_effect_inference / IrProgram.effect_map: examined, exonerated — pipeline-unread but consumed by the check CLI's effects report (a deletion attempt was compiler-refused by those imports; restored).
- The interp's bare-VarId global env is the same family, already filed as #1602.

Verification: full workspace battery 205 suites / 0 FAILED; the #1597 three-package collision repro and the auto-parallel effect-callback probe both green.