### PR TITLE
Direct WASI 0.2 component emission: --component drops the preview1 adapter on the structural leg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,8 @@ dependencies = [
  "wasm-encoder 0.256.0",
  "wasmparser 0.256.0",
  "wasmtime",
+ "wit-component 0.256.0",
+ "wit-parser 0.256.0",
 ]
 
 [[package]]

--- a/crates/almide-wasm-run/Cargo.toml
+++ b/crates/almide-wasm-run/Cargo.toml
@@ -15,6 +15,8 @@ anyhow = "1"
 wasmparser = "0.256"
 wasm-encoder = "0.256"
 wasmtime = "47"
+wit-component = "0.256"
+wit-parser = "0.256"
 
 [lints]
 workspace = true

--- a/crates/almide-wasm-run/src/lib.rs
+++ b/crates/almide-wasm-run/src/lib.rs
@@ -4,5 +4,6 @@
 
 mod host;
 pub mod wasi;
+pub mod wasi_p2;
 
 pub use host::{run_wasm, run_wasm_capped, run_wasm_real_stdin, run_wasm_with, RunResult};

--- a/crates/almide-wasm-run/src/wasi.rs
+++ b/crates/almide-wasm-run/src/wasi.rs
@@ -28,37 +28,41 @@ use wasm_encoder::{
 };
 use wasmparser::{Parser, Payload};
 
-const UNSUPPORTED_MSG: &[u8] = b"Error: host op unsupported in the WASI build\n";
+pub(crate) const UNSUPPORTED_MSG: &[u8] = b"Error: host op unsupported in the WASI build\n";
 // Park-page layout (offsets from park base).
-const IOV: u64 = 0; // two iovec entries (16 bytes)
-const NREAD: u64 = 16;
-const NL: u64 = 24;
-const MSG: u64 = 64;
-const DATA: u64 = 1024; // stdin/entropy bytes
+pub(crate) const IOV: u64 = 0; // two iovec entries (16 bytes)
+pub(crate) const NREAD: u64 = 16;
+pub(crate) const NL: u64 = 24;
+pub(crate) const MSG: u64 = 64;
+pub(crate) const DATA: u64 = 1024; // stdin/entropy bytes
 /// The park span: four pages carved out at the original heap base.
-const PARK_SPAN: u64 = 4 * 65536;
+pub(crate) const PARK_SPAN: u64 = 4 * 65536;
 
