### PR TITLE
wasm-tools 0.257 in lockstep: the family bump dependabot cannot make

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
  "tempfile",
  "toml 1.1.4+spec-1.1.0",
  "wasi-preview1-component-adapter-provider",
- "wasmparser 0.256.0",
+ "wasmparser 0.257.1",
  "wat",
- "wit-component 0.256.0",
+ "wit-component 0.257.1",
 ]
 
 [[package]]
@@ -252,8 +252,8 @@ dependencies = [
  "almide-wasm-run",
  "anyhow",
  "sha2",
- "wasm-encoder 0.256.0",
- "wasmparser 0.256.0",
+ "wasm-encoder 0.257.1",
+ "wasmparser 0.257.1",
  "wasmtime",
 ]
 
@@ -263,11 +263,11 @@ version = "0.12.2"
 dependencies = [
  "almide-wasm",
  "anyhow",
- "wasm-encoder 0.256.0",
- "wasmparser 0.256.0",
+ "wasm-encoder 0.257.1",
+ "wasmparser 0.257.1",
  "wasmtime",
- "wit-component 0.256.0",
- "wit-parser 0.256.0",
+ "wit-component 0.257.1",
+ "wit-parser 0.257.1",
 ]
 
 [[package]]
@@ -2259,16 +2259,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.256.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1492381bfd5ea51c2a99a919b676662559925cb8d7490547ec2e14c1ad3eb1"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.256.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8ad9f0a39050867bda22e6486c316e2e52d20a42154d5bc433934bf738d085"
@@ -2291,14 +2281,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.256.0"
+version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6187f9fce741db43bea48f1ec42174897d763b8cdea7df726f2dd05561848d7"
+checksum = "57460ad9bce753e8a80d47a445cb87c8724ea57f463d9c906a947c41032ce1ac"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.256.0",
- "wasmparser 0.256.0",
+ "wasm-encoder 0.257.1",
+ "wasmparser 0.257.1",
 ]
 
 [[package]]
@@ -2346,8 +2336,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a"
 dependencies = [
  "bitflags 2.11.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "semver",
+ "serde",
 ]
 
 [[package]]
@@ -2769,9 +2761,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.256.0"
+version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d537ec182eed18f560184b870287cf443c4eccc315af178db3eae8811c3b6c"
+checksum = "2e8b7d04a4c9491ffea354923ed70c8826d52c699fe20a52e8ceca95017dddb8"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -2780,10 +2772,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.256.0",
- "wasm-metadata 0.256.0",
- "wasmparser 0.256.0",
- "wit-parser 0.256.0",
+ "wasm-encoder 0.257.1",
+ "wasm-metadata 0.257.1",
+ "wasmparser 0.257.1",
+ "wit-parser 0.257.1",
 ]
 
 [[package]]
@@ -2825,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.256.0"
+version = "0.257.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa073dadefba859cb03f689a0c2e3efc51f883bf86b907eaa9709bfd9e3a00a9"
+checksum = "6f815340f0bb65d9775ae21e56b503b496683557b9b627b195d2766c25fb24ae"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -2839,7 +2831,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-ident",
- "wasmparser 0.256.0",
+ "wasmparser 0.257.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ wat = "1"
 # Structural validation of the assembled v1 module: `wat` assembles without full stack-shape
 # validation, so the test harness validates before accepting a v1 module (invalid → the test
 # harness falls back to native execution; there is no v0 wasm emitter anymore).
-wasmparser = "0.256"
+wasmparser = "0.257"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -59,7 +59,7 @@ toml = "1.1"
 lasso = { version = "0.7", features = ["multi-threaded"] }
 lsp-server = "0.10"
 lsp-types = "0.97"
-wit-component = "0.256"
+wit-component = "0.257"
 wasi-preview1-component-adapter-provider = "47.0.2"
 
 # Cross-platform advisory file lock (flock / LockFileEx) for the shared build

--- a/crates/almide-wasm-run/Cargo.toml
+++ b/crates/almide-wasm-run/Cargo.toml
@@ -12,11 +12,11 @@ description = "The greenfield wasm HOST: the almide.* import surface (print/exit
 [dependencies]
 almide-wasm = { path = "../almide-wasm" }
 anyhow = "1"
