### PR TITLE
External-dependency projects run on the structural wasm leg, and the interp's global init is spaced

### DIFF
--- a/crates/almide-interp/src/dispatch.rs
+++ b/crates/almide-interp/src/dispatch.rs
@@ -1822,9 +1822,11 @@ impl<'a> Interpreter<'a> {
             let clo = Closure {
                 params,
                 body: Rc::new(func.body.clone()),
-                // Top-level fn closes only over top-level lets, modeled by the
-                // root scope.
-                captured: self.root_scope(),
+                // A named fn closes only over top-level lets — the frame of
+                // the SPACE its body's VarIds index (#1602: a module `__`
+                // helper in the flat table captures its module's frame, not
+                // the root's).
+                captured: self.space_scope(self.fn_space_of(func)).clone(),
                 // The fn's DECLARED return type rides along so the closure
                 // boundary can run the same #1226 read-back a direct call
                 // gets (value.as_array as an FnRef leaked raw addresses).

--- a/crates/almide-interp/src/lib.rs
+++ b/crates/almide-interp/src/lib.rs
@@ -163,7 +163,21 @@ pub struct Interpreter<'a> {
     /// The global scope holding evaluated top-level lets. Every top-level fn
     /// call and `FnRef` closure parents off this so globals are visible from
     /// nested calls (not just from `main`'s body). Seeded once, lazily.
+    /// SPACE 0 of the spaced-global model (#1602) — the program root's frame.
     pub(crate) globals: env::Scope,
+    /// Per-MODULE global frames (#1602): space i+1 = `program.modules[i]`.
+    /// Separately-lowered modules each restart `VarId`s at 0, so one shared
+    /// `VarId`-keyed frame let module A's global overwrite module B's (the
+    /// last-wins `by_var` collision). Each module's top-lets now live in its
+    /// own frame, and a lowered fn's hop frame parents off ITS module's
+    /// frame (`space_scope`), so a body's `VarId`s only ever resolve against
+    /// the table they index. Cross-space reads are pre-bound by alias at
+    /// init (see `ensure_globals`); a MUTABLE cross-space alias abstains.
+    pub(crate) module_globals: Vec<env::Scope>,
+    /// `&IrFunction` address → the space whose `VarId`s its body indexes
+    /// (0 = root, i+1 = `modules[i]`). Pool fns are absent (their bodies are
+    /// self-contained — the pool has no top-lets) and default to space 0.
+    pub(crate) fn_space: HashMap<usize, u32>,
     pub(crate) globals_ready: Cell<bool>,
     pub(crate) stdout: String,
     pub(crate) stderr: String,
@@ -370,9 +384,14 @@ impl<'a> Interpreter<'a> {
             }
         }
         let mut module_fns = HashMap::new();
-        for m in &program.modules {
+        let mut fn_space: HashMap<usize, u32> = HashMap::new();
+        for f in &program.functions {
+            fn_space.insert(f as *const IrFunction as usize, 0);
+        }
+        for (i, m) in program.modules.iter().enumerate() {
             for f in &m.functions {
                 module_fns.insert((m.name, f.name), f);
+                fn_space.insert(f as *const IrFunction as usize, i as u32 + 1);
             }
         }
         // A module's `__`-prefixed PRIVATE helpers also join the flat table:
@@ -436,6 +455,8 @@ impl<'a> Interpreter<'a> {
             named_records,
             variant_ctors,
             globals: env::Scope::root(),
+            module_globals: program.modules.iter().map(|_| env::Scope::root()).collect(),
+            fn_space,
             globals_ready: Cell::new(false),
             stdout: String::new(),
             stderr: String::new(),
@@ -692,67 +713,123 @@ impl<'a> Interpreter<'a> {
         // Mark ready up front so a top-let that calls a fn (which itself wants
         // globals) does not recurse into re-seeding.
         self.globals_ready.set(true);
-        let globals = self.globals.clone();
         // DEPENDENCY-ORDERED init (#632, C-007): a top-let whose initializer reads a
         // LATER-declared global (directly or through a fn it calls — `BANNER =
         // make_banner()` reading `APP_NAME`) must see it already bound. Both backends
-        // interprocedurally topo-sort the declaration order (`dependency_init_order`);
-        // evaluating in bare declaration order here left the forward-referenced global
-        // unbound (`unbound variable APP_NAME`) — a WRONG third vote vs the native==wasm
-        // consensus. Reuse the SAME ordering utility so the interp matches by construction.
+        // interprocedurally topo-sort the declaration order; evaluating in bare
+        // declaration order here left the forward-referenced global unbound — a WRONG
+        // third vote vs the native==wasm consensus. Reuse the SAME ordering utility so
+        // the interp matches by construction.
+        //
+        // SPACED identities throughout (#1602): every top-let is a `GVar =
+        // (space, VarId)` — separately-lowered modules each restart `VarId`s
+        // at 0, so a bare-`VarId` index here silently collided (last module
+        // wins). Each decl evaluates in ITS OWN space's frame, and every
+        // module-origin alias of it is bound into the alias's space
+        // IMMEDIATELY after — a topo-later initializer in another space reads
+        // through its own alias `VarId`, so the bind cannot wait.
         use almide_ir::top_let_storage::{
-            build_global_tables, dependency_init_order, top_let_inputs,
+            build_global_tables_spaced, dependency_init_order_spaced, GVar,
         };
-        let mut inputs = Vec::new();
+        let (_globals_info, alias, _offenders) = build_global_tables_spaced(self.program);
+        // Increment-1 boundary: a MUTABLE global aliased across spaces cannot
+        // be modeled by per-space value binds (an assignment through one
+        // alias would not propagate to the others) — abstain by name rather
+        // than vote wrong. Immutable aliases are sound: the bound Value is a
+        // snapshot of a binding that can never change.
+        let mut mutable_decls: std::collections::HashSet<GVar> =
+            std::collections::HashSet::new();
         for tl in &self.program.top_lets {
-            inputs.push(top_let_inputs(tl));
-        }
-        for m in &self.program.modules {
-            for tl in &m.top_lets {
-                inputs.push(top_let_inputs(tl));
+            if tl.mutable {
+                mutable_decls.insert((0, tl.var));
             }
         }
-        let (_globals_info, alias, _offenders) =
-            build_global_tables(&inputs, &self.program.var_table);
-        let order = dependency_init_order(self.program, &alias);
-        // Index every top-let (root + modules) by its VarId so the sorted order can
-        // fetch its initializer. A VarId in `order` but absent here (unreachable) is
-        // skipped; a top-let absent from `order` (defensive) falls back to decl order.
-        let mut by_var: std::collections::HashMap<almide_ir::VarId, &almide_ir::IrExpr> =
+        for (i, m) in self.program.modules.iter().enumerate() {
+            for tl in &m.top_lets {
+                if tl.mutable {
+                    mutable_decls.insert((i as u32 + 1, tl.var));
+                }
+            }
+        }
+        let mut aliases_of: std::collections::HashMap<GVar, Vec<GVar>> =
+            std::collections::HashMap::new();
+        for (&site, &decl) in &alias {
+            if site.0 != decl.0 && mutable_decls.contains(&decl) {
+                return Err(Flow::Unsupported(format!(
+                    "cross-space alias of mutable global `{}`",
+                    almide_ir::top_let_storage::spaced_var(self.program, decl)
+                        .name
+                        .as_str()
+                )));
+            }
+            aliases_of.entry(decl).or_default().push(site);
+        }
+        let order = dependency_init_order_spaced(self.program, &alias);
+        // Index every top-let by its GVar so the sorted order can fetch its
+        // initializer. A GVar in `order` but absent here (unreachable) is
+        // skipped; a top-let absent from `order` (defensive) falls back to
+        // decl order.
+        let mut by_var: std::collections::HashMap<GVar, &almide_ir::IrExpr> =
             std::collections::HashMap::new();
         for tl in &self.program.top_lets {
-            by_var.insert(tl.var, &tl.value);
+            by_var.insert((0, tl.var), &tl.value);
         }
-        for m in &self.program.modules {
+        for (i, m) in self.program.modules.iter().enumerate() {
             for tl in &m.top_lets {
-                by_var.insert(tl.var, &tl.value);
+                by_var.insert((i as u32 + 1, tl.var), &tl.value);
             }
         }
-        let mut seen: std::collections::HashSet<almide_ir::VarId> =
-            std::collections::HashSet::new();
-        let ordered: Vec<(almide_ir::VarId, &almide_ir::IrExpr)> = order
+        let mut seen: std::collections::HashSet<GVar> = std::collections::HashSet::new();
+        let ordered: Vec<(GVar, &almide_ir::IrExpr)> = order
             .iter()
-            .filter_map(|v| by_var.get(v).map(|e| (*v, *e)))
+            .filter_map(|g| by_var.get(g).map(|e| (*g, *e)))
             .chain(
                 // Any top-let the sort omitted (a self-referential cycle the topo-sort
                 // dropped) is appended in declaration order — never silently unbound.
                 self.program
                     .top_lets
                     .iter()
-                    .map(|tl| (tl.var, &tl.value))
-                    .chain(self.program.modules.iter().flat_map(|m| {
-                        m.top_lets.iter().map(|tl| (tl.var, &tl.value))
+                    .map(|tl| ((0, tl.var), &tl.value))
+                    .chain(self.program.modules.iter().enumerate().flat_map(|(i, m)| {
+                        m.top_lets.iter().map(move |tl| ((i as u32 + 1, tl.var), &tl.value))
                     })),
             )
-            .filter(|(v, _)| seen.insert(*v))
+            .filter(|(g, _)| seen.insert(*g))
             .collect();
-        for (var, value) in ordered {
-            match self.eval_expr(value, &globals) {
-                Flow::Value(v) => globals.bind(var, v),
+        for ((space, var), value) in ordered {
+            let frame = self.space_scope(space).clone();
+            match self.eval_expr(value, &frame) {
+                Flow::Value(v) => {
+                    if let Some(sites) = aliases_of.get(&(space, var)) {
+                        for &(s, sv) in sites {
+                            self.space_scope(s).bind(sv, v.clone());
+                        }
+                    }
+                    frame.bind(var, v);
+                }
                 other => return Err(other),
             }
         }
         Ok(())
+    }
+
+    /// The globals frame whose bindings a `VarId` in `space` resolves against
+    /// (#1602): 0 = the program root (`self.globals`), i+1 = `modules[i]`.
+    pub(crate) fn space_scope(&self, space: u32) -> &env::Scope {
+        if space == 0 {
+            &self.globals
+        } else {
+            &self.module_globals[(space - 1) as usize]
+        }
+    }
+
+    /// The space whose `VarTable` `f`'s body indexes. Pool fns (self-contained,
+    /// no top-lets) are absent from the map and resolve to the root frame.
+    pub(crate) fn fn_space_of(&self, f: &IrFunction) -> u32 {
+        self.fn_space
+            .get(&(f as *const IrFunction as usize))
+            .copied()
+            .unwrap_or(0)
     }
 
     fn outcome_from_flow(&self, flow: Flow) -> RunOutcome {
@@ -908,7 +985,16 @@ impl<'a> Interpreter<'a> {
                 break 'tramp cut;
             }
 
-            let (frame, fn_body, clo_body) = bind_hop_frame(&callee, &mut args, base);
+            // #1602: a lowered fn's body indexes ITS space's VarTable, so its
+            // frame parents off that space's globals frame — never the
+            // caller's chain, whose same-numbered VarIds may belong to a
+            // different table. Closures keep their captured chain (which was
+            // built under this rule at creation).
+            let fn_base = match &callee {
+                TailCallee::Fn(f) => self.space_scope(self.fn_space_of(f)).clone(),
+                TailCallee::Clo(_) => base.clone(),
+            };
+            let (frame, fn_body, clo_body) = bind_hop_frame(&callee, &mut args, &fn_base);
             if first_frame.is_none() {
                 first_frame = Some(frame.clone());
             }

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -459,7 +459,8 @@ pub(super) fn lower_one_wasm_module(
 /// `compile_to_wasm_bytes`'s parse + dependency-fetch + import-resolution
 /// phase. Extracted verbatim — prints diagnostics and returns `Err(())` on
 /// any parse/fetch/resolve failure, mirroring the original early returns.
-fn parse_and_resolve_wasm(file: &str) -> Result<(almide::ast::Program, String, resolve::ResolvedModules), ()> {
+#[allow(clippy::type_complexity)]
+fn parse_and_resolve_wasm(file: &str) -> Result<(almide::ast::Program, String, resolve::ResolvedModules, Vec<(project::PkgId, std::path::PathBuf)>), ()> {
     let (program, source_text, parse_errors) = parse_file(file);
 
     if !parse_errors.is_empty() {
@@ -488,7 +489,7 @@ fn parse_and_resolve_wasm(file: &str) -> Result<(almide::ast::Program, String, r
         Err(e) => { err(&format!("{}", e)); return Err(()); }
     };
 
-    Ok((program, source_text, resolved))
+    Ok((program, source_text, resolved, dep_paths))
 }
 
 /// `compile_to_wasm_bytes`'s type-check phase: canonicalize, build the
@@ -608,8 +609,6 @@ fn check_no_native_only_matrix(ir_program: &almide::ir::IrProgram) -> Result<(),
 ///   - main-less library module      → incumbent (#881 export mode — the
 ///                                      structural emitter has no library
 ///                                      form yet)
-///   - external dependency packages  → incumbent (the structural driver
-///                                      resolves without a dep table)
 ///   - host-variant program on the BUILD path → incumbent (its artifact
 ///                                      speaks real WASI fs/env; the WASI
 ///                                      transform's shims cover less)
@@ -624,7 +623,7 @@ fn render_wasm_module_routed(
     v1_self_modules: &[(String, almide_lang::ast::Program, bool)],
     library_ok: bool,
     has_main: bool,
-    has_pkg_deps: bool,
+    dep_paths: &[(project::PkgId, std::path::PathBuf)],
     uses_incumbent_features: bool,
     host_variant: bool,
 ) -> Result<(Vec<u8>, bool), ()> {
@@ -644,7 +643,6 @@ fn render_wasm_module_routed(
         && (std::env::var_os("ALMIDE_WASM_INCUMBENT").is_some()
             || std::env::var_os("ALMIDE_FUEL_PROBE").is_some()
             || !has_main
-            || has_pkg_deps
             || uses_incumbent_features
             || (library_ok && host_variant));
     if incumbent {
@@ -666,7 +664,7 @@ fn render_wasm_module_routed(
         }
         render_wasm_module(source_text, v1_self_modules, library_ok).map(|(b, _)| (b, false))
     };
-    let ir = match almide::wasm_leg::lower_to_ir(file, source_text) {
+    let ir = match almide::wasm_leg::lower_to_ir_with_deps(file, source_text, dep_paths) {
         Ok(ir) => ir,
         Err(e) => return reroute(&format!("front: {e}")),
     };
@@ -824,7 +822,7 @@ fn render_wasm_module(source_text: &str, v1_self_modules: &[(String, almide_lang
 }
 
 pub(crate) fn compile_to_wasm_bytes(file: &str, allow_unverified: bool, verified: bool, library_ok: bool) -> Result<(Vec<u8>, bool), ()> {
-    let (mut program, source_text, mut resolved) = parse_and_resolve_wasm(file)?;
+    let (mut program, source_text, mut resolved, dep_paths) = parse_and_resolve_wasm(file)?;
 
     // v1 `--verified`: capture the FRESH (un-inferred) cross-module siblings now, before the loop
     // below mutates them in place — the v1 pipeline re-runs its own canonicalize/infer/lower from
@@ -846,7 +844,6 @@ pub(crate) fn compile_to_wasm_bytes(file: &str, allow_unverified: bool, verified
     // export mode yet (#1598's sibling surface), so those modules stay on
     // the incumbent leg.
     let has_exports = ir_program.functions.iter().any(|f| !f.export_attrs.is_empty());
-    let has_pkg_deps = resolved.modules.iter().any(|(_, _, pkg, _)| pkg.is_some());
     let host_variant = std::iter::once(&program)
         .chain(resolved.modules.iter().map(|(_, p, _, _)| p))
         .flat_map(|p| p.imports.iter())
@@ -875,7 +872,7 @@ pub(crate) fn compile_to_wasm_bytes(file: &str, allow_unverified: bool, verified
         &v1_self_modules,
         library_ok,
         has_main,
-        has_pkg_deps,
+        &dep_paths,
         has_exports,
         host_variant,
     )

--- a/src/wasm_leg.rs
+++ b/src/wasm_leg.rs
@@ -10,8 +10,22 @@
 
 /// Front half of `run_file`: parse → check → lower → link, returning the
 /// linked IR (unit 6's emission gate shares this exact pipeline so the
-/// interpreter and the wasm backend judge the SAME IR).
+/// interpreter and the wasm backend judge the SAME IR). The dep-free form —
+/// the spine gates and the corpus judge through here.
 pub fn lower_to_ir(path: &str, source_text: &str) -> Result<crate::ir::IrProgram, String> {
+    lower_to_ir_with_deps(path, source_text, &[])
+}
+
+/// The full-front form: external package dependencies resolve through the
+/// SAME table the incumbent driver uses (`resolve_imports_with_deps`), and
+/// dependency modules lower under their VERSIONED name (`pkg_v0_1_0[...]`)
+/// so two major versions of one package coexist without symbol collision —
+/// the incumbent's `lower_one_user_module` versioning, replicated here.
+pub fn lower_to_ir_with_deps(
+    path: &str,
+    source_text: &str,
+    dep_paths: &[(crate::project::PkgId, std::path::PathBuf)],
+) -> Result<crate::ir::IrProgram, String> {
     let tokens = crate::lexer::Lexer::tokenize(source_text);
     let mut parser = crate::parser::Parser::new(tokens).with_file(path);
     let mut program = parser.parse().map_err(|e| format!("parse: {e}"))?;
@@ -19,7 +33,7 @@ pub fn lower_to_ir(path: &str, source_text: &str) -> Result<crate::ir::IrProgram
         return Err(format!("parse errors: {}", parser.errors.len()));
     }
 
-    let mut resolved = crate::resolve::resolve_imports_with_deps(path, &program, &[])
+    let mut resolved = crate::resolve::resolve_imports_with_deps(path, &program, dep_paths)
         .map_err(|e| format!("resolve: {e}"))?;
 
     let canon = crate::canonicalize::canonicalize_program(
@@ -64,11 +78,24 @@ pub fn lower_to_ir(path: &str, source_text: &str) -> Result<crate::ir::IrProgram
             checker.env.self_module_name = Some(crate::intern::sym(&pid.name));
         }
         infer_module_capturing(&mut checker, name, mod_prog, &sources, &mut module_diags);
+        // Dependency modules lower under their VERSIONED name so two major
+        // versions of one package coexist (incumbent's lower_one_user_module
+        // versioning, verbatim). Project-local modules keep their bare name.
+        let versioned = pkg_id.as_ref().map(|pid| {
+            let base = pid.mod_name();
+            match name.strip_prefix(&pid.name) {
+                Some(suffix) => format!("{}{}", base, suffix),
+                None => base,
+            }
+        });
+        if let Some(ref v) = versioned {
+            checker.env.module_versioned_names.insert(crate::intern::sym(name), crate::intern::sym(v));
+        }
         let self_name = checker.env.self_module_name.map(|s| s.to_string());
         let import_table_name = self_name.as_deref().unwrap_or(name);
         let (mod_table, _) = crate::import_table::build_import_table(mod_prog, Some(import_table_name), &checker.env.user_modules);
         let saved_table = std::mem::replace(&mut checker.env.import_table, mod_table);
-        let mod_ir_module = crate::lower::lower_module(name, mod_prog, &checker.env, &checker.type_map, None);
+        let mod_ir_module = crate::lower::lower_module(name, mod_prog, &checker.env, &checker.type_map, versioned);
         checker.env.import_table = saved_table;
         checker.env.self_module_name = saved_self;
         ir.modules.push(mod_ir_module);

--- a/tests/dep_structural_leg_test.rs
+++ b/tests/dep_structural_leg_test.rs
@@ -1,0 +1,133 @@
+//! The pkg_deps route flip: an external-dependency project lowers on the
+//! STRUCTURAL wasm leg (the `has_pkg_deps → incumbent` routing exception is
+//! retired — `wasm_leg::lower_to_ir_with_deps` resolves through the same
+//! dep table as the incumbent driver, and dependency modules lower under
+//! their versioned name). The gate asserts three things on a layered
+//! two-package project: the structural leg emits the module under FORCED
+//! structural routing (a wall would hard-error), the production routing
+//! picks the structural leg (named by ALMIDE_VERIFIED_DEBUG), and the wasm
+//! output is byte-identical to native.
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn tools_available() -> bool {
+    Command::new(almide_bin()).arg("--version").output().is_ok()
+}
+
+fn write(path: &Path, content: &str) {
+    std::fs::create_dir_all(path.parent().unwrap()).expect("mkdir");
+    std::fs::write(path, content).expect("write");
+}
+
+/// The dep_fn_collision_test layering: an app over two path deps, one with
+/// a submodule (`import self.path`) — the shape that exercises pkg_id
+/// self-module naming AND the versioned-name registration in one project.
+fn scratch() -> std::path::PathBuf {
+    let root = std::env::temp_dir().join("almide-dep-structural");
+    let _ = std::fs::remove_dir_all(&root);
+    write(
+        &root.join("shapes").join("almide.toml"),
+        "[package]\nname = \"shapes\"\nversion = \"0.1.0\"\n",
+    );
+    write(
+        &root.join("shapes").join("src").join("path.almd"),
+        "fn close() -> String = \"Z\"\n",
+    );
+    write(
+        &root.join("shapes").join("src").join("mod.almd"),
+        "import self.path\n\npub fn render() -> String = \"<\" + path.close() + \">\"\n\npub effect fn emit() -> String = path.close()\n",
+    );
+    write(
+        &root.join("sqlib").join("almide.toml"),
+        "[package]\nname = \"sqlib\"\nversion = \"0.1.0\"\n",
+    );
+    write(
+        &root.join("sqlib").join("src").join("mod.almd"),
+        "pub fn tag() -> String = \"[sq]\"\n",
+    );
+    write(
+        &root.join("app").join("almide.toml"),
+        "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\nshapes = { path = \"../shapes\" }\nsqlib = { path = \"../sqlib\" }\n",
+    );
+    write(
+        &root.join("app").join("src").join("main.almd"),
+        "import shapes\nimport sqlib\n\neffect fn main() -> Unit = {\n  println(shapes.render())\n  println(shapes.emit()!)\n  println(sqlib.tag())\n}\n",
+    );
+    root.join("app")
+}
+
+#[test]
+fn dep_project_runs_on_the_structural_leg() {
+    if !tools_available() {
+        return;
+    }
+    let app = scratch();
+
+    let native = Command::new(almide_bin())
+        .args(["run", "src/main.almd"])
+        .current_dir(&app)
+        .output()
+        .expect("spawn almide");
+    assert!(
+        native.status.success(),
+        "native run failed:\n{}",
+        String::from_utf8_lossy(&native.stderr)
+    );
+    let native_out = String::from_utf8_lossy(&native.stdout).to_string();
+    assert_eq!(native_out, "<Z>\nZ\n[sq]\n", "native output: {native_out}");
+
+    // Forced-structural: a wall is a hard error here, so success proves the
+    // structural leg itself lowered the dep project (no silent reroute).
+    let forced = Command::new(almide_bin())
+        .args(["run", "src/main.almd", "--target", "wasm"])
+        .env("ALMIDE_WASM_STRUCTURAL", "1")
+        .env("ALMIDE_VERIFIED_DEBUG", "1")
+        .current_dir(&app)
+        .output()
+        .expect("spawn almide");
+    let forced_err = String::from_utf8_lossy(&forced.stderr);
+    assert!(
+        forced.status.success(),
+        "structural leg walled on the dep project (the pkg_deps flip regressed):\n{forced_err}"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&forced.stdout),
+        native_out,
+        "wasm/native divergence on the forced-structural leg"
+    );
+
+    // Production routing: no exception may send the dep project to the
+    // incumbent — the debug env names the winning leg.
+    let routed = Command::new(almide_bin())
+        .args(["run", "src/main.almd", "--target", "wasm"])
+        .env("ALMIDE_VERIFIED_DEBUG", "1")
+        .current_dir(&app)
+        .output()
+        .expect("spawn almide");
+    let routed_err = String::from_utf8_lossy(&routed.stderr);
+    assert!(
+        routed.status.success(),
+        "routed wasm run failed:\n{routed_err}"
+    );
+    assert!(
+        routed_err.contains("structural leg emitted the module"),
+        "production routing did not pick the structural leg for a dep project:\n{routed_err}"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&routed.stdout),
+        native_out,
+        "wasm/native divergence under production routing"
+    );
+}

--- a/tests/interp_spaced_globals_test.rs
+++ b/tests/interp_spaced_globals_test.rs
@@ -1,0 +1,132 @@
+//! #1602: the interp's global init is SPACED. Separately-lowered modules
+//! (the wasm_leg front) each restart `VarId`s at 0, so the interp's old
+//! bare-`VarId` global index collided across spaces — `by_var.insert` kept
+//! the LAST module's initializer for every colliding id, and one shared
+//! frame bound one slot for what are N distinct globals (the #1087
+//! wrong-source class, global edition). Init identity is now `(space,
+//! VarId)`, each module's top-lets live in their own frame, a lowered fn's
+//! hop frame parents off ITS space's frame, and a cross-space read is
+//! pre-bound through the alias table at init. The increment-1 boundary: a
+//! MUTABLE global aliased across spaces abstains by name (`Unsupported`),
+//! never votes wrong.
+
+use std::path::Path;
+
+fn write(path: &Path, content: &str) {
+    std::fs::create_dir_all(path.parent().unwrap()).expect("mkdir");
+    std::fs::write(path, content).expect("write");
+}
+
+/// Lower a multi-module project through the STRUCTURAL front
+/// (`wasm_leg::lower_to_ir` — per-module tables, restarting VarIds) and run
+/// the interp on the linked IR.
+fn run_project(tag: &str, files: &[(&str, &str)]) -> almide_interp::RunOutcome {
+    let root = std::env::temp_dir().join(format!("almide-interp-spaced-{tag}"));
+    let _ = std::fs::remove_dir_all(&root);
+    for (name, content) in files {
+        write(&root.join(name), content);
+    }
+    let entry = root.join("main.almd");
+    let source = std::fs::read_to_string(&entry).expect("read entry");
+    let ir = almide::wasm_leg::lower_to_ir(entry.to_str().unwrap(), &source)
+        .expect("front failed");
+    almide_interp::Interpreter::new(&ir).run_main()
+}
+
+/// Two modules whose top-lets collide on VarId under separate lowering —
+/// each module's fn must read ITS OWN global, and the entry's direct
+/// cross-module reads must resolve through the alias binds.
+#[test]
+fn colliding_module_globals_resolve_per_space() {
+    let out = run_project("collide", &[
+        (
+            "alpha.almd",
+            "pub let TAG = \"alpha\"\n\npub fn get() -> String = TAG\n",
+        ),
+        (
+            "beta.almd",
+            "pub let TAG = \"beta\"\n\npub fn get() -> String = TAG\n",
+        ),
+        (
+            "main.almd",
+            "import alpha\nimport beta\n\nfn main() -> Unit = {\n  println(alpha.get())\n  println(beta.get())\n  println(alpha.TAG)\n  println(beta.TAG)\n}\n",
+        ),
+    ]);
+    assert_eq!(
+        out.status,
+        almide_interp::RunStatus::Ok,
+        "run failed: stderr=<{}>",
+        out.stderr
+    );
+    assert_eq!(out.stdout, "alpha\nbeta\nalpha\nbeta\n", "wrong global resolution");
+}
+
+/// A module global whose initializer reads ANOTHER module's global — the
+/// alias bind must land before the topo-later initializer evaluates.
+#[test]
+fn cross_module_initializer_reads_through_alias() {
+    let out = run_project("xinit", &[
+        ("base.almd", "pub let NAME = \"almide\"\n"),
+        (
+            "banner.almd",
+            "import base\n\npub let LINE = \"[\" + base.NAME + \"]\"\n",
+        ),
+        (
+            "main.almd",
+            "import banner\n\nfn main() -> Unit = {\n  println(banner.LINE)\n}\n",
+        ),
+    ]);
+    assert_eq!(
+        out.status,
+        almide_interp::RunStatus::Ok,
+        "run failed: stderr=<{}>",
+        out.stderr
+    );
+    assert_eq!(out.stdout, "[almide]\n");
+}
+
+/// The increment-1 boundary: a mutable module global read from another
+/// space abstains by name — an honest skip, never a stale-value vote.
+#[test]
+fn mutable_cross_space_alias_abstains() {
+    let out = run_project("mutalias", &[
+        (
+            "counter.almd",
+            "pub var count = 0\n\npub fn bump() -> Unit = {\n  count = count + 1\n}\n",
+        ),
+        (
+            "main.almd",
+            "import counter\n\nfn main() -> Unit = {\n  counter.bump()\n  println(\"${counter.count}\")\n}\n",
+        ),
+    ]);
+    assert!(
+        matches!(out.status, almide_interp::RunStatus::Unsupported(_)),
+        "expected the mutable cross-space abstain; got {:?} stdout=<{}> stderr=<{}>",
+        out.status,
+        out.stdout,
+        out.stderr
+    );
+}
+
+/// Same-space mutability keeps evaluating: a module's own fns mutating the
+/// module's own `var` global is in-space and fully modeled.
+#[test]
+fn same_space_mutable_global_still_evaluates() {
+    let out = run_project("mutlocal", &[
+        (
+            "counter.almd",
+            "var count = 10\n\npub fn bump() -> Unit = {\n  count = count + 1\n}\n\npub fn read() -> Int = count\n",
+        ),
+        (
+            "main.almd",
+            "import counter\n\nfn main() -> Unit = {\n  counter.bump()\n  counter.bump()\n  println(\"${counter.read()}\")\n}\n",
+        ),
+    ]);
+    assert_eq!(
+        out.status,
+        almide_interp::RunStatus::Ok,
+        "run failed: stderr=<{}>",
+        out.stderr
+    );
+    assert_eq!(out.stdout, "12\n");
+}


### PR DESCRIPTION
Closes #1602.

The two queued holes, one PR:

## pkg_deps flip (the exception table's largest row)

The structural front driver resolved imports with an EMPTY dep table, so every external-dependency project rode the \`has_pkg_deps → incumbent\` routing exception — most real-world projects. Now:

- \`wasm_leg::lower_to_ir_with_deps\` threads the SAME dep table the incumbent driver uses into \`resolve_imports_with_deps\`, and dependency modules lower under their versioned name (\`shapes_v0[...]\`) with \`module_versioned_names\` registered — the incumbent's \`lower_one_user_module\` versioning, replicated.
- \`build.rs\`: \`parse_and_resolve_wasm\` returns the fetched dep table, the routing drops \`has_pkg_deps\` from the incumbent OR-chain, and the structural call passes the real deps. The tier-2 verified-to-verified reroute still owns any shape the leg cannot lower.
- Gate: \`tests/dep_structural_leg_test.rs\` — a layered two-package project (submodule import, pkg self-naming, versioned lowering) must (1) emit under FORCED structural routing (a wall is a hard error), (2) win production routing (named by \`ALMIDE_VERIFIED_DEBUG\`), (3) match native byte-for-byte.

## #1602: the interp's global init is spaced

Separately-lowered modules each restart \`VarId\`s at 0, and the interp's global init indexed root + all modules by BARE \`VarId\` — \`by_var.insert\` kept the LAST module's initializer for every colliding id, and one shared frame bound one slot for N distinct globals (the #1087 wrong-source class, global edition). Now:

- Init identity is \`GVar = (space, VarId)\` via \`build_global_tables_spaced\` / \`dependency_init_order_spaced\` — the same utilities the wasm emitter uses, so the third oracle matches by construction.
- Per-module globals frames; a lowered fn's hop frame parents off ITS space's frame (never the caller's chain); \`FnRef\` closures capture their space's frame.
- Cross-space reads pre-bind through the alias table IMMEDIATELY after each decl's init (a topo-later initializer in another space reads through its own alias VarId).
- Increment-1 boundary: a MUTABLE global aliased across spaces abstains by name (\`Unsupported\`), never votes wrong. Same-space mutability keeps evaluating.
- Gate: \`tests/interp_spaced_globals_test.rs\` — 4 tests, A/B-verified: all 4 FAIL on the pre-change interp, all 4 pass now.

## Evidence

- Full battery: 207 suites ok, 0 failures (includes the 3-way oracle gates and the abstain ledger — the abstain set is unchanged).
- Probes: shapes+sqlib layered project emits structurally (3873 B) with native-identical output under both forced and production routing; dep_fn_collision / dep_type_collision / dep_pkg_submodule stay green.