### PR TITLE
Stdin becomes a cursor on the structural wasm leg, and UFCS mut receivers are validated on every path

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ No runtime, no GC, no interpreter — native compiles through Rust to machine co
 <!-- wasm-size:generated:start — rendered from docs/benchmarks/wasm-size.txt by scripts/gen-readme-stats.sh; DO NOT EDIT between the markers -->
 | Program (`almide build --target wasm`, verified, as shipped) | incumbent v1 leg | structural leg |
 |---|---:|---:|
-| Hello, world | **1,096 B** | **4,361 B** |
+| Hello, world | **1,096 B** | **4,459 B** |
 
-Measured on almide 0.59.1, 2026-08-27, from `docs/benchmarks/wasm-size.txt`; no post-hoc optimizer touches the shipped bytes (`--wasm-opt` is opt-in and its output is not the verified module).
+Measured on almide 0.59.2, 2026-08-27, from `docs/benchmarks/wasm-size.txt`; no post-hoc optimizer touches the shipped bytes (`--wasm-opt` is opt-in and its output is not the verified module).
 <!-- wasm-size:generated:end -->
 
 Rust on the same wasm target is 40 KB+ for Hello, world even fully size-tuned; the native minigit CLI binary is 418 KB stripped with 0 dependencies. The byte-by-byte dissection, measured 2026-07-23 on the incumbent leg: **[docs/wasm/WASM-OUTPUT.md](./docs/wasm/WASM-OUTPUT.md)**.

