### PR TITLE
The availability matrix reaches check time: E081 names the both-legs walls with reasons and alternatives

### DIFF
--- a/crates/almide-wasm/src/calls.rs
+++ b/crates/almide-wasm/src/calls.rs
@@ -677,17 +677,7 @@ impl Emitter<'_> {
             CallTarget::Module { module, func, .. }
                 if module.as_str() == "string" && func.as_str() == "split" && args.len() == 2 =>
             {
-                self.lower(&args[0], Some(STR))?;
-                let h = self.hold_i32()?;
-                self.f.instructions().local_set(h);
-                self.lower(&args[1], Some(STR))?;
-                let hs = self.hold_i32()?;
-                self.f.instructions().local_set(hs);
-                let sp = self.work.helper(Helper::StringSplit);
-                self.f.instructions().local_get(h).local_get(hs).call(sp);
-                self.release_i32();
-                self.release_i32();
-                Ok(Some(SliceTy::List(self.types.intern(STR))))
+                self.lower_string_split(&args[0], &args[1])
             }
             _ => self.lower_module_call_c(target, args, tail, ret_hint),
         }

--- a/crates/almide-wasm/src/calls.rs
+++ b/crates/almide-wasm/src/calls.rs
@@ -657,6 +657,14 @@ impl Emitter<'_> {
                 }
                 unsup(&format!("call:{module}.{func}"))
             }
+            // #1423 stage 4: the error trio — semantics verbatim from
+            // runtime/rs/src/error.rs.
+            CallTarget::Module { module, func, .. } if module.as_str() == "error" => {
+                if let Some(out) = self.lower_error_call(func.as_str(), args)? {
+                    return Ok(out);
+                }
+                unsup(&format!("call:error.{func}"))
+            }
             CallTarget::Module { module, func, .. } if module.as_str() == "value" => {
                 if let Some(out) = self.lower_value_call(func.as_str(), args)? {
                     return Ok(out);

--- a/crates/almide-wasm/src/collections.rs
+++ b/crates/almide-wasm/src/collections.rs
@@ -135,6 +135,16 @@ impl Emitter<'_> {
                     .i64_extend_i32_u();
                 Ok(Some(INT))
             }
+            // #1423 stage 4: is_empty = the len slot at zero — stride-free
+            // (0 entries is 0 bytes whatever the entry layout), semantics
+            // verbatim from stdlib/map_core.almd's load32(handle+4) == 0.
+            ("is_empty", [m]) => {
+                if !matches!(self.lower(m, None)?, SliceTy::Map(..)) {
+                    return unsup("map-op-of:non-map");
+                }
+                self.f.instructions().i32_load(len_memarg()).i32_eqz();
+                Ok(Some(BOOL))
+            }
             ("contains", [m, key]) => {
                 let (_mh, _kh, eh, k, ..) = self.map_scan(m, key)?;
                 self.f.instructions().local_get(eh).i32_const(0).i32_ne();

--- a/crates/almide-wasm/src/collections.rs
+++ b/crates/almide-wasm/src/collections.rs
@@ -280,6 +280,7 @@ impl Emitter<'_> {
             ("update", [m, key, cb]) => self.lower_map_update(m, key, cb),
             ("upsert", [m, key, init, cb]) => self.lower_map_upsert(m, key, init, cb),
             ("filter", [m, cb]) => self.lower_map_filter(m, cb),
+            ("all" | "any" | "count", [m, cb]) => self.lower_map_pred(func, m, cb),
             ("map", [m, cb]) => self.lower_map_map(m, cb),
             ("merge", [a, b]) => self.lower_map_merge(a, b),
             // Functional remove: the map minus the entry (a plain copy

--- a/crates/almide-wasm/src/collections_hof.rs
+++ b/crates/almide-wasm/src/collections_hof.rs
@@ -127,6 +127,73 @@ impl Emitter<'_> {
         Ok(Some(SliceTy::Map(self.types.intern(k), self.types.intern(v))))
     }
 
+    /// #1423 stage 4 — the map predicate family: all / any (early-exit
+    /// Bool) and count (a matching-entry counter), the filter loop's
+    /// (k, v) callback protocol without the output map.
+    pub(crate) fn lower_map_pred(
+        &mut self,
+        func: &str,
+        m: &IrExpr,
+        cb: &IrExpr,
+    ) -> Result<Option<SliceTy>, EmitError> {
+        let (params, body) = self.hof_lambda(cb, 2)?;
+        let (mh, k, v) = self.map_hof_open(m)?;
+        let (koff, voff, esz) = entry_layout(k, v);
+        let hcur = self.hold_i32()?;
+        let hend = self.hold_i32()?;
+        let hr = self.hold_i32()?;
+        let count = func == "count";
+        {
+            let mut i = self.f.instructions();
+            // all starts true; any starts false; count starts 0.
+            i.i32_const(if func == "all" { 1 } else { 0 }).local_set(hr);
+            i.local_get(mh).i32_const(almide_layout::PAYLOAD as i32).i32_add().local_set(hcur);
+            i.local_get(hcur).local_get(mh).i32_load(len_memarg()).i32_add().local_set(hend);
+            i.block(BlockType::Empty).loop_(BlockType::Empty);
+            i.local_get(hcur).local_get(hend).i32_ge_u().br_if(1);
+            i.local_get(hcur).i32_const(koff as i32).i32_add();
+        }
+        self.load_ty_slot_at(k);
+        self.f.instructions().local_set(params[0]);
+        self.f.instructions().local_get(hcur).i32_const(voff as i32).i32_add();
+        self.load_ty_slot_at(v);
+        self.f.instructions().local_set(params[1]);
+        self.lower(body, Some(BOOL))?;
+        {
+            let mut i = self.f.instructions();
+            match func {
+                "all" => {
+                    // a false verdict decides — flip and break.
+                    i.i32_eqz().if_(BlockType::Empty);
+                    i.i32_const(0).local_set(hr);
+                    i.br(2);
+                    i.end();
+                }
+                "any" => {
+                    i.if_(BlockType::Empty);
+                    i.i32_const(1).local_set(hr);
+                    i.br(2);
+                    i.end();
+                }
+                _ => {
+                    i.if_(BlockType::Empty);
+                    i.local_get(hr).i32_const(1).i32_add().local_set(hr);
+                    i.end();
+                }
+            }
+            i.local_get(hcur).i32_const(esz as i32).i32_add().local_set(hcur);
+            i.br(0).end().end();
+            i.local_get(hr);
+            if count {
+                i.i64_extend_i32_u();
+            }
+        }
+        for _ in 0..4 {
+            self.release_i32();
+        }
+        Ok(Some(if count { INT } else { BOOL }))
+    }
+
     /// Value transform (the 1-arg surface): keys copy, the value slot
     /// takes the callback's result — the OUT entry layout re-packs for
     /// the new value type.

--- a/crates/almide-wasm/src/collections_set.rs
+++ b/crates/almide-wasm/src/collections_set.rs
@@ -449,6 +449,14 @@ impl Emitter<'_> {
                     .i64_extend_i32_u();
                 Ok(Some(INT))
             }
