### PR TITLE
for-in stops cloning: the list head is borrowed, the binder moves at its last use, and a borrow-only body iterates by reference (#1673)

### DIFF
--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -33,6 +33,7 @@ pub mod pass_builtin_lowering;
 pub mod pass_capture_clone;
 pub mod pass_shared_cell_borrow;
 pub mod pass_clone;
+pub mod pass_clone_loops;
 pub mod pass_top_let_storage;
 pub mod pass_fan_lowering;
 pub mod pass_list_pattern;

--- a/crates/almide-codegen/src/pass_clone.rs
+++ b/crates/almide-codegen/src/pass_clone.rs
@@ -11,6 +11,7 @@ use almide_ir::*;
 use almide_base::{Span, Sym};
 use almide_lang::types::Ty;
 use super::pass::{NanoPass, PassResult, Target};
+use super::pass_clone_loops::{insert_clones_for_in, insert_clones_while};
 
 #[derive(Debug)]
 pub struct CloneInsertionPass;
@@ -50,6 +51,8 @@ impl NanoPass for CloneInsertionPass {
         // so the branch-count memo only needs to track their union. Counts for
         // ids outside every `remaining` are deduct no-ops either way.
         let tracked: HashSet<VarId> = eligible.union(&eligible_plain).copied().collect();
+        // Nothing is fresh at function top level — see `CloneCtx::fresh`.
+        let no_fresh: HashSet<VarId> = HashSet::new();
 
         for func in &mut program.functions {
             // Reset remaining for each function (vars are function-scoped)
@@ -61,12 +64,12 @@ impl NanoPass for CloneInsertionPass {
             };
             reset_remaining(r, e, &syntactic);
             let memo = BranchCounts::compute(&func.body, &tracked);
-            func.body = insert_clones_live(std::mem::take(&mut func.body), &mut CloneCtx { always: a, eligible: e, remaining: r, in_loop: false, memo: &memo });
+            func.body = insert_clones_live(std::mem::take(&mut func.body), &mut CloneCtx { always: a, eligible: e, remaining: r, in_loop: false, memo: &memo, fresh: &no_fresh });
         }
         for tl in &mut program.top_lets {
             reset_remaining(&mut remaining, &eligible, &syntactic);
             let memo = BranchCounts::compute(&tl.value, &tracked);
-            tl.value = insert_clones_live(std::mem::take(&mut tl.value), &mut CloneCtx { always: &always, eligible: &eligible, remaining: &mut remaining, in_loop: false, memo: &memo });
+            tl.value = insert_clones_live(std::mem::take(&mut tl.value), &mut CloneCtx { always: &always, eligible: &eligible, remaining: &mut remaining, in_loop: false, memo: &memo, fresh: &no_fresh });
         }
 
         let IrProgram { modules, var_table, .. } = &mut program;
@@ -87,12 +90,12 @@ impl NanoPass for CloneInsertionPass {
                 };
                 reset_remaining(r, e, &module_syntactic);
                 let memo = BranchCounts::compute(&func.body, &m_tracked);
-                func.body = insert_clones_live(std::mem::take(&mut func.body), &mut CloneCtx { always: a, eligible: e, remaining: r, in_loop: false, memo: &memo });
+                func.body = insert_clones_live(std::mem::take(&mut func.body), &mut CloneCtx { always: a, eligible: e, remaining: r, in_loop: false, memo: &memo, fresh: &no_fresh });
             }
             for tl in module.top_lets.iter_mut() {
                 reset_remaining(&mut m_remaining, &m_eligible, &module_syntactic);
                 let memo = BranchCounts::compute(&tl.value, &m_tracked);
-                tl.value = insert_clones_live(std::mem::take(&mut tl.value), &mut CloneCtx { always: &m_always, eligible: &m_eligible, remaining: &mut m_remaining, in_loop: false, memo: &memo });
+                tl.value = insert_clones_live(std::mem::take(&mut tl.value), &mut CloneCtx { always: &m_always, eligible: &m_eligible, remaining: &mut m_remaining, in_loop: false, memo: &memo, fresh: &no_fresh });
             }
         }
         PassResult { program, changed: true }
