### PR TITLE
The trampoline try marker shrinks to the one bit the fold reads, retiring the last constant-factor quick win

### DIFF
--- a/crates/almide-interp/src/eval.rs
+++ b/crates/almide-interp/src/eval.rs
@@ -511,9 +511,15 @@ impl<'a> Interpreter<'a> {
     /// final value (`run_callable`'s pending list) instead of re-implementing
     /// it: one instrument, two call sites.
     pub(crate) fn try_unwrap_value(&mut self, v: Value, node_ty: &Ty) -> Flow {
-        if matches!(node_ty,
-            Ty::Applied(almide_lang::types::constructor::TypeConstructorId::Option, a) if a.len() == 1)
-        {
+        self.try_unwrap_value_flag(v, marker_is_option_identity(node_ty))
+    }
+
+    /// The flag form: the only fact `!` normalization reads off the marker
+    /// node's type is "is it the C-216 Option identity" — one bit, so the
+    /// trampoline carries the bit instead of cloning a `Ty` per hop
+    /// (#1232, the last quick-win row).
+    pub(crate) fn try_unwrap_value_flag(&mut self, v: Value, opt_identity: bool) -> Flow {
+        if opt_identity {
             if let Value::Option(_) = v {
                 return Flow::val(v);
             }
@@ -868,7 +874,7 @@ impl<'a> Interpreter<'a> {
                             SpineOutcome::Transfer {
                                 next,
                                 next_args,
-                                try_marker: Some(cur.ty.clone()),
+                                try_marker: Some(marker_is_option_identity(&cur.ty)),
                             }
                         }
                         Some(out) => out,
@@ -1044,4 +1050,12 @@ fn lift_to_declared_carrier(ty: &Ty, flow: Flow) -> Flow {
         Flow::Value(v) => Flow::Value(Value::Result(Ok(Box::new(v)))),
         other => other,
     }
+}
+
+/// The C-216 marker fact (see `try_unwrap_value_flag`): a `Try`/`Unwrap`
+/// node TYPED `Option[_]` is the effect-RESULT-layer strip on a
+/// declared-Option effect call — identity on Option values.
+pub(crate) fn marker_is_option_identity(node_ty: &Ty) -> bool {
+    matches!(node_ty,
+        Ty::Applied(almide_lang::types::constructor::TypeConstructorId::Option, a) if a.len() == 1)
 }

--- a/crates/almide-interp/src/lib.rs
+++ b/crates/almide-interp/src/lib.rs
@@ -977,8 +977,9 @@ impl<'a> Interpreter<'a> {
         // First hop's frame — what mut-param copy-out reads. Meaningful only
         // when no transfer happened, and a transfer implies no mut params.
         let mut first_frame: Option<env::Scope> = None;
-        // (marker node type, run length) — pending `Try` normalizations.
-        let mut pending: Vec<(Ty, u32)> = Vec::new();
+        // (marker Option-identity bit, run length) — pending `Try`
+        // normalizations (the bit is the only fact the fold reads, #1232).
+        let mut pending: Vec<(bool, u32)> = Vec::new();
 
         let result = 'tramp: loop {
             if let Some(cut) = self.charge_hop_entry(&callee) {
@@ -1092,7 +1093,7 @@ impl<'a> Interpreter<'a> {
     /// boundary first — and at each level, a `Return(x)` means "that level's fn
     /// returns x", which is the next level's call VALUE. Anything that is not a
     /// value (an abort, a fuel cut) stops the fold where it is.
-    fn fold_pending_try(&mut self, result: Flow, pending: &[(Ty, u32)]) -> Flow {
+    fn fold_pending_try(&mut self, result: Flow, pending: &[(bool, u32)]) -> Flow {
         let mut result = match result {
             Flow::Return(v) | Flow::Value(v) => Flow::Value(v),
             other => other,
@@ -1101,7 +1102,7 @@ impl<'a> Interpreter<'a> {
             for _ in 0..*n {
                 match result {
                     Flow::Value(v) => {
-                        result = match self.try_unwrap_value(v, ty) {
+                        result = match self.try_unwrap_value_flag(v, *ty) {
                             Flow::Return(v) | Flow::Value(v) => Flow::Value(v),
                             other => other,
                         }
@@ -1208,7 +1209,7 @@ pub(crate) enum SpineOutcome<'a> {
     /// `try_marker` carries the `Try`/`Unwrap` marker node's type when the
     /// tail was the effect wrapper `Try{Call}`, so the engine can fold the
     /// normalization over the final value.
-    Transfer { next: TailCallee<'a>, next_args: Vec<Value>, try_marker: Option<Ty> },
+    Transfer { next: TailCallee<'a>, next_args: Vec<Value>, try_marker: Option<bool> },
 }
 
 /// If `main`'s result value is an unhandled error, return the message that the


### PR DESCRIPTION
#1232's quick-win section, closed out. A re-verification sweep of the ledger against HEAD found the state far ahead of the checklist:

**Already landed in earlier rounds** (verified in-tree, each carrying its fix comment): the borrow-inference operand order + cached table, `bundled_sigs` read-guard projection, `varid_remap`'s dropped O(n²) check, `pass_auto_parallel`'s `mem::take`, `flatten_spellings` precompute, the UFCS needle hoist, the interp `variant_ctors` registry (the "biggest single win" row), `continuation_lift`'s empty-chain early-continue, `desugar_nested_unwrap`'s `AnyUnwrap` trigger.

**Falsified by measurement** (recorded in-code, do-not-reapply): the `runtime/rs/fs.rs` `buf.clone()` → `mem::take` row — `take` steals the String's capacity so `read_line` regrows per line; clone measured 4-6% FASTER (2M lines best-of-15).

**This PR lands the one remaining row**: the interp trampoline cloned the `Try` marker node's `Ty` per `!` hop. The fold reads exactly ONE fact off that type — "is it the C-216 Option identity" — so the marker is now that bit (`try_marker: Option<bool>`, `try_unwrap_value_flag`), and the per-hop allocation is gone by construction (beyond the ledger's proposed reference-compare). `try_unwrap_value(ty)` stays as the wrapper for the expression-path caller.

Wall-time on `almide test spec/stdlib/` is unchanged (4.9s — the wasm leg dominates there); the win is per-hop allocation on interp-legged deep `!` chains. interp suite 33+74 green, `almide test` 422/422.

Remaining on #1232 after this: the medium backlog only.