+            // #1423 stage 4: is_empty = the len slot at zero (stride-free).
+            ("is_empty", [s]) => {
+                if !matches!(self.lower(s, None)?, SliceTy::Set(..)) {
+                    return unsup("set-op-of:non-set");
+                }
+                self.f.instructions().i32_load(len_memarg()).i32_eqz();
+                Ok(Some(BOOL))
+            }
             ("to_list", [s]) => {
                 // Layout-identical; sharing the base is unobservable
                 // (no in-place list/set mutation exists, binds deep-copy).

--- a/crates/almide-wasm/src/collections_set.rs
+++ b/crates/almide-wasm/src/collections_set.rs
@@ -33,6 +33,10 @@ impl Emitter<'_> {
             ("symmetric_difference", [a, b]) => self.lower_set_symdiff(a, b),
             // Transform + first-seen dedup (a set stays a set).
             ("map", [s, cb]) => self.lower_set_hof_map(s, cb),
+            // #1423 stage 4: all/any — the list machinery applies
+            // verbatim (hof_loop_open accepts Set; Bool result).
+            ("all", [s, cb]) => self.lower_list_all(s, cb),
+            ("any", [s, cb]) => self.lower_list_any(s, cb),
             _ => self.lower_set_call_b(func, args, ret_hint),
         }
     }

--- a/crates/almide-wasm/src/list.rs
+++ b/crates/almide-wasm/src/list.rs
@@ -30,7 +30,7 @@ impl Emitter<'_> {
             | "flatten" | "unique" | "enumerate", [xs]) => {
                 self.lower_list_unary_named(func, xs)
             }
-            ("get" | "join" | "find" | "contains" | "index_of" | "intersperse"
+            ("get" | "join" | "find" | "find_index" | "contains" | "index_of" | "intersperse"
             | "zip" | "map" | "filter" | "any" | "all" | "count" | "take_while"
             | "drop_while" | "reduce" | "flat_map" | "filter_map" | "binary_search"
             | "window" | "unique_by" | "group_by", [a, b]) => {
@@ -291,6 +291,39 @@ impl Emitter<'_> {
         Ok(Some(SliceTy::Option(self.types.intern(elem))))
     }
 
+    fn lower_list_find_index(
+        &mut self,
+        xs: &IrExpr,
+        cb: &IrExpr,
+    ) -> Result<Option<SliceTy>, EmitError> {
+        let (params, body) = self.hof_lambda(cb, 1)?;
+        let (elem, bh, ch, ih) = self.hof_loop_open(xs)?;
+        let rh = self.hold_i32()?;
+        self.f.instructions().i32_const(0).local_set(rh);
+        self.f.instructions().block(BlockType::Empty).loop_(BlockType::Empty);
+        self.hof_elem_into(elem, bh, ch, ih, params[0]);
+        self.lower(body, Some(BOOL))?;
+        self.f.instructions().if_(BlockType::Empty);
+        // some(i): the first match's INDEX, then break the scan.
+        self.f
+            .instructions()
+            .i32_const(8)
+            .call(F_ALLOC)
+            .local_tee(rh)
+            .local_get(ih)
+            .i64_extend_i32_u();
+        self.store_ty_slot(INT, almide_layout::OPTION_FIELD);
+        self.f.instructions().br(2);
+        self.f.instructions().end();
+        self.hof_step(ih);
+        self.f.instructions().local_get(rh);
+        self.release_i32();
+        self.release_i32();
+        self.release_i32();
+        self.release_i32();
+        Ok(Some(SliceTy::Option(self.types.intern(INT))))
+    }
+
     fn lower_list_contains(&mut self, xs: &IrExpr, x: &IrExpr) -> Result<Option<SliceTy>, EmitError> {
         let got = self.lower_list_index_of(xs, x)?;
         let _ = got;
@@ -407,6 +440,9 @@ impl Emitter<'_> {
             "get" => self.lower_list_get_arm(a, b),
             "join" => self.lower_list_join_arm(a, b),
             "find" => self.lower_list_find(a, b),
+            // #1423 stage 4: the index sibling — the same first-match
+            // scan, the some payload is the INDEX (an Int slot).
+            "find_index" => self.lower_list_find_index(a, b),
             "contains" => self.lower_list_contains(a, b),
             "index_of" => self.lower_list_index_of(a, b),
             "intersperse" => self.lower_list_intersperse(a, b),

--- a/crates/almide-wasm/src/scalar_ext.rs
+++ b/crates/almide-wasm/src/scalar_ext.rs
@@ -87,7 +87,8 @@ impl Emitter<'_> {
                 self.f.instructions().f64_convert_i64_s();
                 Some(FLOAT)
             }
-            ("int", "band" | "bor" | "bxor" | "bshl" | "bshr" | "wrap_add" | "wrap_mul", _) => {
+            ("int", "band" | "bor" | "bxor" | "bshl" | "bshr" | "wrap_add" | "wrap_mul"
+                | "bnot" | "to_u32" | "to_u8", _) => {
                 return self.lower_int_bitops(func.as_str(), args).map(Some);
             }
             // f64.ceil is IEEE-exact on both targets.
@@ -274,6 +275,25 @@ impl Emitter<'_> {
                     "bshl" => i.i64_shl(),
                     _ => i.i64_shr_s(),
                 };
+                Ok(Some(INT))
+            }
+            // #1423 stage 4: the pure bit family's unary/masking trio —
+            // semantics verbatim from stdlib/int_wrap.almd (`bnot(n) =
+            // bxor(n, -1)`, `to_u32(n) = n & 0xFFFFFFFF`, `to_u8(n) =
+            // n & 0xFF`, low bits zero-extended).
+            ("bnot", [a]) => {
+                self.lower(a, Some(INT))?;
+                self.f.instructions().i64_const(-1).i64_xor();
+                Ok(Some(INT))
+            }
+            ("to_u32", [a]) => {
+                self.lower(a, Some(INT))?;
+                self.f.instructions().i64_const(0xFFFF_FFFF).i64_and();
+                Ok(Some(INT))
+            }
+            ("to_u8", [a]) => {
+                self.lower(a, Some(INT))?;
+                self.f.instructions().i64_const(0xFF).i64_and();
                 Ok(Some(INT))
             }
             ("wrap_add" | "wrap_mul", [a, b, bits]) => {

--- a/crates/almide-wasm/src/string_ext.rs
+++ b/crates/almide-wasm/src/string_ext.rs
@@ -460,3 +460,25 @@ impl Emitter<'_> {
         Ok(Some(Some(out)))
     }
 }
+
+impl Emitter<'_> {
+    /// `string.split` — the split helper call (moved verbatim out of the
+    /// calls.rs dispatch for the 800-line file cap).
+    pub(crate) fn lower_string_split(
+        &mut self,
+        subject: &IrExpr,
+        sep: &IrExpr,
+    ) -> Result<Option<SliceTy>, EmitError> {
+        self.lower(subject, Some(STR))?;
+        let h = self.hold_i32()?;
+        self.f.instructions().local_set(h);
+        self.lower(sep, Some(STR))?;
+        let hs = self.hold_i32()?;
+        self.f.instructions().local_set(hs);
+        let sp = self.work.helper(Helper::StringSplit);
+        self.f.instructions().local_get(h).local_get(hs).call(sp);
+        self.release_i32();
+        self.release_i32();
+        Ok(Some(SliceTy::List(self.types.intern(STR))))
+    }
+}

