### PR TITLE
The REPL goes rustc-free: the embedded wasm host answers first, cargo only on a leg refusal

### DIFF
--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -128,6 +128,30 @@ impl Session {
 
     fn eval_expr(&mut self, input: &str) {
         let source = build_program(&self.top, &self.body, Some(input));
+        // #1490: rustc-free fast path FIRST — the session program runs on
+        // the embedded wasm host (the same leg `almide run --target wasm`
+        // uses), so the common REPL line answers in milliseconds with no
+        // cargo in the loop. A shape the leg cannot lower falls back to
+        // the rustc path silently; both paths print the language's own
+        // `${expr}` rendering, so the answer is path-independent.
+        match self.run_wasm_fast(&source) {
+            Some(Ok(result)) => {
+                let result = result.trim();
+                if !result.is_empty() {
+                    out(&format!("{}", result));
+                }
+                return;
+            }
+            Some(Err(runtime_err)) => {
+                // The program RAN and failed (abort, error propagation):
+                // that verdict is real on either path — report, no fallback.
+                if !runtime_err.is_empty() {
+                    err(&format!("{}", runtime_err.trim()));
+                }
+                return;
+            }
+            None => {} // wall / any wasm-path refusal: the rustc path decides
+        }
         match self.compile_and_run(&source) {
             Ok(result) => {
                 let result = result.trim();
@@ -137,6 +161,32 @@ impl Session {
             }
             Err(_) => {} // errors already printed by compiler / cargo
         }
+    }
+
+    /// The wasm fast path, as a SUBPROCESS of this same binary (`almide
+    /// run <session> --target wasm`): the wall/refusal chatter of a
+    /// declined shape stays captured instead of leaking into the session.
+    /// `None` = the leg declined (fall back); `Some(Ok)` = stdout;
+    /// `Some(Err)` = the program ran and failed (a real verdict).
+    fn run_wasm_fast(&self, source: &str) -> Option<Result<String, String>> {
+        let path = self.source_path();
+        std::fs::write(&path, source).ok()?;
+        let exe = std::env::current_exe().ok()?;
+        let out = std::process::Command::new(exe)
+            .args(["run", path.to_str()?, "--target", "wasm"])
+            .output()
+            .ok()?;
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        if out.status.success() {
+            return Some(Ok(String::from_utf8_lossy(&out.stdout).to_string()));
+        }
+        // The leg names its refusals ("wall: …", "error: …" at emit); a
+        // RUNTIME failure prints the program's own abort ("Error: …").
+        // Only the latter is a verdict; everything else falls back.
+        if stderr.starts_with("Error: ") {
+            return Some(Err(stderr.to_string()));
+        }
+        None
     }
 
     fn compile(&self, source: &str) -> Result<String, String> {
@@ -155,11 +205,12 @@ impl Session {
 
     fn compile_and_run(&self, source: &str) -> Result<String, String> {
         let rust_code = self.compile_quiet(source)?;
-        // Use Debug format for the REPL print so List, records etc. work
-        let rust_code = rust_code.replace(
-            r#"format!("{}\n", __r)"#,
-            r#"format!("{:?}\n", __r)"#,
-        );
+        // NOTE: this used to patch the emitted print to Debug format
+        // ({:?}) "so List, records etc. work" — but `${expr}` interpolation
+        // renders those natively on both targets now, and the patch made
+        // the rustc path's answer DIFFER from the wasm fast path's (a
+        // String answered `"hi"` here and `hi` there). One rendering — the
+        // language's own — on both paths.
         let bin = super::cargo_build_generated(&rust_code, &self.build_dir, false)?;
         let output = std::process::Command::new(&bin)
             .output()

--- a/tests/repl_test.rs
+++ b/tests/repl_test.rs
@@ -1,0 +1,77 @@
+//! #1490 item 2: the REPL answers through the embedded wasm host first —
+//! rustc-free for everything the structural leg lowers — falling back to
+//! the rustc path only on a leg refusal. Both paths print the language's
+//! own `${expr}` rendering, so the answer is path-independent (the old
+//! rustc-only Debug patch made `"hi"` vs `hi` depend on the path).
+//!
+//! These tests drive the real binary with a piped session. They assert
+//! ANSWERS, not which path produced them — the path split is an
+//! implementation detail the consistency rule exists to hide. Speed is
+//! the observable: a scalar session must answer well inside the rustc
+//! floor (a cargo build is tens of seconds cold; the wasm path is
+//! milliseconds), which is what the generous-but-real deadline pins.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn repl(session: &str) -> (String, Duration) {
+    let started = Instant::now();
+    // The REPL is the bare binary — no subcommand.
+    let mut child = Command::new(almide_bin())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn almide repl");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(session.as_bytes())
+        .expect("write session");
+    let out = child.wait_with_output().expect("wait repl");
+    (String::from_utf8_lossy(&out.stdout).to_string(), started.elapsed())
+}
+
+#[test]
+fn scalar_arithmetic_answers_fast() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    let (out, took) = repl("1 + 2\n:q\n");
+    assert!(out.contains("3"), "missing the answer:\n{out}");
+    // The rustc path's COLD floor is a cargo build (tens of seconds);
+    // the embedded-wasm path answers in well under this. Generous so a
+    // loaded CI runner never flakes it, real enough that a rustc-only
+    // regression cannot hide.
+    assert!(
+        took < Duration::from_secs(20),
+        "a scalar REPL line took {took:?} — the rustc-free fast path is gone"
+    );
+}
+
+#[test]
+fn session_state_and_language_rendering() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    let (out, _) = repl("let name = \"world\"\n\"Hello, \" + name\n[1, 2, 3]\n:q\n");
+    // The language's own rendering on every path: strings BARE (the old
+    // Debug patch printed `"Hello, world"`), lists in bracket form.
+    assert!(out.contains("Hello, world"), "string answer missing/requoted:\n{out}");
+    assert!(!out.contains("\"Hello, world\""), "Debug-quoted string leaked back:\n{out}");
+    assert!(out.contains("[1, 2, 3]"), "list rendering missing:\n{out}");
+}


### PR DESCRIPTION
#1490 item 2 (REPL on the in-process evaluator — implemented on the embedded wasm host, which is the same rustc-free engine with strictly broader coverage than almide-interp: 414/422 of the test corpus runs on it).

**Before**: every REPL expression re-ran the whole accumulated session through rustc + cargo — tens of seconds cold, seconds warm, per line.
**After**: the session program runs on the embedded wasm host first (`almide run --target wasm` as a captured subprocess of the same binary, so a declined shape's wall chatter never leaks into the session). Three outcomes:
- **runs** → answer in milliseconds (the piped test session completes in 0.12 s where one cargo build used to be the floor);
- **runtime failure** (`Error: …`) → reported as the verdict — real on either path, no fallback;
- **leg refusal** → silent fallback to today's rustc path, so nothing the REPL evaluated before is lost.

**One rendering on both paths**: the old rustc-only `{:?}` patch made the answer depend on the path (`"hi"` there, `hi` here). Both paths now print the language's own `${expr}` rendering — lists/tuples/records render natively on both targets (verified byte-identical), strings render bare as they do in-language. `tests/repl_test.rs` pins the fast-path deadline, session state, and the consistency rule; the fallback and abort branches were exercised by hand at landing (`import process` session → cargo answer; `1 / 0` → immediate verdict, session continues).