### PR TITLE
almide bench: the perf suite's verify-then-time methodology as a user-facing subcommand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ almide test                      # Find all .almd with test blocks (recursive)
 almide test spec/lang/           # Run tests in a directory
 almide test spec/lang/expr_test.almd  # Run a single test file
 almide test --run "pattern"      # Filter tests by name
+almide bench app.almd            # Verify-then-time (median; --target wasm for the embedded host)
 almide compile                    # Module interface (project)
 almide compile parser             # Module interface (by name)
 almide compile app.almd --json    # Module interface (JSON)

--- a/src/cli/bench.rs
+++ b/src/cli/bench.rs
@@ -1,0 +1,131 @@
+//! `almide bench` (#1490 item 3): the perf suite's methodology as a
+//! user-facing subcommand — verify before timing, interleave-free single
+//! program, median headline.
+//!
+//! The methodology is the asset (research/benchmark/perf/bench.py):
+//! 1. run once and take the stdout as the REFERENCE;
+//! 2. every timed run's stdout must byte-match it — a workload whose
+//!    output drifts between runs is measuring different work, and the
+//!    bench refuses instead of averaging nonsense;
+//! 3. one warmup run is discarded, then N timed runs (default 5), the
+//!    headline is the MEDIAN (min/max shown beside it).
+//!
+//! Legs: default = the native release binary (the cargo cache makes
+//! repeat benches skip rustc); `--target wasm` = the embedded wasm host,
+//! timed in-process. Program output is suppressed during timing — the
+//! bench prints the measurement, not the workload.
+
+use std::time::Instant;
+
+use crate::err;
+
+pub fn cmd_bench(file: &str, runs: u32, target: Option<&str>) {
+    let runs = runs.max(1);
+    match target {
+        None | Some("rust") | Some("native") => bench_native(file, runs),
+        Some("wasm") | Some("wasm32") | Some("wasi") => bench_wasm(file, runs),
+        Some(other) => {
+            err(&format!("error: unknown bench target '{other}' (native, wasm)"));
+            std::process::exit(2);
+        }
+    }
+}
+
+fn bench_native(file: &str, runs: u32) {
+    let rs_code = match crate::try_compile(file, false) {
+        Ok(c) => c,
+        Err(e) => {
+            err(&format!("Compile error:\n{e}"));
+            std::process::exit(1);
+        }
+    };
+    err(&format!("bench: building native release binary…"));
+    let bin = match super::run::build_native_cached(&rs_code, false, true, None, &[], None) {
+        Ok(b) => b,
+        Err(e) => {
+            err(&format!("Compile error:\n{e}"));
+            std::process::exit(1);
+        }
+    };
+    let run_once = || -> Result<(Vec<u8>, f64), String> {
+        let started = Instant::now();
+        let out = std::process::Command::new(&bin)
+            .output()
+            .map_err(|e| format!("execution failed: {e}"))?;
+        let secs = started.elapsed().as_secs_f64();
+        if !out.status.success() {
+            return Err(format!(
+                "workload exited {} — bench only times a clean run:\n{}",
+                out.status.code().unwrap_or(-1),
+                String::from_utf8_lossy(&out.stderr)
+            ));
+        }
+        Ok((out.stdout, secs))
+    };
+    run_bench(file, "native (release)", runs, run_once);
+}
+
+fn bench_wasm(file: &str, runs: u32) {
+    let (bytes, structural) = match super::build::compile_to_wasm_bytes(file, false, true, false) {
+        Ok(b) => b,
+        Err(()) => std::process::exit(1),
+    };
+    if !structural {
+        err("error: bench --target wasm needs the structural leg (this program routed to the incumbent artifact, which runs on an external wasmtime — time it there)");
+        std::process::exit(1);
+    }
+    let run_once = move || -> Result<(Vec<u8>, f64), String> {
+        let started = Instant::now();
+        let r = almide_wasm_run::run_wasm(&bytes).map_err(|e| format!("embedded wasm host: {e}"))?;
+        let secs = started.elapsed().as_secs_f64();
+        if r.exit != 0 {
+            return Err(format!("workload exited {} — bench only times a clean run:\n{}", r.exit, r.stderr));
+        }
+        Ok((r.stdout.into_bytes(), secs))
+    };
+    run_bench(file, "wasm (embedded host)", runs, run_once);
+}
+
+fn run_bench<F>(file: &str, leg: &str, runs: u32, mut run_once: F)
+where
+    F: FnMut() -> Result<(Vec<u8>, f64), String>,
+{
+    // Reference + warmup in one: the first run's output is the contract
+    // every timed run must reproduce; its time is discarded.
+    let (reference, _) = match run_once() {
+        Ok(r) => r,
+        Err(e) => {
+            err(&format!("error: {e}"));
+            std::process::exit(1);
+        }
+    };
+    let mut times: Vec<f64> = Vec::with_capacity(runs as usize);
+    for i in 0..runs {
+        match run_once() {
+            Ok((stdout, secs)) => {
+                if stdout != reference {
+                    err(&format!(
+                        "error: run {} produced different output than the reference — the workload is nondeterministic, and a benchmark whose output changes is measuring different work. Pin the workload (seed its randomness, drop wall-clock reads) and re-run.",
+                        i + 1
+                    ));
+                    std::process::exit(1);
+                }
+                times.push(secs);
+            }
+            Err(e) => {
+                err(&format!("error: {e}"));
+                std::process::exit(1);
+            }
+        }
+    }
+    times.sort_by(|a, b| a.partial_cmp(b).expect("times are finite"));
+    let ms = |s: f64| s * 1000.0;
+    let median = times[times.len() / 2];
+    err(&format!(
+        "bench {file} [{leg}]: median {:.2} ms (min {:.2}, max {:.2}, {} run(s) + 1 warmup, output verified identical across all runs)",
+        ms(median),
+        ms(times[0]),
+        ms(times[times.len() - 1]),
+        runs
+    ));
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,6 +2,7 @@
 
 mod run;
 mod build;
+mod bench;
 mod compile;
 mod emit;
 mod check;
@@ -27,6 +28,7 @@ use cargo_build::{cargo_build_cdylib, cargo_build_generated, cargo_build_generat
 
 pub use run::{cmd_run, RunArgs};
 pub use build::{cmd_build, BuildArgs};
+pub use bench::cmd_bench;
 pub use compile::cmd_compile;
 pub use emit::{cmd_emit, EmitArgs};
 pub use check::{cmd_check, cmd_check_json, cmd_check_effects};

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,18 @@ enum Commands {
         #[arg(allow_hyphen_values = true)]
         program_args: Vec<String>,
     },
+    /// Benchmark a program: verify-then-time, median headline (#1490)
+    Bench {
+        /// Source file (default: src/main.almd)
+        file: Option<String>,
+        /// Timed runs after the warmup (default 5)
+        #[arg(long, default_value_t = 5)]
+        runs: u32,
+        /// Leg to time: native (default, release binary) or wasm
+        /// (embedded host)
+        #[arg(long)]
+        target: Option<String>,
+    },
     /// Build a binary
     Build {
         /// Source file (default: src/main.almd)
@@ -893,6 +905,10 @@ fn dispatch(cli: Cli) {
         Commands::Init => cli::cmd_init(),
         Commands::Run { file, no_check, release, target, verified: _, no_verified, time_report, program_args } =>
             dispatch_run(file, no_check, release, target, no_verified, time_report, program_args),
+        Commands::Bench { file, runs, target } => {
+            let file = resolve_file(file);
+            cli::cmd_bench(&file, runs, target.as_deref());
+        }
         Commands::Build { file, o, target, release, fast, unchecked_index, no_check, repr_c, cdylib, emit_unverified, verified: _, no_verified, wasm_opt, component, heap_cap } => {
             let file = resolve_file(file);
             warn_no_verified_deprecated(no_verified);

--- a/tests/bench_test.rs
+++ b/tests/bench_test.rs
@@ -1,0 +1,67 @@
+//! #1490 item 3: `almide bench` — verify-then-time with a median
+//! headline. The refusal is the load-bearing part: a workload whose
+//! output drifts between runs is measuring different work, and the bench
+//! must say so instead of averaging nonsense. The wasm leg keeps these
+//! tests rustc-free (the native leg shares every line but the runner).
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn bench(source: &str, name: &str) -> (bool, String) {
+    let dir = std::env::temp_dir().join("almide-bench-test");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let src = dir.join(name);
+    std::fs::write(&src, source).expect("write");
+    let out = Command::new(almide_bin())
+        .args(["bench", src.to_str().unwrap(), "--target", "wasm", "--runs", "3"])
+        .output()
+        .expect("spawn almide bench");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+#[test]
+fn deterministic_workload_reports_a_verified_median() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    let (ok, err) = bench(
+        "fn fib(n: Int) -> Int = if n < 2 then n else fib(n - 1) + fib(n - 2)\n\nfn main() -> Unit = {\n  println(int.to_string(fib(20)))\n}\n",
+        "fib.almd",
+    );
+    assert!(ok, "bench failed:\n{err}");
+    assert!(err.contains("median"), "no median headline:\n{err}");
+    assert!(
+        err.contains("output verified identical across all runs"),
+        "the verification claim is missing:\n{err}"
+    );
+}
+
+#[test]
+fn drifting_output_is_refused_not_averaged() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    let (ok, err) = bench(
+        "import random\n\neffect fn main() -> Unit = {\n  println(int.to_string(random.int(0, 1000000)))\n}\n",
+        "nondet.almd",
+    );
+    assert!(!ok, "a nondeterministic workload must refuse, got:\n{err}");
+    assert!(
+        err.contains("nondeterministic"),
+        "the refusal must name the cause:\n{err}"
+    );
+}


### PR DESCRIPTION
#1490 item 3 — nobody in the nine-compiler survey ships a user-facing benchmark harness; the perf suite's methodology (research/benchmark/perf/bench.py) was the asset worth exposing, and this is it verbatim:

1. one warmup run's stdout becomes the REFERENCE;
2. every timed run must byte-match it — **a workload whose output drifts is refused, not averaged** (`random.int` demo: the refusal names the cause and tells the author to pin the workload);
3. N timed runs (default 5), the headline is the MEDIAN with min/max beside it.

Legs: `almide bench app.almd` times the native release binary (content-cached — repeat benches skip rustc); `--target wasm` times the embedded host in-process, rustc-free. First measurement on the fib(27) smoke: native 1.90 ms median, embedded wasm 2.71 ms — one source, two legs, one command.

`tests/bench_test.rs` pins the verified-median claim and the nondeterminism refusal on the wasm leg (rustc-free in CI); a clean-exit guard refuses to time a failing run. A program routed to the incumbent wasm artifact gets an honest pointer instead of a wrong number.