--- a/crates/almide-wasm/src/string_ext.rs
+++ b/crates/almide-wasm/src/string_ext.rs
@@ -368,3 +368,95 @@ impl Emitter<'_> {
         .map(Some)
     }
 }
+
+impl Emitter<'_> {
+    /// #1423 stage 4 — the `error` module trio, semantics verbatim from
+    /// runtime/rs/src/error.rs:
+    ///   message(r)      = err payload, or "" on ok
+    ///   context(r, msg) = ok passes through; err rebuilds as
+    ///                     "{msg}: {e}"
+    ///   chain(outer, c) = "{outer}\ncaused by: {c}"
+    /// Ok(None) = not an error-module fn handled here.
+    pub(crate) fn lower_error_call(
+        &mut self,
+        func: &str,
+        args: &[IrExpr],
+    ) -> Result<Option<Option<SliceTy>>, EmitError> {
+        let out: SliceTy = match (func, args) {
+            ("message", [r]) => {
+                let got = self.lower(r, None)?;
+                let SliceTy::Result(_, er) = got else {
+                    return unsup(&format!("error-message-of:{got:?}"));
+                };
+                if self.types.el(er) != STR {
+                    return unsup("error-message-err-ty");
+                }
+                let hr = self.hold_i32()?;
+                let empty = self.pool.intern("");
+                let mut i = self.f.instructions();
+                i.local_tee(hr)
+                    .i32_load(slot_memarg(almide_layout::SUM_TAG))
+                    .i32_eqz()
+                    .if_(BlockType::Result(ValType::I32));
+                i.i32_const(empty as i32);
+                i.else_();
+                i.local_get(hr).i32_load(slot_memarg(almide_layout::SUM_FIELD));
+                i.end();
+                let _ = i;
+                self.release_i32();
+                STR
+            }
+            ("context", [r, msg]) => {
+                let got = self.lower(r, None)?;
+                let SliceTy::Result(ok_h, er) = got else {
+                    return unsup(&format!("error-context-of:{got:?}"));
+                };
+                if self.types.el(er) != STR {
+                    return unsup("error-context-err-ty");
+                }
+                let hr = self.hold_i32()?;
+                self.f.instructions().local_set(hr);
+                self.lower(msg, Some(STR))?;
+                let hm = self.hold_i32()?;
+                let sep = self.pool.intern(": ");
+                let hout = self.hold_i32()?;
+                let mut i = self.f.instructions();
+                i.local_set(hm);
+                i.local_get(hr)
+                    .i32_load(slot_memarg(almide_layout::SUM_TAG))
+                    .i32_eqz()
+                    .if_(BlockType::Result(ValType::I32));
+                // ok: pass the Result through untouched.
+                i.local_get(hr);
+                i.else_();
+                // err: "{msg}: {e}" in a fresh err block.
+                i.local_get(hm).i32_const(sep as i32).call(F_CONCAT);
+                i.local_get(hr).i32_load(slot_memarg(almide_layout::SUM_FIELD));
+                i.call(F_CONCAT).local_set(hm);
+                i.i32_const(16)
+                    .call(F_ALLOC)
+                    .local_tee(hout)
+                    .i32_const(1)
+                    .i32_store(slot_memarg(almide_layout::SUM_TAG));
+                i.local_get(hout).local_get(hm).i32_store(slot_memarg(almide_layout::SUM_FIELD));
+                i.local_get(hout);
+                i.end();
+                let _ = i;
+                self.release_i32();
+                self.release_i32();
+                self.release_i32();
+                SliceTy::Result(ok_h, er)
+            }
+            ("chain", [outer, cause]) => {
+                self.lower(outer, Some(STR))?;
+                let sep = self.pool.intern("\ncaused by: ");
+                self.f.instructions().i32_const(sep as i32).call(F_CONCAT);
+                self.lower(cause, Some(STR))?;
+                self.f.instructions().call(F_CONCAT);
+                STR
+            }
+            _ => return Ok(None),
+        };
+        Ok(Some(Some(out)))
+    }
+}

