### PR TITLE
almide check --profile critical: the bounded profile on every fn, capabilities deny-all with --allow grants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ almide compile                    # Module interface (project)
 almide compile parser             # Module interface (by name)
 almide compile app.almd --json    # Module interface (JSON)
 almide check app.almd             # Type check only
+almide check app.almd --profile critical --allow IO  # Critical profile (#567): bounded rules on every fn, capabilities deny-all
 almide fmt app.almd               # Format source
 almide fmt --check spec/          # Formatting gate (non-zero on drift)
 almide fmt --no-import-edit stdlib/  # Format WITHOUT touching imports (splice-context sources)

--- a/crates/almide-frontend/src/check/bounded.rs
+++ b/crates/almide-frontend/src/check/bounded.rs
@@ -17,11 +17,17 @@ use almide_lang::types::constructor::TypeConstructorId;
 impl Checker {
     pub(crate) fn check_bounded_profile(&mut self, program: &ast::Program) {
         use std::collections::HashMap;
+        // #567 `--profile critical`: the same profile, applied to EVERY fn
+        // (no attribute needed) with capabilities deny-all + `--allow` grants.
+        // Critical only WIDENS what is rejected, so the subset property
+        // (critical-valid ⇒ normal-valid) holds by construction.
+        let critical = self.profile_critical;
         // the user fn index: name -> (is_bounded, body) — the call-graph nodes
         let mut fns: HashMap<&str, (bool, Option<&ast::Expr>)> = HashMap::new();
         for decl in &program.decls {
             if let ast::Decl::Fn { name, attrs, body, .. } = decl {
-                let is_bounded = attrs.iter().any(|a| a.name.as_str() == "bounded");
+                let is_bounded =
+                    critical || attrs.iter().any(|a| a.name.as_str() == "bounded");
                 fns.insert(name.as_str(), (is_bounded, body.as_ref()));
             }
         }
@@ -33,7 +39,7 @@ impl Checker {
             let ast::Decl::Fn { name, attrs, effect, body: Some(body), span, .. } = decl else {
                 continue;
             };
-            if !attrs.iter().any(|a| a.name.as_str() == "bounded") {
+            if !critical && !attrs.iter().any(|a| a.name.as_str() == "bounded") {
                 continue;
             }
             // ALS-B6 / E073: the reachable call graph must be a DAG — a DFS
@@ -62,6 +68,22 @@ impl Checker {
         for mut d in diags {
             if d.file.is_none() {
                 d.file = self.source_file.clone();
+            }
+            // Under critical the author wrote NO attribute — a message telling
+            // them about `@bounded` would name a construct they never used.
+            // Same rules, same codes; only the addressing is rewritten.
+            if critical {
+                d.message = d
+                    .message
+                    .replace("in a @bounded function", "under `--profile critical`");
+                d.context = d.context.replace("@bounded fn", "fn");
+                d.hint = d
+                    .hint
+                    .replace("mark the callee @bounded, or use", "use")
+                    .replace(
+                        "the profile's declared capability is standard output only",
+                        "capabilities start deny-all — grant one with --allow IO|Net|Env|Time|Rand|Process",
+                    );
             }
             self.diagnostics.push(d);
         }
@@ -201,6 +223,15 @@ impl BoundedCx<'_, '_> {
             self.fn_name,
             span.or(self.fn_span),
         ));
+    }
+
+    /// #567: is this effect module GRANTED under `--profile critical`?
+    /// Always false in plain `@bounded` mode (its capability is fixed at
+    /// standard output only — ALS-B9), so attribute-mode behaviour is
+    /// untouched.
+    fn module_granted(&self, m: &str) -> bool {
+        self.checker.profile_critical
+            && self.checker.critical_allow.iter().any(|g| g == m)
     }
 
     fn is_const_int(&self, e: &ast::Expr) -> bool {
@@ -600,6 +631,9 @@ impl BoundedCx<'_, '_> {
                 let m = resolved.as_str();
                 let f = field.as_str();
                 if m == "io" {
+                    if self.module_granted("io") {
+                        return;
+                    }
                     if !(f.starts_with("print") || f.starts_with("eprint")) {
                         self.err(
                             "an effect outside the declared capability is not admissible in a @bounded function",
@@ -611,6 +645,12 @@ impl BoundedCx<'_, '_> {
                     return;
                 }
                 if BOUNDED_DENIED_MODULES.contains(&m) {
+                    // #567: a granted capability un-denies its module wholesale
+                    // (the module is not in the pure set, so return — its calls
+                    // are the capability's own surface, not profile callees)
+                    if self.module_granted(m) {
+                        return;
+                    }
                     // ALS-B9 / E076
                     self.err(
                         "an effect outside the declared capability is not admissible in a @bounded function",

--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -78,6 +78,16 @@ pub struct Checker {
     pub diagnostics: Vec<Diagnostic>,
     pub source_file: Option<String>,
     pub source_text: Option<String>,
+    /// #567 `--profile critical`: the bounded profile (ALS §B) applied to
+    /// EVERY fn of the program under inference — no `@bounded` attribute
+    /// needed — with capabilities starting deny-all. Set by the check CLI
+    /// around the ENTRY program's inference only (imported modules,
+    /// stdlib above all, are the trusted runtime below the profile).
+    pub profile_critical: bool,
+    /// The GRANTED module names under `--profile critical`, already
+    /// expanded from capability names (`--allow Rand` → `random`) at the
+    /// CLI boundary. Empty = deny-all.
+    pub critical_allow: Vec<String>,
     pub(crate) current_span: Option<crate::ast::Span>,
     /// Span of the current call's callee expression (the identifier
     /// / member reference). Set by `check_named_call_spanned` so E002
@@ -493,6 +503,8 @@ impl Checker {
             env, type_map: crate::types::TypeMap::new(),
             diagnostics: Vec::new(),
             source_file: None, source_text: None,
+            profile_critical: false,
+            critical_allow: Vec::new(),
             current_span: None,
             callee_span_hint: None,
             call_span_hint: None,

--- a/docs/roadmap/active/certification-grade.md
+++ b/docs/roadmap/active/certification-grade.md
@@ -100,6 +100,14 @@ MISRA C / Ada Ravenscar / SPARK subset の analog。`almide check --profile crit
 - **Critical は subset であって方言ではない** — 全 Critical コードは通常モードでも
   そのまま有効 (SPARK ⊂ Ada と同じ関係)
 
+**状態 (#567 着地)**: `almide check --profile critical` 稼働 — bounded
+プロファイル (ALS §B, E070–E078) を全関数に適用し、capability は deny-all
+出発で `--allow IO|Net|Env|Time|Rand|Process` が grant。スコープはエントリ
+プログラム (stdlib はプロファイルの下の trusted runtime)。subset 性は
+`tests/critical_profile_test.rs` が全負例で通常モード PASS を突き合わせて
+CI 強制。残: `fan.*` の admissibility (#1628 stage 2 のコスト境界待ち)、
+静的メモリモード (#568)、RC drop カスケード上限。
+
 ### CG-4: Translation validation (L)
 
 belt の思想をビルド単位の証明に拡張: 「この .wasm はこの検証済み IR の正しい翻訳」

--- a/proofs/TOOL-QUALIFICATION.md
+++ b/proofs/TOOL-QUALIFICATION.md
@@ -100,8 +100,9 @@ attested and attached to the release by the trust-spine tag run.
 | Line-level source traceability in generated Rust | #572 | closed — `--trace-map` + review guide |
 | Lean/Rocq proof coverage of the RUNTIME (allocator, free-list, RC ops as shipped) | #576 | model proven (FC-3); implementation gap open |
 | Qualified/minimal wasm execution environment | #865 | not started |
-| Critical-profile subset (`almide check --profile critical`) + static memory mode | #567, #568 | not started |
-| Flight reference app through `make verify` | #776 | not started |
+| Critical-profile subset (`almide check --profile critical`) | #567 | closed — bounded profile on every fn, deny-all capabilities with `--allow` grants, subset property CI-enforced |
+| Static memory mode for the Critical profile | #568 | not started |
+| Flight reference app through `make verify` | #776 | closed — G-F4 chain evidenced end to end; the receipt derives all six stages (`proofs/receipt.sh`) |
 | First dossier-carrying release (fires #571/#1534 closure) | #571, #1534 | machinery live; next tag |
 
 A qualification engineer reading this package starts at §2 (what the

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -42,7 +42,7 @@ fn report_check_errors_or_exit(
 /// call `parse_file` itself so each caller keeps its own parse + any
 /// pre-resolve early-exit check (`cmd_check_effects`'s parse-error gate)
 /// at exactly its original point in the control flow.
-fn resolve_and_typecheck_for_check(file: &str, program: &mut almide::ast::Program, source_text: &str) -> (Vec<diagnostic::Diagnostic>, check_mod::Checker) {
+fn resolve_and_typecheck_for_check(file: &str, program: &mut almide::ast::Program, source_text: &str, critical: Option<&[String]>) -> (Vec<diagnostic::Diagnostic>, check_mod::Checker) {
     let dep_paths = super::dep_paths_from_cwd_toml();
 
     let mut resolved = resolve::resolve_imports_with_deps(file, program, &dep_paths)
@@ -59,7 +59,16 @@ fn resolve_and_typecheck_for_check(file: &str, program: &mut almide::ast::Progra
     // program reads them (drivers infer the entry FIRST; without this the
     // readers see the registration seed — Unknown for non-literal inits).
     almide::resolve::refresh_module_toplets(&mut checker, &resolved.modules);
+    // #567: the critical profile scopes to the ENTRY program only — armed for
+    // exactly this inference call and cleared before the module loop below,
+    // so imported modules (stdlib above all — the trusted runtime BELOW the
+    // profile, full of while loops by design) are never profiled.
+    if let Some(grants) = critical {
+        checker.profile_critical = true;
+        checker.critical_allow = grants.to_vec();
+    }
     let diagnostics = checker.infer_program(program);
+    checker.profile_critical = false;
 
     // #862: an imported module's OWN body was never inferred on the check
     // path, so an E006 (or any other body-level error) inside it stayed
@@ -128,7 +137,7 @@ fn report_timings(r: &almide_base::profile::PhaseReport, total_secs: f64) {
     ));
 }
 
-pub fn cmd_check(file: &str, deny_warnings: bool, timings: bool, stamp: bool) {
+pub fn cmd_check(file: &str, deny_warnings: bool, timings: bool, stamp: bool, critical: Option<&[String]>) {
     // Arm the accounting BEFORE the first source is read; a phase counter that
     // starts mid-pipeline reports a front end with no lexer.
     if timings {
@@ -137,7 +146,7 @@ pub fn cmd_check(file: &str, deny_warnings: bool, timings: bool, stamp: bool) {
     let total_timer = almide_base::profile::ProfileTimer::start(timings);
 
     let (mut program, source_text, parse_errors) = parse_file(file);
-    let (diagnostics, checker) = resolve_and_typecheck_for_check(file, &mut program, &source_text);
+    let (diagnostics, checker) = resolve_and_typecheck_for_check(file, &mut program, &source_text, critical);
 
     // Lower to IR for unused variable analysis (only if no parse or type errors)
     let has_type_errors = diagnostics.iter().any(|d| d.level == diagnostic::Level::Error);
@@ -241,7 +250,7 @@ fn parse_for_json(file: &str) -> (Option<almide::ast::Program>, String, Vec<diag
     (program, input, errors)
 }
 
-pub fn cmd_check_json(file: &str) {
+pub fn cmd_check_json(file: &str, critical: Option<&[String]>) {
     let (parsed, source_text, parse_errors) = parse_for_json(file);
     let Some(mut program) = parsed else {
         for d in &parse_errors {
@@ -252,7 +261,7 @@ pub fn cmd_check_json(file: &str) {
         // success just because the diagnostics got a better shape.
         std::process::exit(1);
     };
-    let (diagnostics, checker) = resolve_and_typecheck_for_check(file, &mut program, &source_text);
+    let (diagnostics, checker) = resolve_and_typecheck_for_check(file, &mut program, &source_text, critical);
 
     // Output each diagnostic as JSON (one per line)
     for d in &parse_errors {
@@ -331,7 +340,7 @@ pub fn cmd_check_effects(file: &str) {
         std::process::exit(1);
     }
 
-    let (diagnostics, checker) = resolve_and_typecheck_for_check(file, &mut program, &source_text);
+    let (diagnostics, checker) = resolve_and_typecheck_for_check(file, &mut program, &source_text, None);
 
     let errors: Vec<_> = diagnostics.iter()
         .filter(|d| d.level == diagnostic::Level::Error)

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,6 +197,16 @@ enum Commands {
         /// not in `fmt`.
         #[arg(long)]
         stamp: bool,
+        /// Check under a named profile. `critical` (#567) applies the bounded
+        /// profile (ALS §B, E070–E078) to EVERY function — no `@bounded`
+        /// attribute needed — with capabilities starting deny-all. A subset,
+        /// not a dialect: critical-valid code is always valid in normal mode.
+        #[arg(long)]
+        profile: Option<String>,
+        /// Grant a capability under `--profile critical` (repeatable):
+        /// IO, Net, Env, Time, Rand, Process
+        #[arg(long)]
+        allow: Vec<String>,
     },
     /// Start the Language Server Protocol server (for editor integration)
     Lsp,
@@ -603,19 +613,70 @@ fn dispatch_test(file: Option<String>, run: Option<String>, no_check: bool, json
 /// `dispatch`'s `Commands::Check` arm. Extracted verbatim — `explain` still
 /// returns early into the caller via its own `bool` return (`true` = already
 /// handled, caller should return).
-fn dispatch_check(file: Option<String>, deny_warnings: bool, json: bool, explain: Option<String>, effects: bool, timings: bool, stamp: bool) {
+fn dispatch_check(file: Option<String>, deny_warnings: bool, json: bool, explain: Option<String>, effects: bool, timings: bool, stamp: bool, profile: Option<String>, allow: Vec<String>) {
     if let Some(code) = explain {
         print_error_explanation(&code);
         return;
     }
+    // #567: `--profile critical` — validate the profile name and expand the
+    // capability grants to module names HERE, so the checker below the CLI
+    // never sees capability vocabulary.
+    let critical: Option<Vec<String>> = match profile.as_deref() {
+        None => {
+            if !allow.is_empty() {
+                eprintln!("error: --allow requires --profile critical");
+                std::process::exit(1);
+            }
+            None
+        }
+        Some("critical") => Some(expand_capability_grants(&allow)),
+        Some(other) => {
+            eprintln!("error: unknown profile `{other}` — the only profile is `critical`");
+            std::process::exit(1);
+        }
+    };
     let file = resolve_file(file);
     if effects {
+        if critical.is_some() {
+            eprintln!("error: --profile is not supported with --effects");
+            std::process::exit(1);
+        }
         cli::cmd_check_effects(&file);
     } else if json {
-        cli::cmd_check_json(&file);
+        cli::cmd_check_json(&file, critical.as_deref());
     } else {
-        cli::cmd_check(&file, deny_warnings, timings, stamp);
+        cli::cmd_check(&file, deny_warnings, timings, stamp, critical.as_deref());
     }
+}
+
+/// `--allow` capability names → the effect-module names the bounded checker
+/// denies (E076). The vocabulary is the effect-inference capability set minus
+/// `Fan`: `fan.*` scheduling stays outside the critical profile until the
+/// component-model async mapping gives its arms a bounded-cost story (#1628).
+fn expand_capability_grants(allow: &[String]) -> Vec<String> {
+    let mut modules: Vec<String> = Vec::new();
+    for cap in allow {
+        let granted: &[&str] = match cap.as_str() {
+            "IO" => &["io", "fs", "log"],
+            "Net" => &["http", "net"],
+            "Env" => &["env", "args"],
+            "Time" => &["datetime", "time", "duration"],
+            "Rand" => &["random"],
+            "Process" => &["process"],
+            other => {
+                eprintln!(
+                    "error: unknown capability `{other}` — grantable capabilities are IO, Net, Env, Time, Rand, Process"
+                );
+                std::process::exit(1);
+            }
+        };
+        for m in granted {
+            if !modules.iter().any(|x| x == m) {
+                modules.push(m.to_string());
+            }
+        }
+    }
+    modules
 }
 
 /// `dispatch`'s `Commands::Ide` arm (nested `IdeCommand` match). Extracted verbatim.
@@ -854,7 +915,7 @@ fn dispatch(cli: Cli) {
             });
         }
         Commands::Test { file, run, no_check, json, target } => dispatch_test(file, run, no_check, json, target),
-        Commands::Check { file, deny_warnings, json, explain, effects, timings, stamp } => dispatch_check(file, deny_warnings, json, explain, effects, timings, stamp),
+        Commands::Check { file, deny_warnings, json, explain, effects, timings, stamp, profile, allow } => dispatch_check(file, deny_warnings, json, explain, effects, timings, stamp, profile, allow),
         Commands::Fix { file, dry_run, json } => {
             let file = resolve_file(file);
             cli::cmd_fix(&file, dry_run, json);

--- a/tests/critical_profile_test.rs
+++ b/tests/critical_profile_test.rs
@@ -1,0 +1,114 @@
+//! #567: `almide check --profile critical` — the bounded profile (ALS §B,
+//! E070–E078) applied to EVERY function of the entry program, capabilities
+//! deny-all with explicit `--allow` grants.
+//!
+//! The load-bearing invariant is the SUBSET PROPERTY (the CG-3 "subset, not
+//! a dialect" rule): critical only widens what is rejected, so every
+//! critical-valid program is normal-valid, and every negative fixture here
+//! is asserted to PASS the normal check — proving the profile adds
+//! rejections without changing the language underneath.
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide() -> &'static str {
+    env!("CARGO_BIN_EXE_almide")
+}
+
+/// Run `almide check <args>` on a source string; returns (success, stderr).
+fn check(source: &str, name: &str, args: &[&str]) -> (bool, String) {
+    let dir = std::env::temp_dir().join("almide-critical-profile");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let src = dir.join(name);
+    std::fs::write(&src, source).expect("write");
+    let out = Command::new(almide())
+        .arg("check")
+        .arg(&src)
+        .args(args)
+        .current_dir(&dir)
+        .output()
+        .expect("spawn almide check");
+    (out.status.success(), String::from_utf8_lossy(&out.stderr).to_string())
+}
+
+const CLEAN: &str = "fn sum_to(n: Int) -> Int = {\n  var acc = 0\n  for i in 0..<10 {\n    acc = acc + i\n  }\n  acc + n\n}\n\nfn main() -> Unit = {\n  println(int.to_string(sum_to(1)))\n}\n";
+
+const WHILE_LOOP: &str = "fn count(n: Int) -> Int = {\n  var i = 0\n  while i < n {\n    i = i + 1\n  }\n  i\n}\n\nfn main() -> Unit = {\n  println(int.to_string(count(5)))\n}\n";
+
+const RECURSION: &str = "fn fact(n: Int) -> Int =\n  if n <= 1 then 1\n  else n * fact(n - 1)\n\nfn main() -> Unit = {\n  println(int.to_string(fact(5)))\n}\n";
+
+const RANDOM: &str = "import random\n\neffect fn main() -> Unit = {\n  let r = random.int(10, 20)\n  println(int.to_string(r))\n}\n";
+
+#[test]
+fn critical_clean_program_passes_both_modes() {
+    let (crit, err) = check(CLEAN, "clean.almd", &["--profile", "critical"]);
+    assert!(crit, "critical rejected the clean program:\n{err}");
+    // the subset witness: the same file under the NORMAL check
+    let (normal, err) = check(CLEAN, "clean.almd", &[]);
+    assert!(normal, "normal check rejected the critical-clean program:\n{err}");
+}
+
+#[test]
+fn while_loop_rejected_under_critical_only() {
+    let (crit, err) = check(WHILE_LOOP, "wh.almd", &["--profile", "critical"]);
+    assert!(!crit, "critical accepted a while loop");
+    assert!(err.contains("E070"), "expected E070, got:\n{err}");
+    // addressed to the profile, not to an attribute the author never wrote
+    assert!(err.contains("--profile critical"), "message not profile-addressed:\n{err}");
+    assert!(!err.contains("@bounded"), "critical diagnostic leaked @bounded addressing:\n{err}");
+    let (normal, err) = check(WHILE_LOOP, "wh.almd", &[]);
+    assert!(normal, "subset property broken — normal check rejected it too:\n{err}");
+}
+
+#[test]
+fn recursion_rejected_under_critical_only() {
+    let (crit, err) = check(RECURSION, "rec.almd", &["--profile", "critical"]);
+    assert!(!crit, "critical accepted recursion");
+    assert!(err.contains("E073"), "expected E073, got:\n{err}");
+    let (normal, err) = check(RECURSION, "rec.almd", &[]);
+    assert!(normal, "subset property broken — normal check rejected it too:\n{err}");
+}
+
+#[test]
+fn capability_deny_all_with_explicit_grant() {
+    // deny-all start: entropy is rejected and the hint names the grant flag
+    let (crit, err) = check(RANDOM, "rand.almd", &["--profile", "critical"]);
+    assert!(!crit, "critical accepted random.int without a grant");
+    assert!(err.contains("E076"), "expected E076, got:\n{err}");
+    assert!(err.contains("--allow"), "hint does not name the grant flag:\n{err}");
+    // the explicit grant admits exactly that capability
+    let (granted, err) =
+        check(RANDOM, "rand.almd", &["--profile", "critical", "--allow", "Rand"]);
+    assert!(granted, "--allow Rand did not admit random.int:\n{err}");
+    // and the grant is per-capability: Time does not cover entropy
+    let (wrong, _) = check(RANDOM, "rand.almd", &["--profile", "critical", "--allow", "Time"]);
+    assert!(!wrong, "--allow Time wrongly admitted random.int");
+    let (normal, err) = check(RANDOM, "rand.almd", &[]);
+    assert!(normal, "subset property broken — normal check rejected it too:\n{err}");
+}
+
+#[test]
+fn cli_vocabulary_is_closed() {
+    let (ok, err) = check(CLEAN, "clean.almd", &["--profile", "bogus"]);
+    assert!(!ok);
+    assert!(err.contains("unknown profile"), "{err}");
+    let (ok, err) = check(CLEAN, "clean.almd", &["--profile", "critical", "--allow", "Bogus"]);
+    assert!(!ok);
+    assert!(err.contains("unknown capability"), "{err}");
+    let (ok, err) = check(CLEAN, "clean.almd", &["--allow", "Rand"]);
+    assert!(!ok);
+    assert!(err.contains("--allow requires --profile critical"), "{err}");
+}
+
+#[test]
+fn attribute_mode_unchanged_by_the_profile_machinery() {
+    // a plain check of a file with NO @bounded attribute must not run the
+    // profile: the while loop passes, exactly as before #567
+    let (normal, err) = check(WHILE_LOOP, "wh.almd", &[]);
+    assert!(normal, "{err}");
+    // and the e07x attribute fixtures still pin @bounded mode — this test
+    // only guards the flag default staying off
+    assert!(Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("crates/almide-frontend/src/check/bounded.rs")
+        .exists());
+}


### PR DESCRIPTION
Closes #567 — the CG-3 Critical profile, increment 1.

**What**: `almide check --profile critical` applies the bounded profile (ALS §B, E070–E078) to EVERY function of the entry program — no `@bounded` attribute needed — with capabilities starting deny-all and granted explicitly: `--allow IO|Net|Env|Time|Rand|Process` (expanded to effect-module names at the CLI boundary; `Fan` is deliberately not grantable until the component-model async mapping gives fan arms a bounded-cost story, #1628 stage 2).

**Subset, not a dialect** (the CG-3 rule): critical only widens what the checker rejects, so critical-valid ⇒ normal-valid holds by construction — and `tests/critical_profile_test.rs` enforces it in CI by asserting every negative fixture PASSES the normal check.

**Scope**: the entry program only; imported modules — stdlib above all — are the trusted runtime below the profile (armed around exactly the entry inference call). Diagnostics reuse the E07x codes but are re-addressed: `under --profile critical`, never `@bounded` (the author wrote no attribute), and the E076 hint names the grant flag. Attribute-mode `@bounded` behaviour is byte-unchanged (existing e07x fixtures untouched, harness green).

**Flagged contracts**: the ledger's flagged set is currently zero (C-006 died with fan.timeout in 0.29.0) — nothing to reject; the profile inherits the rule for free if one ever appears.

Remaining CG-3 items stay open by name in the roadmap status: static memory mode (#568), RC-drop cascade bounds, fan admissibility.