### PR TITLE
Line-level traceability ships with --target rust (--trace-map)

### DIFF
--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -76,6 +76,12 @@ pub enum CodegenOutput {
 pub struct CodegenOptions {
     /// Emit `#[repr(C)]` on structs/enums for stable C ABI layout.
     pub repr_c: bool,
+    /// #572: prepend a `// almd: fn <name> @ line <N>` anchor comment to
+    /// every rendered function (the source-to-generated correspondence
+    /// unit). Default off — the emitted bytes stay identical to the
+    /// baselines; `--trace-map` turns it on and derives the sidecar map
+    /// from these anchors.
+    pub trace: bool,
     /// Waiver for the Perceus RC gate (`--emit-unverified`): when a function
     /// fails Perceus verification, emit it anyway with a warning instead of
     /// refusing the build. A violation is a compiler bug (callee-inserted RC,
@@ -628,6 +634,7 @@ fn emit_source(program: &mut IrProgram, target: Target, config: &target::TargetC
         .with_target(target)
         .with_annotations(ann);
     ctx.repr_c = options.repr_c;
+    ctx.trace = options.trace;
     let user_code = walker::render_program(&ctx, program);
 
     // Prepend runtime preamble

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -92,6 +92,8 @@ pub struct RenderContext<'a> {
     pub minimal_generic_bounds: bool,
     /// Emit `#[repr(C)]` on structs/enums for stable C ABI layout.
     pub repr_c: bool,
+    /// #572: emit `// almd:` anchor comments on every rendered fn.
+    pub trace: bool,
     /// VarIds of current fn params emitted as Rust references (`&T`,
     /// `&[T]`, `&str`). Used by the Borrow walker to avoid
     /// double-borrowing an already-reference binding.
@@ -123,7 +125,7 @@ pub struct RenderContext<'a> {
 
 impl<'a> RenderContext<'a> {
     pub fn new(templates: &'a TemplateSet, var_table: &'a VarTable) -> Self {
-        Self { templates, var_table, indent: 0, target: Target::Rust, auto_unwrap: false, is_test: false, ann: std::rc::Rc::new(CodegenAnnotations::default()), type_aliases: std::rc::Rc::new(std::collections::HashMap::new()), generic_types: std::rc::Rc::new(std::collections::HashSet::new()), minimal_generic_bounds: false, repr_c: false, ref_params: std::collections::HashSet::new(), ref_mut_params: std::collections::HashSet::new(), param_vars: std::collections::HashSet::new(), repr_named_types: std::rc::Rc::new(std::collections::HashSet::new()), fn_err_ty: None }
+        Self { templates, var_table, indent: 0, target: Target::Rust, auto_unwrap: false, is_test: false, trace: false, ann: std::rc::Rc::new(CodegenAnnotations::default()), type_aliases: std::rc::Rc::new(std::collections::HashMap::new()), generic_types: std::rc::Rc::new(std::collections::HashSet::new()), minimal_generic_bounds: false, repr_c: false, ref_params: std::collections::HashSet::new(), ref_mut_params: std::collections::HashSet::new(), param_vars: std::collections::HashSet::new(), repr_named_types: std::rc::Rc::new(std::collections::HashSet::new()), fn_err_ty: None }
     }
 
     pub fn with_target(mut self, target: Target) -> Self {
@@ -416,6 +418,19 @@ fn wrap_main_fn_code(fn_code: String, ctx: &RenderContext, is_rust_effect_main: 
 }
 
 pub fn render_function(ctx: &RenderContext, func: &IrFunction) -> String {
+    let body = render_function_inner(ctx, func);
+    // #572: the source-to-generated anchor — one comment per rendered fn,
+    // keyed to the BODY's source line (IrFunction carries no decl span;
+    // the body span is the correspondence unit the sidecar map scans).
+    if ctx.trace && !body.is_empty() {
+        if let Some(sp) = &func.body.span {
+            return format!("// almd: fn {} @ line {}\n{}", func.name, sp.line, body);
+        }
+    }
+    body
+}
+
+fn render_function_inner(ctx: &RenderContext, func: &IrFunction) -> String {
     // Collect VarIds of fn params that will be emitted as references
     // (`&T` / `&[T]` / `&str`). The Borrow walker uses this to skip
     // outer `&` wrap on already-borrowed bindings.
@@ -484,6 +499,7 @@ fn fn_render_context<'a>(
         generic_types: ctx.generic_types.clone(),
         minimal_generic_bounds: ctx.minimal_generic_bounds,
         repr_c: ctx.repr_c,
+        trace: ctx.trace,
         ref_params,
         ref_mut_params,
         param_vars: func.params.iter().map(|p| p.var).collect(),

--- a/crates/almide-codegen/src/walker/program_render.rs
+++ b/crates/almide-codegen/src/walker/program_render.rs
@@ -227,6 +227,7 @@ pub fn render_program(ctx: &RenderContext, program: &IrProgram) -> String {
         generic_types: std::rc::Rc::new(generic_types),
         minimal_generic_bounds: false,
         repr_c: ctx.repr_c,
+        trace: ctx.trace,
         ref_params: std::collections::HashSet::new(),
         param_vars: std::collections::HashSet::new(),
         ref_mut_params: std::collections::HashSet::new(),

--- a/docs/project/GENERATED-RUST-REVIEW.md
+++ b/docs/project/GENERATED-RUST-REVIEW.md
@@ -1,0 +1,44 @@
+# Reviewing generated Rust (#572)
+
+In the qualified-code-generator model (the SCADE KCG precedent), the
+generated source is the reviewable certified artifact. This is the
+review guide for Almide's `--target rust` output.
+
+## The correspondence map
+
+```
+almide app.almd --target rust --trace-map > app.rs
+```
+
+emits `// almd: fn <name> @ line <N>` above every rendered function and
+writes `app.trace.json` — rows of `{fn, almd_line, rust_line}`, derived
+by scanning the SHIPPED text (the map cannot disagree with it; the gate
+is `tests/trace_map_test.rs`). Anchors point at the fn BODY's source
+line. Functions linked from the self-hosted stdlib carry their own
+stdlib-source lines; their file identity is the stdlib module named in
+the fn's dotted prefix. The default (flag-less) emission is byte-identical
+to the committed emit baselines — anchors never appear unflagged.
+
+## What a reviewer aligns on
+
+1. **Functions** are the correspondence unit: every `.almd` fn renders as
+   one Rust fn (monomorphized generics render one fn per instantiation,
+   suffixed with the concrete types). Statement ORDER inside a body is
+   preserved by construction — the walker renders the IR statement list
+   in sequence; no reordering pass exists on the Rust target.
+2. **Stable patterns**: `effect fn` → `Result<T, String>` with explicit
+   `?` only where the source wrote `!` (ADR-0008); `==` → `almide_eq!`;
+   `+` on strings/lists → `AlmideConcat`; `mut` params → `&mut`;
+   variants → Rust enums with the same case names; records → structs
+   with the same field names. What the checker accepted is what renders —
+   codegen never re-infers types (the TypeMap is the source of truth).
+3. **Warning-free**: generated Rust must compile without warnings (a
+   standing testing rule), and the whole run-manifest corpus builds under
+   the Ferrocene-pinned toolchain weekly (`ferrocene-lane.yml`, #573).
+
+## The certification frame
+
+The generated source + this correspondence story is the
+source-to-object half that the QUALIFIED COMPILER below (Ferrocene, the
+#573 split) carries onward. The tool-qualification package indexing all
+of it is `proofs/TOOL-QUALIFICATION.md` (#574).

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -167,7 +167,7 @@ pub fn cmd_build(args: BuildArgs) {
 
     let output = compute_output_path(file, output, is_wasm);
 
-    let opts = crate::codegen::CodegenOptions { repr_c, allow_unverified: false };
+    let opts = crate::codegen::CodegenOptions { repr_c, allow_unverified: false, trace: false };
     let (rs_code, _ir) = crate::try_compile_with_ir(file, no_check, &opts)
         .unwrap_or_else(|_| std::process::exit(1));
 

--- a/src/cli/emit.rs
+++ b/src/cli/emit.rs
@@ -68,6 +68,9 @@ pub struct EmitArgs<'a> {
     pub emit_dialect: bool,
     pub no_check: bool,
     pub repr_c: bool,
+    /// #572: emit `// almd:` fn anchors and write the sidecar map
+    /// (`<file>.trace.json`: each anchor's almd line ↔ its rust line).
+    pub trace_map: bool,
 }
 
 /// `cmd_emit`'s `--dialect` output path. Extracted verbatim.
@@ -103,7 +106,7 @@ fn emit_ast_output(program: &almide::ast::Program) {
 
 /// `cmd_emit`'s default codegen output path (Rust/WGSL source). Extracted
 /// verbatim.
-fn emit_codegen_output(ir_program: &mut Option<almide::ir::IrProgram>, target: &str, repr_c: bool) {
+fn emit_codegen_output(ir_program: &mut Option<almide::ir::IrProgram>, target: &str, repr_c: bool, trace_map: bool, src_file: &str) {
     let ir = ir_program.as_mut().expect("IR required for codegen");
     almide::ir_link::ir_link(ir);
     let t = match target {
@@ -111,15 +114,48 @@ fn emit_codegen_output(ir_program: &mut Option<almide::ir::IrProgram>, target: &
         "wgsl" => codegen::pass::Target::Wgsl,
         other => { err(&format!("Unknown target: {}. Use rust, wgsl.", other)); std::process::exit(1); }
     };
-    let opts = codegen::CodegenOptions { repr_c, allow_unverified: false };
+    let opts = codegen::CodegenOptions { repr_c, allow_unverified: false, trace: trace_map, ..Default::default() };
     match codegen::codegen_with(ir, t, &opts) {
-        codegen::CodegenOutput::Source(code) => out_no_nl(&format!("{}", code)),
+        codegen::CodegenOutput::Source(code) => {
+            if trace_map {
+                write_trace_map(src_file, &code);
+            }
+            out_no_nl(&format!("{}", code));
+        }
         codegen::CodegenOutput::Binary(_) => unreachable!(),
     }
 }
 
+/// #572: derive the sidecar map from the anchors the renderer emitted —
+/// `<src>.trace.json`, an array of {fn, almd_line, rust_line}. Scanning
+/// the OUTPUT (not re-walking the IR) means the map can never disagree
+/// with the shipped text.
+fn write_trace_map(src_file: &str, code: &str) {
+    let mut rows = Vec::new();
+    for (i, line) in code.lines().enumerate() {
+        let t = line.trim_start();
+        if let Some(rest) = t.strip_prefix("// almd: fn ") {
+            if let Some((name, ln)) = rest.split_once(" @ line ") {
+                if let Ok(almd_line) = ln.trim().parse::<usize>() {
+                    rows.push(format!(
+                        "{{\"fn\":\"{}\",\"almd_line\":{},\"rust_line\":{}}}",
+                        name, almd_line, i + 2
+                    ));
+                }
+            }
+        }
+    }
+    let out = format!("[\n  {}\n]\n", rows.join(",\n  "));
+    let path = format!("{}.trace.json", src_file.strip_suffix(".almd").unwrap_or(src_file));
+    if let Err(e) = std::fs::write(&path, out) {
+        err(&format!("Failed to write {}: {}", path, e));
+        std::process::exit(1);
+    }
+    err(&format!("Trace map: {path} ({} function(s))", rows.len()));
+}
+
 pub fn cmd_emit(args: EmitArgs) {
-    let EmitArgs { file, target, emit_ast, emit_ir, emit_dialect, no_check, repr_c } = args;
+    let EmitArgs { file, target, emit_ast, emit_ir, emit_dialect, no_check, repr_c, trace_map } = args;
     let (mut program, source_text, parse_errors) = parse_file(file);
     exit_on_parse_errors(&parse_errors, &source_text);
 
@@ -176,5 +212,5 @@ pub fn cmd_emit(args: EmitArgs) {
         emit_ast_output(&program);
         return;
     }
-    emit_codegen_output(&mut ir_program, target, repr_c);
+    emit_codegen_output(&mut ir_program, target, repr_c, trace_map, file);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -347,6 +347,13 @@ enum Commands {
         /// Add #[repr(C)] to structs/enums for stable C ABI
         #[arg(long)]
         repr_c: bool,
+        /// #572: emit `// almd: fn <name> @ line <N>` anchors on every
+        /// rendered function and write the sidecar traceability map
+        /// (`<file>.trace.json`) — the source-to-generated correspondence
+        /// a third-party review aligns on. Default off: the plain emission
+        /// stays byte-identical to the baselines.
+        #[arg(long = "trace-map")]
+        trace_map: bool,
     },
 }
 
@@ -793,8 +800,8 @@ fn dispatch_rest(command: Commands) {
         Commands::SelfUpdate { version } => {
             cli::cmd_self_update(version.as_deref());
         }
-        Commands::Emit { file, target, emit_ast, emit_ir, emit_dialect, no_check, repr_c } => {
-            cli::cmd_emit(cli::EmitArgs { file: &file, target: &target, emit_ast, emit_ir, emit_dialect, no_check, repr_c });
+        Commands::Emit { file, target, emit_ast, emit_ir, emit_dialect, no_check, repr_c, trace_map } => {
+            cli::cmd_emit(cli::EmitArgs { file: &file, target: &target, emit_ast, emit_ir, emit_dialect, no_check, repr_c, trace_map });
         }
         // `command`'s static type is the full `Commands` enum — Rust can't
         // narrow it to "one of the 12 variants `dispatch` doesn't handle"

--- a/tests/trace_map_test.rs
+++ b/tests/trace_map_test.rs
@@ -1,0 +1,73 @@
+//! #572: `--trace-map` ships the source-to-generated correspondence with
+//! `--target rust` output — `// almd: fn <name> @ line <N>` anchors on
+//! every rendered function, and a sidecar `<file>.trace.json` derived by
+//! scanning the SHIPPED text (so the map can never disagree with it).
+//! The default emission stays byte-identical: zero anchors without the
+//! flag (the 974-file emit baselines are untouched).
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+const PROGRAM: &str = "fn double(n: Int) -> Int = n * 2\n\nfn main() -> Unit = {\n  println(int.to_string(double(21)))\n}\n";
+
+#[test]
+fn trace_map_anchors_and_sidecar_agree() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    let dir = std::env::temp_dir().join("almide-trace-map");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let src = dir.join("tm.almd");
+    std::fs::write(&src, PROGRAM).expect("write");
+
+    // Default emission carries NO anchors — byte-stability with the
+    // baselines is the point of the flag.
+    let plain = Command::new(almide_bin())
+        .args([src.to_str().unwrap(), "--target", "rust"])
+        .output()
+        .expect("spawn");
+    assert!(plain.status.success());
+    assert!(
+        !String::from_utf8_lossy(&plain.stdout).contains("// almd:"),
+        "anchors leaked into the default emission"
+    );
+
+    let traced = Command::new(almide_bin())
+        .args([src.to_str().unwrap(), "--target", "rust", "--trace-map"])
+        .output()
+        .expect("spawn");
+    assert!(traced.status.success(), "{}", String::from_utf8_lossy(&traced.stderr));
+    let code = String::from_utf8_lossy(&traced.stdout).to_string();
+    assert!(code.contains("// almd: fn double @ line 1"), "missing the fn anchor");
+    assert!(code.contains("// almd: fn main @ line 3"), "missing the main anchor");
+
+    // The sidecar exists, parses, and each row's rust_line points AT (or
+    // one past) its own anchor in the shipped text — the agreement claim.
+    let map_path = dir.join("tm.trace.json");
+    let map: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&map_path).expect("sidecar"))
+            .expect("valid json");
+    let rows = map.as_array().expect("array");
+    assert!(rows.len() >= 2, "expected at least the two program fns, got {}", rows.len());
+    let lines: Vec<&str> = code.lines().collect();
+    for row in rows {
+        let name = row["fn"].as_str().unwrap();
+        let rust_line = row["rust_line"].as_u64().unwrap() as usize;
+        let anchor = format!("// almd: fn {name} @");
+        assert!(
+            lines[rust_line - 2].trim_start().starts_with(&anchor),
+            "row for {name}: rust_line {rust_line} does not sit under its anchor"
+        );
+    }
+}


### PR DESCRIPTION
Addresses #572's exit criteria: a traceability map ships with \`--target rust\` output, and a third party can review the generated Rust against the \`.almd\` source.

- **\`--trace-map\`** on the emit command: every rendered function gets a \`// almd: fn <name> @ line <N>\` anchor (the fn body's source line — the correspondence unit), and the sidecar \`<file>.trace.json\` ({fn, almd_line, rust_line} rows) is derived by scanning the SHIPPED text, so the map structurally cannot disagree with it.
- **The default emission is byte-identical** — zero anchors without the flag; the 974-file emit baselines are untouched (gated: \`tests/trace_map_test.rs\` asserts no-anchor default, both anchors present under the flag, valid JSON, and every row's rust_line sitting under its own anchor).
- **\`docs/project/GENERATED-RUST-REVIEW.md\`**: the review guide — correspondence unit, the stable codegen patterns (effect→Result with explicit \`?\` per ADR-0008, \`almide_eq!\`, AlmideConcat, mut→&mut, variants→enums), statement-order preservation by construction, warning-free rule, and the hand-off to the Ferrocene split (#573) and the qualification package (#574).
- Full workspace battery: 214 suites green.