### PR TITLE
The qualification dossier: trust receipts reformatted, Sigstore-attested, attached to every release tag

### DIFF
--- a/.github/workflows/trust-spine.yml
+++ b/.github/workflows/trust-spine.yml
@@ -24,6 +24,9 @@ on:
     # before this trigger existed each release shipped without the proof spine,
     # the PCC gate, or the corpus wall ever running on that ref.
     branches: [develop, develop-v1, main]
+    # #571: every release tag runs the full spine on ITS tree, and a green
+    # run assembles + attests the qualification dossier (tail steps below).
+    tags: ["v*"]
     paths:
       - 'proofs/**'
       # The corpus wall drives the REAL frontend (parse→check→lower→optimize→
@@ -64,6 +67,11 @@ on:
 concurrency:
   group: trust-spine-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
 
 env:
   # Bump this suffix to force a clean rebuild of the opam (Rocq) cache.
@@ -217,3 +225,40 @@ jobs:
         with:
           path: ~/.opam
           key: opam-${{ runner.os }}-ocaml${{ env.OCAML_VERSION }}-rocq9-${{ env.OPAM_CACHE_VERSION }}
+
+      # ── #571: the qualification dossier, on release tags only ──────────
+      # The spine just verified THIS tree, so the receipt inside the dossier
+      # folds the verdicts via the fingerprint rail (no re-derivation). The
+      # dossier is the trust-layer receipts REFORMATTED — assembled from the
+      # standing artifacts, attested with Sigstore (verify externally:
+      # `gh attestation verify almide-dossier-<tag>.md -R almide/almide`),
+      # and attached to the release (retrying while release.yml creates it).
+      - name: Assemble the qualification dossier
+        if: success() && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          bash scripts/gen-dossier.sh "$TAG" > "almide-dossier-${TAG}.md"
+          tail -5 "almide-dossier-${TAG}.md"
+
+      - name: Attest the dossier (Sigstore)
+        if: success() && startsWith(github.ref, 'refs/tags/v')
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: almide-dossier-*.md
+
+      - name: Attach the dossier to the release
+        if: success() && startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          for i in $(seq 1 20); do
+            if gh release upload "$TAG" "almide-dossier-${TAG}.md" --clobber; then
+              echo "dossier attached"
+              exit 0
+            fi
+            echo "release not ready yet ($i/20) — waiting"
+            sleep 30
+          done
+          echo "::error::release $TAG never appeared — dossier not attached"
+          exit 1