-struct Remap {
-    shim_base: u32,
+pub(crate) struct Remap {
+    pub(crate) shim_base: u32,
+    /// How far NON-import function indices move (0 for the p1 build — it
+    /// keeps the import count at five; the p2 build imports eight, so
+    /// every original index >= 5 shifts by three).
+    pub(crate) shift: u32,
 }
 
 impl Reencode for Remap {
     type Error = std::convert::Infallible;
     fn function_index(&mut self, func: u32) -> Result<u32, wasm_encoder::reencode::Error<Self::Error>> {
-        Ok(if func < 5 { self.shim_base + func } else { func })
+        Ok(if func < 5 { self.shim_base + func } else { func + self.shift })
     }
 }
 
-fn mem(offset: u64) -> MemArg {
+pub(crate) fn mem(offset: u64) -> MemArg {
     MemArg { offset, align: 2, memory_index: 0 }
 }
 
-fn mem8(offset: u64) -> MemArg {
+pub(crate) fn mem8(offset: u64) -> MemArg {
     MemArg { offset, align: 0, memory_index: 0 }
 }
 
 /// Find a function type's index, or append it.
-fn type_index(
+pub(crate) fn type_index(
     types: &mut Vec<(Vec<ValType>, Vec<ValType>)>,
     params: &[ValType],
     results: &[ValType],
@@ -71,19 +75,19 @@ fn type_index(
 }
 
 /// Everything `to_wasi` needs out of the source module, in one parse pass.
-struct Parsed<'a> {
-    types: Vec<(Vec<ValType>, Vec<ValType>)>,
-    func_types: Vec<u32>,
-    tables: TableSection,
-    old_mem_min: u64,
-    parsed_globals: Vec<(GlobalType, Option<i32>, Option<i64>, Option<u64>)>,
-    global_count: u32,
-    heap_global: Option<u32>,
-    exports: ExportSection,
-    main_index: Option<u32>,
-    elements: ElementSection,
-    data: DataSection,
-    bodies: Vec<wasmparser::FunctionBody<'a>>,
+pub(crate) struct Parsed<'a> {
+    pub(crate) types: Vec<(Vec<ValType>, Vec<ValType>)>,
+    pub(crate) func_types: Vec<u32>,
+    pub(crate) tables: TableSection,
+    pub(crate) old_mem_min: u64,
+    pub(crate) parsed_globals: Vec<(GlobalType, Option<i32>, Option<i64>, Option<u64>)>,
+    pub(crate) global_count: u32,
+    pub(crate) heap_global: Option<u32>,
+    pub(crate) exports: ExportSection,
+    pub(crate) main_index: Option<u32>,
+    pub(crate) elements: ElementSection,
+    pub(crate) data: DataSection,
+    pub(crate) bodies: Vec<wasmparser::FunctionBody<'a>>,
 }
 
 /// One global's type and const-init operands (i32/i64/f64 — the only forms
@@ -135,7 +139,7 @@ fn parse_export(e: wasmparser::Export<'_>, p: &mut Parsed<'_>) -> anyhow::Result
     Ok(())
 }
 
-fn parse_module(bytes: &[u8]) -> anyhow::Result<Parsed<'_>> {
+pub(crate) fn parse_module(bytes: &[u8]) -> anyhow::Result<Parsed<'_>> {
     let mut p = Parsed {
         types: Vec::new(),
         func_types: Vec::new(),
@@ -309,9 +313,9 @@ pub fn to_wasi(bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
     exports.export("_start", ExportKind::Func, main_index);
 
     let mut code = CodeSection::new();
-    let mut remap = Remap { shim_base };
+    let mut remap = Remap { shim_base, shift: 0 };
     for b in bodies {
-        code.function(&reencode_body(&b, &mut remap)?);
+        code.function(&reencode_body(&b, &mut remap, 1)?);
     }
     // Shims (their own calls target the NEW imports — no remap).
     code.function(&shim_print(1, park));
@@ -348,7 +352,7 @@ pub fn to_wasi(bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
 /// engine-fault split), and a stock WASI runtime would otherwise surface
 /// 128+SIGABRT. The trailing `unreachable` stays for stack-polymorphic
 /// validity.
-fn reencode_body(b: &wasmparser::FunctionBody<'_>, remap: &mut Remap) -> anyhow::Result<Function> {
+pub(crate) fn reencode_body(b: &wasmparser::FunctionBody<'_>, remap: &mut Remap, exit_fn: u32) -> anyhow::Result<Function> {
     let locals: Vec<(u32, ValType)> = b
         .get_locals_reader()?
         .into_iter()
@@ -361,7 +365,9 @@ fn reencode_body(b: &wasmparser::FunctionBody<'_>, remap: &mut Remap) -> anyhow:
     for op in b.get_operators_reader()? {
         let op = op?;
         if matches!(op, wasmparser::Operator::Unreachable) {
-            f.instructions().i32_const(1).call(1); // proc_exit(1)
+            // A trap becomes the DEFINED failure exit (p1: proc_exit(1);
+            // p2: wasi:cli/exit exit(err)) — both spell "exit code 1".
+            f.instructions().i32_const(1).call(exit_fn);
         }
         let inst = remap.instruction(op).expect("instruction reencode");
         f.instruction(&inst);

--- a/crates/almide-wasm-run/src/wasi_p2.rs
+++ b/crates/almide-wasm-run/src/wasi_p2.rs
@@ -1,0 +1,493 @@
+//! `to_p2` (#1628 stage 1): rewrite an emitted almide module into a
+//! WASI 0.2 COMPONENT directly — the canonical-ABI core imports plus a
+//! wit-component encode of the vendored minimal WIT world, **no preview1
+//! adapter** (the stage-0 wrap carries ~25 KB of adapter; this path
+//! carries none, and the adapter structurally cannot host a guest
+//! scheduler, so stage 2's fan lowering builds on THIS shape).
+//!
+//! Same doctrine as `to_wasi` (#1588), same five-op host surface:
+//! console out, exit codes, stdin (cursor + read-to-end), entropy, the
+//! wall clock. fs/env/process ops keep the DEFINED refusal. The
+//! transform is a post-pass — the emitter's verified envelope is
+//! untouched; the p1 build remains the plain `--target wasm` artifact.
+//!
+//! Canonical-ABI shapes used (WASI 0.2.3, the vendored WIT under
+//! `crates/almide-wasm-run/wit/`):
+//!   - `get-stdin/get-stdout/get-stderr: func() -> own<stream>` → core
+//!     `() -> i32` (handles cached in globals, fetched once);
+//!   - `[method]output-stream.blocking-write-and-flush(list<u8>)` → core
+//!     `(self, ptr, len, retptr)` — the spec caps one write at 4096
+//!     bytes, so the print shims CHUNK;
+//!   - `[method]input-stream.blocking-read(u64)` → core
+//!     `(self, len, retptr)`; the returned list lands via our exported
+//!     `cabi_realloc`; EOF is `err(closed)`;
+//!   - `wall-clock.now() -> datetime` → core `(retptr)`,
+//!     record{u64 seconds, u32 nanos};
+//!   - `get-random-bytes(u64) -> list<u8>` → core `(len, retptr)`;
+//!   - `exit(result)` → core `(i32)`; the component run world only
+//!     carries ok/err, which spells exactly the corpus's 0/1 codes.
+//!
+//! `cabi_realloc` bumps the module's own `__heap` frontier (raw bytes,
+//! never a block: the bump region is never freed, so the allocator's
+//! free-list discipline is undisturbed), growing memory on demand.
+
+use wasm_encoder::{
+    BlockType, CodeSection, ConstExpr, EntityType, ExportKind, Function,
+    FunctionSection, GlobalSection, GlobalType, ImportSection, MemArg, MemorySection, MemoryType,
+    Module, TypeSection, ValType,
+};
+
+use crate::wasi::{
+    mem, mem8, parse_module, reencode_body, type_index, Parsed, Remap, DATA, MSG, PARK_SPAN,
+    UNSUPPORTED_MSG,
+};
+
+// Import indices (8 imports replace the 5 almide.* ones; original
+// non-import indices shift by +3).
+const I_GET_STDIN: u32 = 0;
+const I_GET_STDOUT: u32 = 1;
+const I_GET_STDERR: u32 = 2;
+const I_EXIT: u32 = 3;
+const I_BLOCKING_READ: u32 = 4;
+const I_WRITE_FLUSH: u32 = 5;
+const I_CLOCK_NOW: u32 = 6;
+const I_RANDOM: u32 = 7;
+const IMPORTS: u32 = 8;
+const SHIFT: u32 = IMPORTS - 5;
+
+// Park offsets past the shared ones: retptr scratch (8-aligned).
+const RET: u64 = 32;
+
+/// 8-byte MemArg.
+fn mem64(offset: u64) -> MemArg {
+    MemArg { offset, align: 3, memory_index: 0 }
+}
+
+pub fn to_p2(bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
+    let parsed = parse_module(bytes)?;
+    let Parsed {
+        mut types,
+        func_types,
+        tables,
+        old_mem_min,
+        parsed_globals,
+        global_count,
+        heap_global,
+        exports: _,
+        main_index,
+        elements,
+        mut data,
+        bodies,
+    } = parsed;
+    let main_index = main_index.ok_or_else(|| anyhow::anyhow!("no main export"))?;
+    let heap_global = heap_global.ok_or_else(|| anyhow::anyhow!("no __heap export"))?;
+    let n_funcs = func_types.len() as u32;
+    let shim_base = IMPORTS + n_funcs;
+    // Shim order mirrors the almide.* import order (println, eprintln,
+    // exit, fs_call, host_read), then cabi_realloc and the run wrapper.
+    let f_realloc = shim_base + 5;
+    let f_run = shim_base + 6;
+
+    let heap_init = parsed_globals[heap_global as usize]
+        .1
+        .ok_or_else(|| anyhow::anyhow!("__heap init not i32"))? as u32 as u64;
+    let park: u64 = heap_init;
+    // Globals: originals, then plen, ppos, stdin/stdout/stderr handles.
+    let (g_plen, g_ppos) = (global_count, global_count + 1);
+    let (g_stdin, g_stdout, g_stderr) = (global_count + 2, global_count + 3, global_count + 4);
+    let mut globals = GlobalSection::new();
+    for (idx, (gt, i32v, i64v, f64v)) in parsed_globals.iter().enumerate() {
+        let init = if idx as u32 == heap_global {
+            ConstExpr::i32_const((heap_init + PARK_SPAN) as i32)
+        } else if let Some(v) = i32v {
+            ConstExpr::i32_const(*v)
+        } else if let Some(v) = i64v {
+            ConstExpr::i64_const(*v)
+        } else {
+            ConstExpr::f64_const(f64::from_bits(f64v.expect("global init")).into())
+        };
+        globals.global(*gt, &init);
+    }
+    let mutable_i32 = GlobalType { val_type: ValType::I32, mutable: true, shared: false };
+    globals.global(mutable_i32, &ConstExpr::i32_const(0)); // plen
+    globals.global(mutable_i32, &ConstExpr::i32_const(0)); // ppos
+    globals.global(mutable_i32, &ConstExpr::i32_const(-1)); // stdin
+    globals.global(mutable_i32, &ConstExpr::i32_const(-1)); // stdout
+    globals.global(mutable_i32, &ConstExpr::i32_const(-1)); // stderr
+
+    // Canonical-ABI core types.
+    let t_get = type_index(&mut types, &[], &[ValType::I32]);
+    let t_exit = type_index(&mut types, &[ValType::I32], &[]);
+    let t_read =
+        type_index(&mut types, &[ValType::I32, ValType::I64, ValType::I32], &[]);
+    let t_write = type_index(
+        &mut types,
+        &[ValType::I32, ValType::I32, ValType::I32, ValType::I32],
+        &[],
+    );
+    let t_now = type_index(&mut types, &[ValType::I32], &[]);
+    let t_random = type_index(&mut types, &[ValType::I64, ValType::I32], &[]);
+    // Shim types (the almide.* signatures) + realloc + run.
+    let t_print = type_index(&mut types, &[ValType::I32, ValType::I32], &[]);
+    let t_fs = type_index(&mut types, &[ValType::I32; 5], &[ValType::I64]);
+    let t_hread = type_index(&mut types, &[ValType::I32], &[]);
+    let t_realloc = type_index(&mut types, &[ValType::I32; 4], &[ValType::I32]);
+    let t_run = type_index(&mut types, &[], &[ValType::I32]);
+
+    let mut type_sec = TypeSection::new();
+    for (p, r) in &types {
+        type_sec.ty().function(p.iter().copied(), r.iter().copied());
+    }
+
+    let mut imports = ImportSection::new();
+    imports.import("wasi:cli/stdin@0.2.3", "get-stdin", EntityType::Function(t_get));
+    imports.import("wasi:cli/stdout@0.2.3", "get-stdout", EntityType::Function(t_get));
+    imports.import("wasi:cli/stderr@0.2.3", "get-stderr", EntityType::Function(t_get));
+    imports.import("wasi:cli/exit@0.2.3", "exit", EntityType::Function(t_exit));
+    imports.import(
+        "wasi:io/streams@0.2.3",
+        "[method]input-stream.blocking-read",
+        EntityType::Function(t_read),
+    );
+    imports.import(
+        "wasi:io/streams@0.2.3",
+        "[method]output-stream.blocking-write-and-flush",
+        EntityType::Function(t_write),
+    );
+    imports.import("wasi:clocks/wall-clock@0.2.3", "now", EntityType::Function(t_now));
+    imports.import("wasi:random/random@0.2.3", "get-random-bytes", EntityType::Function(t_random));
+
+    let mut functions = FunctionSection::new();
+    for ti in &func_types {
+        functions.function(*ti);
+    }
+    for ti in [t_print, t_print, t_exit, t_fs, t_hread, t_realloc, t_run] {
+        functions.function(ti);
+    }
+
+    let mut memories = MemorySection::new();
+    memories.memory(MemoryType {
+        minimum: old_mem_min + PARK_SPAN / 65536,
+        maximum: None,
+        memory64: false,
+        shared: false,
+        page_size_log2: None,
+    });
+
+    // Exports: memory survives (the canonical ABI reads/writes it), the
+    // run world's entry is the lifted wrapper, and cabi_realloc is the
+    // host's landing zone for returned lists. main/__heap exports are
+    // DROPPED — a component models its exports, and the world has none
+    // for them.
+    let exports = {
+        let mut e = wasm_encoder::ExportSection::new();
+        e.export("memory", ExportKind::Memory, 0);
+        e.export("wasi:cli/run@0.2.3#run", ExportKind::Func, f_run);
+        e.export("cabi_realloc", ExportKind::Func, f_realloc);
+        e
+    };
+
+    let mut code = CodeSection::new();
+    let mut remap = Remap { shim_base, shift: SHIFT };
+    for b in bodies {
+        code.function(&reencode_body(&b, &mut remap, I_EXIT)?);
+    }
+    code.function(&shim_print(g_stdout, I_GET_STDOUT, park, true));
+    code.function(&shim_print(g_stderr, I_GET_STDERR, park, true));
+    code.function(&shim_exit());
+    code.function(&shim_fs_call(park, g_plen, g_ppos, g_stdin, g_stdout, g_stderr));
+    code.function(&shim_host_read(g_plen, g_ppos));
+    code.function(&shim_cabi_realloc(heap_global));
+    code.function(&shim_run(main_index + SHIFT));
+
+    data.active(0, &ConstExpr::i32_const((park + MSG) as i32), UNSUPPORTED_MSG.iter().copied());
+
+    let mut m = Module::new();
+    m.section(&type_sec)
+        .section(&imports)
+        .section(&functions)
+        .section(&tables)
+        .section(&memories)
+        .section(&globals)
+        .section(&exports)
+        .section(&elements)
+        .section(&code)
+        .section(&data);
+    let mut core = m.finish();
+    wasmparser::validate(&core)?;
+
+    // Embed the world's component-type metadata, then encode WITHOUT an
+    // adapter — the imports above ARE the canonical ABI. The WIT text is
+    // COMPILED IN (include_str!): an installed binary must not depend on
+    // the build tree existing at run time.
+    let mut resolve = wit_parser::Resolve::default();
+    for (name, text) in [
+        ("io.wit", include_str!("../wit/deps/io/package.wit")),
+        ("clocks.wit", include_str!("../wit/deps/clocks/package.wit")),
+        ("random.wit", include_str!("../wit/deps/random/package.wit")),
+        ("cli.wit", include_str!("../wit/deps/cli/package.wit")),
+    ] {
+        resolve
+            .push_str(name, text)
+            .map_err(|e| anyhow::anyhow!("wit {name}: {e}"))?;
+    }
+    let pkg = resolve
+        .push_str("world.wit", include_str!("../wit/world.wit"))
+        .map_err(|e| anyhow::anyhow!("wit world: {e}"))?;
+    let world = resolve
+        .select_world(&[pkg], Some("p2-command"))
+        .map_err(|e| anyhow::anyhow!("world: {e}"))?;
+    wit_component::embed_component_metadata(
+        &mut core,
+        &resolve,
+        world,
+        wit_component::StringEncoding::UTF8,
+    )
+    .map_err(|e| anyhow::anyhow!("embed: {e}"))?;
+    let component = wit_component::ComponentEncoder::default()
+        .module(&core)
+        .map_err(|e| anyhow::anyhow!("module: {e}"))?
+        .encode()
+        .map_err(|e| anyhow::anyhow!("encode: {e}"))?;
+    Ok(component)
+}
+
+/// Fetch-and-cache a stream handle: `if g < 0 { g = get() } g`.
+fn load_handle(i: &mut wasm_encoder::InstructionSink<'_>, g: u32, get_import: u32) {
+    i.global_get(g).i32_const(0).i32_lt_s();
+    i.if_(BlockType::Empty);
+    i.call(get_import).global_set(g);
+    i.end();
+    i.global_get(g);
+}
+
+/// `(ptr, len) -> ()`: chunked blocking-write-and-flush (the spec caps a
+/// single write at 4096 bytes), then a newline write when `newline`.
+fn shim_print(g_handle: u32, get_import: u32, park: u64, newline: bool) -> Function {
+    let (ptr, len) = (0u32, 1u32);
+    let chunk = 2u32;
+    let mut f = Function::new([(1, ValType::I32)]);
+    let mut i = f.instructions();
+    i.block(BlockType::Empty).loop_(BlockType::Empty);
+    i.local_get(len).i32_eqz().br_if(1);
+    // chunk = min(len, 4096)
+    i.local_get(len).i32_const(4096).i32_lt_u();
+    i.if_(BlockType::Result(ValType::I32));
+    i.local_get(len);
+    i.else_();
+    i.i32_const(4096);
+    i.end();
+    i.local_set(chunk);
+    load_handle(&mut i, g_handle, get_import);
+    i.local_get(ptr).local_get(chunk);
+    i.i32_const((park + RET) as i32);
+    i.call(I_WRITE_FLUSH);
+    i.local_get(ptr).local_get(chunk).i32_add().local_set(ptr);
+    i.local_get(len).local_get(chunk).i32_sub().local_set(len);
+    i.br(0).end().end();
+    if newline {
+        i.i32_const(park as i32).i32_const(0x0A).i32_store8(mem8(0));
+        load_handle(&mut i, g_handle, get_import);
+        i.i32_const(park as i32).i32_const(1);
+        i.i32_const((park + RET) as i32);
+        i.call(I_WRITE_FLUSH);
+    }
+    i.end();
+    f
+}
+
+/// `(code) -> ()`: exit(ok) for 0, exit(err) otherwise — the run world's
+/// two codes, which are the deterministic corpus's two codes.
+fn shim_exit() -> Function {
+    let mut f = Function::new([]);
+    let mut i = f.instructions();
+    i.local_get(0).i32_const(0).i32_ne();
+    i.call(I_EXIT);
+    i.unreachable();
+    i.end();
+    f
+}
+
+/// The five-op host contract over p2 (op codes shared with the embedded
+/// host): 30 raw stdout, 31 stdin read-to-end, 35 stdin take-n, 32
+/// entropy, 34 wall clock; anything else = the defined refusal.
+fn shim_fs_call(
+    park: u64,
+    g_plen: u32,
+    g_ppos: u32,
+    g_stdin: u32,
+    g_stdout: u32,
+    g_stderr: u32,
+) -> Function {
+    let (op, _a_ptr, a_len, b_ptr, b_len) = (0u32, 1u32, 2u32, 3u32, 4u32);
+    let total = 5u32;
+    let n = 6u32;
+    let mut f = Function::new([(2, ValType::I32)]);
+    let mut i = f.instructions();
+
+    // op 30: raw stdout append (no newline) — b carries the bytes.
+    i.local_get(op).i32_const(30).i32_eq().if_(BlockType::Empty);
+    // Chunked write, inline (mirrors shim_print's loop without \n).
+    i.block(BlockType::Empty).loop_(BlockType::Empty);
+    i.local_get(b_len).i32_eqz().br_if(1);
+    i.local_get(b_len).i32_const(4096).i32_lt_u();
+    i.if_(BlockType::Result(ValType::I32));
+    i.local_get(b_len);
+    i.else_();
+    i.i32_const(4096);
+    i.end();
+    i.local_set(n);
+    load_handle(&mut i, g_stdout, I_GET_STDOUT);
+    i.local_get(b_ptr).local_get(n);
+    i.i32_const((park + RET) as i32);
+    i.call(I_WRITE_FLUSH);
+    i.local_get(b_ptr).local_get(n).i32_add().local_set(b_ptr);
+    i.local_get(b_len).local_get(n).i32_sub().local_set(b_len);
+    i.br(0).end().end();
+    i.i64_const(0).return_();
+    i.end();
+
+    // op 35: stdin take up to a_len bytes — ONE blocking-read; the list
+    // lands via cabi_realloc; EOF (err) answers 0 bytes.
+    i.local_get(op).i32_const(35).i32_eq().if_(BlockType::Empty);
+    load_handle(&mut i, g_stdin, I_GET_STDIN);
+    i.local_get(a_len).i64_extend_i32_u();
+    i.i32_const((park + RET) as i32);
+    i.call(I_BLOCKING_READ);
+    // result tag 0 = ok(list ptr,len) — err (closed/failed) = 0 bytes.
+    i.i32_const((park + RET) as i32).i32_load(mem(0)).i32_eqz();
+    i.if_(BlockType::Empty);
+    i.i32_const((park + RET) as i32).i32_load(mem(4)).global_set(g_ppos);
+    i.i32_const((park + RET) as i32).i32_load(mem(8)).global_set(g_plen);
+    i.else_();
+    i.i32_const(0).global_set(g_plen);
+    i.end();
+    i.global_get(g_plen).i64_extend_i32_u().return_();
+    i.end();
+
+    // op 31: stdin read-to-end — loop take-4096 into the park data span
+    // (contiguous, host_read's contract); overflow takes the refusal.
+    i.local_get(op).i32_const(31).i32_eq().if_(BlockType::Empty);
+    i.i32_const(0).local_set(total);
+    i.block(BlockType::Empty).loop_(BlockType::Empty);
+    load_handle(&mut i, g_stdin, I_GET_STDIN);
+    i.i64_const(4096);
+    i.i32_const((park + RET) as i32);
+    i.call(I_BLOCKING_READ);
+    i.i32_const((park + RET) as i32).i32_load(mem(0)).i32_eqz().i32_eqz().br_if(1); // err -> EOF
+    i.i32_const((park + RET) as i32).i32_load(mem(8)).local_set(n);
+    i.local_get(n).i32_eqz().br_if(1);
+    // room check: DATA span is the park's tail.
+    i.local_get(total).local_get(n).i32_add();
+    i.i32_const((PARK_SPAN - DATA) as i32).i32_gt_u();
+    i.if_(BlockType::Empty);
+    i.i32_const(1).call(I_EXIT).unreachable();
+    i.end();
+    i.i32_const((park + DATA) as i32).local_get(total).i32_add();
+    i.i32_const((park + RET) as i32).i32_load(mem(4));
+    i.local_get(n);
+    i.memory_copy(0, 0);
+    i.local_get(total).local_get(n).i32_add().local_set(total);
+    i.br(0).end().end();
+    i.i32_const((park + DATA) as i32).global_set(g_ppos);
+    i.local_get(total).global_set(g_plen);
+    i.local_get(total).i64_extend_i32_u().return_();
+    i.end();
+
+    // op 32: entropy — n rides b_len; the list lands via cabi_realloc.
+    i.local_get(op).i32_const(32).i32_eq().if_(BlockType::Empty);
+    i.local_get(b_len).i64_extend_i32_u();
+    i.i32_const((park + RET) as i32);
+    i.call(I_RANDOM);
+    i.i32_const((park + RET) as i32).i32_load(mem(0)).global_set(g_ppos);
+    i.i32_const((park + RET) as i32).i32_load(mem(4)).global_set(g_plen);
+    i.global_get(g_plen).i64_extend_i32_u().return_();
+    i.end();
+
+    // op 34: wall clock, raw nanos (seconds * 1e9 + nanos).
+    i.local_get(op).i32_const(34).i32_eq().if_(BlockType::Empty);
+    i.i32_const((park + RET) as i32);
+    i.call(I_CLOCK_NOW);
+    i.i32_const((park + RET) as i32).i64_load(mem64(0));
+    i.i64_const(1_000_000_000).i64_mul();
+    i.i32_const((park + RET) as i32).i64_load32_u(mem(8));
+    i.i64_add().return_();
+    i.end();
+
+    // Everything else: the defined refusal — the message on stderr, exit 1.
+    load_handle(&mut i, g_stderr, I_GET_STDERR);
+    i.i32_const((park + MSG) as i32);
+    i.i32_const(UNSUPPORTED_MSG.len() as i32);
+    i.i32_const((park + RET) as i32);
+    i.call(I_WRITE_FLUSH);
+    i.i32_const(1).call(I_EXIT);
+    i.unreachable();
+    i.end();
+    f
+}
+
+/// `(dst) -> ()`: copy the parked payload to guest memory.
+fn shim_host_read(g_plen: u32, g_ppos: u32) -> Function {
+    let mut f = Function::new([]);
+    let mut i = f.instructions();
+    i.local_get(0);
+    i.global_get(g_ppos);
+    i.global_get(g_plen);
+    i.memory_copy(0, 0);
+    i.end();
+    f
+}
+
+/// `cabi_realloc(old_ptr, old_size, align, new_size) -> ptr`: bump the
+/// module's own `__heap` frontier (8-aligned raw bytes, never freed —
+/// the block allocator's free lists are undisturbed), growing memory on
+/// demand; a grow failure exits err (the OOM discipline).
+fn shim_cabi_realloc(heap_global: u32) -> Function {
+    let (old_ptr, old_size, _align, new_size) = (0u32, 1u32, 2u32, 3u32);
+    let result = 4u32;
+    let mut f = Function::new([(1, ValType::I32)]);
+    let mut i = f.instructions();
+    // result = (heap + 7) & !7
+    i.global_get(heap_global).i32_const(7).i32_add().i32_const(-8).i32_and();
+    i.local_set(result);
+    // grow if result + new_size overruns memory
+    i.local_get(result).local_get(new_size).i32_add();
+    i.memory_size(0).i32_const(16).i32_shl();
+    i.i32_gt_u();
+    i.if_(BlockType::Empty);
+    i.local_get(new_size).i32_const(0xFFFF).i32_add().i32_const(16).i32_shr_u();
+    i.memory_grow(0);
+    i.i32_const(-1).i32_eq();
+    i.if_(BlockType::Empty);
+    i.i32_const(1).call(I_EXIT).unreachable();
+    i.end();
+    i.end();
+    i.local_get(result).local_get(new_size).i32_add().global_set(heap_global);
+    // realloc semantics: copy min(old_size, new_size) from old_ptr.
+    i.local_get(old_ptr).i32_eqz().i32_eqz();
+    i.if_(BlockType::Empty);
+    i.local_get(result);
+    i.local_get(old_ptr);
+    i.local_get(old_size).local_get(new_size).i32_lt_u();
+    i.if_(BlockType::Result(ValType::I32));
+    i.local_get(old_size);
+    i.else_();
+    i.local_get(new_size);
+    i.end();
+    i.memory_copy(0, 0);
+    i.end();
+    i.local_get(result);
+    i.end();
+    f
+}
+
+/// `() -> i32`: the lifted `wasi:cli/run.run` — call main, answer ok.
+/// (An abort inside main already left through the exit import.)
+fn shim_run(main_index: u32) -> Function {
+    let mut f = Function::new([]);
+    let mut i = f.instructions();
+    i.call(main_index);
+    i.i32_const(0);
+    i.end();
+    f
+}

--- a/crates/almide-wasm-run/wit/deps/cli/package.wit
+++ b/crates/almide-wasm-run/wit/deps/cli/package.wit
@@ -1,0 +1,24 @@
+package wasi:cli@0.2.3;
+
+interface stdin {
+  use wasi:io/streams@0.2.3.{input-stream};
+  get-stdin: func() -> input-stream;
+}
+
+interface stdout {
+  use wasi:io/streams@0.2.3.{output-stream};
+  get-stdout: func() -> output-stream;
+}
+
+interface stderr {
+  use wasi:io/streams@0.2.3.{output-stream};
+  get-stderr: func() -> output-stream;
+}
+
+interface exit {
+  exit: func(status: result);
+}
+
+interface run {
+  run: func() -> result;
+}

--- a/crates/almide-wasm-run/wit/deps/clocks/package.wit
+++ b/crates/almide-wasm-run/wit/deps/clocks/package.wit
@@ -1,0 +1,10 @@
+package wasi:clocks@0.2.3;
+
+interface wall-clock {
+  record datetime {
+    seconds: u64,
+    nanoseconds: u32,
+  }
+
+  now: func() -> datetime;
+}

--- a/crates/almide-wasm-run/wit/deps/io/package.wit
+++ b/crates/almide-wasm-run/wit/deps/io/package.wit
@@ -1,0 +1,22 @@
+package wasi:io@0.2.3;
+
+interface error {
+  resource error;
+}
+
+interface streams {
+  use error.{error};
+
+  variant stream-error {
+    last-operation-failed(error),
+    closed,
+  }
+
+  resource input-stream {
+    blocking-read: func(len: u64) -> result<list<u8>, stream-error>;
+  }
+
+  resource output-stream {
+    blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
+  }
+}

--- a/crates/almide-wasm-run/wit/deps/random/package.wit
+++ b/crates/almide-wasm-run/wit/deps/random/package.wit
@@ -1,0 +1,5 @@
+package wasi:random@0.2.3;
+
+interface random {
+  get-random-bytes: func(len: u64) -> list<u8>;
+}

--- a/crates/almide-wasm-run/wit/world.wit
+++ b/crates/almide-wasm-run/wit/world.wit
@@ -1,0 +1,17 @@
+// The direct-p2 world (#1628 stage 1): the SAME five-op host surface the
+// preview1 shim covers (console out, exit, stdin, entropy, wall clock),
+// spelled as WASI 0.2 interfaces — no adapter. fs/env/process keep the
+// defined refusal inside the shims, exactly as the p1 build.
+package almide:runtime@0.1.0;
+
+world p2-command {
+  import wasi:cli/stdin@0.2.3;
+  import wasi:cli/stdout@0.2.3;
+  import wasi:cli/stderr@0.2.3;
+  import wasi:cli/exit@0.2.3;
+  import wasi:io/streams@0.2.3;
+  import wasi:clocks/wall-clock@0.2.3;
+  import wasi:random/random@0.2.3;
+
+  export wasi:cli/run@0.2.3;
+}

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -347,34 +347,50 @@ fn cmd_build_wasm_direct(file: &str, output: Option<&str>, _no_check: bool, allo
     // the WASI form — same index space, shimmed imports, proc_exit on trap
     // (the #1588 transform; the 578-fixture stock-wasmtime gate is its
     // reproduction witness).
-    let bytes = if structural {
-        match almide_wasm_run::wasi::to_wasi(&bytes) {
-            Ok(w) => w,
-            Err(e) => {
-                err(&format!("error: WASI transform failed — this is an Almide bug: {e}"));
-                std::process::exit(1);
-            }
-        }
-    } else {
-        bytes
-    };
-
-    // `--component` (#1628 stage 0): wrap the WASI core module into a
-    // WASI 0.2 component with the PINNED preview1 adapter (the
-    // wasi-preview1-component-adapter-provider crate — versioned by Cargo,
-    // no vendored blob). Sync surface only; the fan/async component target
-    // is stage 2. The wrap is a packaging step, not a rewrite: the core
-    // module inside is byte-identical to the plain artifact.
-    let bytes = if component {
-        match wrap_component(&bytes) {
+    // `--component` on the STRUCTURAL leg (#1628 stage 1): the DIRECT p2
+    // path — canonical-ABI imports straight off the almide.* module, no
+    // preview1 adapter (~25 KB lighter, and the only shape the stage-2
+    // fan/async lowering can build on). `ALMIDE_COMPONENT_ADAPTER=1` is
+    // the reversible switch back to the stage-0 adapter wrap; the
+    // incumbent leg stays on the adapter path (its module is already
+    // p1-shaped).
+    let direct_p2 = component
+        && structural
+        && std::env::var_os("ALMIDE_COMPONENT_ADAPTER").is_none();
+    let bytes = if direct_p2 {
+        match almide_wasm_run::wasi_p2::to_p2(&bytes) {
             Ok(c) => c,
             Err(e) => {
-                err(&format!("error: component encoding failed — this is an Almide bug: {e}"));
+                err(&format!("error: p2 component transform failed — this is an Almide bug: {e}"));
                 std::process::exit(1);
             }
         }
     } else {
-        bytes
+        let bytes = if structural {
+            match almide_wasm_run::wasi::to_wasi(&bytes) {
+                Ok(w) => w,
+                Err(e) => {
+                    err(&format!("error: WASI transform failed — this is an Almide bug: {e}"));
+                    std::process::exit(1);
+                }
+            }
+        } else {
+            bytes
+        };
+        // Stage-0 adapter wrap (the incumbent leg's component form, and
+        // the structural leg's reversible fallback): the WASI core module
+        // + the Cargo-pinned preview1 adapter. Packaging, not a rewrite.
+        if component {
+            match wrap_component(&bytes) {
+                Ok(c) => c,
+                Err(e) => {
+                    err(&format!("error: component encoding failed — this is an Almide bug: {e}"));
+                    std::process::exit(1);
+                }
+            }
+        } else {
+            bytes
+        }
     };
 
     let pre_size = bytes.len();
@@ -400,8 +416,9 @@ fn cmd_build_wasm_direct(file: &str, output: Option<&str>, _no_check: bool, allo
     let leg = match (structural, component) {
         (true, false) => "structural leg",
         (false, false) => "incumbent v1 leg",
-        (true, true) => "structural leg, WASI 0.2 component",
-        (false, true) => "incumbent v1 leg, WASI 0.2 component",
+        (true, true) if direct_p2 => "structural leg, WASI 0.2 component (direct)",
+        (true, true) => "structural leg, WASI 0.2 component (adapter)",
+        (false, true) => "incumbent v1 leg, WASI 0.2 component (adapter)",
     };
     if !wasm_opt {
         err(&format!(

--- a/tests/component_target_test.rs
+++ b/tests/component_target_test.rs
@@ -98,9 +98,11 @@ fn component_wrap_preserves_behavior_on_both_legs() {
     let comp = dir.join("echo_comp.wasm");
     build(&src, &core, false, false);
     let line = build(&src, &comp, true, false);
+    // #1628 stage 1: the structural leg's component form is the DIRECT
+    // canonical-ABI encode — no preview1 adapter aboard.
     assert!(
-        line.contains("WASI 0.2 component"),
-        "the build line must name the component form:\n{line}"
+        line.contains("WASI 0.2 component (direct)"),
+        "the structural component must take the direct p2 path:\n{line}"
     );
     // A component starts with the component layer marker; a core module
     // does not. (Bytes 4..8: version+layer; layer 1 = component.)
@@ -108,7 +110,31 @@ fn component_wrap_preserves_behavior_on_both_legs() {
     assert_eq!(&comp_bytes[6..8], &[1, 0], "not a component-layer artifact");
 
     let icomp = dir.join("echo_icomp.wasm");
-    build(&src, &icomp, true, true);
+    let iline = build(&src, &icomp, true, true);
+    assert!(
+        iline.contains("component (adapter)"),
+        "the incumbent component stays on the adapter path:\n{iline}"
+    );
+    // The reversible switch: the structural leg's stage-0 adapter wrap.
+    let acomp = dir.join("echo_acomp.wasm");
+    {
+        let o = Command::new(almide_bin())
+            .args([
+                "build",
+                src.to_str().unwrap(),
+                "--target",
+                "wasm",
+                "--component",
+                "-o",
+                acomp.to_str().unwrap(),
+            ])
+            .env("ALMIDE_COMPONENT_ADAPTER", "1")
+            .output()
+            .expect("spawn almide");
+        let e = String::from_utf8_lossy(&o.stderr);
+        assert!(o.status.success(), "adapter fallback failed:\n{e}");
+        assert!(e.contains("component (adapter)"), "fallback must name the adapter form:\n{e}");
+    }
 
     if !wasmtime_available() {
         return;
@@ -124,5 +150,10 @@ fn component_wrap_preserves_behavior_on_both_legs() {
         run_wasmtime(&icomp, STDIN),
         core_out,
         "incumbent component diverged from the core module"
+    );
+    assert_eq!(
+        run_wasmtime(&acomp, STDIN),
+        core_out,
+        "the adapter-fallback component diverged from the core module"
     );
 }


### PR DESCRIPTION
#1628 stage 1.

The stage-0 \`--component\` wrap carried the ~25 KB preview1 adapter — and the adapter structurally cannot host a guest scheduler, so nothing async could ever build on it. The structural leg's component form is now a DIRECT canonical-ABI encode:

- **\`to_p2\`** (\`crates/almide-wasm-run/src/wasi_p2.rs\`): the five \`almide.*\` imports are replaced by eight canonical-ABI core imports (\`wasi:cli/{stdin,stdout,stderr,exit}@0.2.3\`, \`wasi:io/streams\`' \`blocking-read\`/\`blocking-write-and-flush\`, \`wall-clock.now\`, \`get-random-bytes\`); \`main\` lifts to the \`wasi:cli/run\` export; \`cabi_realloc\` bumps the module's own \`__heap\` frontier (raw bytes, never freed — the block allocator's free-list discipline is undisturbed); output CHUNKS at the spec's 4096-byte write cap; stdin EOF is \`err(closed)\`. Same five-op host surface and defined-refusal doctrine as the p1 build (#1588); the emitter's verified envelope is untouched (post-pass).
- **Vendored minimal WIT** (\`crates/almide-wasm-run/wit/\`): subset packages for wasi:io/cli/clocks/random@0.2.3 + the \`p2-command\` world, embedded via \`wit_component::embed_component_metadata\` and encoded with NO adapter.
- **Routing**: structural \`--component\` defaults to direct (the Built line names "component (direct)"); \`ALMIDE_COMPONENT_ADAPTER=1\` is the reversible switch back to the stage-0 wrap; the incumbent leg stays on the adapter path — the leg-commissioning playbook.

## Measured (wasmtime 47.0.2)

- hello-world component: **8,878 B vs 28,149 B** adapter form (3.2× smaller), prints correctly.
- stdin family (op-35 cursor: read_byte/read_line/read_all) byte-identical; FizzBuzz 100-line output hash-identical to native; abort path (stderr + exit 1) identical; a 12 KB single println crosses the 4096-chunk loop hash-identical.
- Gate: \`tests/component_target_test.rs\` extended — direct-form naming, adapter fallback, incumbent adapter, and behavior identity across all three component forms vs the core module.
- Full workspace battery: 213 suites green.

Stage 2 (fan on the p3 callback-lift async ABI) builds directly on this shape — the research and staging live in #1628.