### PR TITLE
CI speed: incremental mutation gate on PRs, uncancelable full sweep, shard weights refreshed from CI's own logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1434,13 +1434,30 @@ jobs:
   # mutant in ci/mutations/ must be CAUGHT by the release-shape net; a
   # surviving mutant or a no-longer-applying patch is red (refresh, never
   # retire).
+  #
+  # #1619: PR runs are INCREMENTAL — only mutants whose patched files (or
+  # patch file, or the shared killer infrastructure) intersect the PR's
+  # change set run, so most PRs finish in seconds instead of ~45 min. The
+  # FULL 40-mutant sweep lives in mutation-sweep.yml (develop pushes in an
+  # uncancelable concurrency group + nightly), where it actually completes —
+  # under ci.yml's cancel-in-progress group the develop sweep was routinely
+  # canceled mid-run, which is standing evidence that never lands. Push
+  # events therefore skip this job entirely (skipped = success for the
+  # required-check, and the sweep workflow owns the push-side evidence).
   commissioned-mutation-gate:
     name: Commissioned mutation gate (the net keeps its teeth)
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    if: github.event_name == 'pull_request' && needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # The incremental scope diffs against the PR base ref.
+          fetch-depth: 0
       - uses: Swatinem/rust-cache@v2
-      - name: mutants must be caught
-        run: bash scripts/check-mutation-gate.sh
+      - name: in-scope mutants must be caught (full sweep lives in mutation-sweep.yml)
+        run: |
+          git fetch -q origin "${{ github.base_ref }}"
+          ALMIDE_MUTATION_SCOPE=incremental \
+          ALMIDE_MUTATION_BASE="origin/${{ github.base_ref }}" \
+            bash scripts/check-mutation-gate.sh

--- a/.github/workflows/mutation-sweep.yml
+++ b/.github/workflows/mutation-sweep.yml
@@ -1,0 +1,53 @@
+name: Mutation sweep (full net)
+
+# #1619: the FULL 40-mutant sweep of ci/mutations/ — the standing evidence
+# that the release-shape net keeps its teeth. It used to run inside ci.yml
+# on every push and PR, where (a) it cost ~45 min per PR for mutants the PR
+# never touched, and (b) ci.yml's `cancel-in-progress: true` concurrency
+# group let the NEXT develop merge cancel the sweep mid-run, so the develop
+# evidence routinely never completed. Here it runs where it cannot be
+# canceled and off the PR critical path:
+#   - develop pushes, in a queued (NOT cancel-in-progress) group — a burst
+#     of merges collapses to "one running + one queued", and the running
+#     sweep always finishes;
+#   - nightly, beside conformance-mutations;
+#   - manual dispatch.
+# PRs run the INCREMENTAL scope inside ci.yml (only mutants intersecting
+# the change set) — see scripts/check-mutation-gate.sh for the scope rule.
+#
+# 4-way positional shard (mutant index mod 4): every mutant costs one
+# release rebuild + one net run, so modulo is the balanced split. ~10 shard
+# mutants x ~45 s warm ≈ 8-12 min wall per shard.
+
+on:
+  push:
+    branches: [develop]
+  schedule:
+    # 05:15 UTC — clear of the 03:00 fuzz night and 04:30 conformance run.
+    - cron: "15 5 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: mutation-sweep-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  sweep:
+    name: Mutation sweep (shard ${{ matrix.shard }}/4)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: Swatinem/rust-cache@v2
+      - name: this shard's mutants must all be caught
+        run: |
+          ALMIDE_MUTATION_SHARDS=4 \
+          ALMIDE_MUTATION_SHARD=${{ matrix.shard }} \
+            bash scripts/check-mutation-gate.sh

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -330,7 +330,7 @@ evidence = "Commissioning PR (2026-08-26): an 801-line probe file under crates/a
 [[gate]]
 path = "scripts/check-mutation-gate.sh"
 class = "EXERCISED"
