### PR TITLE
The Ferrocene lane prints the compiler error on a build failure

### DIFF
--- a/scripts/check-ferrocene-lane.sh
+++ b/scripts/check-ferrocene-lane.sh
@@ -71,8 +71,12 @@ while IFS=$'\t' read -r _hash _exit path; do
   fi
   # 2. The generated program must BUILD under the lane's toolchain (the
   #    shared build dir keeps this incremental across the corpus).
-  if ! "$BIN" build "$path" -o /tmp/ferrocene-lane-out >/dev/null 2>&1; then
+  if ! out=$("$BIN" build "$path" -o /tmp/ferrocene-lane-out 2>&1); then
     echo "FAIL: $path — generated Rust did not build under the lane toolchain" >&2
+    # The compiler's own words, or the finding is not actionable from a
+    # machine without this toolchain (the gen-claims diagnosability rule).
+    printf '%s
+' "$out" | grep -B2 -A8 "^error" | head -40 >&2
     build_fail=$((build_fail + 1))
   fi
 done < "$MANIFEST"


### PR DESCRIPTION
The lane's FIRST dispatched run did its job: 633 fixtures under real rustc 1.95.0, one genuine finding — \`spec/wasm_cross/fan_race_mapper.almd\`'s generated Rust does not build under the pin (it builds under 1.94/1.96, so this is a generated-code MSRV regression to root-cause). But the script swallowed the compiler's output, so the finding is not actionable from a machine without that toolchain. Now a failure prints the error block verbatim (the gen-claims diagnosability rule). Re-dispatching after merge will name the real cause.