### PR TITLE
DO NOT MERGE: audit-lane negative probe (known-advisory pin)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "time",
  "toml 1.1.4+spec-1.1.0",
  "wasi-preview1-component-adapter-provider",
  "wasmparser 0.256.0",
@@ -999,7 +1000,7 @@ checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1513,7 +1514,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -2003,6 +2004,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
 name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,6 +2156,12 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ lsp-server = "0.10"
 lsp-types = "0.97"
 wit-component = "0.256"
 wasi-preview1-component-adapter-provider = "47.0.2"
+time = "0.1.45"
 
 # Cross-platform advisory file lock (flock / LockFileEx) for the shared build
 # scratch dir (see BuildDirLock) — lets CI run the suite in parallel on every


### PR DESCRIPTION
#1534's exit criterion demands the audit gate go RED on a known-vulnerable pin — this draft pins `time 0.1.45` (RUSTSEC-2020-0071) to demonstrate exactly that, then closes unmerged. The red run is the negative evidence; nothing here lands.