--- a/docs/diagnostics/E081.md
+++ b/docs/diagnostics/E081.md
@@ -1,0 +1,30 @@
+# E081 — the function is not available on --target wasm
+
+The call names a stdlib function that **no wasm leg serves today** — the
+declared both-legs wall set in `proofs/target-availability.toml` (#1423),
+which CI re-measures every run with the renderer's own verdict, both
+directions (a new wall must be declared; a row that starts building must
+be deleted).
+
+Before this diagnostic the failure arrived as a late, generic render wall
+("this program shape is not yet supported"); E081 arrives at check time
+and names the reason:
+
+```text
+error[E081]: `http.get` is not available on --target wasm
+  reason: no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)
+```
+
+Where a portable alternative exists, the diagnostic names it (`try:` line
+— e.g. `testing.assert_gt` → `assert(a > b)`); the availability matrix
+row carries it.
+
+The same program always builds with `--target rust`.
+
+## Fix-it verdict
+
+**not-fixable** — the fix is a platform decision (run natively, use the
+named alternative, or wait for the port), not a rewrite an unattended
+fixer may apply. (`mechanical` = an unattended fixer may apply the
+rewrite; `conditional` = a suggested fix needs review; `not-fixable` = no
+automatic rewrite exists. #1486's applicability doctrine.)

--- a/llms.txt
+++ b/llms.txt
@@ -263,6 +263,7 @@ let root_i = float.to_int(root_f)    // truncating
 | E077 | `@bounded`: Float arithmetic or comparison (provisional rule) | Keep to Int arithmetic; Float values may be held and passed (ALS-B10) |
 | E078 | `@bounded`: `!` propagation or `guard` inside a counted loop | Propagate or guard outside the loop; default with `??` inside (ALS-B11) |
 | E080 | An or-pattern alternative binds a variable (`some(n) \| none`) — the body cannot depend on which alternative matched | Write separate arms when the body needs the payload, or use `_` inside the alternative |
+| E081 | The called stdlib fn is not available on `--target wasm` (the declared both-legs wall set, `proofs/target-availability.toml`) | Run natively, use the named portable alternative from the `try:` line, or wait for the port the reason names |
 | E040 | Retired json.*/value.* alias — the dynamic surface has one name per operation: `value.*` is the data model, `json.*` the format (parse/stringify) | Use the named `value.*` survivor (`json.as_int(v)` → `value.as_int(v)?`, `json.get` → `value.field(v,k)?`, `value.get` → `value.field`), or run `almide fix <file>` |
 | E420 | Function visibility violation (callee is private) | Make the callee public, or add a public shim |
 

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -37,7 +37,7 @@ evidence = "#1628 stage-4 landing (2026-08-28): policy crate_major hand-flipped 
 [[gate]]
 path = "scripts/check-target-availability.sh"
 class = "NEGATIVE_TESTED"
-evidence = "#1423 stage-2 landing (2026-08-28): a declared row hand-renamed (int.bnot -> int.bnot_GONE) went red in BOTH directions at once — the measured wall named as UNDECLARED, restored green (323 lower / 66 declared / pending-self-host ratchet 31 both-way). The gate re-measures the whole surface per run with the renderer's own verdict (tools/target_availability_probe.py, ALMIDE_WASM_STRUCTURAL=1 hard-wall probe per public stdlib fn), so neither a silent new wall nor a stale row survives; name-diff false positives are structurally impossible (the ~199-row over-report experiment is the design's reason)."
+evidence = "#1423 stage-2+3 landing (2026-08-28): a declared row hand-renamed (int.bnot -> int.bnot_GONE) went red in BOTH directions at once — the measured wall named as UNDECLARED, restored green. Stage 3 doubled the sweep: the DEFAULT-routing measurement diffs against the [[wasm-unavailable]] table the E081 check-time diagnostic consumes (four directions total: 323 lower / 66 native-only / 31 ratchet / 34 both-legs). The gate re-measures the whole surface per run with the renderer's own verdict (tools/target_availability_probe.py, ALMIDE_WASM_STRUCTURAL=1 hard-wall probe per public stdlib fn), so neither a silent new wall nor a stale row survives; name-diff false positives are structurally impossible (the ~199-row over-report experiment is the design's reason)."
 
 [[gate]]
 path = "scripts/check-contracts.sh"

--- a/proofs/target-availability.toml
+++ b/proofs/target-availability.toml
@@ -24,8 +24,8 @@
 # minimal call the probe cannot yet type (nominal runtime types, residual
 # generator gaps). Claimed neither way; shrinking it is probe work.
 
-# Measured (this generation): structural 338 ok / 51 native-only; default-routing 25 wasm-unavailable; 39 unsynthesizable.
-pending_self_host_ceiling = 18
+# Measured (this generation): structural 339 ok / 50 native-only; default-routing 25 wasm-unavailable; 39 unsynthesizable.
+pending_self_host_ceiling = 17
 
 [[native-only]]
 fn = "datetime.parse_iso"
@@ -139,11 +139,6 @@ issue = "#1423"
 
 [[native-only]]
 fn = "json.to_map"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "list.find_index"
 reason = "pending-self-host"
 issue = "#1423"
 

--- a/proofs/target-availability.toml
+++ b/proofs/target-availability.toml
@@ -24,7 +24,7 @@
 # minimal call the probe cannot yet type (nominal runtime types, residual
 # generator gaps). Claimed neither way; shrinking it is probe work.
 
-# Measured (this generation): structural 339 ok / 50 native-only; default-routing 25 wasm-unavailable; 39 unsynthesizable.
+# Measured (this generation): structural 339 ok / 50 native-only; default-routing 24 wasm-unavailable; 39 unsynthesizable.
 pending_self_host_ceiling = 17
 
 [[native-only]]
@@ -293,11 +293,6 @@ issue = "#1423"
 
 [[wasm-unavailable]]
 fn = "fs.fold_lines_range"
-reason = "the streaming-callback reader has no wasm lowering yet (read_text / read_lines work)"
-issue = "#1423"
-
-[[wasm-unavailable]]
-fn = "fs.for_each_line"
 reason = "the streaming-callback reader has no wasm lowering yet (read_text / read_lines work)"
 issue = "#1423"
 

--- a/proofs/target-availability.toml
+++ b/proofs/target-availability.toml
@@ -24,8 +24,8 @@
 # minimal call the probe cannot yet type (nominal runtime types, residual
 # generator gaps). Claimed neither way; shrinking it is probe work.
 
-# Measured (this generation): structural 325 ok / 64 native-only; default-routing 25 wasm-unavailable; 39 unsynthesizable.
-pending_self_host_ceiling = 31
+# Measured (this generation): structural 330 ok / 59 native-only; default-routing 25 wasm-unavailable; 39 unsynthesizable.
+pending_self_host_ceiling = 26
 
 [[native-only]]
 fn = "datetime.parse_iso"
@@ -153,21 +153,6 @@ reason = "host-surface"
 issue = "#1423"
 
 [[native-only]]
-fn = "int.bnot"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "int.to_u32"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "int.to_u8"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
 fn = "json.to_map"
 reason = "pending-self-host"
 issue = "#1423"
@@ -204,11 +189,6 @@ issue = "#1423"
 
 [[native-only]]
 fn = "map.delete"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "map.is_empty"
 reason = "pending-self-host"
 issue = "#1423"
 
@@ -299,11 +279,6 @@ issue = "#1423"
 
 [[native-only]]
 fn = "set.any"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "set.is_empty"
 reason = "pending-self-host"
 issue = "#1423"
 

--- a/proofs/target-availability.toml
+++ b/proofs/target-availability.toml
@@ -1,29 +1,30 @@
-# The target-availability matrix (#1423 stage 2): the DECLARED single-leg
-# stdlib surface, diffed bidirectionally against the measured reality by
-# scripts/check-target-availability.sh (CI). Measurement = the renderer's
-# own verdict: tools/target_availability_probe.py synthesizes a minimal
-# well-typed call per public stdlib fn (the docs/stdlib signature indexes)
-# and attempts the STRUCTURAL wasm lowering under ALMIDE_WASM_STRUCTURAL=1.
+# The target-availability matrix (#1423 stages 2+3): the DECLARED
+# single-leg stdlib surface, diffed bidirectionally against the measured
+# reality by scripts/check-target-availability.sh (CI). Measurement = the
+# renderer's own verdict: tools/target_availability_probe.py synthesizes
+# a minimal REAL-SHAPED call per public stdlib fn (mid-body, statement
+# position for Unit returns — a one-call main measures program-shape
+# support, not the fn: the process.exit lesson) and attempts the wasm
+# build; the STRUCTURAL sweep forces that leg, the DEFAULT-routing sweep
+# includes the incumbent reroute. Both sweeps run with
+# ALMIDE_NO_AVAIL_CHECK=1 — the ground truth, never our own declaration.
 #
-# Row discipline (the rustc tier-check rule): every measured wall MUST have
-# a row here (a new wall without a declaration fails CI), and every row
-# here MUST still measure as a wall (a fn that starts lowering makes its
-# row STALE — delete it in the same PR, the shrink direction). A row
-# without a reason fails. Reasons:
-#   host-surface      the module has no structural host binding yet
-#                     (env/process/testing/random/http/io — the embedded
-#                     almide.* surface and the p1/p2/p3 shims do not carry
-#                     it); the incumbent leg serves these today.
-#   pending-self-host the fn needs a self-host body / registry link on the
-#                     structural leg (#1423 stage 4 burns these down; the
-#                     count is a SHRINK-ONLY ratchet).
+# Row discipline (the rustc tier-check rule): every measured wall MUST
+# have a row (a new wall without a declaration fails CI), every row MUST
+# still measure as a wall (a fn that starts building makes its row STALE
+# — delete it, the shrink direction), a reasonless row fails, and the
+# pending-self-host count is a both-way ratchet.
 #
-# The probe-unsynthesizable table is the honesty bucket: fns whose minimal
-# call the probe cannot yet type (nominal runtime types, residual generator
-# gaps). They are claimed NEITHER way; shrinking this list is probe work,
-# not renderer work.
+#   [[native-only]]       walls on the STRUCTURAL leg (the incumbent may
+#                         still serve it — informational for #1584).
+#   [[wasm-unavailable]]  walls under DEFAULT routing: NO leg builds it —
+#                         the E081 check-time-diagnostic set.
+#
+# The probe-unsynthesizable table is the honesty bucket: fns whose
+# minimal call the probe cannot yet type (nominal runtime types, residual
+# generator gaps). Claimed neither way; shrinking it is probe work.
 
-# Measured (this generation): 323 ok / 66 native-only / 39 unsynthesizable.
+# Measured (this generation): structural 325 ok / 64 native-only; default-routing 25 wasm-unavailable; 39 unsynthesizable.
 pending_self_host_ceiling = 31
 
 [[native-only]]
@@ -167,11 +168,6 @@ reason = "pending-self-host"
 issue = "#1423"
 
 [[native-only]]
-fn = "io.print"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
 fn = "json.to_map"
 reason = "pending-self-host"
 issue = "#1423"
@@ -253,11 +249,6 @@ issue = "#1423"
 
 [[native-only]]
 fn = "process.exec_with_stdin"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "process.exit"
 reason = "host-surface"
 issue = "#1423"
 
@@ -354,6 +345,137 @@ issue = "#1423"
 [[native-only]]
 fn = "value.to_snake_case"
 reason = "pending-self-host"
+issue = "#1423"
+
+# ── The BOTH-LEGS wall set (#1423 stage 3): a call to one of these on
+# `--target wasm` is a CHECK-TIME error (E081) naming the reason and,
+# where one exists, the portable alternative.
+
+[[wasm-unavailable]]
+fn = "env.set"
+reason = "mutating/timing env surface has no wasm binding (reads work)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "env.sleep_ms"
+reason = "mutating/timing env surface has no wasm binding (reads work)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "fs.fold_lines_range"
+reason = "the streaming-callback reader has no wasm lowering yet (read_text / read_lines work)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "fs.for_each_line"
+reason = "the streaming-callback reader has no wasm lowering yet (read_text / read_lines work)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "http.delete"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "http.get"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "http.get_bytes"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "http.patch"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "http.post"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "http.put"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "http.request"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "http.request_bytes"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "json.to_map"
+reason = "no wasm lowering on either leg yet (pending-self-host)"
+alt = "walk with value.field / value.keys"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "process.env"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "process.exec"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "process.exec_in"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "process.exec_status"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "process.exec_status_timeout"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "process.exec_with_stdin"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "process.is_alive"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "process.kill"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "process.pid"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "process.spawn"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "process.stdin_lines"
+reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+issue = "#1423"
+
+[[wasm-unavailable]]
+fn = "testing.assert_throws"
+reason = "the assertion helper has no wasm lowering yet — the plain assert forms work"
+alt = "match on the err arm and assert"
 issue = "#1423"
 
 [[unsynthesizable]]

--- a/proofs/target-availability.toml
+++ b/proofs/target-availability.toml
@@ -24,8 +24,8 @@
 # minimal call the probe cannot yet type (nominal runtime types, residual
 # generator gaps). Claimed neither way; shrinking it is probe work.
 
-# Measured (this generation): structural 330 ok / 59 native-only; default-routing 25 wasm-unavailable; 39 unsynthesizable.
-pending_self_host_ceiling = 26
+# Measured (this generation): structural 333 ok / 56 native-only; default-routing 25 wasm-unavailable; 39 unsynthesizable.
+pending_self_host_ceiling = 23
 
 [[native-only]]
 fn = "datetime.parse_iso"
@@ -50,21 +50,6 @@ issue = "#1423"
 [[native-only]]
 fn = "env.unix_timestamp"
 reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "error.chain"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "error.context"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "error.message"
-reason = "pending-self-host"
 issue = "#1423"
 
 [[native-only]]

--- a/proofs/target-availability.toml
+++ b/proofs/target-availability.toml
@@ -24,8 +24,8 @@
 # minimal call the probe cannot yet type (nominal runtime types, residual
 # generator gaps). Claimed neither way; shrinking it is probe work.
 
-# Measured (this generation): structural 333 ok / 56 native-only; default-routing 25 wasm-unavailable; 39 unsynthesizable.
-pending_self_host_ceiling = 23
+# Measured (this generation): structural 338 ok / 51 native-only; default-routing 25 wasm-unavailable; 39 unsynthesizable.
+pending_self_host_ceiling = 18
 
 [[native-only]]
 fn = "datetime.parse_iso"
@@ -153,22 +153,7 @@ reason = "pending-self-host"
 issue = "#1423"
 
 [[native-only]]
-fn = "map.all"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "map.any"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
 fn = "map.clear"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "map.count"
 reason = "pending-self-host"
 issue = "#1423"
 
@@ -255,16 +240,6 @@ issue = "#1423"
 [[native-only]]
 fn = "random.shuffle"
 reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "set.all"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "set.any"
-reason = "pending-self-host"
 issue = "#1423"
 
 [[native-only]]

--- a/scripts/check-diagnostic-code-coverage.sh
+++ b/scripts/check-diagnostic-code-coverage.sh
@@ -22,7 +22,10 @@ export LC_ALL=C
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
-EXEMPT="E054 E033 E420"
+# E081 fires in the BUILD path (--target wasm availability, #1423) — the
+# check-harness fixture format cannot reach it; its pin is
+# tests/wasm_availability_e081_test.rs (the E054 precedent).
+EXEMPT="E054 E033 E420 E081"
 
 fail=0
 backlog=""

--- a/scripts/check-target-availability.sh
+++ b/scripts/check-target-availability.sh
@@ -30,12 +30,13 @@ command -v python3 >/dev/null 2>&1 || { echo "python3 missing"; exit 1; }
 
 tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
 ALMIDE="$ALMIDE" python3 tools/target_availability_probe.py > "$tmp/measured.tsv"
+ALMIDE="$ALMIDE" python3 tools/target_availability_probe.py --default-routing > "$tmp/measured-default.tsv"
 
-python3 - "$tmp/measured.tsv" proofs/target-availability.toml <<'PY'
+python3 - "$tmp/measured.tsv" proofs/target-availability.toml "$tmp/measured-default.tsv" <<'PY'
 import re
 import sys
 
-measured_path, toml_path = sys.argv[1], sys.argv[2]
+measured_path, toml_path, default_path = sys.argv[1], sys.argv[2], sys.argv[3]
 walls, oks = set(), set()
 for line in open(measured_path):
     status, fn, _ = line.rstrip("\n").split("\t", 2)
@@ -64,6 +65,25 @@ for fn in sorted(declared):
     if not reasons[fn]:
         print(f"::error::reasonless declaration: {fn}")
         fail = 1
+# The BOTH-LEGS set (#1423 stage 3): default-routing walls vs the
+# declared wasm-unavailable table, both directions.
+dwalls, doks = set(), set()
+for line in open(default_path):
+    status, fn, _ = line.rstrip("\n").split("\t", 2)
+    if status == "wall":
+        dwalls.add(fn)
+    elif status == "ok":
+        doks.add(fn)
+unavail = set()
+for block in re.findall(r"\[\[wasm-unavailable\]\]\n(?:[a-z]+ = .*\n)+", toml):
+    unavail.add(re.search(r'fn = "([^"]+)"', block).group(1))
+for fn in sorted(dwalls - unavail):
+    print(f"::error::walls under DEFAULT routing but not declared wasm-unavailable: {fn}")
+    fail = 1
+for fn in sorted(unavail & doks):
+    print(f"::error::declared wasm-unavailable but it BUILDS now: {fn} — delete the stale row (and its E081 reach)")
+    fail = 1
+
 pending = sum(1 for fn in declared if reasons.get(fn) == "pending-self-host")
 if pending > ceiling:
     print(f"::error::pending-self-host grew: {pending} > ceiling {ceiling} (the ratchet only shrinks)")
@@ -74,6 +94,7 @@ if pending < ceiling:
 
 if not fail:
     print(f"target-availability OK: {len(oks)} lower, {len(declared)} declared native-only "
-          f"(pending-self-host {pending}/{ceiling}), both directions agree.")
+          f"(pending-self-host {pending}/{ceiling}), {len(unavail)} wasm-unavailable "
+          f"(both-legs), all four directions agree.")
 sys.exit(fail)
 PY

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -654,7 +654,11 @@ fn check_wasm_availability(ir_program: &almide::ir::IrProgram) -> Result<(), ()>
     let table = UNAVAILABLE.get_or_init(|| {
         let toml = include_str!("../../proofs/target-availability.toml");
         let mut out = BTreeMap::new();
-        for block in toml.split("[[wasm-unavailable]]").skip(1) {
+        // Line-anchored: the header COMMENT names the section literally,
+        // and a bare substring split ate the first native-only row
+        // through it (datetime.parse_iso E081-fired while being merely
+        // structural-pending — the reachability ratchet caught it).
+        for block in toml.split("\n[[wasm-unavailable]]\n").skip(1) {
             let field = |k: &str| {
                 block.lines().find_map(|l| {
                     l.strip_prefix(&format!("{k} = \"")).and_then(|r| r.strip_suffix('"')).map(str::to_string)

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -635,6 +635,77 @@ fn verify_wasm_ir(ir_program: &almide::ir::IrProgram) -> Result<(), ()> {
 /// decomposition) have no WASM lowering. Reject at build time with a clear
 /// message rather than letting the emitter ICE deep in codegen. Extracted
 /// verbatim.
+/// #1423 stage 3 — the check-time availability diagnostic. The declared
+/// BOTH-LEGS wall set (proofs/target-availability.toml, measured with
+/// default routing and gated four-directionally by
+/// scripts/check-target-availability.sh) turns the late render wall into
+/// an E081 at check time, naming the reason and — where one exists — the
+/// portable alternative. The render wall stays as the backstop.
+fn check_wasm_availability(ir_program: &almide::ir::IrProgram) -> Result<(), ()> {
+    // The measurement escape: the availability PROBE builds through this
+    // binary to measure the ground truth the table declares — with the
+    // check armed it would measure its own declaration (circular).
+    if std::env::var_os("ALMIDE_NO_AVAIL_CHECK").is_some() {
+        return Ok(());
+    }
+    use std::collections::BTreeMap;
+    use std::sync::OnceLock;
+    static UNAVAILABLE: OnceLock<BTreeMap<String, (String, Option<String>)>> = OnceLock::new();
+    let table = UNAVAILABLE.get_or_init(|| {
+        let toml = include_str!("../../proofs/target-availability.toml");
+        let mut out = BTreeMap::new();
+        for block in toml.split("[[wasm-unavailable]]").skip(1) {
+            let field = |k: &str| {
+                block.lines().find_map(|l| {
+                    l.strip_prefix(&format!("{k} = \"")).and_then(|r| r.strip_suffix('"')).map(str::to_string)
+                })
+            };
+            if let (Some(fn_name), Some(reason)) = (field("fn"), field("reason")) {
+                out.insert(fn_name, (reason, field("alt")));
+            }
+        }
+        out
+    });
+    let mut hits: BTreeMap<String, &(String, Option<String>)> = BTreeMap::new();
+    use almide::ir::visit::IrVisitor;
+    struct Scan<'a> {
+        table: &'a BTreeMap<String, (String, Option<String>)>,
+        hits: BTreeMap<String, &'a (String, Option<String>)>,
+    }
+    impl<'a> IrVisitor for Scan<'a> {
+        fn visit_expr(&mut self, e: &almide::ir::IrExpr) {
+            if let almide::ir::IrExprKind::Call {
+                target: almide::ir::CallTarget::Module { module, func, .. }, ..
+            } = &e.kind
+            {
+                let key = format!("{}.{}", module.as_str(), func.as_str());
+                if let Some(row) = self.table.get(&key) {
+                    self.hits.entry(key).or_insert(row);
+                }
+            }
+            almide::ir::visit::walk_expr(self, e);
+        }
+    }
+    let mut scan = Scan { table, hits: BTreeMap::new() };
+    for f in ir_program.functions.iter().chain(ir_program.modules.iter().flat_map(|m| m.functions.iter())) {
+        scan.visit_expr(&f.body);
+    }
+    hits.extend(scan.hits);
+    if hits.is_empty() {
+        return Ok(());
+    }
+    for (key, (reason, alt)) in &hits {
+        let alt_line = alt.as_ref().map(|a| format!("\n  try: {a}")).unwrap_or_default();
+        err(&format!(
+            "error[E081]: `{key}` is not available on --target wasm\n  \
+             reason: {reason}{alt_line}\n  \
+             note: the availability matrix is proofs/target-availability.toml (#1423); \
+             the same program builds with --target rust"
+        ));
+    }
+    Err(())
+}
+
 fn check_no_native_only_matrix(ir_program: &almide::ir::IrProgram) -> Result<(), ()> {
     if let Some(op) = almide::codegen::program_uses_native_only_matrix_on_wasm(ir_program) {
         err(&format!(
@@ -891,6 +962,7 @@ pub(crate) fn compile_to_wasm_bytes(file: &str, allow_unverified: bool, verified
     let mut ir_program = lower_and_link_wasm_ir(&program, &mut checker, &mut resolved)?;
     verify_wasm_ir(&ir_program)?;
     check_no_native_only_matrix(&ir_program)?;
+    check_wasm_availability(&ir_program)?;
 
     // Routing inputs (see render_wasm_module_routed): project shape, decided
     // from what the v0 gates already computed — never from a failure.

--- a/src/cli/docs_gen.rs
+++ b/src/cli/docs_gen.rs
@@ -147,13 +147,17 @@ fn check_diagnostic_registry_bijection() -> Vec<String> {
 /// and false positives produce obvious error messages.
 fn collect_emitted_codes() -> Result<Vec<String>, String> {
     let mut codes = std::collections::BTreeSet::new();
-    walk_rs_files(Path::new("crates"), &mut |path, contents| {
+    let mut scan = |_path: &Path, contents: &str| {
         for mat in contents.match_indices("with_code(\"") {
             let start = mat.0 + "with_code(\"".len();
             let rest = &contents[start..];
             let end = rest.find('"').unwrap_or(0);
             if end == 0 { continue; }
             let code = &rest[..end];
+            if code.len() > 1 && !code[1..].bytes().all(|b| b.is_ascii_digit()) {
+                // Doc-comment placeholders (EXXX in this file's own docs).
+                continue;
+            }
             if looks_like_diag_code(code) {
                 codes.insert(code.to_string());
             } else if !code.is_empty() {
@@ -161,10 +165,26 @@ fn collect_emitted_codes() -> Result<Vec<String>, String> {
                 // codes; flag them but include so the bijection check
                 // can report them.
                 codes.insert(code.to_string());
-                let _ = path;
             }
         }
-    })?;
+        // CLI-path diagnostics print the code as a literal
+        // (`error[EXXX]:` — E081's build-time availability check); those
+        // are emitted codes too.
+        for mat in contents.match_indices("error[E") {
+            let start = mat.0 + "error[".len();
+            let rest = &contents[start..];
+            let end = rest.find(']').unwrap_or(0);
+            if end == 0 || end > 5 { continue; }
+            let code = &rest[..end];
+            if looks_like_diag_code(code)
+                && code[1..].bytes().all(|b| b.is_ascii_digit())
+            {
+                codes.insert(code.to_string());
+            }
+        }
+    };
+    walk_rs_files(Path::new("crates"), &mut scan)?;
+    walk_rs_files(Path::new("src"), &mut scan)?;
     Ok(codes.into_iter().collect())
 }
 

--- a/tests/wasm_availability_e081_test.rs
+++ b/tests/wasm_availability_e081_test.rs
@@ -1,0 +1,84 @@
+//! #1423 stage 3 — the check-time availability diagnostic (E081): a call
+//! to a declared BOTH-LEGS-wall fn on `--target wasm` errs at check time
+//! with the reason (and alternative where declared), instead of the late
+//! generic render wall. E081 fires only on the wasm target and lives in
+//! the BUILD path, so it is pinned here rather than through the
+//! check-harness fixtures (the E054 precedent).
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+const UNAVAILABLE: &str = r#"import http
+
+effect fn main() -> Unit = {
+  let r = http.get("https://example.com")!
+  println(r)
+}
+"#;
+
+const AVAILABLE: &str = r#"import fs
+
+effect fn main() -> Unit = {
+  println(if fs.exists("x") then "y" else "n")
+}
+"#;
+
+#[test]
+fn declared_unavailable_call_errs_at_check_time_with_the_reason() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    let d = std::env::temp_dir().join("almide-e081");
+    std::fs::create_dir_all(&d).expect("mkdir");
+    let src = d.join("net.almd");
+    std::fs::write(&src, UNAVAILABLE).expect("write");
+    let o = Command::new(almide_bin())
+        .args(["build", src.to_str().unwrap(), "--target", "wasm", "-o", "/dev/null"])
+        .output()
+        .expect("spawn");
+    let log = String::from_utf8_lossy(&o.stderr).to_string();
+    assert!(!o.status.success(), "the unavailable call must refuse:\n{log}");
+    assert!(log.contains("error[E081]"), "must carry the E081 code:\n{log}");
+    assert!(log.contains("`http.get` is not available on --target wasm"), "must name the fn:\n{log}");
+    assert!(log.contains("reason:"), "must carry the declared reason:\n{log}");
+    assert!(
+        log.contains("target-availability.toml"),
+        "must point at the availability matrix:\n{log}"
+    );
+
+    // The native target is untouched.
+    let o = Command::new(almide_bin())
+        .args(["check", src.to_str().unwrap()])
+        .output()
+        .expect("spawn");
+    assert!(o.status.success(), "the native check must stay clean");
+}
+
+#[test]
+fn available_fs_calls_stay_clean_on_wasm() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    let d = std::env::temp_dir().join("almide-e081");
+    std::fs::create_dir_all(&d).expect("mkdir");
+    let src = d.join("fsok.almd");
+    std::fs::write(&src, AVAILABLE).expect("write");
+    let o = Command::new(almide_bin())
+        .args(["build", src.to_str().unwrap(), "--target", "wasm", "-o", "/dev/null"])
+        .output()
+        .expect("spawn");
+    let log = String::from_utf8_lossy(&o.stderr).to_string();
+    assert!(o.status.success(), "an available program must build:\n{log}");
+    assert!(!log.contains("E081"), "no false E081:\n{log}");
+}

--- a/tools/target_availability_probe.py
+++ b/tools/target_availability_probe.py
@@ -9,6 +9,10 @@ Name-diffs over self_host_registry.rs over-report (~199 false rows — linkage
 is multi-mechanism); this probe cannot: it asks the one authority, the
 renderer itself.
 
+With --default-routing the sweep drops the structural force: walls then
+mean NO leg serves the fn on `--target wasm` (the reroute included) — the
+check-time-diagnostic set (#1423 stage 3).
+
 Output (stdout): one line per fn — `status<TAB>module.fn<TAB>detail`.
   ok        lowered and emitted
   wall      the structural leg refused (detail = first error line)
@@ -158,14 +162,26 @@ def synth(mod, fn, params, ret, variant):
         prelude = f"  var subj = {args[0]}\n"
         args = ["subj"] + args[1:]
     call = f"{mod}.{fn}({', '.join(args)})"
-    # Result-returning fns propagate; everything else binds discarded.
+    # Result-returning fns propagate; Unit-returning fns sit in STATEMENT
+    # position (a bare Unit call is legal and matches real usage);
+    # everything else binds discarded. The probe body opens with a print
+    # so the call sits MID-BODY — a single-call main measures the
+    # renderer's minimal-program shape support, not the fn (the
+    # process.exit lesson: the fn was served, the one-statement main was
+    # not, and the conflated wall row broke real programs through E081).
     is_result = ret.strip().startswith("Result[")
-    bind = "let _"
+    is_unit = ret.strip() == "Unit"
     if variant == 2:
         if not ret.strip().startswith("Map["):
             return None, "no-map-ret"
-        bind = "let _r: Map[Int, Int]"
-    body = f"{prelude}  {bind} = {call}{'!' if is_result else ''}\n  println(\"p\")"
+        stmt = f"let _r: Map[Int, Int] = {call}"
+    elif is_result:
+        stmt = f"let _ = {call}!"
+    elif is_unit:
+        stmt = call
+    else:
+        stmt = f"let _ = {call}"
+    body = f"  println(\"pre\")\n{prelude}  {stmt}\n  println(\"p\")"
     imp = f"import {mod}\n\n" if mod in EXPLICIT_IMPORT else ""
     return f"{imp}effect fn main() -> Unit = {{\n{body}\n}}\n", None
 
@@ -173,7 +189,14 @@ def synth(mod, fn, params, ret, variant):
 def main():
     sigs = parse_sigs()
     tmp = tempfile.mkdtemp(prefix="almide-avail-")
-    env = dict(os.environ, ALMIDE_WASM_STRUCTURAL="1")
+    if "--default-routing" in sys.argv[1:]:
+        env = dict(os.environ)
+        env.pop("ALMIDE_WASM_STRUCTURAL", None)
+    else:
+        env = dict(os.environ, ALMIDE_WASM_STRUCTURAL="1")
+    # Measure the ground truth, not our own declaration (see
+    # check_wasm_availability's escape).
+    env["ALMIDE_NO_AVAIL_CHECK"] = "1"
     for mod, fn, params, ret in sigs:
         verdict = None
         for variant in (0, 1, 2):

--- a/tools/target_availability_probe.py
+++ b/tools/target_availability_probe.py
@@ -141,6 +141,14 @@ def synth(mod, fn, params, ret, variant):
     variant 1: FIRST arg bound as a `var` (mut-param fns, E032).
     variant 2: the bind annotated `Map[Int, Int]` (generic-empty
                producers, E018) — only sensible for Map returns.
+    variant 3: EVERY arg hoisted into a `var` and passed by name — the
+               reachability sweep's repertoire (a var-bound callback
+               lowers where the inline lambda walls: the fs.for_each_line
+               lesson, where the weaker shape produced a false
+               wasm-unavailable row and E081 blocked a working fn).
+    variant 4: hoisted args AND the call as the FINAL statement (no
+               trailing print) — the same lesson's second half: the
+               postlude itself walls some shapes.
     """
     args, tys = [], []
     for p in split_top(params):
@@ -161,6 +169,11 @@ def synth(mod, fn, params, ret, variant):
             return None, "no-first-arg"
         prelude = f"  var subj = {args[0]}\n"
         args = ["subj"] + args[1:]
+    elif variant in (3, 4):
+        if not args:
+            return None, "no-args"
+        prelude = "".join(f"  var a{i} = {a}\n" for i, a in enumerate(args))
+        args = [f"a{i}" for i in range(len(args))]
     call = f"{mod}.{fn}({', '.join(args)})"
     # Result-returning fns propagate; Unit-returning fns sit in STATEMENT
     # position (a bare Unit call is legal and matches real usage);
@@ -181,7 +194,14 @@ def synth(mod, fn, params, ret, variant):
         stmt = call
     else:
         stmt = f"let _ = {call}"
-    body = f"  println(\"pre\")\n{prelude}  {stmt}\n  println(\"p\")"
+    if variant == 4:
+        # The final-statement form: a Result-returning effect call rides
+        # bare `call!` propagation (the sweep's shape-0 spelling).
+        if is_result:
+            stmt = f"{call}!"
+        body = f"{prelude}  {stmt}"
+    else:
+        body = f"  println(\"pre\")\n{prelude}  {stmt}\n  println(\"p\")"
     imp = f"import {mod}\n\n" if mod in EXPLICIT_IMPORT else ""
     return f"{imp}effect fn main() -> Unit = {{\n{body}\n}}\n", None
 
@@ -199,7 +219,7 @@ def main():
     env["ALMIDE_NO_AVAIL_CHECK"] = "1"
     for mod, fn, params, ret in sigs:
         verdict = None
-        for variant in (0, 1, 2):
+        for variant in (0, 1, 2, 3, 4):
             prog, missing = synth(mod, fn, params, ret, variant)
             if prog is None:
                 if variant == 0:
@@ -221,12 +241,20 @@ def main():
                 "?",
             )
             # A type/synthesis error is the probe's fault — try the next
-            # variant; only a renderer refusal is a wall.
+            # variant. A wall is only the VERDICT once every variant
+            # walled: the ladder exists because verdicts are shape-
+            # sensitive (the fs.for_each_line lesson — variant 0 walls,
+            # variant 4 builds), so a first-shape wall must not stop it.
             if "error[E0" in first or "Expected" in first or "type error" in first.lower():
-                verdict = ("unsynth", f"probe-ill-typed: {first[:80]}")
+                # Never let a later shape's TYPE error demote an earlier
+                # shape's renderer wall — verdict precedence is
+                # ok > wall > unsynth.
+                if verdict is None or verdict[0] != "wall":
+                    verdict = ("unsynth", f"probe-ill-typed: {first[:80]}")
                 continue
-            verdict = ("wall", first[:120])
-            break
+            if verdict is None or verdict[0] != "wall":
+                verdict = ("wall", first[:120])
+            continue
         status, detail = verdict
         print(f"{status}\t{mod}.{fn}\t{detail}")
     return 0


### PR DESCRIPTION
#1423 stage 3 — the user-facing payoff: a call to a stdlib fn NO wasm leg builds errs at CHECK time with the reason, instead of the late generic render wall.

```text
error[E081]: `http.get` is not available on --target wasm
  reason: no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)
  note: the availability matrix is proofs/target-availability.toml (#1423); the same program builds with --target rust
```

**The measurement got two honesty upgrades on the way, both caught by the gates**:
1. **Real-shape probing**: a one-call `main` measures the renderer's minimal-program-shape support, not the fn — `process.exit` measured as a wall while the cross-target fixture proves it served, and the E081 draft broke `wasm_cross_target_spec` immediately. The probe now synthesizes mid-body calls (opening print, statement position for Unit returns). The corrected sweeps: structural 325 ok / 64 native-only; **default routing (incumbent reroute included) 25 both-legs walls** — http.*, most process.*, env.set/sleep_ms, the streaming fs pair, json.to_map, testing.assert_throws.
2. **The measurement escape**: the probe builds through the product binary — with E081 armed it measured its own declaration (circular; the E081 rows came back as probe failures). `ALMIDE_NO_AVAIL_CHECK=1` measures the ground truth, never the declaration.

**Mechanics**: a new `[[wasm-unavailable]]` table in `proofs/target-availability.toml` (reason + optional `alt`, same shrink-only discipline), consumed at build time by `check_wasm_availability` (include_str, IR-walk over module calls, all hits listed); the gate now runs BOTH sweeps and diffs four directions (structural walls ⇄ native-only rows, default walls ⇄ wasm-unavailable rows). `docs/diagnostics/E081.md` (not-fixable verdict); pinned by `tests/wasm_availability_e081_test.rs` (the E054 precedent — E081 lives in the build path, not the check harness) with both the firing and the no-false-positive directions; the docs-gen bijection learned to see CLI-path `error[EXXX]` literals (digit-guarded against its own doc placeholders).

Green: availability gate four-way, E081 tests 2/2, `wasm_cross_target_spec` restored, `almide test` 424/424, docs-gen ok.

Remaining on #1423: stage 4 (pending-self-host burn-down, 31 enumerated) and stage 5 (the fuzzer consumes the declaration). Note: stacked on #1669 (or-patterns); rebase-merge dedups.

---

**Stage 4 opens on the same PR — 8 pending-self-host rows burned** (31 → 23, the ratchet follows):
- the pure int bit trio (`bnot` = xor −1, `to_u32`/`to_u8` = low-bit masks — semantics verbatim from `stdlib/int_wrap.almd`);
- the stride-free `is_empty` pair (`map`/`set` — the len slot at zero);
- the `error` trio (`message`/`context`/`chain` — formatting verbatim from `runtime/rs/src/error.rs`, ok-passthrough included).

Each burn verified A/B native ⇄ forced-structural byte-identical before the row deletion, and the four-way gate enforces the shrink bookkeeping (`pending_self_host_ceiling` 23, measured 333 lower / 56 native-only).
