### PR TITLE
fmt prints the bare ctor back: the eta-synthesis leak in the C-322 fixtures is closed and inverted

### DIFF
--- a/crates/almide-tools/src/fmt_expr.rs
+++ b/crates/almide-tools/src/fmt_expr.rs
@@ -482,6 +482,30 @@ fn fmt_expr_while(out: &mut String, expr: &Expr, depth: usize) {
 
 fn fmt_expr_lambda(out: &mut String, expr: &Expr, depth: usize) {
     let ExprKind::Lambda { params, body, .. } = &expr.kind else { unreachable!() };
+    // #1111's parser synthesis, inverted: a bare builtin ctor parses as
+    // `(__ctor_arg) => some(__ctor_arg)` — printing that form would leak
+    // the internal name into user source (it did: the C-322 fixtures on
+    // 2026-08-28), so the exact synthesized shape prints back as the
+    // bare ctor. A user-written lambda never carries the reserved
+    // `__ctor_arg` spelling, and even if one did, the two forms are
+    // semantically identical.
+    if let [p] = params.as_slice() {
+        if p.name.as_str() == "__ctor_arg" && p.ty.is_none() && p.tuple_names.is_none() {
+            let inner = match &body.kind {
+                ExprKind::Some { expr } => Some(("some", expr)),
+                ExprKind::Ok { expr } => Some(("ok", expr)),
+                ExprKind::Err { expr } => Some(("err", expr)),
+                _ => None,
+            };
+            if let Some((ctor, inner)) = inner {
+                if matches!(&inner.kind, ExprKind::Ident { name } if name.as_str() == "__ctor_arg")
+                {
+                    out.push_str(ctor);
+                    return;
+                }
+            }
+        }
+    }
     out.push('(');
     comma_sep(out, params, |out, p| {
         if let Some(n) = &p.tuple_names { w!(out, "({})", join_syms(n, ", ")); } else { out.push_str(&p.name); }

--- a/crates/almide-tools/src/fmt_expr.rs
+++ b/crates/almide-tools/src/fmt_expr.rs
@@ -489,21 +489,22 @@ fn fmt_expr_lambda(out: &mut String, expr: &Expr, depth: usize) {
     // bare ctor. A user-written lambda never carries the reserved
     // `__ctor_arg` spelling, and even if one did, the two forms are
     // semantically identical.
-    if let [p] = params.as_slice() {
-        if p.name.as_str() == "__ctor_arg" && p.ty.is_none() && p.tuple_names.is_none() {
-            let inner = match &body.kind {
-                ExprKind::Some { expr } => Some(("some", expr)),
-                ExprKind::Ok { expr } => Some(("ok", expr)),
-                ExprKind::Err { expr } => Some(("err", expr)),
-                _ => None,
-            };
-            if let Some((ctor, inner)) = inner {
-                if matches!(&inner.kind, ExprKind::Ident { name } if name.as_str() == "__ctor_arg")
-                {
-                    out.push_str(ctor);
-                    return;
-                }
-            }
+    if let [p] = params.as_slice()
+        && p.name.as_str() == "__ctor_arg"
+        && p.ty.is_none()
+        && p.tuple_names.is_none()
+    {
+        let inner = match &body.kind {
+            ExprKind::Some { expr } => Some(("some", expr)),
+            ExprKind::Ok { expr } => Some(("ok", expr)),
+            ExprKind::Err { expr } => Some(("err", expr)),
+            _ => None,
+        };
+        if let Some((ctor, inner)) = inner
+            && matches!(&inner.kind, ExprKind::Ident { name } if name.as_str() == "__ctor_arg")
+        {
+            out.push_str(ctor);
+            return;
         }
     }
     out.push('(');

--- a/docs/grammar/almide.lark
+++ b/docs/grammar/almide.lark
@@ -328,6 +328,12 @@ ctor_expr: SOME "(" expr ")"
          | ERR "(" expr ")"
          | ERR_UC "(" expr ")"
          | TODO "(" plain_string ")"
+         // #1111: a bare builtin ctor is a FUNCTION VALUE (the parser
+         // synthesizes its eta-expansion) — accepted wherever an
+         // expression atom is.
+         | SOME | SOME_UC
+         | OK | OK_UC
+         | ERR | ERR_UC
 
 // ── control flow ─────────────────────────────────────────────────
 

--- a/spec/lang/ctor_fn_value_test.almd
+++ b/spec/lang/ctor_fn_value_test.almd
@@ -5,18 +5,18 @@
 type Shape = | Circle(Int) | Rect(Int, Int) | Dot
 
 test "bare some maps" {
-  assert_eq([1, 2] |> list.map((__ctor_arg) => some(__ctor_arg)), [some(1), some(2)])
+  assert_eq([1, 2] |> list.map(some), [some(1), some(2)])
 }
 
 test "bare ok and err map" {
-  let oks: List[Result[Int, String]] = [1] |> list.map((__ctor_arg) => ok(__ctor_arg))
+  let oks: List[Result[Int, String]] = [1] |> list.map(ok)
   assert_eq(oks, [ok(1)])
-  let errs: List[Result[Int, String]] = ["e"] |> list.map((__ctor_arg) => err(__ctor_arg))
+  let errs: List[Result[Int, String]] = ["e"] |> list.map(err)
   assert_eq(errs, [err("e")])
 }
 
 test "builtin ctor binds and applies" {
-  let f = (__ctor_arg) => some(__ctor_arg)
+  let f = some
   assert_eq(f(7), some(7))
 }
 

--- a/spec/wasm_cross/ctor_fn_value.almd
+++ b/spec/wasm_cross/ctor_fn_value.almd
@@ -10,13 +10,13 @@
 type Shape = | Circle(Int) | Rect(Int, Int) | Dot
 
 effect fn main() -> Unit = {
-  let opts = [1, 2] |> list.map((__ctor_arg) => some(__ctor_arg))
+  let opts = [1, 2] |> list.map(some)
   println(if opts == [some(1), some(2)] then "some-maps" else "BAD")
-  let oks: List[Result[Int, String]] = [3] |> list.map((__ctor_arg) => ok(__ctor_arg))
+  let oks: List[Result[Int, String]] = [3] |> list.map(ok)
   println(if oks == [ok(3)] then "ok-maps" else "BAD")
-  let errs: List[Result[Int, String]] = ["e"] |> list.map((__ctor_arg) => err(__ctor_arg))
+  let errs: List[Result[Int, String]] = ["e"] |> list.map(err)
   println(if errs == [err("e")] then "err-maps" else "BAD")
-  let f = (__ctor_arg) => some(__ctor_arg)
+  let f = some
   println(if f(7) == some(7) then "bound-applies" else "BAD")
   let shapes = [1, 2] |> list.map(Circle)
   println(if shapes == [Circle(1), Circle(2)] then "user-maps" else "BAD")


### PR DESCRIPTION
A real fmt defect shipped with #1111 (caught while untangling the PR-stack conflicts): the parser synthesizes a bare `some`/`ok`/`err` as its eta-expansion `(__ctor_arg) => some(__ctor_arg)`, and `almide fmt` — which round-trips through the parser — printed the SYNTHESIZED form back, leaking the internal parameter name into user source. The C-322 fixtures on develop carry the leak, which also silently rewrote their bare-ctor asserts into lambda-form asserts — the very shape the feature test exists to distinguish.

**Fix**: `fmt_expr_lambda` inverts the exact synthesized shape — a 1-param lambda named `__ctor_arg` (untyped, untupled) whose body is `some/ok/err(__ctor_arg)` prints as the bare ctor. Idempotent (bare → bare); a user who writes the reserved spelling by hand gets the semantically identical bare form. Both leaked fixtures restore their bare-ctor asserts (0 occurrences of the internal name remain), the ast-manifest rows follow, and the full battery is green: fmt 61/61, parity suites, `almide test` 424/424, cross-target identity on the fixture re-verified.