### PR TITLE
The p3 filesystem write surface: streamed writes with the durability handshake, recursive mkdir, stat-routed removal

### DIFF
--- a/crates/almide-wasm-run/src/wasi_p3.rs
+++ b/crates/almide-wasm-run/src/wasi_p3.rs
@@ -6,9 +6,14 @@
 //!
 //! Same doctrine as `to_p2` (#1588/#1628 stage 1) with the five-op host
 //! surface (console out, exit codes, stdin, entropy, wall clock) PLUS the
-//! filesystem READ surface (increment 2a): exists/is-dir/is-file via
-//! stat-at, read_text/read_bytes via open-at + sync stream reads, guest
-//! paths resolved against the FIRST preopen (`wasmtime run --dir=.`).
+//! filesystem READ surface (increment 2a: exists/is-dir/is-file via
+//! stat-at, read_text/read_bytes via open-at + sync stream reads) AND
+//! the WRITE surface (increment 2d: write/append/write_bytes through
+//! write-via-stream with the completion-future durability handshake,
+//! recursive mkdir_p, remove/remove_all via stat-then-unlink-or-rmdir —
+//! a NON-EMPTY remove_all answers the honest not-empty error until the
+//! recursive walk lands). Guest paths resolve against the FIRST preopen
+//! (`wasmtime run --dir=.`).
 //! Canonical-ABI facts (variant discriminants, payload offsets) are
 //! DERIVED from the vendored WIT at emit time (`FsAbi`), never
 //! hand-counted. fs writes, env and process keep the DEFINED refusal;
@@ -97,7 +102,20 @@ const I_WS_WAIT: u32 = 29; // [waitable-set-wait]
 const I_SUBTASK_DROP: u32 = 30; // [subtask-drop]
 const I_WS_DROP: u32 = 31; // [waitable-set-drop]
 const I_SUBTASK_CANCEL: u32 = 32; // [subtask-cancel] — the loser-arm abandonment
-const IMPORTS: u32 = 33;
+// The filesystem WRITE surface (#1628 increment 2d): write/append streams
+// (the guest keeps the writable end, sync stream.write feeds it, and the
+// completion future.read is the durability handshake), plus the three
+// path ops. All sync lowers, as the read surface.
+const I_FS_WVS: u32 = 33; // [method]descriptor.write-via-stream
+const I_FS_AVS: u32 = 34; // [method]descriptor.append-via-stream
+const I_FS_WNEW: u32 = 35; // [stream-new-0] of write-via-stream
+const I_FS_WWRITE: u32 = 36; // [stream-write-0] of write-via-stream
+const I_FS_WDROP: u32 = 37; // [stream-drop-writable-0] of write-via-stream
+const I_FS_WFUT: u32 = 38; // [future-read-1] of write-via-stream
+const I_FS_MKDIR: u32 = 39; // [method]descriptor.create-directory-at
+const I_FS_UNLINK: u32 = 40; // [method]descriptor.unlink-file-at
+const I_FS_RMDIR: u32 = 41; // [method]descriptor.remove-directory-at
+const IMPORTS: u32 = 42;
 const SHIFT: u32 = IMPORTS - 5;
 
 // Park offsets past the shared ones: retptr / future-payload scratch.
@@ -154,9 +172,11 @@ struct FsAbi {
     ec_access: i32,
     ec_not_permitted: i32,
     ec_is_directory: i32,
+    ec_exist: i32,
     dt_directory: i32,     // descriptor-type case index
     dt_regular_file: i32,
     open_payload: u64,     // result<descriptor, error-code> payload offset
+    unit_payload: u64,     // result<_, error-code> payload offset (the path ops)
     stat_payload: u64,     // result<descriptor-stat, error-code> payload offset
     stat_size: u64,        // full result size (park-span room check)
 }
