### PR TITLE
When both wasm legs wall, both walls are printed — the structural leg's reason is no longer swallowed by the incumbent's

### DIFF
--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -793,7 +793,16 @@ fn render_wasm_module_routed(
         if std::env::var_os("ALMIDE_VERIFIED_DEBUG").is_some() {
             err(&format!("[almide] structural leg declined ({why}) — incumbent renderer"));
         }
-        render_wasm_module(source_text, v1_self_modules, library_ok).map(|(b, _)| (b, false))
+        let res = render_wasm_module(source_text, v1_self_modules, library_ok).map(|(b, _)| (b, false));
+        if res.is_err() {
+            // #1690: BOTH legs refused. The incumbent just printed its own wall
+            // above — without these lines the DEFAULT leg's reason is invisible,
+            // and the reader bisects a function the structural leg lowers fine
+            // for a reason that belongs to the other engine.
+            err(&format!("wall (structural leg, the default): {why}"));
+            err("note: both wasm legs refused this program — the failure above these lines is the incumbent fallback's; the structural leg's own reason is the `wall (structural leg…)` line.");
+        }
+        res
     };
     let ir = match almide::wasm_leg::lower_to_ir_with_deps(file, source_text, dep_paths) {
         Ok(ir) => ir,

--- a/tests/both_walls_reported_test.rs
+++ b/tests/both_walls_reported_test.rs
@@ -1,0 +1,94 @@
+//! #1690: when the structural leg declines and the incumbent fallback also
+//! refuses, only the incumbent's wall used to be printed — the DEFAULT leg's
+//! own reason (often a completely different shape, e.g. the two-mut-param
+//! C-132 write-back) was invisible, and the reader bisected a function the
+//! structural leg lowers fine for a reason that belongs to the other engine.
+//! The router now prints both, each labelled with its leg.
+
+use std::process::Command;
+
+fn almide() -> &'static str {
+    env!("CARGO_BIN_EXE_almide")
+}
+
+/// A fn mutating TWO mut params: outside both legs' subsets today (the
+/// structural leg's C-132 write-back covers one; the incumbent refuses the
+/// index-assign on a mut List param), so the build must fail — with BOTH
+/// reasons on stderr.
+const DOUBLE_WALL: &str = r#"fn two(mut a: List[Int], mut b: List[Int]) -> Int = {
+  a[0] = a[0] + 1
+  list.push(b, 1)
+  a[0]
+}
+
+fn main() -> Unit = {
+  var a = [0]
+  var b: List[Int] = []
+  let r = two(a, b)
+  println("${r}")
+}
+"#;
+
+#[test]
+fn both_leg_walls_are_reported_with_their_leg() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("double_wall.almd");
+    let wasm = dir.path().join("double_wall.wasm");
+    std::fs::write(&src, DOUBLE_WALL).expect("write repro");
+
+    let out = Command::new(almide())
+        .args(["build", src.to_str().unwrap(), "--target", "wasm", "-o", wasm.to_str().unwrap()])
+        .output()
+        .expect("run almide build");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        !out.status.success(),
+        "a program neither leg lowers must fail the build; stderr:\n{stderr}"
+    );
+    // The incumbent's wall keeps its rich diagnostics…
+    assert!(
+        stderr.contains("not in this brick"),
+        "the incumbent's wall text is missing; stderr:\n{stderr}"
+    );
+    // …and the structural leg's own reason is no longer swallowed.
+    assert!(
+        stderr.contains("wall (structural leg, the default):"),
+        "the structural leg's wall line is missing (#1690); stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("both wasm legs refused"),
+        "the both-legs note is missing; stderr:\n{stderr}"
+    );
+}
+
+/// The added lines must NOT appear when the reroute succeeds: a shape the
+/// structural leg declines but the incumbent lowers stays a silent, working
+/// handover (the pre-#1690 contract for the success path).
+const HANDOVER_OK: &str = r#"import env
+
+fn main() -> Unit = {
+  let os = env.os()
+  println(os)
+}
+"#;
+
+#[test]
+fn successful_handover_stays_silent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("handover.almd");
+    let wasm = dir.path().join("handover.wasm");
+    std::fs::write(&src, HANDOVER_OK).expect("write repro");
+
+    let out = Command::new(almide())
+        .args(["build", src.to_str().unwrap(), "--target", "wasm", "-o", wasm.to_str().unwrap()])
+        .output()
+        .expect("run almide build");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(out.status.success(), "host-variant program must build via the incumbent; stderr:\n{stderr}");
+    assert!(
+        !stderr.contains("wall (structural leg"),
+        "the both-walls report leaked into a successful handover; stderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Closes #1690.

When the structural leg declined and the incumbent fallback also refused, only the incumbent's wall was printed. The default leg's own reason was invisible — and it is routinely a *different* reason about a *different* function: the investigation that filed this issue spent an hour bisecting `bump`-shaped functions the structural leg lowers fine, because the printed wall (`index-assign outside the scalar-element store subset`, on `bump`) was the incumbent talking after the structural leg had already refused for the two-mut-param write-back on `two`.

## What changed

`render_wasm_module_routed`'s reroute: when the incumbent fallback ALSO fails, two labelled lines follow its wall —

```
wall: exported `pub fn two` is outside the MIR-lowering subset … C-132 not in this brick
wall (structural leg, the default): call-fn:two:mut-param
note: both wasm legs refused this program — the failure above these lines is the incumbent fallback's; the structural leg's own reason is the `wall (structural leg…)` line.
```

The success path is untouched: a shape the structural leg declines but the incumbent lowers stays a silent working handover, `ALMIDE_VERIFIED_DEBUG=1` narrates as before, and `ALMIDE_WASM_STRUCTURAL=1` keeps its hard-error form.

## Tests

`tests/both_walls_reported_test.rs`, two-sided:
- a two-mut-param program (neither leg lowers it today) must fail with the incumbent's text AND the labelled structural line AND the note;
- a host-variant program (structural declines, incumbent builds) must succeed with none of the new lines on stderr.

## Verification

- `cargo test --release --test both_walls_reported_test`: 2 passed.
- Full `almide test`: **426/426 files pass**.
