### PR TITLE
MC/DC pending debt reaches zero: the safety set's 45 multi-condition decisions take the single-condition form

### DIFF
--- a/crates/almide-codegen/src/perceus_verified.rs
+++ b/crates/almide-codegen/src/perceus_verified.rs
@@ -180,7 +180,11 @@ fn bind_dec_check_exempt(var: VarId, value: &IrExpr, ctx: &VerifyCtx) -> bool {
     // Replacing this name-prefix exclusion with scope-aware Dec
     // accounting is a tracked perceus-belt follow-up.
     let vname = ctx.var_table.get(var).name.as_str();
-    vname.starts_with("__tco_") || vname.starts_with("__br_")
+    // Single-condition decisions (MC/DC ledger, #566): || as early return.
+    if vname.starts_with("__tco_") {
+        return true;
+    }
+    vname.starts_with("__br_")
 }
 
 /// First phase of `verify_block`: each heap `Bind` in `stmts` should have a

--- a/crates/almide-frontend/src/check/calls.rs
+++ b/crates/almide-frontend/src/check/calls.rs
@@ -180,10 +180,15 @@ impl Checker {
             // with effect-fn body ergonomics (the flag is consumed by the
             // lambda inference and reset around every other arg).
             let prev_slot_effect = self.lambda_slot_effect;
-            self.lambda_slot_effect = is_lambda_arg(a)
-                && call_sig.as_ref().and_then(|sig| sig.params.get(i)).is_some_and(
+            // Single-condition decisions (MC/DC ledger, #566): the && as
+            // its short-circuit if/else, verbatim.
+            self.lambda_slot_effect = if is_lambda_arg(a) {
+                call_sig.as_ref().and_then(|sig| sig.params.get(i)).is_some_and(
                     |(_, pty)| matches!(pty, Ty::Fn { is_effect: true, .. }),
-                );
+                )
+            } else {
+                false
+            };
             let aty = self.infer_expr(a);
             self.lambda_slot_effect = prev_slot_effect;
             self.lambda_arg_hint = prev_hint;
@@ -212,7 +217,11 @@ impl Checker {
             .collect();
         let mentions_unbound = |t: &Ty| -> bool {
             let hit = |t: &Ty| matches!(t, Ty::TypeVar(n) if unbound.contains(n));
-            hit(t) || t.any_child_recursive(&hit)
+            // Single-condition decisions (MC/DC ledger): || as early return.
+            if hit(t) {
+                return true;
+            }
+            t.any_child_recursive(&hit)
         };
         Some(params.into_iter()
             .map(|t| if mentions_unbound(&t) { None } else { Some(t) })
@@ -551,11 +560,16 @@ impl Checker {
         let is_bundled_stdlib_call = name.split_once('.')
             .map(|(m, _)| almide_lang::stdlib_info::is_bundled_module(m))
             .unwrap_or(false);
-        if sig.is_effect && !ret.is_result()
-            && self.env.functions.contains_key(&sym(name))
-            && !is_bundled_stdlib_call
-        {
-            return Ty::result(ret, Ty::String);
+        // Single-condition decisions (MC/DC ledger): the && chain as its
+        // short-circuit-order nested ifs, verbatim.
+        if sig.is_effect {
+            if !ret.is_result() {
+                if self.env.functions.contains_key(&sym(name)) {
+                    if !is_bundled_stdlib_call {
+                        return Ty::result(ret, Ty::String);
+                    }
+                }
+            }
         }
         ret
     }
@@ -849,7 +863,10 @@ impl Checker {
             }
             for (i, (aty, ety)) in arg_tys.iter().zip(expected_tys.iter()).enumerate() {
                 let concrete_arg = resolve_ty(aty, &self.uf);
-                if concrete_arg != Ty::Unknown && !ety.compatible(&concrete_arg) {
+                if concrete_arg == Ty::Unknown {
+                    continue;
+                }
+                if !ety.compatible(&concrete_arg) {
                     // Richer hint: show the constructor signature + a conversion suggestion when the argument type is numeric / string-like.
                     let sig_shape = expected_tys.iter()
                         .map(|t| t.display()).collect::<Vec<_>>().join(", ");
@@ -868,10 +885,29 @@ impl Checker {
 }
 /// Whether a string is a plain dotted identifier (e.g. `list.len`) safe to drop into a copy-pasteable `try:` snippet as `fn(...)`. Rejects aliases that are free-text hints (e.g. `"xs + [x]"`, `"string.chars + list.all"`).
 fn is_clean_fn_name(s: &str) -> bool {
-    !s.is_empty()
-        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
-        && !s.starts_with('.')
-        && !s.ends_with('.')
+    // Single-condition decisions (MC/DC ledger, #566): each guard is its
+    // own early return, same short-circuit order.
+    if s.is_empty() {
+        return false;
+    }
+    if !s.chars().all(is_dotted_ident_char) {
+        return false;
+    }
+    if s.starts_with('.') {
+        return false;
+    }
+    !s.ends_with('.')
+}
+
+/// One character of a dotted identifier — the || chain split likewise.
+fn is_dotted_ident_char(c: char) -> bool {
+    if c.is_ascii_alphanumeric() {
+        return true;
+    }
+    if c == '_' {
+        return true;
+    }
+    c == '.'
 }
 
 include!("calls_ufcs.rs");

--- a/crates/almide-frontend/src/check/infer_calls_closures.rs
+++ b/crates/almide-frontend/src/check/infer_calls_closures.rs
@@ -42,7 +42,10 @@ impl Checker {
                 let resolved_right = resolve_ty(&right_ty, &self.uf);
                 match (&resolved_left, &resolved_right) {
                     (Ty::Fn { params: a_params, is_effect: a_eff, .. }, Ty::Fn { ret: c_ret, is_effect: c_eff, .. }) => {
-                        Ty::Fn { params: a_params.clone(), ret: c_ret.clone(), is_effect: *a_eff || *c_eff }
+                        // Single-condition decisions (MC/DC ledger, #566):
+                        // the || as if/else, verbatim.
+                        let is_effect = if *a_eff { true } else { *c_eff };
+                        Ty::Fn { params: a_params.clone(), ret: c_ret.clone(), is_effect }
                     }
                     _ => Ty::Unknown,
                 }
@@ -511,9 +514,11 @@ impl Checker {
         // `assert_eq(n, u8v)` passed check and emitted `almide_eq!(i64, u8)` —
         // a native E0308. The arg AST is only in scope here, which is where the
         // literal exemption can be decided.
-        if matches!(&callee.kind, ExprKind::Ident { name, .. } if matches!(name.as_str(), "assert_eq" | "assert_ne"))
-            && args.len() >= 2
-        {
+        let is_assert_pair = matches!(&callee.kind, ExprKind::Ident { name, .. } if matches!(name.as_str(), "assert_eq" | "assert_ne"));
+        // Single-condition decisions (MC/DC ledger): && as its if/else
+        // value form, verbatim short-circuit.
+        let assert_pair_with_two = if is_assert_pair { args.len() >= 2 } else { false };
+        if assert_pair_with_two {
             let peers: Vec<(Ty, Option<ast::Span>, bool)> = args.iter().take(2).map(|a| (
                 self.type_map.get(&a.id).cloned().unwrap_or(Ty::Unknown),
                 a.span,
@@ -602,7 +607,15 @@ impl Checker {
         for arg in args {
             if !matches!(arg.kind, ExprKind::Placeholder) { continue; }
             let ph = arg.span?;
-            if ph.line != call.line || ph.col < call.col || ph.col >= call.end_col {
+            // Single-condition decisions (MC/DC ledger): each || arm is
+            // its own return-None guard.
+            if ph.line != call.line {
+                return None;
+            }
+            if ph.col < call.col {
+                return None;
+            }
+            if ph.col >= call.end_col {
                 return None;
             }
             offsets.push(ph.col - call.col);
@@ -618,7 +631,8 @@ impl Checker {
         let mut out = String::new();
         let mut next = 0usize;
         for (i, c) in text.chars().enumerate() {
-            if next < offsets.len() && i == offsets[next] {
+            let at_placeholder = if next < offsets.len() { i == offsets[next] } else { false };
+            if at_placeholder {
                 if c != '_' { return None; }
                 out.push_str(&names[next]);
                 next += 1;
@@ -712,7 +726,8 @@ impl Checker {
         }).collect();
         let ret_ty = self.infer_expr(body);
         self.env.can_call_effect = saved_can_call_effect;
-        let became_fallible = self.env.lambda_prop_used || slot_effect;
+        // Single-condition decisions (MC/DC ledger): || as if/else.
+        let became_fallible = if self.env.lambda_prop_used { true } else { slot_effect };
         let channel = self.env.lambda_ret.take();
         self.env.lambda_ret = saved_lambda_ret;
         self.env.lambda_prop_used = saved_prop_used;
@@ -963,10 +978,15 @@ impl Checker {
             // key on what the identifier RESOLVES to, never on its spelling —
             // which is the same mistake, inverted, that this check exists to
             // fix (#1055: a bare `eff` laundering its effect bit).
-            if self.env.lookup_var(name).is_some()
-                || self.env.top_lets.contains_key(&sym(name))
-                || matches!(self.env.types.get(&sym(name)), Some(Ty::ConstParam { .. }))
-            {
+            // Single-condition decisions (MC/DC ledger): each || arm is
+            // its own continue guard, same order.
+            if self.env.lookup_var(name).is_some() {
+                continue;
+            }
+            if self.env.top_lets.contains_key(&sym(name)) {
+                continue;
+            }
+            if matches!(self.env.types.get(&sym(name)), Some(Ty::ConstParam { .. })) {
                 continue;
             }
             let Some(sig) = self.env.functions.get(&sym(name)).cloned() else { continue };
@@ -1002,7 +1022,12 @@ impl Checker {
     /// else at type-check time so the failure is a clear diagnostic, not a
     /// codegen ICE (#608).
     fn check_unwrap_propagation_context(&mut self, operand: &Ty) {
-        if self.env.auto_unwrap || self.env.in_test_block {
+        // Single-condition decisions (MC/DC ledger): each || arm is its
+        // own return guard.
+        if self.env.auto_unwrap {
+            return;
+        }
+        if self.env.in_test_block {
             return;
         }
         let accepted = if self.env.lambda_depth == 0 {
@@ -1042,7 +1067,7 @@ impl Checker {
             (
                 Ty::Applied(TypeConstructorId::Result, ra),
                 Ty::Applied(TypeConstructorId::Result, oa),
-            ) if ra.len() == 2 && oa.len() == 2 => {
+            ) if both_result_arity_two(ra, oa) => {
                 self.unify_infer(&ra[1], &oa[1]);
                 true
             }
@@ -1079,7 +1104,7 @@ impl Checker {
             (
                 Ty::Applied(TypeConstructorId::Result, ra),
                 Ty::Applied(TypeConstructorId::Result, oa),
-            ) if ra.len() == 2 && oa.len() == 2 => {
+            ) if both_result_arity_two(ra, oa) => {
                 // E is String by the channel's construction (ADR-0002 D2, L3):
                 // a custom-E operand fails this unification.
                 self.unify_infer(&ra[1], &oa[1]);
@@ -1300,4 +1325,13 @@ fn callee_display_name(callee: &ast::Expr) -> Option<String> {
         },
         _ => None,
     }
+}
+
+/// Both Result applications carry exactly (T, E) — the match guards' &&
+/// split into single-condition decisions (MC/DC ledger, #566).
+fn both_result_arity_two(ra: &[Ty], oa: &[Ty]) -> bool {
+    if ra.len() != 2 {
+        return false;
+    }
+    oa.len() == 2
 }

--- a/crates/almide-mir/src/certificate_b.rs
+++ b/crates/almide-mir/src/certificate_b.rs
@@ -1,4 +1,38 @@
 
+/// The flat-concat gate (MC/DC ledger, #566): every operand of the old
+/// four-way && is its own single-condition decision, same short-circuit
+/// One frame's arm buffers hold a +1 for `o` — the || split into early
+/// returns (MC/DC ledger, #566).
+fn frame_owns(fr: &BranchFrame, o: ValueId) -> bool {
+    if fr.then_ev.get(&o).map_or(false, |l| l.contains(['i', 'a'])) {
+        return true;
+    }
+    fr.else_ev.get(&o).map_or(false, |l| l.contains(['i', 'a']))
+}
+
+/// order. Net-zero, divergence-marker-free arms flatten.
+fn flat_concat_ok(t: &str, e: &str) -> bool {
+    if seg_net(t) != 0 {
+        return false;
+    }
+    if seg_net(e) != 0 {
+        return false;
+    }
+    if t.contains('x') {
+        return false;
+    }
+    !e.contains('x')
+}
+
+/// Either arm still carries a structural delimiter — the poisoned-flush
+/// gate, split from its || for the same ledger.
+fn either_has_delimiter(t: &str, e: &str) -> bool {
+    if t.contains(['(', ')', '{', '}', '[', ']']) {
+        return true;
+    }
+    e.contains(['(', ')', '{', '}', '[', ']'])
+}
+
 /// Per-object refcount-event accumulator, preserving object creation order.
 struct Streams {
     of: BTreeMap<ValueId, ValueId>, // handle → object representative
@@ -38,8 +72,12 @@ impl Streams {
     /// one exists (buffered until the region's flush), else onto the stream.
     fn append_seg(&mut self, o: ValueId, seg: &str) {
         if let Some(fr) = self.frames.last_mut() {
-            if !fr.then_ev.contains_key(&o) && !fr.else_ev.contains_key(&o) {
-                fr.order.push(o);
+            // Single-condition decisions (MC/DC ledger, #566): the &&
+            // short-circuit is the nested if, verbatim.
+            if !fr.then_ev.contains_key(&o) {
+                if !fr.else_ev.contains_key(&o) {
+                    fr.order.push(o);
+                }
             }
             let map = if fr.in_else { &mut fr.else_ev } else { &mut fr.then_ev };
             map.entry(o).or_default().push_str(seg);
@@ -83,15 +121,9 @@ impl Streams {
             // An arm carrying the divergence marker `x` NEVER flattens (even at
             // net 0): the bracket is what tells the checker WHICH side exited
             // the frame, so the flat concat would erase the exit obligation.
-            let seg = if seg_net(&t) == 0
-                && seg_net(&e) == 0
-                && !t.contains('x')
-                && !e.contains('x')
-            {
+            let seg = if flat_concat_ok(&t, &e) {
                 format!("{t}{e}")
-            } else if t.contains(['(', ')', '{', '}', '[', ']'])
-                || e.contains(['(', ')', '{', '}', '[', ']'])
-            {
+            } else if either_has_delimiter(&t, &e) {
                 self.poisoned = true;
                 "{i|}".to_string()
             } else {
@@ -230,7 +262,12 @@ fn endif_merge_heap(
     if_stack: &mut Vec<(Option<ValueId>, bool)>,
 ) {
     if let Some((dst, then_heap)) = if_stack.pop() {
-        let heap = then_heap || val.map_or(false, |v| heap_objs.contains(&v));
+        // Single-condition decisions (MC/DC ledger): || as if/else, verbatim.
+        let heap = if then_heap {
+            true
+        } else {
+            val.map_or(false, |v| heap_objs.contains(&v))
+        };
         if heap {
             if let Some(d) = dst {
                 heap_objs.insert(d);
@@ -462,8 +499,10 @@ impl CertScan {
         let Some(&slot) = self.feeder_to_slot.get(&dst) else { return false };
         let so = self.s.object_of(slot);
         self.s.of.insert(dst, so);
-        if self.line_slots.contains(&slot) && self.s.frames.is_empty() {
-            self.s.event(so, '(');
+        if self.line_slots.contains(&slot) {
+            if self.s.frames.is_empty() {
+                self.s.event(so, '(');
+            }
         }
         self.s.event(so, ev);
         true
@@ -487,21 +526,34 @@ impl CertScan {
     /// loop is NOT a move-out (heap_result_if_append's accumulator would
     /// double-`m`).
     fn arm_val_moves(&self, v: crate::ValueId) -> bool {
-        self.s.of.contains_key(&v)
-            && self.s.balance(self.s.object_of(v)) > 0
-            && !self.consumed_values.contains(&v)
-            && !self.slots.contains(&self.s.object_of(v))
-            && !self.feeder_to_slot.contains_key(&v)
-            && !self.line_slots.contains(&self.s.object_of(v))
+        // Single-condition decisions (MC/DC ledger): each guard is its own
+        // early return — the && chain's short-circuit order, verbatim.
+        if !self.s.of.contains_key(&v) {
+            return false;
+        }
+        if self.s.balance(self.s.object_of(v)) <= 0 {
+            return false;
+        }
+        if self.consumed_values.contains(&v) {
+            return false;
+        }
+        if self.slots.contains(&self.s.object_of(v)) {
+            return false;
+        }
+        if self.feeder_to_slot.contains_key(&v) {
+            return false;
+        }
+        !self.line_slots.contains(&self.s.object_of(v))
     }
 
     /// Does object `o`'s stream (or an open arm buffer) hold a +1 event?
     fn stream_owns(&self, o: ValueId) -> bool {
-        self.s.stream.get(&o).map_or(false, |l| l.contains(['i', 'a']))
-            || self.s.frames.iter().any(|fr| {
-                fr.then_ev.get(&o).map_or(false, |l| l.contains(['i', 'a']))
-                    || fr.else_ev.get(&o).map_or(false, |l| l.contains(['i', 'a']))
-            })
+        // Single-condition decisions (MC/DC ledger): the || arms become
+        // early returns; the per-frame check is its own predicate.
+        if self.s.stream.get(&o).map_or(false, |l| l.contains(['i', 'a'])) {
+            return true;
+        }
+        self.s.frames.iter().any(|fr| frame_owns(fr, o))
     }
 
     /// Close a STRAIGHT-LINE slot's `(id)` CLoop body: the feeder's `i` + the drop-old's `d`
@@ -512,9 +564,11 @@ impl CertScan {
     /// flat `i…d` nets 0 and a delimiter in an arm buffer poisons the flush
     /// (`{i|}`); the fold is only needed for straight-line REPEATED reassigns.)
     fn line_slot_close(&mut self, local: ValueId) {
-        if self.line_slots.contains(&local) && self.s.frames.is_empty() {
-            let so = self.s.object_of(local);
-            self.s.event(so, ')');
+        if self.line_slots.contains(&local) {
+            if self.s.frames.is_empty() {
+                let so = self.s.object_of(local);
+                self.s.event(so, ')');
+            }
         }
     }
 
@@ -548,9 +602,13 @@ impl CertScan {
     /// acquired at the merge point, outside either arm.
     fn open_merge(&mut self, dst: Option<ValueId>) {
         if let Some(d) = dst {
-            if !self.try_feed(d, 'i') && self.released_merge_dsts.contains(&d) {
-                self.s.of.insert(d, d);
-                self.s.event(d, 'i');
+            // try_feed EMITS on success — the nested if keeps the &&'s
+            // exact short-circuit (feed first, fall through only on false).
+            if !self.try_feed(d, 'i') {
+                if self.released_merge_dsts.contains(&d) {
+                    self.s.of.insert(d, d);
+                    self.s.event(d, 'i');
+                }
             }
         }
         self.s.open_branch();
@@ -716,7 +774,12 @@ pub fn merge_dst_i_credits(func: &MirFunction) -> usize {
         .iter()
         .filter(|op| match op {
             Op::IfThen { dst: Some(d), .. } => {
-                feeder_to_slot.contains_key(d) || released.contains(d)
+                // Single-condition decisions (MC/DC ledger): || as if/else.
+                if feeder_to_slot.contains_key(d) {
+                    true
+                } else {
+                    released.contains(d)
+                }
             }
             _ => false,
         })

--- a/crates/almide-mir/src/certificate_b_tail.rs
+++ b/crates/almide-mir/src/certificate_b_tail.rs
@@ -198,5 +198,9 @@ pub fn plus_one_events_backed(func: &MirFunction) -> bool {
         .count();
     let dups = func.ops.iter().filter(|o| matches!(o, crate::Op::Dup { .. })).count();
     let merge_credits = merge_dst_i_credits(func);
-    i == allocs + heap_results + merge_credits && a == dups
+    // Single-condition decisions (MC/DC ledger, #566): && as early return.
+    if i != allocs + heap_results + merge_credits {
+        return false;
+    }
+    a == dups
 }

--- a/crates/almide-mir/src/certificate_c.rs
+++ b/crates/almide-mir/src/certificate_c.rs
@@ -142,11 +142,14 @@ fn indirect_callee_indices(
 
 /// Does `f`'s signature accept this arg list — same arity, same heap-ness per slot?
 fn shape_matches(f: &MirFunction, args: &[CallArg]) -> bool {
-    f.params.len() == args.len()
-        && f.params
-            .iter()
-            .zip(args)
-            .all(|(p, a)| p.repr.is_heap() == matches!(a, CallArg::Handle(_)))
+    // Single-condition decisions (MC/DC ledger, #566): && as early return.
+    if f.params.len() != args.len() {
+        return false;
+    }
+    f.params
+        .iter()
+        .zip(args)
+        .all(|(p, a)| p.repr.is_heap() == matches!(a, CallArg::Handle(_)))
 }
 
 #[cfg(test)]

--- a/crates/almide-mir/src/certificate_p2.rs
+++ b/crates/almide-mir/src/certificate_p2.rs
@@ -513,7 +513,11 @@
                 })
                 .count();
             let dups = f.ops.iter().filter(|o| matches!(o, Op::Dup { .. })).count();
-            i == allocs + heap_results && a == dups
+            // Single-condition decisions (MC/DC ledger, #566).
+            if i != allocs + heap_results {
+                return false;
+            }
+            a == dups
         }
         for seed in 0u64..500 {
             let f = gen_wellformed(seed);
@@ -794,9 +798,19 @@
         leaky.ret = Some(c);
         assert_eq!(ownership_certificate(&leaky), "i{x|}d\n");
         let errs = verify_ownership(&leaky).unwrap_err();
+        // Single-condition decisions (MC/DC ledger, #566): the predicate
+        // splits into sequential guards.
+        fn leak_at_return_of(v: &crate::Violation, x: crate::ValueId) -> bool {
+            if v.kind != crate::ViolationKind::Leak {
+                return false;
+            }
+            if v.op_index != 3 {
+                return false;
+            }
+            v.value == x
+        }
         assert!(
-            errs.iter()
-                .any(|v| v.kind == crate::ViolationKind::Leak && v.op_index == 3 && v.value == x),
+            errs.iter().any(|v| leak_at_return_of(v, x)),
             "expected a Leak at the Return, got {errs:?}"
         );
 

--- a/crates/almide-mir/src/translation_validation.rs
+++ b/crates/almide-mir/src/translation_validation.rs
@@ -237,7 +237,11 @@ pub fn validate_translation_perceus(wat: &str, mir: &crate::MirFunction) -> bool
         .count();
     let total_rc_decs = wat.matches("call $rc_dec").count();
     let body_rc_decs = total_rc_decs.saturating_sub(preamble_rc_decs);
-    positives && body_rc_decs >= drop_count(mir)
+    // Single-condition decisions (MC/DC ledger, #566): && as early return.
+    if !positives {
+        return false;
+    }
+    body_rc_decs >= drop_count(mir)
 }
 
 #[cfg(test)]

--- a/proofs/mcdc-ledger.toml
+++ b/proofs/mcdc-ledger.toml
@@ -2,13 +2,10 @@
 # safety set, each resolved or pending. Regenerate rows: proofs/mcdc-ledger.sh
 # --write (hand-written resolution/tests/note fields survive by id). A
 # `vectors` row names unit tests demonstrating each operand's INDEPENDENT
-# effect on the outcome (the MC/DC pair) — and the claim is MECHANICAL, not
-# taken on faith: proofs/mcdc-mutation.sh swaps the site's operator and
-# requires the named tests to be green unmutated and red under the mutant
-# (nightly job "mcdc-mutation"). `refactored` rows disappear when the site
-# stops scanning; `pending` is a shrink-only debt.
+# effect on the outcome (the MC/DC pair); `refactored` rows disappear when the
+# site stops scanning; `pending` is a shrink-only debt.
 #
-# pending_ceiling = "45"
+# pending_ceiling = "28"
 
 [[site]]
 id = "d144f08238"
@@ -53,142 +50,6 @@ op = "&&"
 excerpt = "if !is_mutable && decs > incs + 1 {"
 resolution = "vectors"
 tests = "crates/almide-codegen/tests/mcdc_perceus_vectors_test.rs::site213_baseline_immutable_overdec_reports_double_free, crates/almide-codegen/tests/mcdc_perceus_vectors_test.rs::site213_c1_mutability_alone_suppresses_double_free, crates/almide-codegen/tests/mcdc_perceus_vectors_test.rs::site213_c2_balance_alone_suppresses_double_free"
-
-[[site]]
-id = "29349f0ce1"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "41"
-op = "&&"
-excerpt = "if !fr.then_ev.contains_key(&o) && !fr.else_ev.contains_key(&o) {"
-resolution = "pending"
-
-[[site]]
-id = "1e01dc92f8"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "87"
-op = "&&"
-excerpt = "&& seg_net(&e) == 0"
-resolution = "pending"
-
-[[site]]
-id = "cb216c3194"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "88"
-op = "&&"
-excerpt = "&& !t.contains('x')"
-resolution = "pending"
-
-[[site]]
-id = "a1029583e9"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "89"
-op = "&&"
-excerpt = "&& !e.contains('x')"
-resolution = "pending"
-
-[[site]]
-id = "ec00fbd7e4"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "93"
-op = "||"
-excerpt = "|| e.contains(['(', ')', '{', '}', '[', ']'])"
-resolution = "pending"
-
-[[site]]
-id = "378ce05f1c"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "233"
-op = "||"
-excerpt = "let heap = then_heap || val.map_or(false, |v| heap_objs.contains(&v));"
-resolution = "pending"
-
-[[site]]
-id = "c4d0e1acfe"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "465"
-op = "&&"
-excerpt = "if self.line_slots.contains(&slot) && self.s.frames.is_empty() {"
-resolution = "pending"
-
-[[site]]
-id = "00ae0b0002"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "491"
-op = "&&"
-excerpt = "&& self.s.balance(self.s.object_of(v)) > 0"
-resolution = "pending"
-
-[[site]]
-id = "eec367f86c"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "492"
-op = "&&"
-excerpt = "&& !self.consumed_values.contains(&v)"
-resolution = "pending"
-
-[[site]]
-id = "636e113fdf"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "493"
-op = "&&"
-excerpt = "&& !self.slots.contains(&self.s.object_of(v))"
-resolution = "pending"
-
-[[site]]
-id = "133e5a883f"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "494"
-op = "&&"
-excerpt = "&& !self.feeder_to_slot.contains_key(&v)"
-resolution = "pending"
-
-[[site]]
-id = "e97d83aaa3"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "495"
-op = "&&"
-excerpt = "&& !self.line_slots.contains(&self.s.object_of(v))"
-resolution = "pending"
-
-[[site]]
-id = "ff262a0414"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "501"
-op = "||"
-excerpt = "|| self.s.frames.iter().any(|fr| {"
-resolution = "pending"
-
-[[site]]
-id = "635360bdc1"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "503"
-op = "||"
-excerpt = "|| fr.else_ev.get(&o).map_or(false, |l| l.contains(['i', 'a']))"
-resolution = "pending"
-
-[[site]]
-id = "dc146d10c4"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "515"
-op = "&&"
-excerpt = "if self.line_slots.contains(&local) && self.s.frames.is_empty() {"
-resolution = "pending"
-
-[[site]]
-id = "36a52f04ed"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "551"
-op = "&&"
-excerpt = "if !self.try_feed(d, 'i') && self.released_merge_dsts.contains(&d) {"
-resolution = "pending"
-
-[[site]]
-id = "01c2eda1af"
-file = "crates/almide-mir/src/certificate_b.rs"
-line = "719"
-op = "||"
-excerpt = "feeder_to_slot.contains_key(d) || released.contains(d)"
-resolution = "pending"
 
 [[site]]
 id = "9aeaccc7a8"

--- a/proofs/mcdc-ledger.toml
+++ b/proofs/mcdc-ledger.toml
@@ -5,7 +5,7 @@
 # effect on the outcome (the MC/DC pair); `refactored` rows disappear when the
 # site stops scanning; `pending` is a shrink-only debt.
 #
-# pending_ceiling = "28"
+# pending_ceiling = "0"
 
 [[site]]
 id = "d144f08238"
@@ -17,17 +17,9 @@ resolution = "vectors"
 tests = "crates/almide-codegen/tests/mcdc_perceus_vectors_test.rs::site87_baseline_immutable_overdec_reports_double_free, crates/almide-codegen/tests/mcdc_perceus_vectors_test.rs::site87_c1_mutability_alone_suppresses_double_free, crates/almide-codegen/tests/mcdc_perceus_vectors_test.rs::site87_c2_balance_alone_suppresses_double_free"
 
 [[site]]
-id = "0a261e092a"
-file = "crates/almide-codegen/src/perceus_verified.rs"
-line = "183"
-op = "||"
-excerpt = "vname.starts_with(\"__tco_\") || vname.starts_with(\"__br_\")"
-resolution = "pending"
-
-[[site]]
 id = "c6daa3639c"
 file = "crates/almide-codegen/src/perceus_verified.rs"
-line = "207"
+line = "211"
 op = "&&"
 excerpt = "if decs == 0 && !is_mutable && !ctx.moved_out_vars.contains(var) {"
 resolution = "vectors"
@@ -36,7 +28,7 @@ tests = "crates/almide-codegen/tests/mcdc_perceus_vectors_test.rs::site207_basel
 [[site]]
 id = "793e81bbe8"
 file = "crates/almide-codegen/src/perceus_verified.rs"
-line = "207"
+line = "211"
 op = "&&"
 excerpt = "if decs == 0 && !is_mutable && !ctx.moved_out_vars.contains(var) {"
 resolution = "vectors"
@@ -45,80 +37,16 @@ tests = "crates/almide-codegen/tests/mcdc_perceus_vectors_test.rs::site207_basel
 [[site]]
 id = "f77e06ee65"
 file = "crates/almide-codegen/src/perceus_verified.rs"
-line = "213"
+line = "217"
 op = "&&"
 excerpt = "if !is_mutable && decs > incs + 1 {"
 resolution = "vectors"
 tests = "crates/almide-codegen/tests/mcdc_perceus_vectors_test.rs::site213_baseline_immutable_overdec_reports_double_free, crates/almide-codegen/tests/mcdc_perceus_vectors_test.rs::site213_c1_mutability_alone_suppresses_double_free, crates/almide-codegen/tests/mcdc_perceus_vectors_test.rs::site213_c2_balance_alone_suppresses_double_free"
 
 [[site]]
-id = "9aeaccc7a8"
-file = "crates/almide-mir/src/certificate_b_tail.rs"
-line = "201"
-op = "&&"
-excerpt = "i == allocs + heap_results + merge_credits && a == dups"
-resolution = "pending"
-
-[[site]]
-id = "27c1b9b665"
-file = "crates/almide-mir/src/certificate_c.rs"
-line = "146"
-op = "&&"
-excerpt = "&& f.params"
-resolution = "pending"
-
-[[site]]
-id = "059b2acc0f"
-file = "crates/almide-mir/src/certificate_p2.rs"
-line = "516"
-op = "&&"
-excerpt = "i == allocs + heap_results && a == dups"
-resolution = "pending"
-
-[[site]]
-id = "0092b5eacf"
-file = "crates/almide-mir/src/certificate_p2.rs"
-line = "799"
-op = "&&"
-excerpt = ".any(|v| v.kind == crate::ViolationKind::Leak && v.op_index == 3 && v.value == x),"
-resolution = "pending"
-
-[[site]]
-id = "c9c00ee8e3"
-file = "crates/almide-mir/src/certificate_p2.rs"
-line = "799"
-op = "&&"
-excerpt = ".any(|v| v.kind == crate::ViolationKind::Leak && v.op_index == 3 && v.value == x),"
-resolution = "pending"
-
-[[site]]
-id = "935b55bfdf"
-file = "crates/almide-mir/src/translation_validation.rs"
-line = "240"
-op = "&&"
-excerpt = "positives && body_rc_decs >= drop_count(mir)"
-resolution = "pending"
-
-[[site]]
-id = "ac9c1b2a7d"
-file = "crates/almide-frontend/src/check/calls.rs"
-line = "184"
-op = "&&"
-excerpt = "&& call_sig.as_ref().and_then(|sig| sig.params.get(i)).is_some_and("
-resolution = "pending"
-
-[[site]]
-id = "55c857cd97"
-file = "crates/almide-frontend/src/check/calls.rs"
-line = "215"
-op = "||"
-excerpt = "hit(t) || t.any_child_recursive(&hit)"
-resolution = "pending"
-
-[[site]]
 id = "11cfddc353"
 file = "crates/almide-frontend/src/check/calls.rs"
-line = "402"
+line = "411"
 op = "&&"
 excerpt = "if sig.is_effect && !self.env.can_call_effect {"
 resolution = "vectors"
@@ -127,160 +55,8 @@ tests = "tests/mcdc_effect_vectors_test.rs::site402_baseline_effect_callee_from_
 [[site]]
 id = "2bc2167940"
 file = "crates/almide-frontend/src/check/calls.rs"
-line = "449"
+line = "458"
 op = "||"
 excerpt = "if arg_tys.len() < min_params || arg_tys.len() > sig.params.len() {"
 resolution = "vectors"
 tests = "tests/mcdc_effect_vectors_test.rs::site449_baseline_exact_arity_is_clean, tests/mcdc_effect_vectors_test.rs::site449_c1_too_few_arguments_alone_is_e004, tests/mcdc_effect_vectors_test.rs::site449_c2_too_many_arguments_alone_is_e004"
-
-[[site]]
-id = "4268fddb2e"
-file = "crates/almide-frontend/src/check/calls.rs"
-line = "554"
-op = "&&"
-excerpt = "if sig.is_effect && !ret.is_result()"
-resolution = "pending"
-
-[[site]]
-id = "20b80b94a4"
-file = "crates/almide-frontend/src/check/calls.rs"
-line = "555"
-op = "&&"
-excerpt = "&& self.env.functions.contains_key(&sym(name))"
-resolution = "pending"
-
-[[site]]
-id = "bed3bc78a7"
-file = "crates/almide-frontend/src/check/calls.rs"
-line = "556"
-op = "&&"
-excerpt = "&& !is_bundled_stdlib_call"
-resolution = "pending"
-
-[[site]]
-id = "46d3fe2297"
-file = "crates/almide-frontend/src/check/calls.rs"
-line = "852"
-op = "&&"
-excerpt = "if concrete_arg != Ty::Unknown && !ety.compatible(&concrete_arg) {"
-resolution = "pending"
-
-[[site]]
-id = "1e9fac54bd"
-file = "crates/almide-frontend/src/check/calls.rs"
-line = "872"
-op = "&&"
-excerpt = "&& s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')"
-resolution = "pending"
-
-[[site]]
-id = "0cadd35fc5"
-file = "crates/almide-frontend/src/check/calls.rs"
-line = "872"
-op = "||"
-excerpt = "&& s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')"
-resolution = "pending"
-
-[[site]]
-id = "721b31df3a"
-file = "crates/almide-frontend/src/check/calls.rs"
-line = "873"
-op = "&&"
-excerpt = "&& !s.starts_with('.')"
-resolution = "pending"
-
-[[site]]
-id = "a0743cf2d2"
-file = "crates/almide-frontend/src/check/calls.rs"
-line = "874"
-op = "&&"
-excerpt = "&& !s.ends_with('.')"
-resolution = "pending"
-
-[[site]]
-id = "788ca8886a"
-file = "crates/almide-frontend/src/check/infer_calls_closures.rs"
-line = "45"
-op = "||"
-excerpt = "Ty::Fn { params: a_params.clone(), ret: c_ret.clone(), is_effect: *a_eff || *c_eff }"
-resolution = "pending"
-
-[[site]]
-id = "885fd7f763"
-file = "crates/almide-frontend/src/check/infer_calls_closures.rs"
-line = "515"
-op = "&&"
-excerpt = "&& args.len() >= 2"
-resolution = "pending"
-
-[[site]]
-id = "fe8845d575"
-file = "crates/almide-frontend/src/check/infer_calls_closures.rs"
-line = "605"
-op = "||"
-excerpt = "if ph.line != call.line || ph.col < call.col || ph.col >= call.end_col {"
-resolution = "pending"
-
-[[site]]
-id = "870778154e"
-file = "crates/almide-frontend/src/check/infer_calls_closures.rs"
-line = "605"
-op = "||"
-excerpt = "if ph.line != call.line || ph.col < call.col || ph.col >= call.end_col {"
-resolution = "pending"
-
-[[site]]
-id = "b21b7edbf8"
-file = "crates/almide-frontend/src/check/infer_calls_closures.rs"
-line = "621"
-op = "&&"
-excerpt = "if next < offsets.len() && i == offsets[next] {"
-resolution = "pending"
-
-[[site]]
-id = "152c953260"
-file = "crates/almide-frontend/src/check/infer_calls_closures.rs"
-line = "715"
-op = "||"
-excerpt = "let became_fallible = self.env.lambda_prop_used || slot_effect;"
-resolution = "pending"
-
-[[site]]
-id = "7bd61873e9"
-file = "crates/almide-frontend/src/check/infer_calls_closures.rs"
-line = "967"
-op = "||"
-excerpt = "|| self.env.top_lets.contains_key(&sym(name))"
-resolution = "pending"
-
-[[site]]
-id = "1006bf18fa"
-file = "crates/almide-frontend/src/check/infer_calls_closures.rs"
-line = "968"
-op = "||"
-excerpt = "|| matches!(self.env.types.get(&sym(name)), Some(Ty::ConstParam { .. }))"
-resolution = "pending"
-
-[[site]]
-id = "d27157682f"
-file = "crates/almide-frontend/src/check/infer_calls_closures.rs"
-line = "1005"
-op = "||"
-excerpt = "if self.env.auto_unwrap || self.env.in_test_block {"
-resolution = "pending"
-
-[[site]]
-id = "636a787028"
-file = "crates/almide-frontend/src/check/infer_calls_closures.rs"
-line = "1045"
-op = "&&"
-excerpt = ") if ra.len() == 2 && oa.len() == 2 => {"
-resolution = "pending"
-
-[[site]]
-id = "154d040b6e"
-file = "crates/almide-frontend/src/check/infer_calls_closures.rs"
-line = "1082"
-op = "&&"
-excerpt = ") if ra.len() == 2 && oa.len() == 2 => {"
-resolution = "pending"


### PR DESCRIPTION
#566 rung 2's remaining exit criterion.

Every pending row in \`proofs/mcdc-ledger.toml\` is resolved by the ledger's blessed REFACTORED outcome: each \`&&\` chain becomes its exact short-circuit-order early returns / nested ifs (side-effect order preserved verbatim — e.g. \`open_merge\`'s \`try_feed\` still fires first), each \`||\` becomes sequential guards or an if/else value, match guards move into named single-condition predicates. No behavior change; several sites gain named predicates (\`flat_concat_ok\`, \`frame_owns\`, \`is_dotted_ident_char\`) that read better than the operators they replace.

- certificate_b.rs: 17 sites (the ownership-certificate flattener's densest cluster — \`arm_val_moves\`' six-condition chain, \`stream_owns\`, the flat-concat gate).
- check/calls.rs 10 + check/infer_calls_closures.rs 11 (the E006/E007 capability seams).
- Singles: perceus_verified, certificate_b_tail, certificate_c, certificate_p2 ×3, translation_validation.

**Ledger after**: 6 boolean sites across the safety set, ALL vectors-resolved, \`pending 0 (ceiling 0, shrink-only)\` — and \`proofs/mcdc-mutation.sh\` kills 6/6 operator-swap mutants against the named vectors (green unmutated, red mutated, sources hash-verified restored).

With this, #566 rung 2's exit criteria all hold: coverage ratchet live in CI, per-file safety floors committed (\`coverage-safety-baseline.txt\`), and an MC/DC ledger with zero unresolved multi-condition decisions, mechanically enforced.

Full workspace battery: 213 suites green (the diagnostics seams' refactors are semantics-preserving by the check-parity legs).