--- a/crates/almide-frontend/src/check/calls_ufcs.rs
+++ b/crates/almide-frontend/src/check/calls_ufcs.rs
@@ -45,6 +45,15 @@ impl Checker {
             return ty;
         }
         if let Some(ty) = self.check_call_target_convention(&obj_concrete, &field, &obj_ty, arg_tys) {
+            // The convention path's `check_named_call` populated
+            // `last_mut_params` and nothing consumed it: an immutable
+            // receiver of a `mut self` method sailed through (native died
+            // in rustc E0596, wasm RAN and mutated the let — a leg split),
+            // and the STALE entry then fired E032 on the NEXT call
+            // (`println("${...}")` accused of a mut param it never had).
+            // Validate with the receiver at argument 0, like the builtin
+            // path above (#1624).
+            self.validate_ufcs_mut_args(&field, object, args);
             return ty;
         }
         if let Some(ty) = self.check_call_target_typevar_protocol(&obj_concrete, &field) {
@@ -54,9 +63,12 @@ impl Checker {
         if self.env.functions.contains_key(&sym(&field)) {
             let mut all_args = vec![obj_ty];
             all_args.extend(arg_tys.iter().cloned());
-            return self.check_named_call(&field, &all_args);
+            let ty = self.check_named_call(&field, &all_args);
+            self.validate_ufcs_mut_args(&field, object, args);
+            return ty;
         }
         if let Some(ty) = self.check_call_target_cross_module_ufcs(&obj_concrete, &field, &obj_ty, arg_tys) {
+            self.validate_ufcs_mut_args(&field, object, args);
             return ty;
         }
         if let Some(ty) = self.check_call_target_e002_hint(builtin_module, &field, object) {

--- a/crates/almide-wasm-run/src/host.rs
+++ b/crates/almide-wasm-run/src/host.rs
@@ -61,6 +61,36 @@ impl StdinSource {
             StdinSource::Drained => Vec::new(),
         }
     }
+
+    /// Take UP TO `n` bytes off the stream's cursor (op 35 — the
+    /// incremental sibling of op 31's drain). A fixed buffer serves its
+    /// front; the real stream reads lazily WITHOUT draining, so a
+    /// terminal program keeps native's line-at-a-time interleaving (a
+    /// line-buffered read blocks until Enter, not until EOF). A later
+    /// op-31 drain still answers the remainder.
+    fn take(&mut self, n: usize) -> Vec<u8> {
+        if n == 0 {
+            return Vec::new();
+        }
+        match self {
+            StdinSource::Buf(b) => {
+                let k = n.min(b.len());
+                b.drain(..k).collect()
+            }
+            StdinSource::RealOnce => {
+                use std::io::Read;
+                let mut buf = vec![0u8; n];
+                match std::io::stdin().read(&mut buf) {
+                    Ok(got) => {
+                        buf.truncate(got);
+                        buf
+                    }
+                    Err(_) => Vec::new(),
+                }
+            }
+            StdinSource::Drained => Vec::new(),
+        }
+    }
 }
 
 /// io_err = Display — VERBATIM the native runtime's formatting, so error
@@ -316,6 +346,8 @@ fn fs_dispatch_host(op: i32, a: &str, b: &[u8]) -> (i64, Vec<u8>) {
         }
         // stdin read (up to n = a bytes) — the harness has no stdin.
         31 => (pack(0, 0), Vec::new()),
+        // incremental stdin (op 35) — same empty answer in the harness.
+        35 => (pack(0, 0), Vec::new()),
         // cwd — the same std::env the native runtime reads.
         33 => match std::env::current_dir() {
             Ok(p) => ok_text(p.to_string_lossy().replace('\\', "/")),
@@ -479,6 +511,18 @@ fn run_wasm_src(
          b_ptr: i32,
          b_len: i32|
          -> wasmtime::Result<i64> {
+            // op 35 = incremental stdin (up to a_len bytes off the cursor).
+            // Handled BEFORE the a/b buffer reads: the count rides in
+            // a_len with a null a_ptr, and materializing it as a guest
+            // buffer would read a_len bytes of guest memory (the 4 GiB
+            // trap the op-31 comment in the emitter records).
+            if op == 35 {
+                let n = i64::from(a_len).max(0) as usize;
+                let got = caller.data().stdin.lock().expect("stdin").take(n);
+                let len = got.len();
+                *caller.data().fs_buf.lock().expect("fs buf") = got;
+                return Ok((len as i64) & 0xFFFF_FFFF);
+            }
             let mem = caller
                 .get_export("memory")
                 .and_then(|e| e.into_memory())

--- a/crates/almide-wasm-run/src/wasi.rs
+++ b/crates/almide-wasm-run/src/wasi.rs
@@ -402,11 +402,11 @@ fn shim_exit() -> Function {
     f
 }
 
-/// The almide `fs_call` contract over WASI: ops 30/31/32/34 supported,
+/// The almide `fs_call` contract over WASI: ops 30/31/32/34/35 supported,
 /// everything else takes the defined refusal (stderr + exit 1).
 fn shim_fs_call(park: u64, g_plen: u32, g_pcap: u32) -> Function {
     // params: 0=op 1=a_ptr 2=a_len 3=b_ptr 4=b_len; locals: 5=total 6=nread
-    let (op, b_ptr, b_len, total, nread) = (0u32, 3u32, 4u32, 5u32, 6u32);
+    let (op, a_len, b_ptr, b_len, total, nread) = (0u32, 2u32, 3u32, 4u32, 5u32, 6u32);
     let mut f = Function::new([(2, ValType::I32)]);
     let mut i = f.instructions();
 
@@ -420,6 +420,40 @@ fn shim_fs_call(park: u64, g_plen: u32, g_pcap: u32) -> Function {
     i.i32_const((park + NREAD) as i32);
     i.call(0).drop();
     i.i64_const(0).return_();
+    i.end();
+
+    // op 35: incremental stdin — ONE fd_read of up to min(a_len, 4096)
+    // bytes into the park data region (the count rides in a_len, op 32's
+    // b_len convention). Short reads are the contract ("up to n"): the
+    // guest's read_line/read_byte loops ask byte-at-a-time, so one
+    // fd_read per call is exactly the incumbent leg's cadence. An errno
+    // or EOF answers 0 bytes.
+    i.local_get(op).i32_const(35).i32_eq().if_(BlockType::Empty);
+    i.i32_const(park as i32).i32_const((park + DATA) as i32).i32_store(mem(IOV));
+    // len = clamp(a_len, 0..=4096) — unsigned min folds a negative count
+    // into the 4096 arm, and 4096 stays inside the fixed park span.
+    i.local_get(a_len).i32_const(0).i32_lt_s().if_(BlockType::Empty);
+    i.i32_const(0).local_set(a_len);
+    i.end();
+    i.local_get(a_len).i32_const(4096).i32_lt_u().if_(BlockType::Result(ValType::I32));
+    i.local_get(a_len);
+    i.else_();
+    i.i32_const(4096);
+    i.end();
+    i.local_set(nread);
+    i.i32_const(park as i32).local_get(nread).i32_store(mem(IOV + 4));
+    i.i32_const(0);
+    i.i32_const((park + IOV) as i32);
+    i.i32_const(1);
+    i.i32_const((park + NREAD) as i32);
+    i.call(4); // fd_read
+    i.if_(BlockType::Empty); // errno != 0 → 0 bytes
+    i.i32_const(0).global_set(g_plen);
+    i.i64_const(0).return_();
+    i.end();
+    i.i32_const(park as i32).i32_load(mem(NREAD)).local_set(nread);
+    i.local_get(nread).global_set(g_plen);
+    i.local_get(nread).i64_extend_i32_u().return_();
     i.end();
 
     // op 31: stdin read-to-end into the park data region (grown on demand).

--- a/crates/almide-wasm/src/fs_meta.rs
+++ b/crates/almide-wasm/src/fs_meta.rs
@@ -24,6 +24,7 @@ pub(crate) const OP_TEMP_DIR: i32 = 28;
 pub(crate) const OP_ARGS: i32 = 29;
 pub(crate) const OP_STDOUT_RAW: i32 = 30;
 pub(crate) const OP_STDIN_READ: i32 = 31;
+pub(crate) const OP_STDIN_TAKE: i32 = 35;
 pub(crate) const OP_RANDOM_GET: i32 = 32;
 pub(crate) const OP_CWD: i32 = 33;
 pub(crate) const OP_WALL_NOW: i32 = 34;
@@ -112,6 +113,18 @@ impl Emitter<'_> {
         let mut i = self.f.instructions();
         i.i32_const(op);
         i.i32_const(0).i32_const(0).i32_const(0).i32_const(0);
+        i.call(F_FS_CALL);
+        Ok(())
+    }
+
+    /// Incremental stdin (op 35): up to `count` bytes off the stream's
+    /// cursor. The count rides in the a_len SLOT with a null a_ptr — a
+    /// scalar, never a guest buffer (the op-31 comment's 4 GiB trap) —
+    /// and the host special-cases the op before its buffer reads.
+    pub(crate) fn fs_call_stdin_take(&mut self, count: i32) -> Result<(), EmitError> {
+        let mut i = self.f.instructions();
+        i.i32_const(OP_STDIN_TAKE);
+        i.i32_const(0).i32_const(count).i32_const(0).i32_const(0);
         i.call(F_FS_CALL);
         Ok(())
     }

--- a/crates/almide-wasm/src/host_env.rs
+++ b/crates/almide-wasm/src/host_env.rs
@@ -9,7 +9,7 @@ use wasm_encoder::BlockType;
 
 use crate::emitter::Emitter;
 use crate::fs_meta::{
-    OP_ARGS, OP_CWD, OP_ENV_GET, OP_ENV_OS, OP_STDIN_READ, OP_STDOUT_RAW, OP_TEMP_DIR,
+    OP_ARGS, OP_CWD, OP_ENV_GET, OP_ENV_OS, OP_STDIN_TAKE, OP_STDOUT_RAW, OP_STDIN_READ, OP_TEMP_DIR,
 };
 use crate::*;
 
@@ -105,6 +105,86 @@ impl Emitter<'_> {
                 self.fs_take_text()?;
                 Some(STR)
             }
+            // One byte off the stdin CURSOR (op 35): parked len 0 = EOF
+            // -> -1, else the byte zero-extended — the native intrinsic's
+            // exact contract, and the read composes with read_line /
+            // read_n_bytes on the same cursor.
+            ("io", "read_byte", []) => {
+                self.fs_call_stdin_take(1)?;
+                let hret = self.hold_i64()?;
+                let hb = self.hold_i32()?;
+                let mut i = self.f.instructions();
+                i.local_set(hret);
+                i.local_get(hret).i64_const(0xFFFF_FFFF).i64_and().i64_eqz();
+                i.if_(BlockType::Result(wasm_encoder::ValType::I64));
+                i.i64_const(-1);
+                i.else_();
+                i.i32_const(1).call(F_ALLOC).local_set(hb);
+                i.local_get(hb)
+                    .i32_const(almide_layout::PAYLOAD as i32)
+                    .i32_add()
+                    .call(F_HOST_READ);
+                i.local_get(hb).i64_load8_u(crate::bytes::byte_k(0));
+                i.end();
+                let _ = i;
+                self.release_i32();
+                self.release_i64();
+                Some(INT)
+            }
+            // Byte-at-a-time off the stdin cursor until '\n' (excluded)
+            // or EOF, trailing '\r' stripped — native
+            // read_line().trim_end_matches and the incumbent leg's fd-0
+            // cadence, on the SAME 4096 line cap as its scratch. RAW
+            // String like read_all (the frontend absorbs the `!` on this
+            // @intrinsic effect call; the read itself cannot fail).
+            ("io", "read_line", []) => {
+                let hbuf = self.hold_i32()?;
+                let hn = self.hold_i32()?;
+                let hret = self.hold_i64()?;
+                {
+                    let mut i = self.f.instructions();
+                    i.i32_const(4096).call(F_ALLOC).local_set(hbuf);
+                    i.i32_const(0).local_set(hn);
+                    i.block(BlockType::Empty).loop_(BlockType::Empty);
+                    i.local_get(hn).i32_const(4096).i32_ge_u().br_if(1);
+                }
+                self.fs_call_stdin_take(1)?;
+                {
+                    let mut i = self.f.instructions();
+                    i.local_set(hret);
+                    // EOF -> done with what we have.
+                    i.local_get(hret).i64_const(0xFFFF_FFFF).i64_and().i64_eqz().br_if(1);
+                    // park byte -> buf[n].
+                    i.local_get(hbuf)
+                        .i32_const(almide_layout::PAYLOAD as i32)
+                        .i32_add()
+                        .local_get(hn)
+                        .i32_add()
+                        .call(F_HOST_READ);
+                    // newline -> done (NOT counted).
+                    i.local_get(hbuf).local_get(hn).i32_add();
+                    i.i64_load8_u(crate::bytes::byte_k(0));
+                    i.i64_const(10).i64_eq().br_if(1);
+                    i.local_get(hn).i32_const(1).i32_add().local_set(hn);
+                    i.br(0).end().end();
+                    // strip one trailing '\r' (CRLF endings).
+                    i.local_get(hn).i32_const(0).i32_gt_u().if_(BlockType::Empty);
+                    i.local_get(hbuf).local_get(hn).i32_add().i32_const(1).i32_sub();
+                    i.i64_load8_u(crate::bytes::byte_k(0)).i64_const(13).i64_eq();
+                    i.if_(BlockType::Empty);
+                    i.local_get(hn).i32_const(1).i32_sub().local_set(hn);
+                    i.end();
+                    i.end();
+                    // the block was allocated len=4096; the LINE's length
+                    // is what the string observes.
+                    i.local_get(hbuf).local_get(hn).i32_store(len_memarg());
+                    i.local_get(hbuf);
+                }
+                self.release_i64();
+                self.release_i32();
+                self.release_i32();
+                Some(STR)
+            }
             ("io", "write", [b]) => {
                 self.lower(b, Some(SliceTy::Scalar(Scalar::Bytes)))?;
                 self.io_stdout_raw()?;
@@ -175,14 +255,22 @@ impl Emitter<'_> {
                 i.if_(BlockType::Result(wasm_encoder::ValType::I32));
                 i.i32_const(0).call(F_ALLOC);
                 i.else_();
-                // n does NOT cross the boundary: a len slot makes the
-                // host read guest memory (i64::MAX once pulled 4 GiB out
-                // of a 17-page instance) and even a 0-len read validates
-                // the pointer. The harness has no stdin, so the host
-                // answers the WHOLE stream and the count cap would be
-                // applied guest-side when a real host arrives.
-                i.i32_const(OP_STDIN_READ);
-                i.i32_const(0).i32_const(0).i32_const(0).i32_const(0);
+                // The count rides the a_len SLOT of op 35 (never a guest
+                // buffer — a len slot makes the host read guest memory;
+                // i64::MAX once pulled 4 GiB out of a 17-page instance).
+                // The host serves UP TO n bytes off the stdin CURSOR, so
+                // sequential reads compose with read_byte/read_line
+                // exactly as native's shared stdin handle does.
+                i.i32_const(OP_STDIN_TAKE);
+                i.i32_const(0);
+                i.local_get(hn).i64_const(0x7FFF_FFFF).i64_lt_s();
+                i.if_(BlockType::Result(wasm_encoder::ValType::I64));
+                i.local_get(hn);
+                i.else_();
+                i.i64_const(0x7FFF_FFFF);
+                i.end();
+                i.i32_wrap_i64();
+                i.i32_const(0).i32_const(0);
                 i.call(F_FS_CALL);
                 let _ = i;
                 // decode: n bytes → n i64 slots (never errs)

--- a/docs/benchmarks/wasm-size.txt
+++ b/docs/benchmarks/wasm-size.txt
@@ -5,8 +5,8 @@
 #             never edited by hand in README.md. The bytes are machine-independent:
 #             the emitters are pure Rust and the structural leg's build artifact is
 #             the #1588 WASI form.
-version          = almide 0.59.1
+version          = almide 0.59.2
 date             = 2026-08-27
 program          = fn main() -> Unit = { println("Hello, world!") }
-structural_bytes = 4361
+structural_bytes = 4459
 incumbent_bytes  = 1096

--- a/tests/io_stdin_seq_test.rs
+++ b/tests/io_stdin_seq_test.rs
@@ -1,0 +1,93 @@
+//! Sequential stdin composition across the whole read family (#1598's io
+//! tail): `read_byte` / `read_line` / `read_n_bytes` / `read_all` share ONE
+//! stdin cursor on the structural wasm leg (host op 35 — incremental take)
+//! exactly as native's shared stdin handle, so interleaved reads see the
+//! stream in order. Before this, the leg's only stdin op drained the whole
+//! stream on first read: `read_n_bytes(3)` answered EVERYTHING and a second
+//! read answered nothing, and read_line/read_byte walled to the incumbent.
+//!
+//! Stdin-reading programs cannot live in the spec suites (the harness does
+//! not pipe per-file stdin), so this Command-with-stdin test is the
+//! executable evidence, the io_read_all_test pattern.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn almide() -> &'static str {
+    env!("CARGO_BIN_EXE_almide")
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+const PROGRAM: &str = r#"import io
+
+effect fn main() -> Unit = {
+  let a = io.read_n_bytes(3)
+  let b = io.read_byte()
+  let l1 = io.read_line()!
+  let l2 = io.read_line()!
+  let rest = io.read_all()
+  let e1 = io.read_byte()
+  let e2 = io.read_line()!
+  println("a=${a} b=${b} l1=${l1} l2=${l2} rest=${rest} e1=${e1} e2=[${e2}]")
+}
+"#;
+
+/// CRLF + LF lines, a byte prefix, an unterminated tail, then EOF probes.
+const STDIN: &str = "ABCDone\r\ntwo\nrest-bytes";
+
+const EXPECTED: &str =
+    "a=[65, 66, 67] b=68 l1=one l2=two rest=rest-bytes e1=-1 e2=[]\n";
+
+fn run_with_stdin(file: &std::path::Path, wasm: bool, stdin: &str) -> (i32, String, String) {
+    let mut args = vec!["run", file.to_str().unwrap()];
+    if wasm {
+        args.push("--target");
+        args.push("wasm");
+    }
+    let mut child = Command::new(almide())
+        .args(&args)
+        .env("ALMIDE_WASM_STRUCTURAL", if wasm { "1" } else { "" })
+        .current_dir(repo_root())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn almide");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(stdin.as_bytes())
+        .expect("write stdin");
+    let out = child.wait_with_output().expect("wait almide");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+#[test]
+fn stdin_reads_compose_on_one_cursor_native_and_structural() {
+    let dir = std::env::temp_dir().join("almide-io-stdin-seq");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let file = dir.join("seq.almd");
+    std::fs::write(&file, PROGRAM).expect("write");
+
+    let (code, native, stderr) = run_with_stdin(&file, false, STDIN);
+    assert_eq!(code, 0, "native run failed:\n{stderr}");
+    assert_eq!(native, EXPECTED, "native output drifted from the pinned contract");
+
+    // Forced-structural: a wall is a hard error, so success proves the
+    // structural leg itself served every read off its op-35 cursor.
+    let (code, wasm, stderr) = run_with_stdin(&file, true, STDIN);
+    assert_eq!(
+        code, 0,
+        "structural leg failed the stdin sequence (walled or diverged):\n{stderr}"
+    );
+    assert_eq!(wasm, native, "wasm/native stdin-sequence divergence");
+}

--- a/tests/ufcs_mut_receiver_test.rs
+++ b/tests/ufcs_mut_receiver_test.rs
@@ -1,0 +1,99 @@
+//! #1624: the convention-method UFCS path (`m.put(k)` → `Mem.put(m, k)`)
+//! validates its `mut self` receiver like every other call path. The gap
+//! had two faces: an immutable receiver type-checked (native then died in
+//! rustc E0596 while wasm RAN and mutated the `let` — a leg split, the
+//! #1027 class), and the un-consumed `last_mut_params` fired E032 on the
+//! NEXT call (`println("${...}")` accused of a mut param it never had).
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn tools_available() -> bool {
+    Command::new(almide_bin()).arg("--version").output().is_ok()
+}
+
+fn check(src: &str, tag: &str) -> (bool, String) {
+    let dir = std::env::temp_dir().join("almide-ufcs-mut-receiver");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let path = dir.join(format!("{tag}.almd"));
+    std::fs::write(&path, src).expect("write");
+    let out = Command::new(almide_bin())
+        .args(["check", path.to_str().unwrap()])
+        .output()
+        .expect("spawn almide");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.success(), text)
+}
+
+const LET_RECEIVER: &str = r#"import io
+
+type Mem = { ks: List[String] }
+
+effect fn Mem.put(mut self: Mem, k: String) -> Unit = {
+  self.ks = self.ks + [k]
+}
+
+effect fn main() -> Unit = {
+  let m = Mem { ks: [] }
+  m.put("a")!
+  io.print(int.to_string(list.len(m.ks)))
+}
+"#;
+
+const VAR_THEN_PRINTLN: &str = r#"type Mem = { ks: List[String] }
+
+effect fn Mem.put(mut self: Mem, k: String) -> Unit = {
+  self.ks = self.ks + [k]
+}
+
+effect fn main() -> Unit = {
+  var m = Mem { ks: [] }
+  m.put("a")!
+  println("${m.ks}")
+}
+"#;
+
+#[test]
+fn immutable_receiver_of_mut_convention_method_is_e032() {
+    if !tools_available() {
+        return;
+    }
+    let (ok, text) = check(LET_RECEIVER, "let_receiver");
+    assert!(
+        !ok,
+        "a `let` receiver of a `mut self` method type-checked — the #1624 \
+         leg split (wasm mutates, native dies in rustc):\n{text}"
+    );
+    assert!(
+        text.contains("E032") && text.contains("'m'"),
+        "expected E032 naming the receiver:\n{text}"
+    );
+}
+
+#[test]
+fn stale_mut_params_do_not_accuse_the_next_call() {
+    if !tools_available() {
+        return;
+    }
+    let (ok, text) = check(VAR_THEN_PRINTLN, "var_then_println");
+    assert!(
+        ok,
+        "println after a convention-method call was accused of a mut param \
+         it never had (#1624's stale-table misfire):\n{text}"
+    );
+}


### PR DESCRIPTION
Closes #1624. The stdin half closes the io tail of #1598's exception-table row.

## Stdin cursor (io read family, structural leg)

The leg's only stdin op drained the whole stream on first read: \`read_n_bytes(3)\` answered EVERYTHING, a second read answered nothing, and \`read_line\`/\`read_byte\` walled to the incumbent. Now:

- **Host op 35** (incremental take): up to \`a_len\` bytes off ONE stdin cursor. The count rides the a_len slot with a null pointer — a scalar, never a guest buffer (the recorded 4 GiB trap) — and the host special-cases the op before its buffer reads. The embedded host serves a fixed buffer's front or reads the REAL stream lazily (a terminal keeps native's line-at-a-time interleaving); a later op-31 \`read_all\` still drains the remainder.
- **The WASI shim** (\`to_wasi\`) maps op 35 to a single capped \`fd_read\`, so built artifacts on stock runtimes get the same cursor.
- **Emitter cells**: \`read_byte\` (EOF → -1), \`read_line\` (byte-at-a-time until \`\\n\` excluded, trailing \`\\r\` stripped, 4096 cap — the incumbent leg's exact cadence and native's \`trim_end_matches\` contract), and \`read_n_bytes\` now honors its count.
- Probes: \`read_n_bytes(3) → read_byte → read_line×2 → read_all → EOF probes\` byte-identical across native / structural / **stock wasmtime**. Gate: \`tests/io_stdin_seq_test.rs\` (Command-with-pipe — stdin cannot live in the spec suites, the io_read_all_test precedent).

## #1624: UFCS mut-receiver validation (a leg split at the checker)

The convention-method path (\`m.put(k)\` → \`Mem.put(m, k)\`) populated \`last_mut_params\` and never consumed it — same gap on the bare user-fn and cross-module UFCS arms (the builtin arm was fixed in #1027):

1. A \`let\` receiver of a \`mut self\` method type-checked: native died in rustc E0596 ("codegen produced invalid Rust"), **wasm ran and mutated the let** — target-dependent behavior from a checker gap.
2. The stale entry accused the NEXT call: \`println("\${m.ks}")\` after a convention-method call was rejected with E032 naming a mut parameter println never had.

\`validate_ufcs_mut_args\` (receiver at argument 0) is now wired into all three arms. The let receiver is E032 on BOTH legs identically; var receivers unaffected. Gate: \`tests/ufcs_mut_receiver_test.rs\`, **A/B-verified** (both tests fail on the pre-fix compiler).

## Evidence

Full workspace battery: 210 suites green, zero failures (no manifest drift — the corpus contains neither shape).