-evidence = "Greenfield CI mutation-gate job (2026-08-20..26, PORTLOG stages 74+): both verdict directions observed in real operation — 40-42 pre-authored mutants caught green on every push, and the no-longer-applies direction fired at the stage-39 split refresh (a drifted patch went red until refreshed, never retired). All 40 patches re-verified apply-clean against this tree at commissioning."
+evidence = "Greenfield CI mutation-gate job (2026-08-20..26, PORTLOG stages 74+): both verdict directions observed in real operation — 40-42 pre-authored mutants caught green on every push, and the no-longer-applies direction fired at the stage-39 split refresh (a drifted patch went red until refreshed, never retired). All 40 patches re-verified apply-clean against this tree at commissioning. Split evidence model since #1619: PR runs are INCREMENTAL (a mutant is in scope when the PR's change set touches its patched files, the patch itself, or the shared killer infrastructure — crates/almide-wasm/tests/ or the runner script, which put EVERY mutant in scope), and the FULL 40-mutant sweep's standing evidence is .github/workflows/mutation-sweep.yml: develop pushes in an uncancelable concurrency group plus the 05:15 UTC nightly, 4-way positional shard. Under ci.yml's cancel-in-progress group the develop sweep was routinely canceled mid-run (run 33045982751: 18/40 then canceled), which is why push-side evidence moved to the sweep workflow."
 
 [[gate]]
 path = "scripts/check-fmt-gate.sh"

--- a/scripts/check-mutation-gate.sh
+++ b/scripts/check-mutation-gate.sh
@@ -22,18 +22,40 @@ if ! git diff --quiet; then
   exit 2
 fi
 
-# Scope (ratified 2026-08-20): ALMIDE_MUTATION_SCOPE=incremental runs only
-# the mutants whose patched files intersect the work in flight (committed
-# ahead of origin/greenfield + staged); CI's mutation-gate job always runs
-# the FULL sweep on every push, so no verification is lost — the landing
-# cycle just stops re-proving untouched mutants locally.
+# Scope (ratified 2026-08-20; CI wiring #1619): ALMIDE_MUTATION_SCOPE=
+# incremental runs only the mutants whose patched files intersect the work
+# in flight. The diff base is @{upstream} locally, or ALMIDE_MUTATION_BASE
+# when set (CI passes the PR base ref — the checkout's upstream is not it).
+# A change to the SHARED KILLER INFRASTRUCTURE (the killer suites under
+# crates/almide-wasm/tests/, or this runner itself) puts EVERY mutant in
+# scope: a PR cannot un-kill a mutant whose code and killers it did not
+# touch, and this rule is what closes the "except through the shared test
+# infrastructure" hole. The FULL sweep's standing evidence is the
+# mutation-sweep workflow (develop pushes uncancelable + nightly), so no
+# verification is lost — PRs just stop re-proving untouched mutants.
 SCOPE="${ALMIDE_MUTATION_SCOPE:-full}"
 CHANGED=""
 if [ "$SCOPE" = "incremental" ]; then
-  CHANGED=$( (git diff --name-only @{upstream}...HEAD 2>/dev/null; git diff --name-only --cached) | sort -u)
+  if [ -n "${ALMIDE_MUTATION_BASE:-}" ]; then
+    CHANGED=$(git diff --name-only "${ALMIDE_MUTATION_BASE}...HEAD" | sort -u)
+  else
+    CHANGED=$( (git diff --name-only @{upstream}...HEAD 2>/dev/null; git diff --name-only --cached) | sort -u)
+  fi
   echo "incremental scope; changed files:"
   echo "$CHANGED" | sed 's/^/  /'
+  if echo "$CHANGED" | grep -qE '^(crates/almide-wasm/tests/|scripts/check-mutation-gate\.sh$)'; then
+    echo "shared killer infrastructure changed — every mutant is in scope"
+    SCOPE=full
+  fi
 fi
+
+# Sharding (#1619): the full sweep fans out across CI jobs by position —
+# mutant i runs on the job where i % ALMIDE_MUTATION_SHARDS ==
+# ALMIDE_MUTATION_SHARD. Positional, not weighted: every mutant costs one
+# rebuild + one net run, so modulo IS the balanced split. Defaults run
+# everything in one process (local behavior unchanged).
+SHARDS="${ALMIDE_MUTATION_SHARDS:-1}"
+SHARD="${ALMIDE_MUTATION_SHARD:-0}"
 
 # --lib carries the direct invariant referees (the layout-order judge
 # that replaced mutant 015's heap-adjacency kill after class-rounded
@@ -41,8 +63,13 @@ fi
 SUITES=(--lib --test backend_parity --test fuzz_differential --test alias_semantics --test tail_calls)
 fail=0
 