@@ -188,7 +191,7 @@ fn count_syntactic(expr: &IrExpr, counts: &mut HashMap<VarId, u32>) {
 // only ever touches ids present in `remaining`, whose key set is an eligible
 // set, so dropping untracked ids is behavior-neutral and keeps the per-branch
 // maps (and the absorb cost of merging them upward) small.
-struct BranchCounts {
+pub(crate) struct BranchCounts {
     map: HashMap<*const IrExpr, Rc<HashMap<VarId, u32>>>,
 }
 
@@ -378,13 +381,19 @@ fn reset_remaining(remaining: &mut HashMap<VarId, u32>, eligible: &HashSet<VarId
 /// helpers), so each fn stays at or under the `max-params` limit. `in_loop`
 /// flips to `true` for a nested loop body/cond — built as a fresh `CloneCtx`
 /// reborrowing `remaining` (same shape as `HoistCtx` in pass_licm_hoist.rs).
-struct CloneCtx<'a> {
-    always: &'a HashSet<VarId>,
-    eligible: &'a HashSet<VarId>,
-    remaining: &'a mut HashMap<VarId, u32>,
-    in_loop: bool,
+pub(crate) struct CloneCtx<'a> {
+    pub(crate) always: &'a HashSet<VarId>,
+    pub(crate) eligible: &'a HashSet<VarId>,
+    pub(crate) remaining: &'a mut HashMap<VarId, u32>,
+    pub(crate) in_loop: bool,
     /// Per-body branch-count memo (#1230) — see [`BranchCounts`].
-    memo: &'a BranchCounts,
+    pub(crate) memo: &'a BranchCounts,
+    /// Vars rebound on EVERY iteration of the innermost enclosing loop — the
+    /// loop's own binders and the `let`s at its body's top level (#1673).
+    /// Their last use in that body is a move even though `in_loop` holds:
+    /// the next iteration binds a fresh value. Empty outside loops and
+    /// inside lambda bodies (a closure may run many times per iteration).
+    pub(crate) fresh: &'a HashSet<VarId>,
 }
 
 fn make_clone(id: VarId, ty: Ty, span: Option<Span>) -> IrExpr {
@@ -417,8 +426,9 @@ fn insert_clones_var(id: VarId, ty: Ty, span: Option<Span>, ctx: &mut CloneCtx) 
     if ctx.eligible.contains(&id) {
         if let Some(r) = ctx.remaining.get_mut(&id) {
             *r = r.saturating_sub(1);
-            if *r == 0 && !ctx.in_loop {
-                // Last use outside a loop → move (no clone)
+            if *r == 0 && (!ctx.in_loop || ctx.fresh.contains(&id)) {
+                // Last use outside a loop — or of a var the loop rebinds
+                // every iteration (#1673) — → move (no clone)
                 return IrExpr { kind: IrExprKind::Var { id }, ty, span, def_id: None };
             }
         }
@@ -518,24 +528,6 @@ fn insert_clones_match(subject: IrExpr, arms: Vec<IrMatchArm>, ctx: &mut CloneCt
     IrExprKind::Match { subject: Box::new(new_subject), arms: new_arms }
 }
 
-/// `ForIn { var, var_tuple, iterable, body }` arm of [`insert_clones_live`]:
-/// the iterable is NOT in the loop, the body IS.
-fn insert_clones_for_in(var: VarId, var_tuple: Option<Vec<VarId>>, iterable: IrExpr, body: Vec<IrStmt>, ctx: &mut CloneCtx) -> IrExprKind {
-    let new_iterable = insert_clones_live(iterable, ctx);
-    let mut loop_ctx = CloneCtx { always: ctx.always, eligible: ctx.eligible, remaining: ctx.remaining, in_loop: true, memo: ctx.memo };
-    let new_body = insert_clone_stmts_live(body, &mut loop_ctx);
-    IrExprKind::ForIn { var, var_tuple, iterable: Box::new(new_iterable), body: new_body }
-}
-
-/// `While { cond, body }` arm of [`insert_clones_live`]: cond and body are
-/// both in the loop.
-fn insert_clones_while(cond: IrExpr, body: Vec<IrStmt>, ctx: &mut CloneCtx) -> IrExprKind {
-    let mut loop_ctx = CloneCtx { always: ctx.always, eligible: ctx.eligible, remaining: ctx.remaining, in_loop: true, memo: ctx.memo };
-    let new_cond = insert_clones_live(cond, &mut loop_ctx);
-    let new_body = insert_clone_stmts_live(body, &mut loop_ctx);
-    IrExprKind::While { cond: Box::new(new_cond), body: new_body }
-}
-
 /// The E0505 guard's borrow scan (#809/#866): the vars passed BY BORROW at
 /// the top level of a call's arguments (or its method receiver). Such a var
 /// stays borrowed until the call itself executes, so a MOVE of it anywhere in
@@ -578,6 +570,7 @@ fn insert_clones_runtime_call(args: Vec<IrExpr>, ctx: &mut CloneCtx) -> Vec<IrEx
         remaining: ctx.remaining,
         in_loop: ctx.in_loop,
         memo: ctx.memo,
+        fresh: ctx.fresh,
     };
     args.into_iter().map(|a| insert_clones_live(a, &mut call_ctx)).collect()
 }
@@ -599,6 +592,7 @@ fn insert_clones_call(target: CallTarget, args: Vec<IrExpr>, type_args: Vec<Ty>,
             remaining: ctx.remaining,
             in_loop: ctx.in_loop,
             memo: ctx.memo,
+            fresh: ctx.fresh,
         };
         let args = args.into_iter().map(|a| insert_clones_live(a, &mut call_ctx)).collect();
         let target = match target {
@@ -692,7 +686,7 @@ fn insert_clones_member(object: IrExpr, field: Sym, ty: Ty, span: Option<Span>, 
     access
 }
 
-fn insert_clones_live(expr: IrExpr, ctx: &mut CloneCtx) -> IrExpr {
+pub(crate) fn insert_clones_live(expr: IrExpr, ctx: &mut CloneCtx) -> IrExpr {
     let ty = expr.ty.clone();
     let span = expr.span;
 
@@ -734,6 +728,15 @@ fn insert_clones_live(expr: IrExpr, ctx: &mut CloneCtx) -> IrExpr {
             }
             IrExprKind::Borrow { expr: Box::new(inner), as_str, mutable }
         },
+        // A closure body may run any number of times per loop iteration, so
+        // nothing the enclosing loop rebinds is fresh inside it (#1673): walk
+        // the lambda with an empty `fresh` set, otherwise unchanged.
+        kind @ IrExprKind::Lambda { .. } => {
+            let no_fresh: HashSet<VarId> = HashSet::new();
+            let mut lam_ctx = CloneCtx { always: ctx.always, eligible: ctx.eligible, remaining: ctx.remaining, in_loop: ctx.in_loop, memo: ctx.memo, fresh: &no_fresh };
+            let e = IrExpr { kind, ty: ty.clone(), span, def_id: None };
+            return e.map_children(&mut |child| insert_clones_live(child, &mut lam_ctx));
+        }
         // Default: recurse into every child through the exhaustive `map_children`
         // chokepoint. Every node whose clone insertion is just "recurse into the
         // children, left to right" lands here — BinOp/UnOp/Lambda/StringInterp/
@@ -764,7 +767,7 @@ fn count_target_use(target: VarId, eligible: &HashSet<VarId>, remaining: &mut Ha
     }
 }
 
-fn insert_clone_stmts_live(stmts: Vec<IrStmt>, ctx: &mut CloneCtx) -> Vec<IrStmt> {
+pub(crate) fn insert_clone_stmts_live(stmts: Vec<IrStmt>, ctx: &mut CloneCtx) -> Vec<IrStmt> {
     stmts.into_iter().map(|s| {
         let kind = match s.kind {
             IrStmtKind::Bind { var, mutability, ty, value } => IrStmtKind::Bind {

--- a/crates/almide-codegen/src/pass_clone.rs
+++ b/crates/almide-codegen/src/pass_clone.rs
@@ -11,7 +11,7 @@ use almide_ir::*;
 use almide_base::{Span, Sym};
 use almide_lang::types::Ty;
 use super::pass::{NanoPass, PassResult, Target};
-use super::pass_clone_loops::{insert_clones_for_in, insert_clones_while};
+use super::pass_clone_loops::{insert_clones_for_in, insert_clones_while, take_borrowed_loop_vars};
 
 #[derive(Debug)]
 pub struct CloneInsertionPass;
@@ -98,6 +98,9 @@ impl NanoPass for CloneInsertionPass {
                 tl.value = insert_clones_live(std::mem::take(&mut tl.value), &mut CloneCtx { always: &m_always, eligible: &m_eligible, remaining: &mut m_remaining, in_loop: false, memo: &memo, fresh: &no_fresh });
             }
         }
+        // Loop binders the bodies only borrowed (#1673): the walker binds them
+        // `&T` off `xs.iter()`.
+        program.codegen_annotations.borrowed_loop_vars = take_borrowed_loop_vars();
         PassResult { program, changed: true }
     }
 }

--- a/crates/almide-codegen/src/pass_clone_loops.rs
+++ b/crates/almide-codegen/src/pass_clone_loops.rs
@@ -144,8 +144,10 @@ fn body_writes_var(body: &[IrStmt], v: VarId) -> bool {
     struct W { v: VarId, hit: bool }
     impl almide_ir::visit::IrVisitor for W {
         fn visit_expr(&mut self, e: &IrExpr) {
-            if let IrExprKind::Borrow { expr: inner, mutable: true, .. } = &e.kind {
-                if matches!(&inner.kind, IrExprKind::Var { id } if *id == self.v) { self.hit = true; }
+            if let IrExprKind::Borrow { expr: inner, mutable: true, .. } = &e.kind
+                && matches!(&inner.kind, IrExprKind::Var { id } if *id == self.v)
+            {
+                self.hit = true;
             }
             almide_ir::visit::walk_expr(self, e);
         }

--- a/crates/almide-codegen/src/pass_clone_loops.rs
+++ b/crates/almide-codegen/src/pass_clone_loops.rs
@@ -1,0 +1,99 @@
+//! The loop arms of the clone pass (`ForIn` / `While`) and the two facts a
+//! loop knows that the flat last-use count does not (#1673):
+//!
+//! 1. A `List` iterable renders as `xs.iter().cloned()` — a SHARED borrow for
+//!    the loop's duration — so a `Clone` under it only ever produced a
+//!    throwaway copy of the whole list. It is stripped unless the body writes
+//!    the list, where the temporary copy is what keeps the body's `&mut` legal.
+//! 2. The loop's own binders and its body's top-level `let`s are rebound on
+//!    every iteration, so their last use in the body is a move even inside
+//!    the loop (`CloneCtx::fresh`).
+//!
+//! Split out of `pass_clone.rs` to keep that file under the `max-lines` limit.
+
+use std::collections::HashSet;
+use almide_ir::*;
+use almide_lang::types::{Ty, TypeConstructorId};
+use super::pass_clone::{CloneCtx, insert_clones_live, insert_clone_stmts_live};
+
+/// `ForIn { var, var_tuple, iterable, body }` arm of [`insert_clones_live`]:
+/// the iterable is NOT in the loop, the body IS.
+pub(crate) fn insert_clones_for_in(var: VarId, var_tuple: Option<Vec<VarId>>, iterable: IrExpr, body: Vec<IrStmt>, ctx: &mut CloneCtx) -> IrExprKind {
+    let new_iterable = strip_list_iterable_clone(insert_clones_live(iterable, ctx), &body);
+    let fresh = loop_fresh_vars(Some(var), var_tuple.as_deref(), &body);
+    let mut loop_ctx = CloneCtx { always: ctx.always, eligible: ctx.eligible, remaining: ctx.remaining, in_loop: true, memo: ctx.memo, fresh: &fresh };
+    let new_body = insert_clone_stmts_live(body, &mut loop_ctx);
+    IrExprKind::ForIn { var, var_tuple, iterable: Box::new(new_iterable), body: new_body }
+}
+
+/// `While { cond, body }` arm of [`insert_clones_live`]: cond and body are
+/// both in the loop.
+pub(crate) fn insert_clones_while(cond: IrExpr, body: Vec<IrStmt>, ctx: &mut CloneCtx) -> IrExprKind {
+    let fresh = loop_fresh_vars(None, None, &body);
+    let mut loop_ctx = CloneCtx { always: ctx.always, eligible: ctx.eligible, remaining: ctx.remaining, in_loop: true, memo: ctx.memo, fresh: &fresh };
+    let new_cond = insert_clones_live(cond, &mut loop_ctx);
+    let new_body = insert_clone_stmts_live(body, &mut loop_ctx);
+    IrExprKind::While { cond: Box::new(new_cond), body: new_body }
+}
+
+/// `Clone(Var xs)` as a `List` loop head → `Var xs`, unless `body` writes
+/// `xs`. The renderer iterates a List by `.iter().cloned()`, which borrows
+/// `xs` for the whole loop; a clone there is a full copy of the list that no
+/// one reads (#1673 — 735 ns per iteration on an 8-field object before a
+/// single field was touched). A body that assigns `xs`, writes `xs[i]`, or
+/// passes `xs` to an in-place op holds `&mut xs` under that borrow, and the
+/// throwaway copy is the only thing keeping rustc's E0502 away — keep it.
+fn strip_list_iterable_clone(iterable: IrExpr, body: &[IrStmt]) -> IrExpr {
+    let is_list = matches!(&iterable.ty, Ty::Applied(TypeConstructorId::List, _));
+    match iterable.kind {
+        IrExprKind::Clone { expr: inner }
+            if is_list && matches!(&inner.kind, IrExprKind::Var { id } if !body_writes_var(body, *id)) =>
+        {
+            *inner
+        }
+        kind => IrExpr { kind, ..iterable },
+    }
+}
+
+/// The vars a loop rebinds on every iteration: its own binders plus the
+/// top-level `let`s of its body. Deliberately shallow — a `let` inside a
+/// nested loop or lambda belongs to THAT scope's freshness, and a `let`
+/// inside an `if`/`match` arm is left conservative (cloned) rather than
+/// reasoned about here.
+fn loop_fresh_vars(var: Option<VarId>, var_tuple: Option<&[VarId]>, body: &[IrStmt]) -> HashSet<VarId> {
+    let mut fresh: HashSet<VarId> = var.into_iter().collect();
+    fresh.extend(var_tuple.into_iter().flatten().copied());
+    for s in body {
+        if let IrStmtKind::Bind { var, .. } = &s.kind { fresh.insert(*var); }
+    }
+    fresh
+}
+
+/// Does any statement of `body` (at any depth, lambdas included) write `v`:
+/// reassign it, write an element/field/key of it, or `&mut`-borrow it (the
+/// form `list.push(v, …)` takes after `BorrowInsertionPass`)?
+fn body_writes_var(body: &[IrStmt], v: VarId) -> bool {
+    struct W { v: VarId, hit: bool }
+    impl almide_ir::visit::IrVisitor for W {
+        fn visit_expr(&mut self, e: &IrExpr) {
+            if let IrExprKind::Borrow { expr: inner, mutable: true, .. } = &e.kind {
+                if matches!(&inner.kind, IrExprKind::Var { id } if *id == self.v) { self.hit = true; }
+            }
+            almide_ir::visit::walk_expr(self, e);
+        }
+        fn visit_stmt(&mut self, s: &IrStmt) {
+            match &s.kind {
+                IrStmtKind::Assign { var, .. } if *var == self.v => self.hit = true,
+                IrStmtKind::IndexAssign { target, .. }
+                | IrStmtKind::MapInsert { target, .. }
+                | IrStmtKind::FieldAssign { target, .. } if *target == self.v => self.hit = true,
+                _ => {}
+            }
+            almide_ir::visit::walk_stmt(self, s);
+        }
+    }
+    use almide_ir::visit::IrVisitor;
+    let mut w = W { v, hit: false };
+    for s in body { w.visit_stmt(s); }
+    w.hit
+}

--- a/crates/almide-codegen/src/pass_clone_loops.rs
+++ b/crates/almide-codegen/src/pass_clone_loops.rs
@@ -11,10 +11,23 @@
 //!
 //! Split out of `pass_clone.rs` to keep that file under the `max-lines` limit.
 
+use std::cell::RefCell;
 use std::collections::HashSet;
 use almide_ir::*;
 use almide_lang::types::{Ty, TypeConstructorId};
 use super::pass_clone::{CloneCtx, insert_clones_live, insert_clone_stmts_live};
+
+thread_local! {
+    /// Loop binders whose bodies only borrow them — collected per program by
+    /// [`insert_clones_for_in`], drained into `CodegenAnnotations::borrowed_loop_vars`
+    /// by the pass's `run` (see [`take_borrowed_loop_vars`]).
+    static BORROWED_LOOP_VARS: RefCell<HashSet<VarId>> = RefCell::new(HashSet::new());
+}
+
+/// Hand the collected set to the pass and reset for the next program.
+pub(crate) fn take_borrowed_loop_vars() -> HashSet<VarId> {
+    BORROWED_LOOP_VARS.with(|c| std::mem::take(&mut *c.borrow_mut()))
+}
 
 /// `ForIn { var, var_tuple, iterable, body }` arm of [`insert_clones_live`]:
 /// the iterable is NOT in the loop, the body IS.
@@ -23,7 +36,62 @@ pub(crate) fn insert_clones_for_in(var: VarId, var_tuple: Option<Vec<VarId>>, it
     let fresh = loop_fresh_vars(Some(var), var_tuple.as_deref(), &body);
     let mut loop_ctx = CloneCtx { always: ctx.always, eligible: ctx.eligible, remaining: ctx.remaining, in_loop: true, memo: ctx.memo, fresh: &fresh };
     let new_body = insert_clone_stmts_live(body, &mut loop_ctx);
+    // With the body's clones and moves placed, a binder every use of which
+    // sits under a shared borrow / field read / clone never needs an owned
+    // element at all: iterate `xs.iter()` and bind `&T` (#1673). A List head
+    // only — a Map loop consumes its pairs by value.
+    let is_list = matches!(&new_iterable.ty, Ty::Applied(TypeConstructorId::List, _));
+    if is_list && var_tuple.is_none() && only_borrowed_uses(&new_body, var) {
+        BORROWED_LOOP_VARS.with(|c| { c.borrow_mut().insert(var); });
+    }
     IrExprKind::ForIn { var, var_tuple, iterable: Box::new(new_iterable), body: new_body }
+}
+
+/// Is every occurrence of `v` in `body` one the Rust walker renders the same
+/// for a `&T` binder as for a `T` one: `&v` (a shared `Borrow`, which coerces
+/// from `&&T`), `v.field` (auto-deref), or `v.clone()` (resolves to
+/// `T::clone` through the reference)? A bare occurrence (a move), a `&mut`,
+/// a match subject, an interpolation, or any use inside a closure / fused
+/// iterator chain (whose captures must own) says no.
+fn only_borrowed_uses(body: &[IrStmt], v: VarId) -> bool {
+    struct Scan { v: VarId, ok: bool }
+    impl almide_ir::visit::IrVisitor for Scan {
+        fn visit_expr(&mut self, e: &IrExpr) {
+            if !self.ok { return; }
+            let is_v = |x: &IrExpr| matches!(&x.kind, IrExprKind::Var { id } if *id == self.v);
+            match &e.kind {
+                IrExprKind::Borrow { expr, mutable: false, .. } if is_v(expr) => return,
+                IrExprKind::Member { object, .. } if is_v(object) => return,
+                IrExprKind::Clone { expr } if is_v(expr) => return,
+                IrExprKind::Var { id } if *id == self.v => { self.ok = false; return; }
+                IrExprKind::Lambda { .. } | IrExprKind::IterChain { .. } => {
+                    if uses_var_anywhere(e, self.v) { self.ok = false; }
+                    return;
+                }
+                _ => {}
+            }
+            almide_ir::visit::walk_expr(self, e);
+        }
+    }
+    use almide_ir::visit::IrVisitor;
+    let mut s = Scan { v, ok: true };
+    for st in body { s.visit_stmt(st); }
+    s.ok
+}
+
+/// Does `v` occur anywhere under `e` (closure bodies included)?
+fn uses_var_anywhere(e: &IrExpr, v: VarId) -> bool {
+    struct U { v: VarId, hit: bool }
+    impl almide_ir::visit::IrVisitor for U {
+        fn visit_expr(&mut self, e: &IrExpr) {
+            if matches!(&e.kind, IrExprKind::Var { id } if *id == self.v) { self.hit = true; }
+            if !self.hit { almide_ir::visit::walk_expr(self, e); }
+        }
+    }
+    use almide_ir::visit::IrVisitor;
+    let mut u = U { v, hit: false };
+    u.visit_expr(e);
+    u.hit
 }
 
 /// `While { cond, body }` arm of [`insert_clones_live`]: cond and body are

--- a/crates/almide-codegen/src/walker/expressions_control.rs
+++ b/crates/almide-codegen/src/walker/expressions_control.rs
@@ -191,8 +191,11 @@ fn render_expr_for_in(ctx: &RenderContext, expr: &IrExpr) -> String {
         _ => {
             let base = render_expr(ctx, iterable);
             // List types: .iter().cloned() works for both RcCow<Vec<T>>
-            // (via Deref) and plain Vec<T>, giving owned T values.
+            // (via Deref) and plain Vec<T>, giving owned T values. A binder
+            // the body only borrows (`borrowed_loop_vars`, #1673) skips the
+            // per-element copy: `.iter()` binds `&T`.
             match &iterable.ty {
+                Ty::Applied(TypeConstructorId::List, _) if ctx.ann.borrowed_loop_vars.contains(var) => format!("{}.iter()", base),
                 Ty::Applied(TypeConstructorId::List, _) => format!("{}.iter().cloned()", base),
                 _ => base,
             }

--- a/crates/almide-ir/src/annotations.rs
+++ b/crates/almide-ir/src/annotations.rs
@@ -27,6 +27,13 @@ pub struct CodegenAnnotations {
     /// (the #486-class fragility: a rename scheme change silently broke
     /// classification with no gate).
     pub always_clone_vars: HashSet<VarId>,
+    /// `for x in xs` binders the body only ever BORROWS (every occurrence
+    /// sits directly under a shared `Borrow`, a `Member` read, or a `Clone`),
+    /// so the Rust loop iterates `xs.iter()` and binds `x: &T` — no per-element
+    /// copy at all (#1673). Decided by `CloneInsertionPass` after it has
+    /// placed the body's clones and moves. A bare (moving) use, a `&mut`, a
+    /// closure capture, a match on `x`, or a tuple binder keeps `.cloned()`.
+    pub borrowed_loop_vars: HashSet<VarId>,
     /// §4 Stage 1 — the unified top-let storage attribute, computed once by
     /// `TopLetStoragePass` and asserted equal to every legacy predicate by
     /// the walker-side agreement verifier. Stage 2 makes consumers read THIS

--- a/crates/almide-ir/src/use_count.rs
+++ b/crates/almide-ir/src/use_count.rs
@@ -117,8 +117,16 @@ fn count_uses_in_expr(expr: &IrExpr, table: &mut VarTable) {
         // ForIn/While: count the loop body once, then extra-count every
         // outer-scope var referenced in it (both need the same treatment —
         // a loop body runs N times, so outer captures are used N times too).
-        IrExprKind::ForIn { iterable: lead, body, .. }
-        | IrExprKind::While { cond: lead, body } => count_uses_in_loop_body(lead, body, table),
+        // The ForIn's own binders are rebound on every iteration, so they
+        // are body-locals, not outer captures — bumping them made every
+        // `for v in xs { f(v) }` clone `v` for a body that consumed it once
+        // (#1673).
+        IrExprKind::ForIn { iterable, body, var, var_tuple } => {
+            let mut loop_vars = vec![*var];
+            if let Some(t) = var_tuple { loop_vars.extend(t.iter().copied()); }
+            count_uses_in_loop_body(iterable, body, &loop_vars, table)
+        }
+        IrExprKind::While { cond, body } => count_uses_in_loop_body(cond, body, &[], table),
         IrExprKind::Lambda { params, body, .. } => count_uses_in_lambda(params, body, table),
         IrExprKind::StringInterp { parts } => count_uses_in_string_interp(parts, table),
         IrExprKind::IterChain { source, steps, collector, .. } => {
@@ -169,9 +177,10 @@ fn count_uses_in_call(target: &CallTarget, args: &[IrExpr], table: &mut VarTable
 /// expression, then the body normally, then extra-count outer-scope vars
 /// referenced in the body (a loop body runs N times, so outer captures used
 /// inside it are used N times too — this is what triggers clone insertion).
-fn count_uses_in_loop_body(lead: &IrExpr, body: &[IrStmt], table: &mut VarTable) {
+fn count_uses_in_loop_body(lead: &IrExpr, body: &[IrStmt], loop_vars: &[VarId], table: &mut VarTable) {
     count_uses_in_expr(lead, table);
-    let body_locals = collect_bound_vars(body);
+    let mut body_locals = collect_bound_vars(body);
+    body_locals.extend(loop_vars.iter().map(|v| v.0));
     for s in body { count_uses_in_stmt(s, table); }
     bump_outer_vars_in_loop(body, &body_locals, table);
 }

--- a/tests/for_in_clone_elision_test.rs
+++ b/tests/for_in_clone_elision_test.rs
@@ -33,6 +33,7 @@ fn tool_available() -> bool {
 }
 
 /// Emit Rust for `source` and return the body of `pub fn main`.
+/// (Shared by the clone-elision and the borrowed-binder tests below.)
 fn emitted_main(source: &str, tag: &str) -> String {
     let dir = std::env::temp_dir().join(format!("almide-forin-clone-{}-{}", tag, std::process::id()));
     std::fs::create_dir_all(&dir).unwrap();
@@ -151,4 +152,39 @@ fn map_loop_still_consumes_a_copy_when_the_map_is_used_after() {
           println(\"${t} ${list.len(map.keys(m))}\")\n\
         }\n", "map");
     assert!(body.contains("for (k, v) in m.clone()"), "a Map loop iterates BY VALUE — the copy is what keeps `m` alive for the later use:\n{body}");
+}
+
+#[test]
+fn binder_the_body_only_borrows_iterates_by_reference() {
+    if !tool_available() { eprintln!("skipping: almide binary not available"); return; }
+    let body = emitted_main(&format!("{PRELUDE}\
+        fn main() -> Unit = {{\
+          let us: List[U] = [U {{ a: 1 }}, U {{ a: 2 }}]\
+          let names: List[String] = [\"ab\", \"c\"]\
+          var t = 0\
+          for u in us {{ t = t + hitu(u) }}\
+          for u in us {{ t = t + u.a }}\
+          for s in names {{ t = t + string.len(s) }}\
+          println(\"${{t}}\")\
+        }}\n"), "borrowed-binder");
+    assert!(body.contains("for u in us.iter() {"), "a binder only ever passed by `&` never needs an owned element:\n{body}");
+    assert!(body.contains("hitu(&u)"), "the borrowed call site is unchanged (`&&T` coerces):\n{body}");
+    assert!(body.contains("for s in names.iter() {"), "a String binder read through `&*s` iterates by reference too:\n{body}");
+    assert!(!body.contains("iter().cloned()"), "no loop in this program consumes its element — every `.cloned()` here is a copy nobody reads:\n{body}");
+}
+
+#[test]
+fn binder_that_is_consumed_or_matched_keeps_the_element_copy() {
+    if !tool_available() { eprintln!("skipping: almide binary not available"); return; }
+    let body = emitted_main(&format!("{PRELUDE}\
+        fn main() -> Unit = {{\
+          let us: List[U] = [U {{ a: 1 }}]\
+          let data: List[Value] = [value.int(1)]\
+          var t = 0\
+          for v in data {{ t = t + hit(v) }}\
+          for u in us {{ t = t + (match u {{ U {{ a }} => a }}) }}\
+          println(\"${{t}}\")\
+        }}\n"), "consumed-binder");
+    assert!(body.contains("for v in data.iter().cloned() {") && body.contains("hit(v)"), "an owned-arg call consumes the element — it must be copied out of the list, then moved:\n{body}");
+    assert!(body.contains("for u in us.iter().cloned() {"), "a match subject binds payloads by value — the element stays owned:\n{body}");
 }

--- a/tests/for_in_clone_elision_test.rs
+++ b/tests/for_in_clone_elision_test.rs
@@ -1,0 +1,154 @@
+//! `for x in xs` clone elision (#1673).
+//!
+//! The idiomatic loop lowered to `xs.clone().iter().cloned()` and cloned the
+//! loop variable again at every consuming use: a whole-list copy on loop
+//! entry, one element copy per iteration, and a third copy at the call. The
+//! first is a borrow (`.iter()` never consumes `xs`), the third is a move
+//! (the loop rebinds `x` every iteration). These tests pin the emitted
+//! shapes: the two redundant clones are gone, and the cases where a copy IS
+//! load-bearing — the body writes the list, an outer loop variable is used
+//! inside an inner loop, a closure captures it — keep theirs.
+//!
+//! Emit-shape tests, in the mold of `tco_accumulator_move_test.rs`: they
+//! assert on `--target rust` output, so a regression shows up as the exact
+//! `.clone()` that came back. Skips cleanly when the `almide` binary is
+//! unavailable (CI builds it first; locally `cargo build --release`).
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn tool_available() -> bool {
+    Command::new(almide_bin()).arg("--version").output().is_ok()
+}
+
+/// Emit Rust for `source` and return the body of `pub fn main`.
+fn emitted_main(source: &str, tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!("almide-forin-clone-{}-{}", tag, std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let src = dir.join("prog.almd");
+    std::fs::write(&src, source).unwrap();
+    let output = Command::new(almide_bin())
+        .args([src.to_str().unwrap(), "--target", "rust"])
+        .output()
+        .expect("failed to spawn almide");
+    let rust = String::from_utf8_lossy(&output.stdout).to_string();
+    std::fs::remove_dir_all(&dir).ok();
+    assert!(output.status.success(), "--target rust emit failed:\n{}", String::from_utf8_lossy(&output.stderr));
+    let start = rust.find("pub fn main(").unwrap_or_else(|| panic!("emitted Rust has no `pub fn main(`:\n{rust}"));
+    let rest = &rust[start..];
+    let end = rest.find("\n}").map(|i| i + 2).unwrap_or(rest.len());
+    rest[..end].to_string()
+}
+
+const PRELUDE: &str = "type U = { a: Int }\n\
+    fn hit(v: Value) -> Int = match value.as_int(v) { ok(n) => n, err(_) => 0 }\n\
+    fn hitu(u: U) -> Int = u.a\n";
+
+#[test]
+fn list_loop_borrows_the_list_and_moves_the_element() {
+    if !tool_available() { eprintln!("skipping: almide binary not available"); return; }
+    let body = emitted_main(&format!("{PRELUDE}\
+        fn main() -> Unit = {{\n\
+          let data: List[Value] = [value.int(1), value.int(2)]\n\
+          var t = 0\n\
+          for v in data {{ t = t + hit(v) }}\n\
+          for v in data {{ t = t + hit(v) }}\n\
+          println(\"${{t}}\")\n\
+        }}\n"), "borrow-move");
+    assert!(body.contains("for v in data.iter().cloned()"), "the list is borrowed by `.iter()`, a clone under it is a throwaway copy:\n{body}");
+    assert!(!body.contains("data.clone()"), "whole-list clone is back on the loop head:\n{body}");
+    assert!(body.contains("hit(v)"), "the loop variable is rebound every iteration; its last use is a move:\n{body}");
+    assert!(!body.contains("v.clone()"), "loop-variable clone is back:\n{body}");
+}
+
+#[test]
+fn body_bound_let_moves_at_its_last_use() {
+    if !tool_available() { eprintln!("skipping: almide binary not available"); return; }
+    let body = emitted_main(&format!("{PRELUDE}\
+        fn main() -> Unit = {{\n\
+          let data: List[Value] = [value.int(1), value.int(2)]\n\
+          var t = 0\n\
+          for v in data {{\n\
+            let w = v\n\
+            t = t + hit(w)\n\
+          }}\n\
+          println(\"${{t}}\")\n\
+        }}\n"), "let-move");
+    assert!(body.contains("let w: Value = v;"), "`let w = v` is the loop variable's last use — a move:\n{body}");
+    assert!(body.contains("hit(w)") && !body.contains("w.clone()"), "a body-level `let` is rebound every iteration too:\n{body}");
+}
+
+#[test]
+fn body_that_writes_the_list_keeps_the_head_copy() {
+    if !tool_available() { eprintln!("skipping: almide binary not available"); return; }
+    let body = emitted_main(&format!("{PRELUDE}\
+        fn main() -> Unit = {{\n\
+          var xs: List[String] = [\"u\", \"v\"]\n\
+          for s in xs {{ list.push(xs, s) }}\n\
+          println(\"${{list.len(xs)}}\")\n\
+        }}\n"), "writes");
+    assert!(body.contains("for s in xs.clone().iter().cloned()"), "`list.push(xs, …)` holds `&mut xs` under the loop's borrow — the head copy is load-bearing:\n{body}");
+    assert!(body.contains("almide_rt_list_push(&mut xs, s)"), "the pushed element is still the loop variable's last use (a move):\n{body}");
+}
+
+#[test]
+fn outer_loop_variable_used_in_an_inner_loop_still_clones() {
+    if !tool_available() { eprintln!("skipping: almide binary not available"); return; }
+    let body = emitted_main(&format!("{PRELUDE}\
+        fn main() -> Unit = {{\n\
+          let data: List[Value] = [value.int(1), value.int(2)]\n\
+          var t = 0\n\
+          for v in data {{\n\
+            for i in 0..<2 {{ t = t + hit(v) + i }}\n\
+          }}\n\
+          println(\"${{t}}\")\n\
+        }}\n"), "nested");
+    assert!(body.contains("hit(v.clone())"), "an outer loop variable is NOT fresh inside the inner loop — it must clone:\n{body}");
+}
+
+#[test]
+fn loop_variable_captured_by_a_closure_still_clones() {
+    if !tool_available() { eprintln!("skipping: almide binary not available"); return; }
+    let body = emitted_main(&format!("{PRELUDE}\
+        fn main() -> Unit = {{\n\
+          let data: List[Value] = [value.int(1), value.int(2)]\n\
+          var t = 0\n\
+          for v in data {{\n\
+            let f = () => hit(v)\n\
+            t = t + f() + f()\n\
+          }}\n\
+          println(\"${{t}}\")\n\
+        }}\n"), "closure");
+    // The capture pass hands the closure its own copy (`__cap_N`), and the
+    // closure body clones THAT on every call — the loop variable itself is
+    // consumed once, by the capture bind. Before #1673 that bind read
+    // `v.clone().clone()`: the capture pass's copy, cloned again by the
+    // in-loop always-clone rule.
+    assert!(body.contains("= v.clone();"), "the capture bind copies the loop variable exactly once:\n{body}");
+    assert!(!body.contains("v.clone().clone()"), "the double clone on the capture bind is back:\n{body}");
+    assert!(body.contains("hit(__cap_"), "the closure body must read its own capture, never the loop variable:\n{body}");
+}
+
+#[test]
+fn map_loop_still_consumes_a_copy_when_the_map_is_used_after() {
+    if !tool_available() { eprintln!("skipping: almide binary not available"); return; }
+    let body = emitted_main("fn eat(s: String) -> Int = string.len(s)\n\
+        fn main() -> Unit = {\n\
+          let m: Map[String, String] = [\"a\": \"x\"]\n\
+          var t = 0\n\
+          for (k, v) in m { t = t + eat(k) + eat(v) }\n\
+          println(\"${t} ${list.len(map.keys(m))}\")\n\
+        }\n", "map");
+    assert!(body.contains("for (k, v) in m.clone()"), "a Map loop iterates BY VALUE — the copy is what keeps `m` alive for the later use:\n{body}");
+}


### PR DESCRIPTION
Closes #1673.

`for x in xs` lowered to `xs.clone().iter().cloned()` and then cloned `x` again at every consuming use — a whole-list copy on loop entry, one element copy per iteration, a third copy at the call. Measured on the #1673 workload: 735 ns per iteration before a single field was read.

Three facts the clone pass now knows, in commit order:

1. **The loop's own binders are body-locals** (`use_count.rs`). They are rebound every iteration, so they are not outer captures; bumping them made every `for v in xs { f(v) }` clone `v` for a body that consumed it once.
2. **A List head is a borrow; binders are fresh per iteration** (`pass_clone.rs`, new `pass_clone_loops.rs`). `.iter()` never consumes `xs`, so the `Clone` under it is stripped — unless the body *writes* the list (`list.push(xs, …)`, `xs[i] = …`, `xs = …`), where the throwaway copy is what keeps the body's `&mut` legal (`body_writes_var`). `CloneCtx::fresh` carries the loop binders plus the body's top-level `let`s; their last use is a move even under `in_loop`. Nested loops and closure bodies get an empty `fresh` (an outer binder used inside them is not fresh there). The loop arms moved to `pass_clone_loops.rs` — `pass_clone.rs` was already over codopsy's 800-line limit.
3. **A borrow-only body iterates by reference** (`borrowed_loop_vars` annotation). When every occurrence of the binder sits under a shared `Borrow`, a `Member` read, or a `Clone` — and none inside a lambda / fused chain — the walker emits `xs.iter()` and binds `&T`: no per-element copy at all. A bare (moving) use, a `&mut`, a match subject, an interpolation, or a tuple binder keeps `.cloned()`.

**What does not move**: a Map loop still consumes a copy when the map is used after (it iterates by value); an outer binder used in an inner loop still clones; a closure-captured binder is copied exactly once by the capture bind (it was `v.clone().clone()` before).

**Evidence**
- 8 emit-shape tests (`tests/for_in_clone_elision_test.rs`), each asserting the exact `.clone()` that must be present or absent.
- Native sweep: every `spec/wasm_cross`, `spec/programs`, `examples` program (664) run with this compiler vs v0.59.2 — byte-identical stdout/stderr/exit.
- `cargo test --workspace --release`: 224 suites, 0 failed. `scripts/check-perf-ratio.sh`: every anchored row ok (fft 1.176 → 1.160).
- codopsy `almide-codegen`: A(91) / 34 warnings before and after.

**Measured** (1M iterations, arm64, ns/op, this branch alone vs v0.59.2):

| | before | after |
|---|---:|---:|
| empty `for v in data` over 1000 8-field `Value`s | 802 | **0** |
| `for v in data { value.field(v, "id") }` (borrow-only) | 1190 | 382 |
| `User.decode(v)` in a loop (consuming) | 1662 | 882 |

Combined with #1680 and the decode-borrow PR that follows, the decode loop lands at 514 ns (from 1693).