### PR TITLE
Reserved constructor names get a rename-or-backtick hint at binding position instead of the expected-identifier misdirection

### DIFF
--- a/crates/almide-syntax/src/parser/helpers.rs
+++ b/crates/almide-syntax/src/parser/helpers.rs
@@ -266,6 +266,15 @@ impl Parser {
         let hint = match (&tok.token_type, tok.value.as_str()) {
             (TokenType::Underscore, _) => "\n  Hint: '_' can only be used in match patterns, not as a variable name.",
             (TokenType::Test, _) => "\n  Hint: `test \"...\"` is a top-level form. Got here mid-declaration — either the previous fn/type/impl is missing a closing `}`, or the test block shouldn't be in this file at all (harness-submitted code).",
+            // The Result/Option constructors are keywords in BOTH spellings ("ok"
+            // and "Ok" lex to the same token), and they are exactly what a model
+            // trained on Go or Rust reaches for as a binding name (#1694). Without
+            // these arms the error says "Expected identifier (got Err 'err')" and
+            // the generic check-the-token-before hint points AWAY from the fix.
+            (TokenType::Ok, _) => "\n  Hint: 'ok' is the built-in Result constructor ok(v) — a reserved word, not a binding name. Rename the binding (e.g. res), or write it in backticks (`ok`) to use the keyword as a name. Also reserved: err, some, none and their capitalized forms.",
+            (TokenType::Err, _) => "\n  Hint: 'err' is the built-in Result constructor err(e) — a reserved word, not a binding name. Rename the binding (e.g. e, msg), or write it in backticks (`err`) to use the keyword as a name. Also reserved: ok, some, none and their capitalized forms.",
+            (TokenType::Some, _) => "\n  Hint: 'some' is the built-in Option constructor some(v) — a reserved word, not a binding name. Rename the binding, or write it in backticks (`some`) to use the keyword as a name. Also reserved: ok, err, none and their capitalized forms.",
+            (TokenType::None, _) => "\n  Hint: 'none' is the built-in Option constructor — a reserved word, not a binding name. Rename the binding, or write it in backticks (`none`) to use the keyword as a name. Also reserved: ok, err, some and their capitalized forms.",
             // A backtick lands here only as a MALFORMED escape — the lexer
             // declines one enclosing no identifier character (#1457). Binding
             // position never reaches `unknown_char_error`, so the hint that

--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -831,6 +831,7 @@ fn types, Result) — wrap those in a named Codec type or convert at the boundar
 - `1 :: 2 :: []` → **WRONG**. Write `[1, 2]`. There is no cons operator `::`
 - `fn foo<T>(x: T)` → **WRONG**. Write `fn foo[T](x: T)`. Use `[]` for generics, not `<>`
 - `let mut x = 1` → **WRONG**. Write `var x = 1`. `mut` is only a parameter modifier (`fn f(mut x: Int)`), not a binding modifier
+- `let err = f()` → **WRONG**. `ok`/`err`/`some`/`none` (and capitalized forms) are the built-in Result/Option constructors — reserved words. Rename the binding (`let msg = f()`), or backtick-escape to keep the name (`let `err` = f()`)
 - Nested `fn` inside a function → **WRONG**. All `fn` must be top-level. Use `let helper = (x) => ...` for local functions
 - `match x { ... pattern => expr }` with `...` → **WRONG**. No spread in patterns
 - `async fn` / `await` → **WRONG**. Almide has no async/await. Use `fan.any` / `fan.settle` / `fan.race` / `fan.bounded` block forms

--- a/tests/diagnostics/reserved-ctor-binding/broken.almd
+++ b/tests/diagnostics/reserved-ctor-binding/broken.almd
@@ -1,0 +1,8 @@
+// `err` is the Result constructor keyword — binding it used to die with a raw
+// "Expected identifier (got Err 'err')" whose hint pointed at the token BEFORE.
+fn main() -> Unit = {
+  let err = compute()
+  println("${err}")
+}
+
+fn compute() -> Int = 2

--- a/tests/diagnostics/reserved-ctor-binding/fixed.almd
+++ b/tests/diagnostics/reserved-ctor-binding/fixed.almd
@@ -1,0 +1,6 @@
+fn main() -> Unit = {
+  let msg = compute()
+  println("${msg}")
+}
+
+fn compute() -> Int = 2

--- a/tests/diagnostics/reserved-ctor-binding/meta.toml
+++ b/tests/diagnostics/reserved-ctor-binding/meta.toml
@@ -1,0 +1,2 @@
+expects_error = "Expected identifier"
+hint_substring = "built-in Result constructor err(e)"


### PR DESCRIPTION
Closes #1694.

`let err = 2` used to say `Expected identifier (got Err 'err')` with the generic "check the token just BEFORE this position" hint — the internal token type leaking through, no statement that the word is reserved, and a hint pointing away from the fix. These four names (`ok`/`err`/`some`/`none`, both spellings each) are exactly what a model trained on Go or Rust reaches for as a binding name.

## What changed

- `expect_ident` gains four arms in its existing hint table (the `fan`-import precedent): each names the constructor (`'err' is the built-in Result constructor err(e) — a reserved word, not a binding name`), offers the rename, offers the backtick escape (`` `err` `` — verified working for all four), and lists the other reserved names.
- `tests/diagnostics/reserved-ctor-binding/` — broken/fixed/meta trio on the existing harness; the harness pins that the broken form carries the new hint and the fixed form compiles.
- One WRONG line in `docs/CHEATSHEET.md` beside `let mut` — the model-facing half of the fix.

No new error code: this stays the expected-identifier diagnostic with a specific hint, so no registry/llms.txt ceremony and no E-number allocation (a shared mutable resource with concurrent sessions).

## Verification

- `almide check` on all four names + capitalized spellings shows the specific hint; backtick escape still binds (`` let `err` = 2 `` runs).
- `cargo test --release --test diagnostic_harness_test`: 6 passed (new case included).
- Full `almide test`: **426/426 files pass** (417 wasm, 9 native fallback).
- New fixture's `fixed.almd` is `fmt --check` clean.
