### PR TITLE
Static-memory discipline for the Critical profile, gated on the flight reference app

### DIFF
--- a/docs/project/PARTITIONED-RUNTIME.md
+++ b/docs/project/PARTITIONED-RUNTIME.md
@@ -1,0 +1,50 @@
+# Partitioned-runtime requirements (#568)
+
+What a partition-style host (ARINC 653-shaped time/space partitioning, or
+any environment that budgets memory and CPU per component) must provide to
+run a Critical-profile Almide wasm artifact, and what the artifact itself
+guarantees. Every guarantee row names its enforcing gate — this document
+describes machinery, it does not add any.
+
+## What the artifact guarantees (space)
+
+| Property | Mechanism | Gate |
+|---|---|---|
+| Fixed heap budget | `almide build --heap-cap <bytes>` bakes a bump-frontier ceiling into the module; exceeding it is the DEFINED abort (`Error: out of memory`, exit 1) at a deterministic point — never silent growth | `tests/static_memory_test.rs::fixed_heap_budget_suffices_and_is_enforced` |
+| Steady-state allocation discipline | `almide check --profile critical` (#567) rejects allocation inside counted loops, runtime-length heap constructors, closures, recursion and `while` — a critical-clean program's loop bodies allocate at most bounded transients (scalar-to-string conversion for the declared print capability) | `tests/static_memory_test.rs::reference_app_is_critical_clean` |
+| Allocation-free kernel arithmetic | The control-law fns' emitted Rust carries no heap tokens (no Vec/Box/String/format!/clone/RcCow) | `tests/static_memory_test.rs::kernel_fns_emit_allocation_free_rust` (and `tests/wcet_kernel_test.rs` for the Float kernel) |
+| Single non-shared linear memory, no thread imports | The structural leg emits one memory, never shared, and imports only the five-op host surface (p1: `wasi_snapshot_preview1`; p2/p3 components: the vendored WIT worlds) | `tests/static_memory_test.rs::artifact_is_partition_shaped` |
+| Bounded stack | Under `--profile critical` the call graph is a DAG (recursion rejected, E073), so stack depth is bounded by the static call-graph depth; wasm's own stack is host-bounded on top | the profile gate (`tests/critical_profile_test.rs`) |
+
+## What the host must provide
+
+1. **A WASI host for the artifact's declared surface only** — console
+   out, exit codes, stdin, entropy, wall clock. Everything else is the
+   defined refusal inside the artifact (message + exit 1), so the host
+   needs no filesystem, network, or process surface. The three artifact
+   forms: preview1 core module (default `--target wasm`), WASI 0.2
+   component (`--component`), WASI 0.3 component (experimental,
+   `ALMIDE_COMPONENT_P3=1` — #1628 stage 2).
+2. **Memory partitioning**: the linear memory declares its initial pages;
+   a host enforcing a per-partition memory quota can additionally set a
+   wasmtime `StoreLimits` ceiling — the artifact's own `--heap-cap` abort
+   fires FIRST when the budget is the tighter bound, keeping the failure
+   the defined one.
+3. **Time partitioning**: the artifact never blocks except in host I/O
+   calls and contains no timers, signals or threads, so a fuel- or
+   epoch-based preemption hook (wasmtime `-W epoch-interruption`) is
+   sufficient for a time quantum. The deterministic compute meter
+   (C-320, `compute.*` budgets) is the in-language quantum — a program
+   that meters its hot loop yields deterministically, independent of
+   host preemption.
+4. **No ambient concurrency**: the guest is single-threaded by
+   construction; the host must not require thread imports (none exist to
+   satisfy).
+
+## The qualification boundary
+
+A qualified/minimal execution environment for this artifact class —
+which host, qualified how — is #865's scope, not this document's. This
+document is the artifact-side half of that contract: everything the host
+has to provide is enumerated above, and everything above it is gated in
+this repo's CI.

--- a/docs/roadmap/active/certification-grade.md
+++ b/docs/roadmap/active/certification-grade.md
@@ -105,8 +105,11 @@ MISRA C / Ada Ravenscar / SPARK subset の analog。`almide check --profile crit
 出発で `--allow IO|Net|Env|Time|Rand|Process` が grant。スコープはエントリ
 プログラム (stdlib はプロファイルの下の trusted runtime)。subset 性は
 `tests/critical_profile_test.rs` が全負例で通常モード PASS を突き合わせて
-CI 強制。残: `fan.*` の admissibility (#1628 stage 2 のコスト境界待ち)、
-静的メモリモード (#568)、RC drop カスケード上限。
+CI 強制。静的メモリ規律 (#568) も着地: 参照アプリが critical-clean +
+カーネル emit 無割当 + `--heap-cap` 固定予算で完走(予算超過は決定的
+OOM abort)、分割ホスト要件は docs/project/PARTITIONED-RUNTIME.md。
+残: `fan.*` の admissibility (#1628 stage 2 のコスト境界待ち)、
+RC drop カスケード上限。
 
 ### CG-4: Translation validation (L)
 

--- a/proofs/TOOL-QUALIFICATION.md
+++ b/proofs/TOOL-QUALIFICATION.md
@@ -101,7 +101,7 @@ attested and attached to the release by the trust-spine tag run.
 | Lean/Rocq proof coverage of the RUNTIME (allocator, free-list, RC ops as shipped) | #576 | model proven (FC-3); implementation gap open |
 | Qualified/minimal wasm execution environment | #865 | not started |
 | Critical-profile subset (`almide check --profile critical`) | #567 | closed — bounded profile on every fn, deny-all capabilities with `--allow` grants, subset property CI-enforced |
-| Static memory mode for the Critical profile | #568 | not started |
+| Static memory mode for the Critical profile | #568 | closed — the reference app is critical-clean with allocation-free kernel emission and completes under a fixed enforced `--heap-cap` budget; host requirements in `docs/project/PARTITIONED-RUNTIME.md` |
 | Flight reference app through `make verify` | #776 | closed — G-F4 chain evidenced end to end; the receipt derives all six stages (`proofs/receipt.sh`) |
 | First dossier-carrying release (fires #571/#1534 closure) | #571, #1534 | machinery live; next tag |
 

--- a/tests/static_memory_test.rs
+++ b/tests/static_memory_test.rs
@@ -1,0 +1,214 @@
+//! #568: static-memory discipline for the Critical profile, evidenced on
+//! the flight reference app (spec/wasm_cross/flight_pid_control.almd,
+//! C-230). Three claims, each mechanical:
+//!
+//! 1. the app is CRITICAL-CLEAN — `almide check --profile critical`
+//!    accepts it (bounded rules on every fn, capabilities deny-all; its
+//!    only effect is the blessed print family);
+//! 2. the KERNEL fns' emitted Rust is allocation-free (the WCET-shape
+//!    token gate, as tests/wcet_kernel_test.rs pins for the Float
+//!    kernel) — steady-state control arithmetic touches no heap;
+//! 3. the wasm artifact runs to completion under a FIXED heap budget
+//!    (`--heap-cap`), and the budget is REAL: an unbounded-allocation
+//!    program under the same cap meets the defined OOM abort ("Error:
+//!    out of memory", exit 1) instead of growing without bound. The
+//!    partition-friendly shape (single memory, non-shared, no thread
+//!    imports) is asserted on the artifact bytes.
+//!
+//! The requirements a partitioned host must provide are documented in
+//! docs/project/PARTITIONED-RUNTIME.md.
+
+use std::path::Path;
+use std::process::Command;
+
+const APP: &str = "spec/wasm_cross/flight_pid_control.almd";
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn wasmtime_available() -> bool {
+    Command::new("wasmtime").arg("--version").output().is_ok_and(|o| o.status.success())
+}
+
+/// The emitted text between `pub fn <name>` and its closing brace at
+/// column 0 — crude but stable for the kernel's flat fns.
+fn fn_body<'a>(code: &'a str, name: &str) -> &'a str {
+    let start = code
+        .find(&format!("pub fn {name}"))
+        .unwrap_or_else(|| panic!("emitted Rust lost fn {name}"));
+    let rest = &code[start..];
+    let end = rest.find("\n}\n").map(|i| i + 3).unwrap_or(rest.len());
+    &rest[..end]
+}
+
+#[test]
+fn reference_app_is_critical_clean() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    let out = Command::new(almide_bin())
+        .args(["check", APP, "--profile", "critical"])
+        .output()
+        .expect("spawn almide check");
+    assert!(
+        out.status.success(),
+        "the flight reference app fell out of the critical profile:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn kernel_fns_emit_allocation_free_rust() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    let out = Command::new(almide_bin())
+        .args([APP, "--target", "rust"])
+        .output()
+        .expect("spawn almide");
+    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+    let code = String::from_utf8_lossy(&out.stdout).to_string();
+    for name in ["fmul", "pid_step"] {
+        let body = fn_body(&code, name);
+        for forbidden in ["Vec", "Box<", "String", "format!", ".clone()", "RcCow"] {
+            assert!(
+                !body.contains(forbidden),
+                "{name}'s emitted body grew `{forbidden}` — the static-memory shape broke:\n{body}"
+            );
+        }
+    }
+}
+
+#[test]
+fn fixed_heap_budget_suffices_and_is_enforced() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    if !wasmtime_available() {
+        return;
+    }
+    let dir = std::env::temp_dir().join("almide-static-memory");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+
+    // The reference app completes its full trace under a fixed 1 MiB
+    // heap budget baked into the artifact.
+    let app_wasm = dir.join("pid-cap.wasm");
+    let out = Command::new(almide_bin())
+        .args([
+            "build",
+            APP,
+            "--target",
+            "wasm",
+            "--heap-cap",
+            "1048576",
+            "-o",
+            app_wasm.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn almide build");
+    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+    let run = Command::new("wasmtime")
+        .args(["run", app_wasm.to_str().unwrap()])
+        .output()
+        .expect("spawn wasmtime");
+    assert!(run.status.success(), "{}", String::from_utf8_lossy(&run.stderr));
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(stdout.lines().count(), 16, "the 16-step trace lost lines:\n{stdout}");
+
+    // The same budget is ENFORCED: unbounded growth meets the defined
+    // OOM abort at a deterministic point, not silent expansion.
+    let glutton = dir.join("glutton.almd");
+    std::fs::write(
+        &glutton,
+        "effect fn main() -> Unit = {\n  var xs: List[Int] = []\n  for i in 0..<100000 {\n    xs = xs + [i]\n  }\n  println(int.to_string(list.len(xs)))\n}\n",
+    )
+    .expect("write");
+    let glutton_wasm = dir.join("glutton-cap.wasm");
+    let out = Command::new(almide_bin())
+        .args([
+            "build",
+            glutton.to_str().unwrap(),
+            "--target",
+            "wasm",
+            "--heap-cap",
+            "1048576",
+            "-o",
+            glutton_wasm.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn almide build");
+    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+    let run = Command::new("wasmtime")
+        .args(["run", glutton_wasm.to_str().unwrap()])
+        .output()
+        .expect("spawn wasmtime");
+    assert_eq!(run.status.code(), Some(1), "the OOM abort must answer exit 1");
+    assert!(
+        String::from_utf8_lossy(&run.stderr).contains("out of memory"),
+        "the OOM abort must be the defined message:\n{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+}
+
+#[test]
+fn artifact_is_partition_shaped() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    let dir = std::env::temp_dir().join("almide-static-memory");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let app_wasm = dir.join("pid-shape.wasm");
+    let out = Command::new(almide_bin())
+        .args([
+            "build",
+            APP,
+            "--target",
+            "wasm",
+            "--heap-cap",
+            "1048576",
+            "-o",
+            app_wasm.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn almide build");
+    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+    let bytes = std::fs::read(&app_wasm).expect("read wasm");
+
+    // Single non-shared memory, no thread-flavoured imports: the space
+    // half of the partition claim, read off the artifact itself.
+    let mut memories = 0;
+    for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
+        match payload.expect("parse wasm") {
+            wasmparser::Payload::MemorySection(rdr) => {
+                for m in rdr {
+                    let m = m.expect("memory");
+                    assert!(!m.shared, "the artifact grew a SHARED memory");
+                    memories += 1;
+                }
+            }
+            wasmparser::Payload::ImportSection(rdr) => {
+                for group in rdr {
+                    for item in group.expect("imports") {
+                        let (_, imp) = item.expect("import");
+                        assert!(
+                            !imp.module.contains("thread") && !imp.name.contains("thread"),
+                            "the artifact grew a thread import: {}::{}",
+                            imp.module,
+                            imp.name
+                        );
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(memories, 1, "expected exactly one linear memory");
+}


### PR DESCRIPTION
Closes #568.

Three mechanical claims, each read off the artifacts (`tests/static_memory_test.rs`):

1. **The reference app is critical-clean** — `almide check spec/wasm_cross/flight_pid_control.almd --profile critical` accepts it: bounded rules on every fn, capabilities deny-all, the Q16.16 Int-only control law inside the counted loop. (The #567 profile shipped yesterday is what makes this a one-line gate.)
2. **Kernel arithmetic emits allocation-free Rust** — `fmul`/`pid_step` bodies carry no heap tokens (the WCET-shape gate, extended from #569's Float kernel to the flight app's fixed-point one).
3. **A fixed heap budget suffices AND is enforced** — the app completes its 16-step trace under `--heap-cap 1048576` baked into the wasm artifact, and an unbounded-allocation program under the SAME cap meets the defined OOM abort (`Error: out of memory`, exit 1) at a deterministic point. The budget is the artifact's own, not the host's goodwill. The partition shape (one non-shared linear memory, no thread imports) is asserted on the bytes.

**`docs/project/PARTITIONED-RUNTIME.md`** documents the host-side half: the five-op-only WASI surface, memory quota layering (artifact cap fires first), epoch/fuel preemption as the time quantum with the C-320 deterministic meter as the in-language one, and no ambient concurrency to provide. The qualified-host question stays #865's scope, referenced as the boundary.

Exit criteria of #568 as filed: representative control-loop program with provably bounded allocation → claim 1-3 on the C-230 app; runtime requirements documented for partitioned hosts → the new doc.