### PR TITLE
Rewrite the almide-stats command around the derived README blocks

### DIFF
--- a/.claude/commands/almide-stats.md
+++ b/.claude/commands/almide-stats.md
@@ -1,32 +1,48 @@
 # Update README Stats
 
-Measure current quantitative data and update README.md.
+The README no longer carries hand-written counts: every number is either
+rendered by a script from a source in the tree, or carries the date it was
+measured, and `scripts/check-readme-numbers.sh` fails CI on a bare one. So
+"updating the stats" means regenerating, and measuring only where a stamped
+baseline is the source.
 
-## Metrics to Measure
+## Regenerate (no measurement — derives from the tree)
 
-1. **Stdlib functions and modules**
-   ```bash
-   grep -c '^\[' stdlib/defs/*.toml | awk -F: '{sum += $2} END {print sum " functions across " NR " modules"}'
-   ```
+```bash
+bash scripts/gen-readme-stats.sh        # stdlib functions/modules (from docs/stdlib signature indexes),
+                                        # spec/ test files, contract count; renders the Hello, world
+                                        # size table from docs/benchmarks/wasm-size.txt
+bash scripts/gen-claims.sh              # contract-ledger claims block + proofs/STAGE-STATUS.md
+almide run tools/almide-gates/src/main.almd -- bench docs/benchmarks --readme
+                                        # build-speed block from docs/benchmarks/build-speed.txt
+```
 
-2. **Test file counts**
-   ```bash
-   almide test 2>&1 | grep "All .* passed"           # Rust target
-   almide test --target wasm 2>&1 | tail -3           # WASM target
-   ```
+The lefthook pre-commit hooks run the first two whenever their inputs change;
+running them by hand is for a fresh checkout or after a stdlib change
+(regenerate the signature indexes first: `make stdlib-docs`).
 
-3. **MSR** — Only if `/almide-msr` was run recently. Otherwise note the last known value.
+## Re-measure (only when the compiler changed the thing being measured)
 
-## README Locations to Update
+```bash
+bash scripts/gen-readme-stats.sh --measure     # Hello, world on both wasm legs → docs/benchmarks/wasm-size.txt
+almide run tools/almide-gates/src/main.almd -- bench docs/benchmarks
+                                               # build-speed baseline → docs/benchmarks/build-speed.txt
+```
 
-- Line ~82: `Standard library — N functions across M modules`
-- Line ~209: `| Stdlib | N functions across M modules |`
-- Line ~210: `| Tests | N test files pass (Rust), M pass (WASM) |`
-- Line ~211: `| MSR | N/M exercises pass (...) |`
+Both baselines carry the binary version and the date; CI rebuilds Hello,
+world and demands the stamped bytes, so a changed emitter is re-stamped here,
+never edited in README.md.
 
-## Steps
+## MSR
 
-1. Measure all metrics above
-2. Compare with current README values
-3. Update only values that changed
-4. Commit: `Update README stats: {brief summary of changes}`
+Measured by [almide-dojo](https://github.com/almide/almide-dojo), not here.
+When a new run lands, update the scorecard table and its date in README.md
+(the line must keep a `YYYY-MM-DD`, or the numbers gate rejects it).
+
+## Check
+
+```bash
+bash scripts/gen-readme-stats.sh --check && bash scripts/check-readme-numbers.sh && bash scripts/gen-claims.sh --check
+```
+
+Commit as one line, e.g. `Regenerate README stats after the stdlib change`.


### PR DESCRIPTION
`.claude/commands/almide-stats.md` still told the reader to count stdlib functions with `grep -c '^\[' stdlib/defs/*.toml` — a directory retired with the self-hosted stdlib — and to hand-edit README lines by number. Since #1605 every README count is rendered by `scripts/gen-readme-stats.sh` / `gen-claims.sh` / the gates tool's `--readme` mode from stamped sources, and `scripts/check-readme-numbers.sh` refuses a bare hand-written one. The command now says that: regenerate (derived from the tree), re-measure (only the two stamped baselines, only when the compiler changed what they measure), MSR stays in Dojo with a dated line, and the check to run.

Docs-only: this PR is also the first run that restores develop's grammar-gate memo (#1612) — its Emit & Format time is the warm-path measurement.