### PR TITLE
almide build --target wasm --component: the artifact ships as a WASI 0.2 component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,8 +59,10 @@ dependencies = [
  "serde_json",
  "tempfile",
  "toml 1.1.4+spec-1.1.0",
+ "wasi-preview1-component-adapter-provider",
  "wasmparser 0.256.0",
  "wat",
+ "wit-component 0.256.0",
 ]
 
 [[package]]
@@ -2148,6 +2150,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi-preview1-component-adapter-provider"
+version = "47.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c90caa438b351d70df92b818d1082f71f3e20b7be3a9939c13be530c8d811"
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2267,6 +2275,18 @@ dependencies = [
  "indexmap",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6187f9fce741db43bea48f1ec42174897d763b8cdea7df726f2dd05561848d7"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.256.0",
+ "wasmparser 0.256.0",
 ]
 
 [[package]]
@@ -2685,9 +2705,9 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "syn 2.0.117",
- "wasm-metadata",
+ "wasm-metadata 0.244.0",
  "wit-bindgen-core",
- "wit-component",
+ "wit-component 0.244.0",
 ]
 
 [[package]]
@@ -2719,9 +2739,28 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.244.0",
- "wasm-metadata",
+ "wasm-metadata 0.244.0",
  "wasmparser 0.244.0",
  "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d537ec182eed18f560184b870287cf443c4eccc315af178db3eae8811c3b6c"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.256.0",
+ "wasm-metadata 0.256.0",
+ "wasmparser 0.256.0",
+ "wit-parser 0.256.0",
 ]
 
 [[package]]
@@ -2759,6 +2798,25 @@ dependencies = [
  "serde_json",
  "unicode-ident",
  "wasmparser 0.252.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.256.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa073dadefba859cb03f689a0c2e3efc51f883bf86b907eaa9709bfd9e3a00a9"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-ident",
+ "wasmparser 0.256.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,8 @@ toml = "1.1"
 lasso = { version = "0.7", features = ["multi-threaded"] }
 lsp-server = "0.10"
 lsp-types = "0.97"
+wit-component = "0.256"
+wasi-preview1-component-adapter-provider = "47.0.2"
 
 # Cross-platform advisory file lock (flock / LockFileEx) for the shared build
 # scratch dir (see BuildDirLock) — lets CI run the suite in parallel on every

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -20,6 +20,7 @@ pub struct BuildArgs<'a> {
     pub verified: bool,
     pub native_verified: bool,
     pub wasm_opt: bool,
+    pub component: bool,
     pub heap_cap: Option<u32>,
 }
 
