### PR TITLE
Module initializers with inner binds lower in their own frame: the modinit:inner-binds wall retires

### DIFF
--- a/crates/almide-wasm/src/emit.rs
+++ b/crates/almide-wasm/src/emit.rs
@@ -186,15 +186,19 @@ fn emit_program_pass(
         for ll in pending {
             let plan = FnPlan {
                 ret: ll.ret,
-                cur_module: None,
+                cur_module: ll.cur_module.clone(),
                 var_space: ll.var_space,
                 effect_raw: ll.effect_raw,
                 in_main: false,
                 env_captures: Some(ll.captures.clone()),
                 // Closure hops always charge (TailCallee::Clo mirror) —
                 // unless the whole meter elided (no regions anywhere).
+                // #1627 synthetic initializers never hop-charge (native
+                // charges nothing for reaching a top-let's value), but
+                // their bodies stay metered like the main prologue whose
+                // inline lowering they replace.
                 metered: !meter.user.is_empty(),
-                charge_entry: !meter.user.is_empty(),
+                charge_entry: !meter.user.is_empty() && ll.charge_hop,
             };
             let (f, calls) = lower_fn(&ll.params, plan, &ll.body, &[], &ctx, &mut pool)?;
             display_helper_calls

--- a/crates/almide-wasm/src/emitter.rs
+++ b/crates/almide-wasm/src/emitter.rs
@@ -714,6 +714,8 @@ impl Emitter<'_> {
                     body: body.clone(),
                     captures: captures.clone(),
                     var_space: self.var_space,
+                    cur_module: None,
+                    charge_hop: true,
                 });
                 let slot = self.work.slot(TableEntry::Lambda(j));
                 if captures.is_empty() {

--- a/crates/almide-wasm/src/emitter.rs
+++ b/crates/almide-wasm/src/emitter.rs
@@ -707,16 +707,9 @@ impl Emitter<'_> {
                     .zip(offsets.iter().skip(1))
                     .map(|(&(v, t), &off)| (v, t, off, self.cells.contains(&v)))
                     .collect();
-                let j = self.work.register_lambda(LiftedLambda {
-                    params: ps,
-                    ret: def.ret,
-                    effect_raw,
-                    body: body.clone(),
-                    captures: captures.clone(),
-                    var_space: self.var_space,
-                    cur_module: None,
-                    charge_hop: true,
-                });
+                let j = self.work.register_closure_lambda(
+                    ps, def.ret, effect_raw, body.clone(), captures.clone(), self.var_space,
+                );
                 let slot = self.work.slot(TableEntry::Lambda(j));
                 if captures.is_empty() {
                     let block = self.pool.intern_block(&(slot).to_le_bytes());

--- a/crates/almide-wasm/src/func.rs
+++ b/crates/almide-wasm/src/func.rs
@@ -62,6 +62,42 @@ impl Pool {
     }
 }
 
+/// #1627: does this module-space initializer carry inner binds? Those
+/// binds index the MODULE's VarTable, so the value cannot lower inline in
+/// the calling frame — it needs its own.
+fn initializer_needs_own_frame(il: &crate::InitLet, ctx: &Ctx) -> Result<bool, EmitError> {
+    if il.space == 0 {
+        return Ok(false);
+    }
+    let mut probe: Vec<(VarId, SliceTy)> = Vec::new();
+    let mut probe_seen: HashSet<VarId> = HashSet::new();
+    collect_binds(&il.tl.value, &mut probe, &mut probe_seen, ctx.types)?;
+    Ok(!probe.is_empty())
+}
+
+/// #1627: register the binds-carrying module initializer as a synthetic
+/// zero-param entry on the lifted pipeline — lowered in its own frame
+/// with the module's space and name — and call_indirect it exactly as a
+/// closure would (env 0: nothing to capture; no hop charge: native
+/// charges nothing for reaching a top-let's value).
+fn emit_modinit_call(em: &mut crate::emitter::Emitter<'_>, il: &crate::InitLet, declared: SliceTy) {
+    let j = em.work.register_lambda(crate::LiftedLambda {
+        params: Vec::new(),
+        ret: Some(declared),
+        effect_raw: None,
+        body: il.tl.value.clone(),
+        captures: Vec::new(),
+        var_space: il.space,
+        cur_module: il.module.clone(),
+        charge_hop: false,
+    });
+    let slot = em.work.slot(crate::TableEntry::Lambda(j));
+    let ti = em.work.itype(vec![ValType::I32], Some(declared.val_type()));
+    em.f.instructions().i32_const(0); // env: unused
+    em.f.instructions().i32_const(slot as i32);
+    em.f.instructions().call_indirect(0, ti);
+}
+
 /// Lower one function body (used for `main` and every program function):
 /// params become the leading locals, collected Binds follow, then the
 /// scratch locals (interp cursor, tmp i32, match/unwrap subjects).
@@ -131,19 +167,11 @@ pub(crate) fn lower_fn(
             // inner binds need main locals.
             seen.insert(tl.var);
             collect_binds(&tl.value, &mut binds, &mut seen, ctx.types)?;
-        } else {
-            // A MODULE-space initializer (#1596): its inner binds would
-            // index a different VarTable than main's locals map, so
-            // increment 1 admits only bind-free initializers (literals,
-            // ctor/fn-call values). The rest wall honestly — and the
-            // routing rerroutes the program to the incumbent leg.
-            let mut probe: Vec<(VarId, SliceTy)> = Vec::new();
-            let mut probe_seen: HashSet<VarId> = HashSet::new();
-            collect_binds(&tl.value, &mut probe, &mut probe_seen, ctx.types)?;
-            if !probe.is_empty() {
-                return unsup("modinit:inner-binds");
-            }
         }
+        // A MODULE-space initializer (#1596/#1627) allocates NOTHING in
+        // this frame: bind-free values lower inline against globals only,
+        // and binds-carrying values become synthetic lifted entries whose
+        // own frame holds their locals (the emission loop below).
     }
     collect_binds(body, &mut binds, &mut seen, ctx.types)?;
 