+idx=-1
 for patch in ci/mutations/*.patch; do
   name=$(basename "$patch")
+  idx=$((idx + 1))
+  if [ $((idx % SHARDS)) -ne "$SHARD" ]; then
+    continue
+  fi
   if [ "$SCOPE" = "incremental" ]; then
     patch_files=$(grep '^+++ b/' "$patch" | sed 's|+++ b/||' | sort -u)
     in_scope=0

--- a/scripts/ci-test-weights.txt
+++ b/scripts/ci-test-weights.txt
@@ -10,23 +10,38 @@
 # two ~180s targets the file called 5s. Guessing which targets matter is the
 # thing that failed; this is the whole profile.
 #
-# Captured 2026-08-08 from one `cargo test --workspace` on an M-series laptop
 # (Running/finished-in pairs). CI runners are slower, but packing needs only the
 # RATIOS. Targets under 5s are omitted — they are within the default's noise.
 # Refresh by rerunning that command when the shard job's balance report drifts.
-wasm_runtime_test                276
-native_v1_differential_test      138
-examples_parity_test             35
-crossmod_matrix_test             29
-semantic_laws_test               27
-charge_probe_test                26
-almide_mir                       25
-wasm_dispatch_coverage_test      24
-bridge_test                      19
-almide_egg_lab                   19
-fmt_test                         17
-fuzz_test                        15
-io_read_all_test                 13
-eval_test                        9
-mcp_test                         9
-diagnostic_harness_test          7
+# Refreshed 2026-08-27 by scripts/refresh-ci-test-weights.sh from a CI run's own
+# shard logs (Running/finished-in pairs, summed per target across shards).
+wasm_runtime_test                516
+run_parity                       284
+backend_parity                   223
+surface_matrix                   213
+diagnostic_harness_test          193
+fuzz_differential                142
+wasm_dispatch_coverage_test      100
+check_parity                     97
+libm_trig_cross_target_test      55
+kernel_conformance_test          51
+charge_probe_test                45
+bridge_test                      45
+almide_mir                       37
+fmt_test                         33
+fuzz_test                        32
+libm_atan_tanh_cross_target_test 28
+http_timeout_native_test         27
+almide_egg_lab                   24
+native_v1_differential_test      21
+rc_placement_snapshot_test       15
+examples_parity_test             12
+crossmod_matrix_test             12
+regex_fuzz_test                  10
+stdlib_examples_test             9
+semantic_laws_test               8
+gauntlet                         7
+bytes_unwrap_callarg_test        6
+fmt_corpus_test                  6
+heap_cap_test                    6
+bytes_coalesce_call_arg_test     6

--- a/scripts/refresh-ci-test-weights.sh
+++ b/scripts/refresh-ci-test-weights.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Refresh scripts/ci-test-weights.txt from CI's OWN shard logs (#1615).
+#
+# The weights file is the shard packer's only input, and its header demands
+# every line be measured. The original capture was a laptop session; this
+# makes the refresh a command: given a ci.yml run id (default: the latest
+# completed develop run), pull the four `Test Rust (shard N/4)` job logs,
+# pair each `Running tests/<name>.rs` / `Running unittests … (deps/<name>-…)`
+# line with its `test result: … finished in Ns` line (cargo executes targets
+# sequentially, so the two streams pair FIFO), sum per target across shards,
+# and rewrite the weights file with every target at or above the 5 s default
+# (below it, the default's noise floor covers them — balance, never
+# coverage, exactly as the file header says).
+#
+# Also the drift report the header mentions: prints each shard's measured
+# `Cargo tests` total so the max/min skew is visible at refresh time.
+#
+# Usage: bash scripts/refresh-ci-test-weights.sh [run-id]
+
+set -euo pipefail
+export LC_ALL=C
+cd "$(dirname "$0")/.."
+
+RUN_ID="${1:-}"
+if [ -z "$RUN_ID" ]; then
+  RUN_ID=$(gh run list --workflow ci.yml --branch develop --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+  echo "using latest green develop ci.yml run: $RUN_ID"
+fi
+
+JOB_IDS=$(gh run view "$RUN_ID" --json jobs --jq '.jobs[] | select(.name | test("Test Rust \\(shard")) | .databaseId')
+if [ "$(echo "$JOB_IDS" | grep -c .)" -eq 0 ]; then
+  echo "FAIL: run $RUN_ID has no 'Test Rust (shard N/4)' jobs" >&2
+  exit 1
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+for job in $JOB_IDS; do
+  gh api "repos/{owner}/{repo}/actions/jobs/$job/logs" > "$TMP/$job.log"
+done
+
+python3 - "$TMP" <<'EOF'
+import os, re, sys
+from collections import defaultdict
+
+tmp = sys.argv[1]
+weights = defaultdict(float)
+ansi = re.compile(r"\x1b\[[0-9;]*m")
+running_test = re.compile(r"Running\s+tests/([A-Za-z0-9_]+)\.rs\s+\(")
+running_unit = re.compile(r"Running\s+unittests\s+\S+\s+\(.*/deps/([A-Za-z0-9_]+)-[0-9a-f]{16}\)")
+result = re.compile(r"test result: \w+\. .* finished in ([0-9.]+)s")
+
+for logf in sorted(os.listdir(tmp)):
+    queue, total = [], 0.0
+    with open(os.path.join(tmp, logf), errors="replace") as fh:
+        for line in fh:
+            line = ansi.sub("", line)
+            m = running_test.search(line) or running_unit.search(line)
+            if m:
+                queue.append(m.group(1))
+                continue
+            m = result.search(line)
+            if m and queue:
+                secs = float(m.group(1))
+                weights[queue.pop(0)] += secs
+                total += secs
+    if queue:
+        print(f"WARN: {logf}: {len(queue)} Running line(s) without a result "
+              f"(a crashed target?) — dropped: {', '.join(queue)}", file=sys.stderr)
+    print(f"  shard {logf.split('.')[0]}: measured test time {total:.0f}s")
+
+rows = sorted(((n, s) for n, s in weights.items() if s >= 5.0),
+              key=lambda kv: -kv[1])
+if not rows:
+    print("FAIL: no measured targets at or above 5s — wrong logs?", file=sys.stderr)
+    sys.exit(1)
+
+path = "scripts/ci-test-weights.txt"
+with open(path) as fh:
+    head = []
+    for line in fh:
+        if line.startswith("#"):
+            head.append(line)
+        else:
+            break
+
+import datetime
+stamp = os.environ.get("WEIGHTS_DATE") or datetime.date.today().isoformat()
+head = [l for l in head if not l.startswith("# Captured ") and not l.startswith("# Refreshed ")]
+head.append(f"# Refreshed {stamp} by scripts/refresh-ci-test-weights.sh from a CI run's own\n")
+head.append("# shard logs (Running/finished-in pairs, summed per target across shards).\n")
+
+with open(path, "w") as fh:
+    fh.writelines(head)
+    for name, secs in rows:
+        fh.write(f"{name:<32} {secs:.0f}\n")
+print(f"wrote {len(rows)} measured target(s) to {path}")
+EOF