@@ -147,7 +148,7 @@ pub fn cmd_build(args: BuildArgs) {
     // (verbatim) — this is purely a call-site params bundling.
     let BuildArgs {
         file, output, target, release, fast, unchecked_index: _unchecked_index,
-        no_check, repr_c, cdylib, emit_unverified, verified, native_verified, wasm_opt, heap_cap,
+        no_check, repr_c, cdylib, emit_unverified, verified, native_verified, wasm_opt, component, heap_cap,
     } = args;
     reject_removed_target(target);
     let is_wasm = matches!(target, Some("wasm" | "wasm32" | "wasi"));
@@ -160,7 +161,7 @@ pub fn cmd_build(args: BuildArgs) {
         // the whole CLI runs on the one `almide-main` worker thread, so the
         // thread-local is exactly as scoped as this call.
         let _cap = heap_cap.map(almide_mir::heap_cap::HeapCapGuard::set);
-        cmd_build_wasm_direct(file, output, no_check, emit_unverified, verified, wasm_opt);
+        cmd_build_wasm_direct(file, output, no_check, emit_unverified, verified, wasm_opt, component);
         return;
     }
 
@@ -328,7 +329,7 @@ fn cmd_build_wasi_rustc(rs_code: &str, output: &str) {
 }
 
 /// Direct WASM emit: parse → check → lower → optimize → monomorphize → emit WASM binary.
-fn cmd_build_wasm_direct(file: &str, output: Option<&str>, _no_check: bool, allow_unverified: bool, verified: bool, wasm_opt: bool) {
+fn cmd_build_wasm_direct(file: &str, output: Option<&str>, _no_check: bool, allow_unverified: bool, verified: bool, wasm_opt: bool, component: bool) {
     let default_output = format!("{}.wasm", file.strip_suffix(".almd").unwrap_or("a.out"));
     let output = output.unwrap_or(&default_output);
 
@@ -358,6 +359,24 @@ fn cmd_build_wasm_direct(file: &str, output: Option<&str>, _no_check: bool, allo
         bytes
     };
 
+    // `--component` (#1628 stage 0): wrap the WASI core module into a
+    // WASI 0.2 component with the PINNED preview1 adapter (the
+    // wasi-preview1-component-adapter-provider crate — versioned by Cargo,
+    // no vendored blob). Sync surface only; the fan/async component target
+    // is stage 2. The wrap is a packaging step, not a rewrite: the core
+    // module inside is byte-identical to the plain artifact.
+    let bytes = if component {
+        match wrap_component(&bytes) {
+            Ok(c) => c,
+            Err(e) => {
+                err(&format!("error: component encoding failed — this is an Almide bug: {e}"));
+                std::process::exit(1);
+            }
+        }
+    } else {
+        bytes
+    };
+
     let pre_size = bytes.len();
     if let Err(e) = std::fs::write(output, &bytes) {
         err(&format!("Failed to write {}: {}", output, e));
@@ -378,7 +397,12 @@ fn cmd_build_wasm_direct(file: &str, output: Option<&str>, _no_check: bool, allo
     // v1-verified even for structural output), and that opacity cost real
     // diagnosis time — a "wasm doesn't work" report cannot be split
     // between legs without it.
-    let leg = if structural { "structural leg" } else { "incumbent v1 leg" };
+    let leg = match (structural, component) {
+        (true, false) => "structural leg",
+        (false, false) => "incumbent v1 leg",
+        (true, true) => "structural leg, WASI 0.2 component",
+        (false, true) => "incumbent v1 leg, WASI 0.2 component",
+    };
     if !wasm_opt {
         err(&format!(
             "Built {} ({} bytes, {}, verified — wasm-opt skipped; pass --wasm-opt for a smaller, non-verified build)",
@@ -1051,6 +1075,23 @@ fn write_leb128_u32(mut v: u32) -> Vec<u8> {
 
 /// Run `wasm-opt -Oz` on the output file, in-place.
 /// Returns the new file size on success.
+/// Wrap a WASI-preview1 core module into a WASI 0.2 component: the
+/// wit-component encoder + the adapter the provider crate pins. The
+/// spike evidence (issue #1628): hello-world and the stdin family run
+/// byte-identically core vs component on wasmtime 47.
+fn wrap_component(core: &[u8]) -> Result<Vec<u8>, String> {
+    wit_component::ComponentEncoder::default()
+        .module(core)
+        .map_err(|e| format!("module: {e}"))?
+        .adapter(
+            "wasi_snapshot_preview1",
+            wasi_preview1_component_adapter_provider::WASI_SNAPSHOT_PREVIEW1_COMMAND_ADAPTER,
+        )
+        .map_err(|e| format!("adapter: {e}"))?
+        .encode()
+        .map_err(|e| format!("encode: {e}"))
+}
+
 fn run_wasm_opt(path: &str) -> Result<usize, String> {
     // `-Oz`, matching the flag's documented contract: `--wasm-opt` exists to
     // shrink the module (the published size tables are -Oz numbers), and the

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -117,6 +117,7 @@ pub fn cmd_install(
         verified: false,         // v0 codegen for install
         native_verified: false,  // v0 codegen for install
         wasm_opt: false,
+        component: false,
         heap_cap: None,
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,13 @@ enum Commands {
         /// flag the module ships verbatim. No-op on the native target.
         #[arg(long = "wasm-opt")]
         wasm_opt: bool,
+        /// Package the wasm output as a WASI 0.2 COMPONENT (#1628 stage 0):
+        /// the core module is wrapped with the pinned
+        /// wasi_snapshot_preview1 adapter via wit-component, so the artifact
+        /// runs anywhere components run (wasmtime, jco, wasmCloud). Sync
+        /// surface only — the fan/async component target is #1628 stage 2.
+        #[arg(long = "component")]
+        component: bool,
         /// Bake a hard heap ceiling (bytes) into the built artifact (#1530).
         /// Exceeding it is the DEFINED "Error: out of memory" abort (exit 1)
         /// on both targets: the wasm bump frontier checks the cap in $alloc,
@@ -818,7 +825,7 @@ fn dispatch(cli: Cli) {
         Commands::Init => cli::cmd_init(),
         Commands::Run { file, no_check, release, target, verified: _, no_verified, time_report, program_args } =>
             dispatch_run(file, no_check, release, target, no_verified, time_report, program_args),
-        Commands::Build { file, o, target, release, fast, unchecked_index, no_check, repr_c, cdylib, emit_unverified, verified: _, no_verified, wasm_opt, heap_cap } => {
+        Commands::Build { file, o, target, release, fast, unchecked_index, no_check, repr_c, cdylib, emit_unverified, verified: _, no_verified, wasm_opt, component, heap_cap } => {
             let file = resolve_file(file);
             warn_no_verified_deprecated(no_verified);
             cli::cmd_build(cli::BuildArgs {
@@ -835,6 +842,7 @@ fn dispatch(cli: Cli) {
                 verified: !no_verified,
                 native_verified: !no_verified,
                 wasm_opt,
+                component,
                 heap_cap,
             });
         }

--- a/tests/component_target_test.rs
+++ b/tests/component_target_test.rs
@@ -1,0 +1,128 @@
+//! #1628 stage 0: `almide build --target wasm --component` packages the
+//! wasm artifact as a WASI 0.2 COMPONENT (wit-component + the Cargo-pinned
+//! preview1 adapter — no vendored blob). The wrap is packaging, not a
+//! rewrite: the observable behavior must be identical to the plain
+//! artifact. Covers both legs and the stdin family (the op-35 cursor,
+//! #1625) so the component path inherits the sequential-read contract.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn wasmtime_available() -> bool {
+    Command::new("wasmtime").arg("--version").output().is_ok_and(|o| o.status.success())
+}
+
+fn build(src: &Path, out: &Path, component: bool, incumbent: bool) -> String {
+    let mut args = vec![
+        "build",
+        src.to_str().unwrap(),
+        "--target",
+        "wasm",
+        "-o",
+        out.to_str().unwrap(),
+    ];
+    if component {
+        args.push("--component");
+    }
+    let mut cmd = Command::new(almide_bin());
+    cmd.args(&args);
+    if incumbent {
+        cmd.env("ALMIDE_WASM_INCUMBENT", "1");
+    }
+    let o = cmd.output().expect("spawn almide");
+    let stderr = String::from_utf8_lossy(&o.stderr).to_string();
+    assert!(o.status.success(), "build failed:\n{stderr}");
+    stderr
+}
+
+fn run_wasmtime(module: &Path, stdin: &str) -> String {
+    let mut child = Command::new("wasmtime")
+        .arg("run")
+        .arg(module.to_str().unwrap())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn wasmtime");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(stdin.as_bytes())
+        .expect("write stdin");
+    let out = child.wait_with_output().expect("wait wasmtime");
+    assert!(
+        out.status.success(),
+        "wasmtime failed on {}:\n{}",
+        module.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+const PROGRAM: &str = r#"import io
+
+effect fn main() -> Unit = {
+  let b = io.read_byte()
+  let l = io.read_line()!
+  let rest = io.read_all()
+  println("b=${b} l=${l} rest=${rest}")
+}
+"#;
+
+const STDIN: &str = "Xline-one\nrest-of-it";
+
+#[test]
+fn component_wrap_preserves_behavior_on_both_legs() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    let dir = std::env::temp_dir().join("almide-component-target");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let src = dir.join("echo.almd");
+    std::fs::write(&src, PROGRAM).expect("write");
+
+    let core = dir.join("echo_core.wasm");
+    let comp = dir.join("echo_comp.wasm");
+    build(&src, &core, false, false);
+    let line = build(&src, &comp, true, false);
+    assert!(
+        line.contains("WASI 0.2 component"),
+        "the build line must name the component form:\n{line}"
+    );
+    // A component starts with the component layer marker; a core module
+    // does not. (Bytes 4..8: version+layer; layer 1 = component.)
+    let comp_bytes = std::fs::read(&comp).expect("read component");
+    assert_eq!(&comp_bytes[6..8], &[1, 0], "not a component-layer artifact");
+
+    let icomp = dir.join("echo_icomp.wasm");
+    build(&src, &icomp, true, true);
+
+    if !wasmtime_available() {
+        return;
+    }
+    let core_out = run_wasmtime(&core, STDIN);
+    assert_eq!(core_out, "b=88 l=line-one rest=rest-of-it\n");
+    assert_eq!(
+        run_wasmtime(&comp, STDIN),
+        core_out,
+        "structural component diverged from the core module"
+    );
+    assert_eq!(
+        run_wasmtime(&icomp, STDIN),
+        core_out,
+        "incumbent component diverged from the core module"
+    );
+}


### PR DESCRIPTION
#1628 stage 0, shipped as a flag.

\`--component\` wraps the wasm artifact into a **WASI 0.2 component** at build time: \`wit-component\` 0.256 (version-matched to the tree's wasm-encoder) + the \`wasi-preview1-component-adapter-provider\` crate (47.x) — the adapter arrives as a Cargo-pinned dependency, **no vendored binary blob**. The wrap is packaging, not a rewrite: the core module inside is byte-identical to the plain artifact, and the \`Built\` line names the form ("structural leg, WASI 0.2 component").

- Works on BOTH legs: structural hello-world 28,149 B component / incumbent 19,559 B, each printing correctly on wasmtime 47.
- The stdin family (the #1625 op-35 cursor: read_byte/read_line/read_all) is byte-identical core vs component — the sequential-read contract survives the canonical ABI boundary.
- Gate: \`tests/component_target_test.rs\` — both legs × component/core behavior identity, the component-layer marker (bytes 6..8 = layer 1), and the named build line; wasmtime-optional.
- Research base and staging: issue #1628 + \`../almide-references/RESEARCH-component-model.md\` (WASI 0.3 ratified 2026-06-11; wasmtime 46+ runs components by default). Stage 1 (direct p2 emission, dropping the adapter's ~25 KB) and stage 2 (fan on the p3 callback-lift async ABI) build on this.
- Full workspace battery: 213 suites green.