@@ -272,17 +300,25 @@ pub(crate) fn lower_fn(
             let Some(&(gidx, declared)) = ctx.globals.get(&(il.space, tl.var)) else {
                 return unsup(&format!("bind-ty:{}", ty_name(&tl.ty)));
             };
-            // A module initializer lowers in ITS OWN space: its Var reads
-            // index that module's table and its bare Named calls resolve
-            // module-qualified first (#1596).
-            let saved_space = em.var_space;
-            let saved_module = em.cur_module;
-            em.var_space = il.space;
-            em.cur_module = il.module.as_deref();
-            let lowered = em.lower(&tl.value, Some(declared));
-            em.var_space = saved_space;
-            em.cur_module = saved_module;
-            lowered?;
+            // #1627: a MODULE-space initializer whose value carries inner
+            // binds cannot lower inline (its binds index the module's
+            // VarTable, not this frame's locals map) — it becomes a
+            // synthetic entry in its own frame instead.
+            if initializer_needs_own_frame(il, ctx)? {
+                emit_modinit_call(&mut em, il, declared);
+            } else {
+                // A module initializer lowers in ITS OWN space: its Var
+                // reads index that module's table and its bare Named calls
+                // resolve module-qualified first (#1596).
+                let saved_space = em.var_space;
+                let saved_module = em.cur_module;
+                em.var_space = il.space;
+                em.cur_module = il.module.as_deref();
+                let lowered = em.lower(&tl.value, Some(declared));
+                em.var_space = saved_space;
+                em.cur_module = saved_module;
+                lowered?;
+            }
             if matches!(
                 declared,
                 SliceTy::List(_)

--- a/crates/almide-wasm/src/lib.rs
+++ b/crates/almide-wasm/src/lib.rs
@@ -478,6 +478,14 @@ pub(crate) struct LiftedLambda {
     /// The variable space the body's VarIds index (the lifting fn's own
     /// space — a lambda inside a module fn reads module-space globals).
     pub(crate) var_space: u32,
+    /// The module whose bare Named calls the body resolves first. `None`
+    /// for real lambdas (their calls resolved at lift time); `Some` for
+    /// the #1627 synthetic module-initializer entries.
+    pub(crate) cur_module: Option<String>,
+    /// Closure hops charge one meter unit at entry; a #1627 synthetic
+    /// initializer does NOT — its call is a lowering artifact, and native
+    /// charges nothing for reaching a top-let's value.
+    pub(crate) charge_hop: bool,
 }
 
 /// A call_indirect signature at the wasm value-type level.

--- a/crates/almide-wasm/src/work.rs
+++ b/crates/almide-wasm/src/work.rs
@@ -185,5 +185,29 @@ impl FnWork {
         v.push(ll);
         i
     }
+
+    /// A REAL closure lift: no module of its own, hop-charged. The #1627
+    /// synthetic module initializers are the one other construction site
+    /// (crate::func::emit_modinit_call) and spell their fields directly.
+    pub(crate) fn register_closure_lambda(
+        &self,
+        params: Vec<(almide_ir::VarId, crate::SliceTy)>,
+        ret: Option<crate::SliceTy>,
+        effect_raw: Option<crate::SliceTy>,
+        body: almide_ir::IrExpr,
+        captures: Vec<(almide_ir::VarId, crate::SliceTy, u32, bool)>,
+        var_space: u32,
+    ) -> u32 {
+        self.register_lambda(crate::LiftedLambda {
+            params,
+            ret,
+            effect_raw,
+            body,
+            captures,
+            var_space,
+            cur_module: None,
+            charge_hop: true,
+        })
+    }
 }
 

--- a/tests/crossmod_matrix_test.rs
+++ b/tests/crossmod_matrix_test.rs
@@ -62,6 +62,11 @@ var nums = [1, 2]
 
 let PAIR = ("a", 1)
 
+let DERIVED = {
+  let parts = ["mod", "init"]
+  parts |> list.join("-")
+}
+
 fn bump() -> Unit = {
   count = count + 1
 }
@@ -138,6 +143,21 @@ struct Cell {
 
 fn cells() -> Vec<Cell> {
     vec![
+        Cell {
+            name: "module_toplet_initializer_with_inner_binds",
+            // #1627: a module-space top-let whose initializer carries inner
+            // binds walled the structural leg (`modinit:inner-binds`) and
+            // the incumbent reroute walled too (unbound VarId) — the
+            // program was unbuildable on wasm while native ran it fine.
+            // The initializer now lowers as a synthetic zero-param entry
+            // in its OWN frame (module space + module name), called from
+            // main's prologue through the funcref table.
+            main: r#"import self as m
+effect fn main() -> Unit = println(m.DERIVED)
+"#,
+            expected: "mod-init",
+            status: Status::Works,
+        },
         Cell {
             name: "generic_fn_mutates_module_var",
             // #788: a MONOMORPHIZED copy of a generic module fn alpha-renamed


### PR DESCRIPTION
Closes #1627 — increment 2 of the spaced-globals arc (#1596/#1602), a prerequisite row for incumbent retirement (#1584).

**Design A from the issue, via the existing lifted pipeline**: a MODULE-space top-let initializer whose value carries inner binds registers as a synthetic zero-param entry (`LiftedLambda` grows `cur_module` — bare Named calls resolve module-qualified — and `charge_hop: false` — native charges nothing for reaching a top-let's value, so the synthetic call must not perturb the C-320 deterministic meter). `FnPlan` already carries the space, so `collect_binds` allocates the initializer's locals in its OWN frame by construction — the VarId-collision class the wall existed to prevent is unrepresentable, which is why design B (bind-VarId uniquing) stayed rejected. Main's prologue `call_indirect`s it through the funcref table exactly as a closure call would, then the existing block-copy + `global_set` land the value.

**A/B against the released binary (0.59.1)**: a module with `let TABLE = { let base = list.range(0,4); base |> list.map((x) => x*3) }` + a heap-string sibling was **unbuildable on wasm** — the structural leg walled `modinit:inner-binds` and the incumbent reroute walled `unbound var VarId(1)`. With this change it builds on the structural leg and the output is byte-identical to native. The refusal string is gone from the tree.

**Evidence**: the new crossmod matrix cell (`module_toplet_initializer_with_inner_binds`) exercises it Rust + wasm byte-compared every CI run; `wasm_runtime_test` 79/79 green twice consecutively; the full `almide test` battery 422/422. Bind-free module initializers keep the inline lowering byte-for-byte (no size-ledger movement).