--- a/scripts/gen-dossier.sh
+++ b/scripts/gen-dossier.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# The qualification dossier (#571): the trust-layer receipts REFORMATTED
+# into one versioned bundle per release — never an independent deliverable
+# (an independently-authored dossier is certification theater; this one is
+# assembled verbatim from the artifacts CI already derives and gates).
+#
+# Contents (each section names its generating instrument):
+#   1. the trust receipt          — proofs/receipt.sh (fingerprint-honest)
+#   2. the release seal           — proofs/releases/<tag>.toml (audit freeze)
+#   3. the formal-credit table    — proofs/FORMAL-CREDIT.md (#575)
+#   4. the derived stage block    — proofs/STAGE-STATUS.md (gen-claims)
+#   5. gate-verification summary  — proofs/gate-verification.toml counts
+#   6. contract-ledger summary    — docs/contracts/contracts.toml counts +
+#                                   the flagged-for-revision list (the
+#                                   KNOWN PROBLEMS section, never hidden)
+#   7. the MC/DC ledger state     — proofs/mcdc-ledger.toml (#566)
+#   8. an input manifest          — sha256 of every source artifact, so the
+#                                   bundle is REPRODUCIBLE and externally
+#                                   checkable (regenerate, byte-compare)
+#
+# SIGNING: the release workflow attests the dossier with GitHub artifact
+# attestation (Sigstore keyless) — verify externally with
+#   gh attestation verify almide-dossier-<tag>.md -R almide/almide
+# Key-based signing beyond that is #1534's scope.
+#
+# Usage: bash scripts/gen-dossier.sh vX.Y.Z [--no-receipt] > dossier.md
+#   --no-receipt: skip the receipt run (local smoke without Rocq); the
+#   section then states MISSING loudly rather than silently.
+
+set -uo pipefail
+export LC_ALL=C
+cd "$(dirname "$0")/.."
+
+TAG="${1:?usage: gen-dossier.sh vX.Y.Z [--no-receipt]}"
+NO_RECEIPT="${2:-}"
+
+section() { printf '\n---\n\n## %s\n\n' "$1"; }
+
+echo "# Almide qualification dossier — ${TAG}"
+echo
+echo "Generated $(date -u +%Y-%m-%dT%H:%M:%SZ) by scripts/gen-dossier.sh."
+echo "Every section is the verbatim output of a standing, gated instrument;"
+echo "the dossier asserts nothing those instruments do not. Reproduce:"
+echo '`git checkout '"$TAG"' && bash scripts/gen-dossier.sh '"$TAG"'`.'
+
+section "1. Trust receipt (proofs/receipt.sh)"
+if [ "$NO_RECEIPT" = "--no-receipt" ]; then
+  echo '**MISSING — generated with --no-receipt (local smoke).** A release'
+  echo 'dossier without this section is not a release dossier.'
+else
+  if ! bash proofs/receipt.sh 2>&1; then
+    echo
+    echo '**RECEIPT FAILED — see above. This dossier documents a tree that'
+    echo 'did NOT verify.**'
+    exit 1
+  fi
+fi
+
+section "2. Release seal (proofs/releases/${TAG}.toml)"
+if [ -f "proofs/releases/${TAG}.toml" ]; then
+  echo '```toml'
+  cat "proofs/releases/${TAG}.toml"
+  echo '```'
+else
+  echo "**MISSING — no seal for ${TAG} yet.** The seal is written on develop"
+  echo "after the tag (release procedure step 7); regenerate the dossier then."
+fi
+
+section "3. Formal-credit claims (proofs/FORMAL-CREDIT.md, #575)"
+cat proofs/FORMAL-CREDIT.md
+
+section "4. Derived stage block (proofs/STAGE-STATUS.md)"
+cat proofs/STAGE-STATUS.md
+
+section "5. Gate-verification summary (proofs/gate-verification.toml)"
+python3 - <<'EOF'
+import re
+s = open('proofs/gate-verification.toml').read()
+classes = re.findall(r'class = "(\w+)"', s)
+from collections import Counter
+c = Counter(classes)
+total = sum(c.values())
+print(f"{total} verdict-bearing gates, every one classified by how it can fail:")
+print()
+for k in ["KERNEL_PROVEN", "MUTATION_TESTED", "NEGATIVE_TESTED", "EXERCISED", "UNVERIFIED"]:
+    if c.get(k):
+        print(f"- {k}: {c[k]}")
+print()
+print("UNVERIFIED ceiling: 0 (shrink-only; a gate without failure evidence")
+print("cannot ship).")
+EOF
+
+section "6. Contract ledger summary + KNOWN PROBLEMS"
+python3 - <<'EOF'
+import re
+s = open('docs/contracts/contracts.toml').read()
+ids = re.findall(r'^id\s+= "(C-\d+)"', s, re.M)
+flagged = re.findall(r'^id\s+= "(C-\d+)"\n(?:[^\[]*?)^status\s+= "flagged-for-revision"', s, re.M)
+print(f"{len(ids)} cross-target contracts; every one carries evidence of")
+print("class >= fixture and a bidirectional fixture link")
+print("(scripts/check-contracts.sh).")
+print()
+if flagged:
+    print(f"KNOWN PROBLEMS — {len(flagged)} contract(s) flagged for revision")
+    print("(the count may only shrink):")
+    for c in flagged:
+        print(f"- {c}")
+else:
+    print("KNOWN PROBLEMS: no contracts flagged for revision.")
+EOF
+
+section "7. MC/DC ledger state (proofs/mcdc-ledger.toml, #566)"
+bash proofs/mcdc-ledger.sh 2>&1 | tail -1
+
+section "8. Input manifest (sha256 — reproducibility rail)"
+echo '```'
+sha256sum \
+  proofs/FORMAL-CREDIT.md \
+  proofs/STAGE-STATUS.md \
+  proofs/gate-verification.toml \
+  proofs/mcdc-ledger.toml \
+  docs/contracts/contracts.toml \
+  scripts/gen-dossier.sh \
+  2>/dev/null || shasum -a 256 \
+  proofs/FORMAL-CREDIT.md \
+  proofs/STAGE-STATUS.md \
+  proofs/gate-verification.toml \
+  proofs/mcdc-ledger.toml \
+  docs/contracts/contracts.toml \
+  scripts/gen-dossier.sh
+[ -f "proofs/releases/${TAG}.toml" ] && { sha256sum "proofs/releases/${TAG}.toml" 2>/dev/null || shasum -a 256 "proofs/releases/${TAG}.toml"; }
+echo '```'


### PR DESCRIPTION
Addresses #571 (closure follows the first tagged release carrying the dossier).

The dossier is the trust-layer receipts REFORMATTED — never an independent deliverable (an independently-authored dossier is certification theater; #571's own framing):

- **\`scripts/gen-dossier.sh vX.Y.Z\`** assembles one versioned markdown bundle from the standing gated instruments, each section verbatim: the trust receipt (\`proofs/receipt.sh\`, fingerprint-honest — a tree that did not verify CANNOT yield a dossier: a red receipt aborts with "documents a tree that did NOT verify"), the release seal, the formal-credit claims table (#575), the derived stage block, the gate-verification class summary (unverified ceiling 0), the contract-ledger summary **with the KNOWN PROBLEMS section** (flagged-for-revision contracts — currently zero — never hidden), the MC/DC ledger state (#566), and a sha256 input manifest as the reproducibility rail (regenerate at the tag, byte-compare).
- **trust-spine.yml gains a \`v*\` tag trigger**: every release tag runs the FULL spine on its tree; a green run assembles the dossier (the receipt folds via the fingerprint rail — no re-derivation), **attests it with Sigstore** (\`actions/attest-build-provenance\`; verify externally with \`gh attestation verify almide-dossier-<tag>.md -R almide/almide\`), and attaches it to the release with a retry loop while release.yml creates it. Key-based signing beyond the attestation is deferred to #1534 by name.
- Local smoke: \`--no-receipt\` stamps its section "MISSING — not a release dossier" loudly; a missing seal likewise. Assembly verified against v0.59.2's seal (8 sections, 320 contracts, flagged 0).