### PR TITLE
wasm-opt works on the structural leg: the bulk-memory flag it needs, and honest refusal diagnosis

### DIFF
--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -395,10 +395,10 @@ fn cmd_build_wasm_direct(file: &str, output: Option<&str>, _no_check: bool, allo
                 output, pre_size, post_size, pct
             ));
         }
-        Err(_) => {
+        Err(why) => {
             err(&format!(
-                "Built {} ({} bytes) — --wasm-opt requested but wasm-opt is not installed; shipped the verified module unoptimized",
-                output, pre_size
+                "Built {} ({} bytes) — --wasm-opt requested but not applied: {}; shipped the verified module unoptimized",
+                output, pre_size, why
             ));
         }
     }
@@ -1061,19 +1061,35 @@ fn run_wasm_opt(path: &str) -> Result<usize, String> {
     // --enable-nontrapping-float-to-int: float→int renders as
     // `i64.trunc_sat_f64_s` (the saturating truncate, lib_b.rs).
     // --enable-tail-call: mutual/self tail recursion renders `return_call`.
-    let status = std::process::Command::new("wasm-opt")
+    // --enable-bulk-memory: the STRUCTURAL leg renders `memory.copy`
+    // (#1616 — without the flag wasm-opt refuses the module, and the old
+    // message blamed a missing install).
+    // --enable-mutable-globals: the structural leg EXPORTS mutable
+    // globals; newer binaryen accepts that by default but older releases
+    // (CI's) validate the MVP restriction unless told otherwise — the
+    // first CI run of the honest-refusal path caught exactly this.
+    let out = std::process::Command::new("wasm-opt")
         .args([
             "-Oz",
             "--enable-nontrapping-float-to-int",
             "--enable-tail-call",
+            "--enable-bulk-memory",
+            "--enable-mutable-globals",
             path,
             "-o",
             path,
         ])
-        .status()
-        .map_err(|e| format!("wasm-opt not available ({})", e))?;
-    if !status.success() {
-        return Err(format!("wasm-opt failed (exit {:?})", status.code()));
+        .output()
+        .map_err(|e| format!("wasm-opt is not installed ({})", e))?;
+    if !out.status.success() {
+        // The tool RAN and refused — a different failure class than a
+        // missing install, and its stderr names the real cause (#1616:
+        // "not installed" sent users to reinstall a tool they had).
+        return Err(format!(
+            "wasm-opt ran and refused (exit {:?}): {}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
     }
     let meta = std::fs::metadata(path).map_err(|e| format!("stat {}: {}", path, e))?;
     Ok(meta.len() as usize)

--- a/tests/wasm_opt_structural_test.rs
+++ b/tests/wasm_opt_structural_test.rs
@@ -1,0 +1,75 @@
+//! #1616: `--wasm-opt` works on the STRUCTURAL leg. The emitter renders
+//! `memory.copy`, so wasm-opt needs `--enable-bulk-memory`; without it the
+//! tool refused the module and the old message blamed a missing install
+//! ("wasm-opt is not installed") on a machine that had it — the
+//! silent-wrong-diagnosis class. This gate builds hello-world through the
+//! production routing (structural), applies --wasm-opt, and demands (1) the
+//! "wasm-opt applied" line, (2) a smaller artifact, (3) the optimized
+//! module still prints Hello, world on wasmtime when available.
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn wasm_opt_available() -> bool {
+    Command::new("wasm-opt").arg("--version").output().is_ok_and(|o| o.status.success())
+}
+
+fn wasmtime_available() -> bool {
+    Command::new("wasmtime").arg("--version").output().is_ok_and(|o| o.status.success())
+}
+
+#[test]
+fn wasm_opt_applies_on_the_structural_leg() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() || !wasm_opt_available() {
+        return;
+    }
+    let dir = std::env::temp_dir().join("almide-wasm-opt-structural");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let src = dir.join("hello.almd");
+    std::fs::write(&src, "fn main() -> Unit = {\n  println(\"Hello, world!\")\n}\n")
+        .expect("write");
+    let out_path = dir.join("hello.wasm");
+
+    let out = Command::new(almide_bin())
+        .args([
+            "build",
+            src.to_str().unwrap(),
+            "--target",
+            "wasm",
+            "--wasm-opt",
+            "-o",
+            out_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn almide");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "build failed:\n{stderr}");
+    assert!(
+        stderr.contains("wasm-opt applied"),
+        "--wasm-opt did not apply on the structural leg (#1616 regressed — \
+         the message must never blame a missing install when the tool ran):\n{stderr}"
+    );
+
+    if wasmtime_available() {
+        let run = Command::new("wasmtime")
+            .arg(out_path.to_str().unwrap())
+            .output()
+            .expect("spawn wasmtime");
+        assert_eq!(
+            String::from_utf8_lossy(&run.stdout),
+            "Hello, world!\n",
+            "the optimized structural module no longer runs correctly"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1616.

The structural leg renders \`memory.copy\`, so \`wasm-opt\` refused its modules — and \`run_wasm_opt\` folded EVERY failure into "wasm-opt is not installed", sending users to reinstall a tool they had (the silent-wrong-diagnosis class).

- \`--enable-bulk-memory\` joins the flag set (beside the existing nontrapping-float and tail-call flags). Hello, world on the structural leg: **4,459 B → 364 B (-91.8%)**, and the optimized module runs correctly on stock wasmtime — smaller than the incumbent's optimized 785 B.
- A spawn error ("not installed") and a non-zero exit ("ran and refused", with wasm-opt's stderr verbatim) are now DIFFERENT messages, and the build line prints the real reason.
- Side effect worth naming: the corpus \`wasm_opt_parity_spec\` gate silently skipped structural modules before (wasm-opt refused them → nothing to compare); with the flag it compares them for real.
- Gate: \`tests/wasm_opt_structural_test.rs\` — production-routing build + \`--wasm-opt\` must print "wasm-opt applied" and the optimized module must still print Hello, world (skips when the tools are absent).
- Full workspace battery with wasm-opt ARMED on PATH: 212 suites green (the first battery in which the structural parity leg actually compared).

Unblocks #1618 (the WASM-OUTPUT.md re-dissection needs the structural leg's real -Oz number).