@@ -204,15 +224,18 @@ fn fs_abi(resolve: &wit_parser::Resolve) -> anyhow::Result<FsAbi> {
     let stat_align = sa.align(&Type::Id(stat)).align_wasm32() as u64;
     let stat_sz = sa.size(&Type::Id(stat)).size_wasm32() as u64;
     let open_payload = 4u64.max(ec_align); // own<descriptor> aligns 4
+    let unit_payload = ec_align; // result<_, error-code>: the err IS the payload
     let stat_payload = stat_align.max(ec_align);
     Ok(FsAbi {
         ec_no_entry: case(ec, "no-entry")?,
         ec_access: case(ec, "access")?,
         ec_not_permitted: case(ec, "not-permitted")?,
         ec_is_directory: case(ec, "is-directory")?,
+        ec_exist: case(ec, "exist")?,
         dt_directory: case(dt, "directory")?,
         dt_regular_file: case(dt, "regular-file")?,
         open_payload,
+        unit_payload,
         stat_payload,
         stat_size: stat_payload + stat_sz,
     })
@@ -337,6 +360,17 @@ pub fn to_p3(bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
         &[],
     );
     let t_aopen = type_index(&mut types, &[ValType::I32; 2], &[ValType::I32]);
+    // write-via-stream: (self, stream, offset:i64) -> future — the future
+    // returns DIRECTLY (1 flat result), as stdio's write-via-stream.
+    let t_wvs = type_index(
+        &mut types,
+        &[ValType::I32, ValType::I32, ValType::I64],
+        &[ValType::I32],
+    );
+    // append-via-stream: (self, stream) -> future.
+    let t_avs = type_index(&mut types, &[ValType::I32; 2], &[ValType::I32]);
+    // path ops: (self, ptr, len, retptr).
+    let t_pathop = type_index(&mut types, &[ValType::I32; 4], &[]);
     let t_ws_new = type_index(&mut types, &[], &[ValType::I32]);
     let t_ws_join = type_index(&mut types, &[ValType::I32; 2], &[]);
     let t_ws_wait = type_index(&mut types, &[ValType::I32; 2], &[ValType::I32]);
@@ -388,6 +422,15 @@ pub fn to_p3(bytes: &[u8]) -> anyhow::Result<Vec<u8>> {
         (I_SUBTASK_DROP, "$root", "[subtask-drop]", t_drop),
         (I_WS_DROP, "$root", "[waitable-set-drop]", t_drop),
         (I_SUBTASK_CANCEL, "$root", "[subtask-cancel]", t_call),
+        (I_FS_WVS, fs_types, "[method]descriptor.write-via-stream", t_wvs),
+        (I_FS_AVS, fs_types, "[method]descriptor.append-via-stream", t_avs),
+        (I_FS_WNEW, fs_types, "[stream-new-0][method]descriptor.write-via-stream", t_new),
+        (I_FS_WWRITE, fs_types, "[stream-write-0][method]descriptor.write-via-stream", t_rw),
+        (I_FS_WDROP, fs_types, "[stream-drop-writable-0][method]descriptor.write-via-stream", t_drop),
+        (I_FS_WFUT, fs_types, "[future-read-1][method]descriptor.write-via-stream", t_fut_read),
+        (I_FS_MKDIR, fs_types, "[method]descriptor.create-directory-at", t_pathop),
+        (I_FS_UNLINK, fs_types, "[method]descriptor.unlink-file-at", t_pathop),
+        (I_FS_RMDIR, fs_types, "[method]descriptor.remove-directory-at", t_pathop),
     ];
     assert_eq!(import_list.len() as u32, IMPORTS, "IMPORTS count drift");
     let mut imports = ImportSection::new();
@@ -974,6 +1017,166 @@ fn shim_fs_call(
     i.end();
     i.local_get(sl).i32_load(mem(24 + abi.open_payload)).local_set(d);
     fs_read_tail(&mut i, park, f_realloc, g_ppos, g_plen, d, rx, fut, buf, cap, total, n);
+    i.end();
+
+    // ── The filesystem WRITE surface (#1628 increment 2d) ─────────────
+
+    // ops 2/15 (write: create|truncate), 16 (append: create), 3
+    // (write_bytes: the List[Int] payload packs to raw bytes first).
+    // Shape: open-at(write) → stream.new → write/append-via-stream hands
+    // the host the readable end → sync stream.write feeds the writable
+    // end → drop writable → future.read is the DURABILITY handshake
+    // (blocks until the host wrote every byte) → resource-drop → ok.
+    i.local_get(op).i32_const(2).i32_eq();
+    i.local_get(op).i32_const(15).i32_eq().i32_or();
+    i.local_get(op).i32_const(16).i32_eq().i32_or();
+    i.local_get(op).i32_const(3).i32_eq().i32_or();
+    i.if_(BlockType::Empty);
+    fs_preopen(&mut i, g_pre, park);
+    i.global_get(g_pre).i32_const(0).i32_lt_s();
+    i.if_(BlockType::Empty);
+    fs_err(&mut i, g_ppos, g_plen, park, MSG_NOPRE, E_NOPRE.len());
+    i.end();
+    // write_bytes: pack the 8-byte slots' low bytes into a compact buffer.
+    i.local_get(op).i32_const(3).i32_eq();
+    i.if_(BlockType::Empty);
+    i.local_get(b_len).i32_const(3).i32_shr_u().local_set(cap);
+    i.i32_const(0).i32_const(0).i32_const(8).local_get(cap).call(f_realloc).local_set(buf);
+    i.i32_const(0).local_set(j);
+    i.block(BlockType::Empty).loop_(BlockType::Empty);
+    i.local_get(j).local_get(cap).i32_ge_u().br_if(1);
+    i.local_get(buf).local_get(j).i32_add();
+    i.local_get(b_ptr).local_get(j).i32_const(3).i32_shl().i32_add();
+    i.i32_load8_u(mem8(0));
+    i.i32_store8(mem8(0));
+    i.local_get(j).i32_const(1).i32_add().local_set(j);
+    i.br(0).end().end();
+    i.local_get(buf).local_set(b_ptr);
+    i.local_get(cap).local_set(b_len);
+    i.end();
+    // open for write: append keeps the tail (create), write truncates.
+    i.global_get(g_pre);
+    i.i32_const(1); // path-flags: symlink-follow
+    i.local_get(a_ptr).local_get(a_len);
+    i.local_get(op).i32_const(16).i32_eq();
+    i.if_(BlockType::Result(ValType::I32));
+    i.i32_const(1); // open-flags: create
+    i.else_();
+    i.i32_const(9); // open-flags: create|truncate
+    i.end();
+    i.i32_const(2); // descriptor-flags: write
+    i.i32_const((park + RET) as i32);
+    i.call(I_FS_OPEN);
+    i.i32_const((park + RET) as i32).i32_load8_u(mem8(0));
+    i.if_(BlockType::Empty);
+    i.i32_const((park + RET) as i32).i32_load8_u(mem8(abi.open_payload)).local_set(n);
+    fs_open_err_map(&mut i, g_ppos, g_plen, park, abi, n);
+    i.end();
+    i.i32_const((park + RET) as i32).i32_load(mem(abi.open_payload)).local_set(d);
+    // the write stream: tx = high half, rx = low half (the stdio packing).
+    i.call(I_FS_WNEW).local_set(s64);
+    i.local_get(s64).i64_const(32).i64_shr_u().i32_wrap_i64().local_set(rx); // rx local holds TX
+    i.local_get(op).i32_const(16).i32_eq();
+    i.if_(BlockType::Result(ValType::I32));
+    i.local_get(d).local_get(s64).i32_wrap_i64().call(I_FS_AVS);
+    i.else_();
+    i.local_get(d).local_get(s64).i32_wrap_i64().i64_const(0).call(I_FS_WVS);
+    i.end();
+    i.local_set(fut);
+    // sync write loop on the LOCAL writable end.
+    i.block(BlockType::Empty).loop_(BlockType::Empty);
+    i.local_get(b_len).i32_eqz().br_if(1);
+    i.local_get(rx);
+    i.local_get(b_ptr).local_get(b_len);
+    i.call(I_FS_WWRITE);
+    i.i32_const(4).i32_shr_u().local_set(n);
+    i.local_get(n).i32_eqz().br_if(1);
+    i.local_get(b_ptr).local_get(n).i32_add().local_set(b_ptr);
+    i.local_get(b_len).local_get(n).i32_sub().local_set(b_len);
+    i.br(0).end().end();
+    i.local_get(rx).call(I_FS_WDROP);
+    i.local_get(fut).i32_const((park + RET) as i32).call(I_FS_WFUT).drop();
+    i.local_get(d).call(I_FS_RESDROP);
+    i.i64_const(0).return_();
+    i.end();
+
+    // op 7: mkdir_p — create-directory-at per '/'-prefix, exist ignored
+    // (idempotent, the create_dir_all shape); the FULL path's non-exist
+    // error surfaces through the shared map.
+    i.local_get(op).i32_const(7).i32_eq();
+    i.if_(BlockType::Empty);
+    fs_preopen(&mut i, g_pre, park);
+    i.global_get(g_pre).i32_const(0).i32_lt_s();
+    i.if_(BlockType::Empty);
+    fs_err(&mut i, g_ppos, g_plen, park, MSG_NOPRE, E_NOPRE.len());
+    i.end();
+    i.i32_const(0).local_set(j);
+    i.block(BlockType::Empty).loop_(BlockType::Empty);
+    i.local_get(j).local_get(a_len).i32_gt_u().br_if(1);
+    // segment boundary: end-of-path or '/'
+    i.local_get(j).local_get(a_len).i32_eq();
+    i.local_get(j).local_get(a_len).i32_lt_u();
+    i.local_get(a_ptr).local_get(j).i32_add().i32_load8_u(mem8(0)).i32_const(47).i32_eq();
+    i.i32_and().i32_or();
+    i.local_get(j).i32_const(0).i32_gt_u().i32_and();
+    i.if_(BlockType::Empty);
+    i.global_get(g_pre);
+    i.local_get(a_ptr).local_get(j);
+    i.i32_const((park + RET) as i32);
+    i.call(I_FS_MKDIR);
+    // the FULL path's error decides; 'exist' is success (idempotent).
+    i.local_get(j).local_get(a_len).i32_eq();
+    i.i32_const((park + RET) as i32).i32_load8_u(mem8(0)).i32_and();
+    i.if_(BlockType::Empty);
+    i.i32_const((park + RET) as i32).i32_load8_u(mem8(abi.unit_payload)).local_set(n);
+    i.local_get(n).i32_const(abi.ec_exist).i32_ne();
+    i.if_(BlockType::Empty);
+    fs_open_err_map(&mut i, g_ppos, g_plen, park, abi, n);
+    i.end();
+    i.end();
+    i.end();
+    i.local_get(j).i32_const(1).i32_add().local_set(j);
+    i.br(0).end().end();
+    i.i64_const(0).return_();
+    i.end();
+
+    // ops 8/9: remove / remove_all — stat decides file vs directory (the
+    // embedded host's `is_dir()` shape); a NON-EMPTY directory under op 9
+    // answers the honest not-empty error (the recursive walk is a later
+    // increment, not a refusal).
+    i.local_get(op).i32_const(8).i32_eq();
+    i.local_get(op).i32_const(9).i32_eq().i32_or();
+    i.if_(BlockType::Empty);
+    fs_preopen(&mut i, g_pre, park);
+    i.global_get(g_pre).i32_const(0).i32_lt_s();
+    i.if_(BlockType::Empty);
+    fs_err(&mut i, g_ppos, g_plen, park, MSG_NOPRE, E_NOPRE.len());
+    i.end();
+    i.global_get(g_pre);
+    i.i32_const(1);
+    i.local_get(a_ptr).local_get(a_len);
+    i.i32_const((park + STATRET) as i32);
+    i.call(I_FS_STAT);
+    i.i32_const((park + STATRET) as i32).i32_load8_u(mem8(0));
+    i.if_(BlockType::Empty);
+    i.i32_const((park + STATRET) as i32).i32_load8_u(mem8(abi.stat_payload)).local_set(n);
+    fs_open_err_map(&mut i, g_ppos, g_plen, park, abi, n);
+    i.end();
+    i.i32_const((park + STATRET) as i32).i32_load8_u(mem8(abi.stat_payload));
+    i.i32_const(abi.dt_directory).i32_eq();
+    i.if_(BlockType::Empty);
+    i.global_get(g_pre).local_get(a_ptr).local_get(a_len).i32_const((park + RET) as i32);
+    i.call(I_FS_RMDIR);
+    i.else_();
+    i.global_get(g_pre).local_get(a_ptr).local_get(a_len).i32_const((park + RET) as i32);
+    i.call(I_FS_UNLINK);
+    i.end();
+    i.i32_const((park + RET) as i32).i32_load8_u(mem8(0));
+    i.if_(BlockType::Empty);
+    i.i32_const((park + RET) as i32).i32_load8_u(mem8(abi.unit_payload)).local_set(n);
+    fs_open_err_map(&mut i, g_ppos, g_plen, park, abi, n);
+    i.end();
+    i.i64_const(0).return_();
     i.end();
 
     // op 42: ABANDON slot k (k rides b_len; the path args are unused) —

--- a/crates/almide-wasm-run/wit/p3/deps/filesystem/package.wit
+++ b/crates/almide-wasm-run/wit/p3/deps/filesystem/package.wit
@@ -96,8 +96,13 @@ interface types {
 
   resource descriptor {
     read-via-stream: func(offset: filesize) -> tuple<stream<u8>, future<result<_, error-code>>>;
+    write-via-stream: func(data: stream<u8>, offset: filesize) -> future<result<_, error-code>>;
+    append-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
+    create-directory-at: async func(path: string) -> result<_, error-code>;
     open-at: async func(path-flags: path-flags, path: string, open-flags: open-flags, %flags: descriptor-flags) -> result<descriptor, error-code>;
+    remove-directory-at: async func(path: string) -> result<_, error-code>;
     stat-at: async func(path-flags: path-flags, path: string) -> result<descriptor-stat, error-code>;
+    unlink-file-at: async func(path: string) -> result<_, error-code>;
   }
 }
 

--- a/crates/almide-wasm-run/wit/p3/world.wit
+++ b/crates/almide-wasm-run/wit/p3/world.wit
@@ -5,8 +5,9 @@
 // drives it with sync stream builtins and retires the subtask before
 // task-return) — PLUS the filesystem READ surface (increment 2a:
 // exists/is-dir/is-file via stat-at, read_text/read_bytes via open-at +
-// read-via-stream against the first preopen). fs writes, env and
-// process keep the defined refusal inside the shims.
+// read-via-stream against the first preopen) and WRITE surface
+// (increment 2d: write/append/write_bytes/mkdir_p/remove/remove_all).
+// env and process keep the defined refusal inside the shims.
 package almide:runtime-p3@0.1.0;
 
 world p3-command {

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -900,13 +900,25 @@ pub(crate) fn compile_to_wasm_bytes(file: &str, allow_unverified: bool, verified
     // export mode yet (#1598's sibling surface), so those modules stay on
     // the incumbent leg.
     let has_exports = ir_program.functions.iter().any(|f| !f.export_attrs.is_empty());
-    let host_variant = std::iter::once(&program)
-        .chain(resolved.modules.iter().map(|(_, p, _, _)| p))
-        .flat_map(|p| p.imports.iter())
-        .any(|d| {
-            matches!(d, almide::ast::Decl::Import { path, .. }
-                if path.first().is_some_and(|r| matches!(r.as_str(), "fs" | "env" | "process")))
-        });
+    let imports_module = |names: &[&str]| {
+        std::iter::once(&program)
+            .chain(resolved.modules.iter().map(|(_, p, _, _)| p))
+            .flat_map(|p| p.imports.iter())
+            .any(|d| {
+                matches!(d, almide::ast::Decl::Import { path, .. }
+                    if path.first().is_some_and(|r| names.contains(&r.as_str())))
+            })
+    };
+    // Build-time host routing: env/process ride the incumbent (no
+    // structural surface); fs rides the incumbent because the p1
+    // `to_wasi` transform carries no fs ops — EXCEPT when the build is
+    // headed for the direct p3 component (#1628 increment 2d), whose
+    // shim now carries the full fs read+write surface, so fs programs
+    // flip to the structural leg there by default (#1584's first
+    // default-route slice).
+    let p3_requested = std::env::var_os("ALMIDE_COMPONENT_P3").is_some();
+    let host_variant = imports_module(&["env", "process"])
+        || (imports_module(&["fs"]) && !p3_requested);
     // #1598 CLOSED as per-fn auto-flip: the matrix/io module pre-scan is
     // GONE. The linked surfaces (io.read_all via the host's op-31 drain
     // joined io.print/write/write_bytes/read_n_bytes; the measured matrix

--- a/tests/component_p3_test.rs
+++ b/tests/component_p3_test.rs
@@ -557,6 +557,54 @@ werr=No such file or directory (os error 2)
 }
 
 #[test]
+fn p3_requested_fs_builds_route_structurally_by_default() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    let d = dir().join("fsflip");
+    std::fs::create_dir_all(&d).expect("mkdir");
+    let src = d.join("flip.almd");
+    std::fs::write(
+        &src,
+        "import fs
+
+effect fn main() -> Unit = {
+  println(if fs.exists(\"x\") then \"y\" else \"n\")
+}
+",
+    )
+    .expect("write");
+    // With the p3 component requested, an fs program's build takes the
+    // STRUCTURAL leg by default (#1584's first default-route slice) —
+    // no ALMIDE_WASM_STRUCTURAL override.
+    let o = Command::new(almide_bin())
+        .args(["build", src.to_str().unwrap(), "--target", "wasm", "--component", "-o",
+               d.join("flip_p3.wasm").to_str().unwrap()])
+        .env("ALMIDE_COMPONENT_P3", "1")
+        .output()
+        .expect("spawn almide");
+    let log = String::from_utf8_lossy(&o.stderr).to_string();
+    assert!(o.status.success(), "build failed:\n{log}");
+    assert!(
+        log.contains("structural leg, WASI 0.3 component (direct, async ABI)"),
+        "the p3-requested fs build must route structurally by default:\n{log}"
+    );
+    // Without the p3 request the incumbent keeps the route (the p1/p2
+    // transforms carry no fs ops).
+    let o = Command::new(almide_bin())
+        .args(["build", src.to_str().unwrap(), "--target", "wasm", "--component", "-o",
+               d.join("flip_ad.wasm").to_str().unwrap()])
+        .output()
+        .expect("spawn almide");
+    let log = String::from_utf8_lossy(&o.stderr).to_string();
+    assert!(o.status.success(), "build failed:\n{log}");
+    assert!(
+        log.contains("incumbent v1 leg"),
+        "the non-p3 fs build must keep the incumbent route:\n{log}"
+    );
+}
+
+#[test]
 fn p3_component_abort_answers_exit_one() {
     if Command::new(almide_bin()).arg("--version").output().is_err() {
         return;

--- a/tests/component_p3_test.rs
+++ b/tests/component_p3_test.rs
@@ -497,6 +497,65 @@ fn p3_component_fan_any_cancels_the_losers() {
     assert_eq!(code, 0, "a leaked loser subtask would trap at task exit");
 }
 
+// The filesystem WRITE surface (#1628 increment 2d): recursive mkdir_p
+// (create-directory-at per prefix, exist idempotent), write (truncate) /
+// append / write_bytes (slot packing) through write-via-stream with the
+// completion-future durability handshake, remove / remove_all via
+// stat-then-unlink-or-rmdir, and the missing-parent error leg — all
+// byte-identical to the incumbent adapter leg.
+const FS_WRITE: &str = r#"import fs
+
+effect fn main() -> Unit = {
+  let _ = fs.mkdir_p("wtmp/deep/nest")!
+  let _ = fs.write("wtmp/deep/nest/x.txt", "written-body")!
+  let _ = fs.append("wtmp/deep/nest/x.txt", "+tail")!
+  println(fs.read_text("wtmp/deep/nest/x.txt")!)
+  let _ = fs.write_bytes("wtmp/deep/nest/b.bin", [72, 73, 10])!
+  println(fs.read_text("wtmp/deep/nest/b.bin")!)
+  let _ = fs.remove("wtmp/deep/nest/x.txt")!
+  let _ = fs.remove("wtmp/deep/nest/b.bin")!
+  let _ = fs.remove("wtmp/deep/nest")!
+  let _ = fs.remove_all("wtmp/deep")!
+  println(if fs.exists("wtmp/deep") then "BAD-still-there" else "cleaned")
+  match fs.write("wtmp/deep/nope.txt", "x") {
+    ok(_)  => println("BAD-ghost-dir"),
+    err(m) => println("werr=${m}"),
+  }
+  let _ = fs.remove("wtmp")!
+}
+"#;
+
+#[test]
+fn p3_component_writes_the_filesystem() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    let d = dir().join("fswrite");
+    std::fs::create_dir_all(&d).expect("mkdir");
+    let src = d.join("wr.almd");
+    std::fs::write(&src, FS_WRITE).expect("write");
+    let p3 = d.join("wr_p3.wasm");
+    build_p3_structural(&src, &p3);
+    if !wasmtime_available() {
+        return;
+    }
+    let Some((out, err, code)) = run_p3_dir(&p3, &d) else {
+        return;
+    };
+    assert_eq!(
+        out,
+        "written-body+tail
+HI
+
+cleaned
+werr=No such file or directory (os error 2)
+",
+        "fs write surface diverged (stderr: {err})"
+    );
+    assert_eq!(code, 0);
+    assert!(!d.join("wtmp").exists(), "the fixture must clean up after itself");
+}
+
 #[test]
 fn p3_component_abort_answers_exit_one() {
     if Command::new(almide_bin()).arg("--version").output().is_err() {


### PR DESCRIPTION
#1628 stage 2, increment 2d — the write half of the fs surface, the prerequisite the route flip (#1584) and #1663's original scope note both named.

**What lights up on the direct WASI 0.3 component** (`ALMIDE_COMPONENT_P3=1`):
- `fs.write` / `fs.write_bytes` (List[Int] slot packing in-guest) / `fs.append` → `open-at` (create|truncate / create) + `write-via-stream` / `append-via-stream`: the guest keeps the writable end, feeds it with sync `stream.write`, drops it, and **`future.read` on the completion future is the durability handshake** — return implies every byte reached the host, the same doctrine as stdio's drain.
- `fs.mkdir_p` → `create-directory-at` per `/`-prefix, `exist` idempotent (the `create_dir_all` shape); the full path's real error surfaces through the shared WIT-derived map.
- `fs.remove` / `fs.remove_all` → `stat-at` routes file vs directory to `unlink-file-at` / `remove-directory-at` (the embedded host's `is_dir()` shape). A NON-empty `remove_all` answers the honest `not-empty` error — the recursive walk is a later increment, documented, not a refusal.
- Missing-parent write errs with the native `io::Error` string.

**ABI discipline** (the #1661 doctrine, applied and once again load-bearing): the new `result<_, error-code>` payload offset and the `exist` discriminant are WIT-derived (`FsAbi.unit_payload`, `ec_exist`) — the first draft hand-guessed offset 1 where the canonical answer is align(error-code)=4, and the sig for `write-via-stream` (future returns DIRECTLY, no retptr — wit-parser's 1-flat-result rule) was caught by wit-component's own world-decode refusal, exactly the loud failure the derive-not-hand-count policy is for.

**Evidence**: the full write→read-back→remove round-trip byte-identical native / p3 / incumbent adapter (A/B diffed); `p3_component_writes_the_filesystem` pins it with the missing-parent error leg and asserts fixture self-cleanup; `component_p3_test` 7/7.

---

**Second commit — the first default-route slice of #1584's flip**: with `ALMIDE_COMPONENT_P3=1` set, an fs program's BUILD now takes the structural leg by default (no `ALMIDE_WASM_STRUCTURAL` override) — the p3 shim carries the full fs read+write surface this PR completes, so the reroute reason is gone for that destination. Non-p3 fs builds keep the incumbent (the p1/p2 transforms carry no fs ops — that port is the flip's remaining rock), and env/process stay incumbent everywhere. `p3_requested_fs_builds_route_structurally_by_default` pins both directions; `component_p3_test` 8/8, `almide test` 422/422, `wasm_runtime_test` 79/79.
