### PR TITLE
Security baseline: SECURITY.md, RustSec audit lane, and attested release assets

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,34 @@
+name: Dependency audit (RustSec)
+
+# #1534: the dependency tree against the RustSec advisory database —
+# weekly, on every lockfile change, and on demand. An advisory with no
+# fixed release gets an issue, not a silence; permanent ignores need a
+# written justification HERE.
+
+on:
+  schedule:
+    - cron: "20 6 * * 1"
+  push:
+    branches: [develop]
+    paths: ["Cargo.lock", "**/Cargo.toml", ".github/workflows/dependency-audit.yml"]
+  pull_request:
+    paths: ["Cargo.lock", "**/Cargo.toml", ".github/workflows/dependency-audit.yml"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: cargo audit (advisory database)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "dep-audit"
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: Audit the lockfile
+        run: cargo audit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ env:
 
 permissions:
   contents: write
+  # #1534: release-asset attestation (Sigstore).
+  id-token: write
+  attestations: write
 
 jobs:
   build:
@@ -127,6 +130,14 @@ jobs:
             *-rc*) bash scripts/count-release-blockers.sh || true ;;
             *)     bash scripts/count-release-blockers.sh --gate ;;
           esac
+
+      # #1534: every release asset is Sigstore-attested — verify with
+      #   gh attestation verify <asset> -R almide/almide
+      # (documented in SECURITY.md). The checksums file is attested too.
+      - name: Attest release assets (Sigstore)
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: release/*
 
       - name: Create GitHub Release
         env:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report privately via **GitHub Security Advisories**:
+https://github.com/almide/almide/security/advisories/new — do not open a
+public issue for an unfixed vulnerability. You should receive an initial
+response within 7 days. Coordinated disclosure: we ask for a 90-day window
+(shorter by agreement once a fix ships).
+
+In scope: the compiler and its emitted code (a miscompilation that breaks
+the memory-safety claims IS a security bug — see the severity taxonomy in
+`docs/project/ISSUE-TAXONOMY.md`: `I-unsound` / `I-miscompile` are
+release-blocking by CI policy), the runtime (`runtime/rs`), the wasm legs
+and their host shims, and the release pipeline.
+
+## Supported versions
+
+The latest minor release line receives fixes. Older lines: fixes are not
+backported; upgrade. Release-blocker policy: a FINAL tag cannot ship over
+an open `I-unsound` / `I-miscompile` / `I-divergence` / `regression`
+issue (enforced by the release workflow, #1482).
+
+## Dependency policy
+
+The dependency tree is audited in CI against the RustSec advisory
+database (`cargo audit`, weekly + on every lockfile change — see
+`.github/workflows/dependency-audit.yml`). An advisory with no fixed
+release is triaged in an issue rather than silenced; permanent ignores
+require a written justification in the workflow file.
+
+## Release integrity
+
+Every release ships `almide-checksums.sha256`, and release artifacts are
+**attested with Sigstore** (GitHub artifact attestation). Verify any
+downloaded asset:
+
+```
+gh attestation verify <asset> -R almide/almide
+```
+
+The qualification dossier attached to each release (`almide-dossier-*.md`)
+carries the trust-chain receipts for that tag; it is attested the same way.


### PR DESCRIPTION
Addresses #1534 (A3-1). Closure follows the audit lane's first run and the next signed release.

- **SECURITY.md**: private reporting via GitHub Security Advisories (7-day response, 90-day coordinated disclosure), the scope statement that a memory-safety-breaking miscompilation IS a security bug (tied to the I-severity taxonomy and the #1482 release-blocker gate), supported-versions policy, and the verification command for attested artifacts.
- **\`.github/workflows/dependency-audit.yml\`**: \`cargo audit\` against the RustSec advisory database — weekly, on every lockfile/manifest change, and on PRs touching them. Policy stated in the workflow: unfixed advisories get an issue, permanent ignores need written justification in the file.
- **release.yml**: every release asset (binaries + checksums) is **Sigstore-attested** (\`actions/attest-build-provenance\`); \`gh attestation verify <asset> -R almide/almide\` is the documented check. This extends the dossier attestation (#1635) to the whole asset set — signing past checksums, exactly the issue's exit shape.