### PR TITLE
Executable doc fences: marked stdlib examples check and run byte-exactly in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1021,6 +1021,9 @@ jobs:
       - name: fmt gate (spec/ + examples/ stay formatted, #919; gauntlet reject cells excluded by the manifest)
         run: ALMIDE_BIN=/tmp/almide-bin/almide bash scripts/check-fmt-gate.sh
 
+      - name: Doc fences execute (#1490 — marked stdlib examples check/run byte-exactly)
+        run: ALMIDE_BIN=/tmp/almide-bin/almide bash scripts/check-doc-fences.sh
+
       - name: Forbidden impurities (no raw clocks/threads in the compile path)
         run: scripts/check-forbidden-impurities.sh
 

--- a/docs/stdlib/list.md
+++ b/docs/stdlib/list.md
@@ -394,6 +394,21 @@ Remove consecutive duplicates.
 list.dedup([1, 1, 2, 2, 1]) // => [1, 2, 1]
 ```
 
+Executable pin of the ADJACENT-duplicates rule (dedup is not distinct —
+the trailing `1` survives), gated by `scripts/check-doc-fences.sh`:
+
+```almd run
+fn main() -> Unit = {
+  let xs = list.dedup([1, 1, 2, 2, 1])
+  println(xs |> list.map((x) => int.to_string(x)) |> list.join(","))
+  println(int.to_string(list.len(xs)))
+}
+```
+```output
+1,2,1
+3
+```
+
 ### `list.zip_with(xs: List[A], ys: List[B], f: Fn[A, B] -> C) -> List[C]`
 
 Combine two lists element-wise using a function.

--- a/docs/stdlib/regex.md
+++ b/docs/stdlib/regex.md
@@ -73,6 +73,32 @@ regex.captures("b+", "aabbb!")               // => some(["bbb"])
 regex.captures("(z)", "abc")                 // => none
 ```
 
+Executable form of the rows above — gated by `scripts/check-doc-fences.sh`
+(this is the function whose documented behavior once drifted from the
+implementation, #1432; the pin below cannot):
+
+```almd run
+import regex
+
+fn show(o: Option[List[String]]) -> String = match o {
+  some(xs) => "[" + (xs |> list.join(",")) + "]",
+  none => "none",
+}
+
+effect fn main() -> Unit = {
+  println(show(regex.captures("(\\w+)@(\\w+)", "user@host")))
+  println(show(regex.captures("(x)?(y)", "y")))
+  println(show(regex.captures("b+", "aabbb!")))
+  println(show(regex.captures("(z)", "abc")))
+}
+```
+```output
+[user@host,user,host]
+[y,,y]
+[bbb]
+none
+```
+
 <!-- BEGIN GENERATED SIGNATURE INDEX (make stdlib-docs) — do not edit by hand -->
 
 ## Signature index (8 functions)

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -24,7 +24,7 @@ re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).
 >
-> **Stage 5 (auditability): 7 release seal(s); 66 verification gates classified
+> **Stage 5 (auditability): 7 release seal(s); 67 verification gates classified
 > (0 UNVERIFIED under a shrink-only ceiling); TOR with 9 enforced rows;
 > gap analysis consolidated in proofs/DO330-GAP.md (reference-gated).**
 <!-- stages:generated:end -->

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -20,6 +20,11 @@
 # unverified_ceiling = "0"
 
 [[gate]]
+path = "scripts/check-doc-fences.sh"
+class = "NEGATIVE_TESTED"
+evidence = "#1490 landing (2026-08-28): the output-drift direction demonstrated before first green — the list.md run-fence's pinned output hand-flipped 3->4 went red with the diff shown, restored green. The probe also caught the gate's own first bug: unescaped backticks in two FAIL messages parsed as command substitution and swallowed the run/cmp block entirely, so the corrupted doc passed — fixed before landing (the reason the negative probe is mandatory). Blind-scan floor: zero marked fences under docs/stdlib/ is a hard FAIL (#976 class)."
+
+[[gate]]
 path = "scripts/check-contracts.sh"
 class = "MUTATION_TESTED"
 evidence = "flight-evidence-gaps.md F1 progress-2 (2026-07-04): spec-resolution mutation test (nonexistent ALS section reference => FAIL) SIGPIPE FLAKE FIXED (2026-08-16): seven membership tests were `printf '%s\\n' \"$SET\" | grep -q \"$x\"`, which is a RACE under this script's `set -o pipefail` — `grep -q` exits the instant it matches and closes the pipe, so a `printf` still writing dies of SIGPIPE and the PIPELINE reports failure even though the element WAS found. The gate then declared a contract \"not in the ledger\", naming whichever id lost the race, so it accused a DIFFERENT contract every time (observed: C-084, C-059, C-087). Measured on the 286-id ledger: an EARLY match false-failed 1 run in 400 and a LATE match never did — exactly the shape the race predicts, since a late match leaves nothing left to write. Locally the gate was red about 1 run in 6. All seven now read from a here-string via a single `has()` helper, so there is no pipe to break: 25 consecutive runs green, 0 red. This is not cosmetic — a verdict-bearing gate that is randomly red teaches everyone to re-run until green, which is also what you do to a real failure, and CI's green history on this gate was therefore luck rather than evidence. 2026-08-27: the #1544 canonical reservation range emptied (C-310..C-318 ported verbatim with the 0.59.2 checker landing); negative directions re-demonstrated at the closure — a gap inside the formerly-reserved range now fails the CONTIGUITY branch (C-315 removed locally: red, restored: green), and the retired collision branch is unreachable by construction (LO>HI)."

--- a/scripts/check-doc-fences.sh
+++ b/scripts/check-doc-fences.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# DOC-FENCE GATE (#1490 item 1 — the doctest class)
+# =================================================
+#
+# The stdlib docs are hand-written prose, and a documented behavior that
+# drifts from the implementation is a training-corpus bug models learn
+# from (the `regex.captures` drift, almide#1432, broke a downstream tool).
+# This gate makes documented examples EXECUTABLE:
+#
+#   ```almd check     — the fence is a complete program; `almide check`
+#                       must accept it (the LLM-surface gate's contract,
+#                       extended to docs/stdlib/).
+#   ```almd run       — the fence is a complete program AND the next
+#                       ```output fence pins its stdout BYTE-EXACTLY.
+#                       Runs on the embedded wasm host (`almide run
+#                       --target wasm` — rustc-free, deterministic).
+#
+# Plain ```almd stays a highlighting label for fragments, deliberate
+# ✗-examples and idiom halves — out of scope on purpose; the gate checks
+# the promise, not the prose. Growing coverage means completing an
+# example and promoting its marker, one fence at a time.
+#
+# Usage: check-doc-fences.sh    (uses target/release/almide or PATH)
+set -euo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="${ALMIDE_BIN:-}"
+if [ -z "$BIN" ]; then
+  if [ -x "$ROOT/target/release/almide" ]; then BIN="$ROOT/target/release/almide"; else BIN="almide"; fi
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+checked=0
+ran=0
+for f in "$ROOT"/docs/stdlib/*.md; do
+  base=$(basename "$f")
+  # Split the file into numbered fences with their kind:
+  #   check.N.almd / run.N.almd / run.N.out
+  awk -v out="$TMP/$base" '
+    /^```almd check[ \t]*$/  { kind="check"; n++; on=1; next }
+    /^```almd run[ \t]*$/    { kind="run"; n++; on=1; next }
+    /^```output[ \t]*$/      { if (lastrun) { kind="out"; on=1; next } }
+    /^```/                   { if (on && kind=="run") lastrun=n; else if (on) lastrun=0; on=0; next }
+    on && kind=="check"      { print > (out ".check." n ".almd") }
+    on && kind=="run"        { print > (out ".run." n ".almd") }
+    on && kind=="out"        { print > (out ".run." lastrun ".out") }
+  ' "$f"
+
+  for snip in "$TMP/$base".check.*.almd; do
+    [ -e "$snip" ] || continue
+    checked=$((checked + 1))
+    if ! "$BIN" check "$snip" > "$TMP/out.txt" 2>&1; then
+      echo "FAIL: $base check-fence $(basename "$snip") does not check:"
+      sed 's/^/  /' "$TMP/out.txt" | head -12
+      fail=1
+    fi
+  done
+
+  for snip in "$TMP/$base".run.*.almd; do
+    [ -e "$snip" ] || continue
+    ran=$((ran + 1))
+    want="${snip%.almd}.out"
+    if [ ! -e "$want" ]; then
+      echo "FAIL: $base run-fence $(basename "$snip") has no output fence after it"
+      fail=1
+      continue
+    fi
+    if ! "$BIN" run "$snip" --target wasm > "$TMP/got.txt" 2> "$TMP/err.txt"; then
+      echo "FAIL: $base run-fence $(basename "$snip") did not run:"
+      sed 's/^/  /' "$TMP/err.txt" | head -12
+      fail=1
+      continue
+    fi
+    if ! cmp -s "$TMP/got.txt" "$want"; then
+      echo "FAIL: $base run-fence $(basename "$snip") output drifted from its output fence:"
+      diff "$want" "$TMP/got.txt" | sed 's/^/  /' | head -12
+      fail=1
+    fi
+  done
+done
+
+if [ "$checked" -eq 0 ] && [ "$ran" -eq 0 ]; then
+  echo "FAIL: no marked fences found under docs/stdlib/ — the gate went blind (#976 class)" >&2
+  exit 1
+fi
+echo "doc-fences: $checked check fence(s), $ran run fence(s) verified across docs/stdlib/"
+exit $fail


### PR DESCRIPTION
#1490 item 1 (the ranked-first row: doc tests over docs/ code fences — the class that already bit once, #1432).

`scripts/check-doc-fences.sh` extends the LLM-surface gate's opt-in contract to `docs/stdlib/`:
- ````almd check`` — the fence is a complete program; `almide check` must accept it;
- ````almd run`` — the fence is a complete program AND the following ````output`` fence pins its stdout **byte-exactly**, executed on the embedded wasm host (rustc-free, deterministic, no external wasmtime needed in the checks job).

Plain ````almd`` stays a highlighting label for fragments and deliberate ✗-examples — the gate checks the promise, not the prose; coverage grows by promoting fences one at a time.

**Seeded where it bit**: `regex.captures` — the function whose documented behavior drifted from the implementation long enough to break a downstream tool — now carries an executable pin of all four documented rows, plus `list.dedup`'s adjacent-duplicates rule. Blind-scan floor: zero marked fences is a hard FAIL.

The negative probe before first green caught the gate's own first bug: unescaped backticks in two FAIL messages parsed as bash command substitution and swallowed the entire run/compare block, so a corrupted output fence PASSED — exactly the decorative-gate failure mode the gate-verification ledger exists to catch (its row records the incident).

Remaining #1490 items (REPL-on-interp, `almide bench`, `test --fuzz`, user coverage) stay open on the bundle issue — they are independent by its own definition of done.