### PR DESCRIPTION
Addresses #1619 (items 1, 2, 4) and #1615 (item 1).

## Mutation gate (#1619)

- **PR runs are incremental**: \`ALMIDE_MUTATION_SCOPE=incremental\` with \`ALMIDE_MUTATION_BASE=origin/<base>\` — only mutants whose patched files (or patch file) intersect the PR's change set run; most PRs finish in seconds instead of ~45 min. A change to the shared killer infrastructure (\`crates/almide-wasm/tests/\` or the runner script) puts EVERY mutant in scope — the rule that closes the "except through shared test infrastructure" hole. (This PR touches the runner, so its own gate run is the full sweep — the last one on the PR path.)
- **The full sweep moves where it cannot be canceled**: new \`mutation-sweep.yml\` — develop pushes in a \`cancel-in-progress: false\` concurrency group + a 05:15 UTC nightly + dispatch, as a 4-way positional shard (\`ALMIDE_MUTATION_SHARDS/SHARD\`, mutant index mod 4 — every mutant costs one rebuild + one net run, so modulo is the balanced split). Under ci.yml's cancel-in-progress group the develop sweep was routinely canceled mid-run (run 33045982751: 18/40, then canceled) — standing evidence that never landed. ci.yml's job is now PR-only.
- **Ledger** (\`proofs/gate-verification.toml\`): the \`check-mutation-gate.sh\` row now names the incremental coverage rule and the sweep workflow as the full-sweep evidence.

Not in this PR: killer-first per-mutant ordering (#1619 item 3) — nightly-only optimization once the sweep is off the PR path.

## Shard weights (#1615)

- New \`scripts/refresh-ci-test-weights.sh\`: pulls the four \`Test Rust (shard N/4)\` job logs for a ci.yml run (default: latest green develop run), pairs \`Running\`/\`test result: … finished in\` lines FIFO, sums per target across shards, rewrites \`scripts/ci-test-weights.txt\` (≥5 s targets, every line measured), and prints each shard's measured total as the drift report the file header asks for.
- Weights refreshed from run 33042019116 (2026-08-27): 30 measured targets. The 2026-08-08 laptop capture was badly stale — \`wasm_runtime_test\` 276→516 s, and \`run_parity\` (284 s), \`backend_parity\` (223 s), \`surface_matrix\` (213 s) did not exist in the file at all.
- Measured skew on that run: 431/560/582/775 s (344 s max−min). Predicted packing with the new weights: 757–762 s (5 s spread) — the critical shard drops ~3 min.