-wasmparser = "0.256"
-wasm-encoder = "0.256"
+wasmparser = "0.257"
+wasm-encoder = "0.257"
 wasmtime = "47"
-wit-component = "0.256"
-wit-parser = "0.256"
+wit-component = "0.257"
+wit-parser = "0.257"
 
 [lints]
 workspace = true

--- a/crates/almide-wasm/Cargo.toml
+++ b/crates/almide-wasm/Cargo.toml
@@ -11,8 +11,8 @@ almide-ir = { path = "../almide-ir" }
 almide-base = { path = "../almide-base" }
 almide-types = { path = "../almide-types" }
 almide-layout = { path = "../almide-layout" }
-wasm-encoder = { version = "0.256", features = ["wasmparser"] }
-wasmparser = "0.256"
+wasm-encoder = { version = "0.257", features = ["wasmparser"] }
+wasmparser = "0.257"
 
 [dev-dependencies]
 almide-corpus = { path = "../almide-corpus" }
@@ -20,7 +20,7 @@ anyhow = "1"
 almide-spine = { path = "../almide-spine" }
 almide-wasm-run = { path = "../almide-wasm-run" }
 almide = { path = "../.." }
-wasmparser = "0.256"
+wasmparser = "0.257"
 wasmtime = "47"
 sha2 = "0.10"
 

--- a/src/cli/bench.rs
+++ b/src/cli/bench.rs
@@ -39,7 +39,7 @@ fn bench_native(file: &str, runs: u32) {
             std::process::exit(1);
         }
     };
-    err(&format!("bench: building native release binary…"));
+    err("bench: building native release binary…");
     let bin = match super::run::build_native_cached(&rs_code, false, true, None, &[], None) {
         Ok(b) => b,
         Err(e) => {

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -939,7 +939,7 @@ pub(crate) fn compile_to_wasm_bytes(file: &str, allow_unverified: bool, verified
 /// the name section (still present — validation runs before
 /// [`strip_wasm_name_section`]). `None` only if the module is too broken
 /// to walk section-by-section; the caller still reports the offset.
-fn wasm_function_at(bytes: &[u8], offset: usize) -> Option<String> {
+fn wasm_function_at(bytes: &[u8], offset: u64) -> Option<String> {
     use wasmparser::{KnownCustom, Name, Parser, Payload, TypeRef};
     let mut imported_funcs: u32 = 0;
     let mut code_index: u32 = 0;

--- a/src/cli/repl.rs
+++ b/src/cli/repl.rs
@@ -138,7 +138,7 @@ impl Session {
             Some(Ok(result)) => {
                 let result = result.trim();
                 if !result.is_empty() {
-                    out(&format!("{}", result));
+                    out(result);
                 }
                 return;
             }
@@ -146,7 +146,7 @@ impl Session {
                 // The program RAN and failed (abort, error propagation):
                 // that verdict is real on either path — report, no fallback.
                 if !runtime_err.is_empty() {
-                    err(&format!("{}", runtime_err.trim()));
+                    err(runtime_err.trim());
                 }
                 return;
             }
@@ -226,7 +226,11 @@ impl Session {
     }
 
     fn source_path(&self) -> PathBuf {
-        self.repl_dir.join("repl.almd")
+        // Per-process: two concurrent REPLs (parallel tests, two shells)
+        // sharing one fixed file clobbered each other's session between
+        // the write and the subprocess read — the fast path then ran the
+        // OTHER session's program and answered nothing.
+        self.repl_dir.join(format!("repl-{}.almd", std::process::id()))
     }
 
     fn print_history(&self) {


### PR DESCRIPTION
Replaces #1566, whose single-crate wasmparser bump broke the build by design: the wasm-tools family (wasmparser / wasm-encoder / wit-parser / wit-component / wat) shares types across crates, so it moves in LOCKSTEP or not at all — dependabot's per-crate PRs cannot express that. All pins go 0.256 → 0.257 together (wat already rode #1568 to 1.257.1).

One API drift absorbed: wasmparser 0.257 reports validation-error offsets as `u64` — `wasm_function_at`'s signature follows (the range-containment test then matches naturally).

Verified on the bumped train: both component legs (p2 direct + p3 async, byte-identity suites), wasm-opt structural, static-memory, crossmod matrix, and the spec/wasm_cross test files — all green locally; the full corpus rides CI.