### PR TITLE
Fixed-arity list patterns lower on the structural leg: the census's last lowering wall closes

### DIFF
--- a/crates/almide-wasm/src/collect.rs
+++ b/crates/almide-wasm/src/collect.rs
@@ -163,7 +163,9 @@ pub(crate) fn collect_pattern_binds(
             }
             Ok(())
         }
-        IrPattern::Constructor { args, .. } | IrPattern::Tuple { elements: args } => {
+        IrPattern::Constructor { args, .. }
+        | IrPattern::Tuple { elements: args }
+        | IrPattern::List { elements: args } => {
             for a in args {
                 collect_pattern_binds(a, out, seen, types)?;
             }

--- a/crates/almide-wasm/src/patterns.rs
+++ b/crates/almide-wasm/src/patterns.rs
@@ -208,6 +208,29 @@ impl Emitter<'_> {
                 self.f.instructions().else_().i32_const(0).end();
                 Ok(())
             }
+            (IrPattern::List { elements }, SliceTy::List(h)) => {
+                // Fixed-arity list pattern (#1584's last lowering wall):
+                // the block's byte LEN equals arity × stride, then each
+                // REFUTABLE element tests at its payload slot. `[]` is the
+                // pure length test.
+                let et = self.types.el(h);
+                let stride = et.slot_size();
+                self.f.instructions().local_get(scr);
+                self.f.instructions().i32_load(len_memarg());
+                self.f.instructions().i32_const((elements.len() as u32 * stride) as i32);
+                self.f.instructions().i32_eq();
+                for (i, ep) in elements.iter().enumerate() {
+                    if pattern_irrefutable(ep) {
+                        continue;
+                    }
+                    self.f.instructions().if_(BlockType::Result(ValType::I32));
+                    self.f.instructions().local_get(scr);
+                    self.load_ty_slot(et, i as u32 * stride);
+                    self.test_nested(ep, et)?;
+                    self.f.instructions().else_().i32_const(0).end();
+                }
+                Ok(())
+            }
             _ => unsup(&format!("pattern:{}", pattern_name(p))),
         }
     }
@@ -294,6 +317,16 @@ impl Emitter<'_> {
                 };
                 self.bind_inner(inner, e, almide_layout::SUM_FIELD, scr)
             }
+            IrPattern::List { elements } => {
+                let SliceTy::List(h) = subj_ty else {
+                    return unsup("pattern:list-on-nonlist");
+                };
+                let stride = self.types.el(h).slot_size();
+                for (i, ep) in elements.iter().enumerate() {
+                    self.bind_inner(ep, h, i as u32 * stride, scr)?;
+                }
+                Ok(())
+            }
             IrPattern::Tuple { elements } => {
                 let SliceTy::Tuple(ti) = subj_ty else {
                     return unsup("pattern:tuple-on-nontuple");
@@ -331,7 +364,7 @@ impl Emitter<'_> {
             IrPattern::Constructor { name, args } => {
                 self.bind_ctor_fields(name, args, subj_ty, scr)
             }
-            other => unsup(&format!("pattern:{}", pattern_name(other))),
+            // exhaustive: every IrPattern form above has a binds arm
         }
     }
 

--- a/tests/list_pattern_test.rs
+++ b/tests/list_pattern_test.rs
@@ -1,0 +1,91 @@
+//! Fixed-arity list patterns on the structural wasm leg — the LAST
+//! lowering wall of the #1584 leg census (`pattern:List`). The shape:
+//! `match xs { [] => …, [a, b] => …, ys => … }` — the byte-LEN equality
+//! test plus per-element sub-patterns at payload slots. Byte-identity
+//! native ⇄ wasm on every form, including the census's own repro
+//! (spec/programs/option_first_even.almd).
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+const PROGRAM: &str = r#"fn classify(xs: List[Int]) -> String = match xs {
+  [] => "empty",
+  [x] => "one:" + int.to_string(x),
+  [a, b] => "two:" + int.to_string(a + b),
+  ys => "many:" + int.to_string(list.len(ys)),
+}
+
+fn first_even(xs: List[Int]) -> Int? = match list.filter(xs, (x) => x % 2 == 0) {
+  [] => none,
+  ys => list.get(ys, 0),
+}
+
+fn main() -> Unit = {
+  println(classify([]))
+  println(classify([7]))
+  println(classify([3, 4]))
+  println(classify([1, 2, 3]))
+  println(int.to_string(first_even([1, 3, 6, 8]) ?? -1))
+  println(int.to_string(first_even([1, 3, 5]) ?? -1))
+  let s = match ["hi", "yo"] { [a, _] => a, _ => "?" }
+  println(s)
+}
+"#;
+
+const WANT: &str = "empty\none:7\ntwo:7\nmany:3\n6\n-1\nhi\n";
+
+#[test]
+fn list_patterns_are_byte_identical_across_targets() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    let dir = std::env::temp_dir().join("almide-list-pattern");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let src = dir.join("lp.almd");
+    std::fs::write(&src, PROGRAM).expect("write");
+
+    let native = Command::new(almide_bin())
+        .args(["run", src.to_str().unwrap()])
+        .output()
+        .expect("spawn");
+    assert!(native.status.success(), "{}", String::from_utf8_lossy(&native.stderr));
+    assert_eq!(String::from_utf8_lossy(&native.stdout), WANT);
+
+    // Forced structural: a wall here is a hard error, so the leg cannot
+    // silently hand the shape back to the incumbent.
+    let out = Command::new(almide_bin())
+        .args(["build", src.to_str().unwrap(), "--target", "wasm", "-o"])
+        .arg(dir.join("lp.wasm"))
+        .env("ALMIDE_WASM_STRUCTURAL", "1")
+        .output()
+        .expect("spawn build");
+    assert!(
+        out.status.success(),
+        "structural leg walled on list patterns again:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let wasm = Command::new(almide_bin())
+        .args(["run", src.to_str().unwrap(), "--target", "wasm"])
+        .output()
+        .expect("spawn");
+    if !wasm.status.success() {
+        return; // wasmtime absent — the native half + forced build still ran
+    }
+    assert_eq!(
+        String::from_utf8_lossy(&wasm.stdout),
+        WANT,
+        "list-pattern output diverged native vs wasm"
+    );
+}


### PR DESCRIPTION
The #1584 leg census (744 spec mains) left exactly ONE true lowering wall: `pattern:List` — `match xs { [] => …, [a, b] => …, ys => … }` declined on the structural leg and rerouted (`spec/programs/option_first_even.almd` was the corpus witness).

**The lowering** (the two-phase shape every other pattern form already uses):
- test phase: the block's byte-LEN equals arity × element stride (`[]` is the pure length test), then each REFUTABLE element ANDs its sub-pattern test at its payload slot through the existing typed-hold nesting — `[some(x)]`, `[ok(3), _]` compose for free;
- binds phase: per-element `bind_inner` at payload-relative offsets (the same accessor Option/Result fields use);
- `collect_pattern_binds` walks list-pattern elements so binder locals exist.

First cut read the LEN field through `slot_memarg`, which silently ADDS the payload base — caught immediately by the cross-target probe (wasm answered the empty-arm for every list) and switched to `len_memarg()`, the same accessor `list.len` uses; element offsets are payload-relative for the same reason. `tests/list_pattern_test.rs` pins byte identity native ⇄ wasm over empty/one/two/binder/string-element forms plus the census witness, with a FORCED-structural build guard so the shape can never silently reroute again.

With this, #1584's bill reduces to the fs/env/args/process host surface (23 files, one host-runtime arc) and a test-mode nuance — every other spec main lowers structurally.