### PR TITLE
WASM-OUTPUT re-dissected: both legs, fresh anatomy, and the crossover story

### DIFF
--- a/docs/wasm/WASM-OUTPUT.md
+++ b/docs/wasm/WASM-OUTPUT.md
@@ -1,162 +1,167 @@
-# WASM Output — What's in the Binary, and Why It's Small
+# WASM Output — What's in the Binary, and Why
 
-Almide emits WebAssembly **directly**: the certified MIR renders to WAT and assembles
-to a binary. There is no LLVM, no Cranelift, no wasm-bindgen, and no compiled
-standard-library object code inside the module. This document dissects a real
-module byte by byte, explains where the size comes from, and states exactly what
-the size claims mean.
+Almide emits WebAssembly **directly** — no LLVM, no Cranelift, no wasm-bindgen,
+and no compiled standard-library object code inside the module. Since the
+commissioning (#1599) there are **two verified renderers**: the **structural
+leg** (crates/almide-wasm, wasm-encoder, the default `--target wasm` path) and
+the **incumbent v1 leg** (the certified MIR→WAT renderer, reachable with
+`ALMIDE_WASM_INCUMBENT=1` and as the automatic reroute for shapes the
+structural leg declines). This document dissects real modules from BOTH legs
+byte by byte and states exactly what the size claims mean.
 
-All numbers below were measured on 2026-07-23 with the current `develop` compiler,
-`rustc 1.94.1` (for the Rust comparison), and `wasm-opt` (Binaryen) version 129.
-Reproduce any of them with the commands shown.
+The headline Hello, world bytes are CI-derived: `docs/benchmarks/wasm-size.txt`
+(re-measured by `scripts/gen-readme-stats.sh`, gated since #1605). Everything
+else below was measured 2026-08-27 on the current `develop` compiler with
+`wasm-opt` (Binaryen) 132 and `wasm-objdump` (WABT) 1.0.41; the Rust comparison
+rows retain their 2026-07-23 measurement (`rustc 1.94.1`). Reproduce any number
+with the commands at the bottom.
 
-## The headline numbers
+## The headline numbers (measured 2026-08-27)
 
-| Program | Almide (verified, as shipped) | Almide + `wasm-opt -Oz` | Rust `--release` (default) | Rust size-tuned¹ |
+| Program | structural (default, verified) | structural + `-Oz` | incumbent v1 (verified) | incumbent + `-Oz` |
 |---|---:|---:|---:|---:|
-| Hello, world | **703 B** | **545 B** | 64,430 B | 40,754 B |
-| FizzBuzz 1–100 | **1,793 B** | **1,092 B** | — | 42,434 B |
-| Fibonacci (recursive) | 1,441 B | 771 B | — | — |
-| Closure + `call_indirect` | 2,744 B | 1,672 B | — | — |
-| Variant match + Float display² | 11,965 B | 6,868 B | — | — |
-| Recursive-generic ADT repr³ | 32,264 B | 17,941 B | — | — |
+| Hello, world | 4,459 B | **364 B** | 1,096 B | 788 B |
+| FizzBuzz 1–100 | 4,716 B | **1,162 B** | 2,168 B | 1,346 B |
+| Fibonacci (recursive) | 4,490 B | **894 B** | 1,791 B | 1,035 B |
+| Recursive-generic ADT repr¹ | **14,088 B** | **9,320 B** | 34,723 B | 21,883 B |
 
-¹ `wasm32-wasip1`, `opt-level = "z"`, `lto = true`, `strip = true`, `panic = "abort"`,
-`codegen-units = 1` — the full size-minimization profile, which most projects do not enable.
-² The jump comes from `float.to_string`: printing a Float links the self-hosted
-Dragon4 shortest-round-trip printer — the single largest thing the demand linker
-ever pulls in. Programs that never display a Float never pay for it.
-³ `spec/wasm_cross/compound_repr_recursive_interp.almd` — recursive ADTs, mutually
-recursive records, generic instantiations, and their full `${…}` repr machinery.
+¹ `spec/wasm_cross/compound_repr_recursive_interp.almd` — recursive ADTs,
+mutually recursive records, generic instantiations, and their full `${…}` repr
+machinery.
 
-Two honest framings for that table:
+**The crossover, in one paragraph.** The structural leg carries a fixed
+~3.5 KB runtime preamble (allocator family, COW gates, the itoa scratch, OOM
+path — 38 support functions in the Hello, world module), so on near-empty
+programs its raw module is larger than the incumbent's. On real programs the
+relationship inverts — the ADT-repr row is 14.1 KB structural vs 34.7 KB
+incumbent, and over the full 600+-fixture corpus the greenfield VERDICT
+records **4.11 MB aggregate structural vs 10.54 MB incumbent**. And after
+`wasm-opt -Oz`, the structural module is the smallest of all four columns on
+every row measured: the preamble is statically reachable (a table-driven
+allocator that the module's own call graph mostly never enters), and `-Oz`'s
+whole-module DCE deletes what the in-renderer reachability pass must
+conservatively keep. Hello, world drops 4,459 → 364 bytes: **one** function
+survives.
 
-- The comparison is against **Rust on the same `wasm32-wasip1` target**, because
-  Rust is Almide's native-side backend and the closest apples-to-apples toolchain.
-  The gap is a *toolchain floor* difference — Rust links `std`'s formatting
-  machinery into every `println!`; Almide's runtime is a few hundred bytes of
-  hand-written WAT, reachability-pruned per program — not a statement about
+Two honest framings:
+
+- The July Rust comparison stands as context: Rust `wasm32-wasip1` Hello,
+  world is 64,430 B default / 40,754 B with the full size profile
+  (`opt-level="z"`, `lto`, `strip`, `panic="abort"`, `codegen-units=1`,
+  measured 2026-07-23). The gap is a *toolchain floor* difference — Rust links
+  `std`'s formatting machinery into every `println!` — not a statement about
   language quality.
 - The **shipped** Almide binary is the *verified* one (see below). The
-  `wasm-opt` column requires running it yourself, which takes the module
-  outside the verified envelope.
+  `wasm-opt` column requires the explicit `--wasm-opt` opt-in, which takes
+  the module outside the verified envelope.
 
-## What is actually inside a module
+## Section anatomy — Hello, world, both legs
 
-Section layout of the 703-byte Hello, world (via `wasm-objdump -h`):
+Structural leg, as shipped (4,459 B, via `wasm-objdump -h`):
 
 | Section | Size | Contents |
 |---|---:|---|
-| Type | 21 B | 4 function signatures |
-| Import | 35 B | 1 WASI import (`fd_write`) |
-| Function | 6 B | index table for 5 functions |
+| Type | 113 B | 19 signatures |
+| Import | 179 B | 5 WASI imports (`fd_write`, `proc_exit`, `random_get`, `clock_time_get`, `fd_read`) |
+| Function | 40 B | index table for 39 functions |
+| Table + Elem | 6 B | funcref table (empty here — no closures) |
 | Memory | 3 B | one linear memory |
-| Global | 23 B | 4 globals (bump pointer, env cache, …) |
-| Export | 19 B | `_start` + memory |
-| Code | 567 B | the 5 function bodies |
-| Data | 19 B | 1 segment — the `"Hello, world!"` string |
-| Custom `name` | 50 B | function names only (locals stripped — see below) |
+| Global | 97 B | 14 globals (heap cursor, free-list heads, park-buffer state, …) |
+| Export | 35 B | `_start` + memory |
+| Code | 3,694 B | 39 bodies: `main` + the 38-function preamble (allocator family with size classes, RC/COW gates, itoa, string equality, the WASI park-buffer glue) |
+| Data | 261 B | the string pool (`"Hello, world!"` + the OOM/trap messages) |
 
-The 5 functions are `alloc`, `rc_dec`, `main`, `print_str`, `_start` — exactly
-what this program's call graph reaches, out of a **~50-function hand-written
-runtime preamble** (bump allocator, refcounts, list primitives, `itoa`,
-division-by-zero traps, WASI glue for args/env/fs/…) plus the self-hosted
-stdlib. **Reachability DCE inside the verified renderer** prunes every import,
-preamble helper, data segment, and program function the compiled call graph
-doesn't reach — before the module is assembled, not as a post-processing pass
-(see below). That preamble **is the entire runtime**: there is no GC, no
-interpreter, no reflection metadata, and no compiled stdlib object code.
+The same module after `wasm-opt -Oz` (364 B): Type 12 B, Import 35 B
+(`fd_write` alone survives), Function 2 B, Memory 3 B, Global 8 B, Export
+35 B, Code 92 B (**one** function), Data 149 B. That is the whole story of the
+structural preamble: it is *linked* support code, and a whole-module optimizer
+proves almost all of it dead for a program this small. (The "tier-0 preamble"
+idea — dropping the allocator family in-renderer when DCE proves no dynamic
+allocation is reachable — would move the shipped 4.4 KB most of the way toward
+that 364 B without leaving the verified envelope; this document is where it
+gets measured if it lands.)
+
+Incumbent v1 leg (1,096 B): Type 26 B, Import 70 B (2 WASI imports), Function
+9 B, Memory 3 B, Global 38 B, Export 40 B, Code 739 B (8 functions — `alloc`,
+`rc_dec`, `main`, `print_str`, `_start` and three helpers), Data 46 B, plus a
+98-byte `name` custom section (function names only; locals stripped — a
+wasmtime trap backtrace prints them, worth the bytes). The incumbent's +393 B
+since the July measurement (703 → 1,096 B) is the deterministic-meter and
+stdin plumbing that landed with the C-320 arc.
 
 ### Where the stdlib went
 
 Almide's stdlib is 969 functions across 43 modules — but they are **self-hosted
 in Almide** and linked *on demand*. The compiler scans the lowered program for
-called dispatch names (`string.len`, `map.set`, `list.sort_by`, …) and links only
-the matching self-host sources, iterating to a fixpoint so a linked function's
-own callees follow. Hello, world links **zero** stdlib functions; FizzBuzz links
-the handful behind `int.to_string`. An unused module contributes nothing — and
-anything it *does* pull in that turns out unreachable (e.g. a helper the linked
-source calls only on a branch this program's monomorphization never takes) is
-then swept by the same reachability DCE described above.
+called dispatch names (`string.len`, `map.set`, `list.sort_by`, …) and links
+only the matching self-host sources, iterating to a fixpoint so a linked
+function's own callees follow. Hello, world links **zero** stdlib functions;
+FizzBuzz links the handful behind `int.to_string`. An unused module
+contributes nothing — and anything it *does* pull in that turns out
+unreachable is swept by reachability DCE before assembly.
 
 ### Why the value model stays small
 
 - **i64-uniform slots.** Every scalar is an i64; every heap value is a
-  length-prefixed block of i64 slots addressed by an i32 handle. No per-type
-  layouts to describe, no metadata to carry.
+  length-prefixed block addressed by an i32 handle. No per-type layouts, no
+  metadata.
 - **Variants are `tag @ slot 0`.** A `match` compiles to integer compares —
   no vtables, no type descriptors.
 - **Monomorphization → direct calls.** Generics are specialized at compile
   time; the only indirect calls are closures, through a single funcref table.
-- **Reachability DCE, in two layers.** The demand linker above decides *which
-  self-hosted stdlib sources* enter the program at all; the wasm renderer's own
-  reachability pass then decides which of the resulting preamble helpers,
-  imports, data segments, and functions the final call graph actually reaches,
-  and drops the rest before assembling the module.
+- **Reachability DCE, in two layers.** The demand linker decides *which
+  self-hosted stdlib sources* enter the program; the renderer's reachability
+  pass then drops unreached helpers, imports, and data segments before the
+  module is assembled.
 
 ## What's still not the smallest possible module, and why
 
 The verified pipeline **ships the bytes its own rendering process produced**.
-Every module built on the default path carries a machine-checked
-ownership/refcount certificate (re-verified by the Rocq-checked kernel on each
-build). Reachability DCE and the name-section trim above happen *inside* that
-same certified renderer, before the module is ever assembled — the shipped
-bytes are still exactly what the trust-spine produced, nothing external has
-touched them. `wasm-opt` is a different kind of thing: an **external,
-unverified transform applied to the renderer's finished output**, so running
-it would replace bytes the trust-spine produced with bytes a separate,
-un-certified tool rewrote. That line is why it stays opt-in:
-
-- The **name section** keeps one entry per function (~50 B here) — that's
-  what a wasmtime trap backtrace prints (`<unknown>!funcname`), and the
-  diagnostics value is worth the few dozen bytes it costs. Only *local* names
-  (`$v1`, `$v2`, …, zero backtrace value, and often the single largest part of
-  an un-trimmed name section) are dropped.
-- `wasm-opt`'s further gains — instruction selection, local coalescing,
-  cross-function inlining, and more aggressive DCE than a reachability BFS
-  can safely do inline — go beyond what the verified renderer itself
-  guarantees, so they stay a separate, explicit step.
-
-If you want minimum bytes and accept leaving the verified envelope:
+Every module built on the default path is emit-time validated, and the
+incumbent leg additionally carries a machine-checked ownership/refcount
+certificate re-verified by the Rocq-checked kernel each build. `wasm-opt` is a
+different kind of thing: an **external, unverified transform applied to the
+renderer's finished output** — running it replaces bytes the pipeline produced
+with bytes a separate, un-certified tool rewrote. That line is why it stays
+opt-in:
 
 ```bash
-almide build app.almd --target wasm --wasm-opt   # runs: wasm-opt -Oz \
-#   --enable-nontrapping-float-to-int --enable-tail-call  (the features the
-#   v1 renderer actually emits — no SIMD in the default output)
+almide build app.almd --target wasm --wasm-opt   # runs: wasm-opt -Oz
+#   --enable-nontrapping-float-to-int --enable-tail-call --enable-bulk-memory
+#   --enable-mutable-globals
+#   (the features the two legs actually emit — no SIMD in the default output;
+#    bulk-memory is the structural leg's memory.copy and mutable-globals its
+#    exported globals, #1616)
 ```
 
-(`--all-features` is required — the runtime's fs helpers return multi-value
-pairs, and the float printer uses post-MVP integer ops. Binaryen then squeezes
-further: Hello, world drops from 703 B to 545 B.)
-
-**`-Oz` trades speed for those bytes.** The verified renderer versions hot
-loops into a guarded fast path with the bounds checks discharged up front
-(`render_wasm_bce.rs`); `-Oz`'s code folding merges the near-identical fast
-and slow copies back into one checked loop, measured ~3× slower on
-spectralnorm. Use `-Oz` for size-critical cold code; benchmark before applying
-it to compute kernels.
+**`-Oz` trades speed for those bytes.** The incumbent renderer versions hot
+loops into a guarded fast path with bounds checks discharged up front;
+`-Oz`'s code folding merges the near-identical copies back into one checked
+loop, measured ~3× slower on spectralnorm. Use `-Oz` for size-critical cold
+code; benchmark before applying it to compute kernels.
 
 ## Determinism and the cross-target contract
 
-The emitted bytes are **deterministic across host architectures**: the compiler
-built natively (x86-64/aarch64) and the compiler built as wasm32 (the
-playground) produce byte-identical modules for all 270 cross-target fixtures —
-a CI gate (`scripts/check-host-determinism.sh`), not an aspiration. And every
-program that compiles for both targets produces **byte-identical stdout/stderr/
-exit code** native ⇄ wasm, tracked contract-by-contract in
+The emitted bytes are **deterministic across host architectures**: the
+compiler built natively (x86-64/aarch64) and the compiler built as wasm32 (the
+playground) produce byte-identical modules for the cross-target fixture corpus
+— a CI gate (`scripts/check-host-determinism.sh`), not an aspiration. And
+every program that compiles for both targets produces **byte-identical
+stdout/stderr/exit code** native ⇄ wasm, tracked contract-by-contract in
 [docs/contracts/](../contracts).
 
 ## Reproducing the measurements
 
 ```bash
-# Almide
-echo 'fn main() -> Unit = println("Hello, world!")' > hello.almd
-almide build hello.almd --target wasm -o hello.wasm      # 703 B (verified)
-almide build hello.almd --target wasm --wasm-opt -o hello.min.wasm  # 545 B
-wasm-objdump -h hello.wasm                                # the section table above
+# Almide — structural (default) and incumbent legs, plain and -Oz
+printf 'fn main() -> Unit = {\n  println("Hello, world!")\n}\n' > hello.almd
+almide build hello.almd --target wasm -o hello.wasm                    # structural, verified
+almide build hello.almd --target wasm --wasm-opt -o hello.min.wasm     # structural, -Oz
+ALMIDE_WASM_INCUMBENT=1 almide build hello.almd --target wasm -o hello_v1.wasm
+wasm-objdump -h hello.wasm                                             # the section tables above
 
-# Rust (same target, full size profile)
+# Rust (same target, full size profile — 2026-07-23 numbers)
 cargo new rhello && cd rhello
 # [profile.release] opt-level="z", lto=true, strip=true, panic="abort", codegen-units=1
-cargo build --release --target wasm32-wasip1             # 40,754 B
+cargo build --release --target wasm32-wasip1
 ```


### PR DESCRIPTION
Closes #1618.

The dissection described a 703 B Hello, world measured 2026-07-23 on the leg most builds no longer take. Rewritten for the two-leg reality (measured 2026-08-27, wasm-opt 132 / wasm-objdump 1.0.41; the Rust comparison rows keep their dated 2026-07-23 numbers):

- **Four-column headline table** (structural / structural -Oz / incumbent / incumbent -Oz) over four programs. Hello, world: 4,459 / **364** / 1,096 / 788 B; the ADT-repr row: **14,088** structural vs 34,723 incumbent raw.
- **The crossover, stated as a curve**: the structural leg's fixed ~3.5 KB preamble makes tiny programs larger raw, real programs smaller (corpus aggregate 4.11 MB vs 10.54 MB per the greenfield VERDICT), and after \`-Oz\` the structural module is smallest on every measured row (hello survives as ONE function — the "tier-0 preamble" idea is named as the in-envelope path to most of that, with this doc as its measurement site).
- Section anatomy re-measured for both legs, including the incumbent's +393 B since July (the C-320 meter + stdin plumbing) and the exact wasm-opt flag set (\`--enable-bulk-memory\`, \`--enable-mutable-globals\` — #1616's fixes, which this doc depends on).
- The derived-numbers rule holds: the headline defers to \`docs/benchmarks/wasm-size.txt\` (CI-checked), everything else carries its measurement date. \`docs-gen --check\` and \`check-readme-numbers.sh\` green.