### PR TITLE
Derived decode's borrow signature reaches every mirror key: Option-of-heap Codec fields build native again

### DIFF
--- a/crates/almide-codegen/src/pass_borrow_inference.rs
+++ b/crates/almide-codegen/src/pass_borrow_inference.rs
@@ -392,9 +392,41 @@ fn infer_program_fn_borrows(program: &mut IrProgram, sigs: &mut HashMap<String, 
     }
 }
 
+/// Upsert one MIRROR key (`owner` is the claimant's `mod::name` identity —
+/// unique across modules, so same-named fns in two modules stay two
+/// claimants). Mirrors are shared namespace, so the first claimant
+/// keeps the key (`or_insert`'s arbitration against same-named fns and against
+/// canonical entries) — but the claimant itself must keep its mirror CURRENT
+/// across fixed-point iterations. Frozen `or_insert` mirrors were #1713: a
+/// derived decode whose record has an Option-of-heap field infers `Ref` only
+/// in round 1 (round 0 runs before the generated option workers' signatures
+/// exist), so the bare `Type.decode` key a cross-module call site carries kept
+/// round 0's `Own` while the definition emitted `&Value` — E0308 on a program
+/// `check` had passed.
+fn upsert_mirror(
+    sigs: &mut HashMap<String, Vec<ParamBorrow>>,
+    owners: &mut HashMap<String, String>,
+    key: String,
+    owner: &str,
+    borrows: &[ParamBorrow],
+) {
+    use std::collections::hash_map::Entry;
+    match sigs.entry(key) {
+        Entry::Occupied(mut e) => {
+            if owners.get(e.key()).is_some_and(|o| o == owner) {
+                *e.get_mut() = borrows.to_vec();
+            }
+        }
+        Entry::Vacant(e) => {
+            owners.insert(e.key().clone(), owner.to_string());
+            e.insert(borrows.to_vec());
+        }
+    }
+}
+
 /// One fixed-point iteration's pass over module functions. Same shape and
 /// same safety rationale as `infer_program_fn_borrows`.
-fn infer_program_module_borrows(program: &mut IrProgram, sigs: &mut HashMap<String, Vec<ParamBorrow>>) {
+fn infer_program_module_borrows(program: &mut IrProgram, sigs: &mut HashMap<String, Vec<ParamBorrow>>, mirror_owners: &mut HashMap<String, String>) {
     for module in &mut program.modules {
         let mod_name = module.name.to_string();
         MOD_SCOPE.with(|m| *m.borrow_mut() = Some(mod_name.clone()));
@@ -441,7 +473,8 @@ fn infer_program_module_borrows(program: &mut IrProgram, sigs: &mut HashMap<Stri
                 // or another module keeps its own signature — the same
                 // last-resort rule MODULE_METHOD_FNS applies to its tail key.
                 if func.name.as_str().contains('.') {
-                    sigs.entry(func.name.to_string()).or_insert_with(|| borrows.clone());
+                    let owner = format!("{}::{}", mod_name, func.name);
+                    upsert_mirror(sigs, mirror_owners, func.name.to_string(), &owner, &borrows);
                 }
                 // …and, for a NAMESPACED derive (`varlib.Pigment.decode` — the
                 // fn is named `mod.Type.method` once its type is `mod.Type`,
@@ -453,13 +486,14 @@ fn infer_program_module_borrows(program: &mut IrProgram, sigs: &mut HashMap<Stri
                 // above miss because they prefix the origin a second time.
                 let segs: Vec<&str> = func.name.as_str().split('.').collect();
                 if segs.len() > 2 {
+                    let owner = format!("{}::{}", mod_name, func.name);
                     let tail = format!("{}.{}", segs[segs.len() - 2], segs[segs.len() - 1]);
-                    sigs.entry(format!("{}::{}", mod_name, tail)).or_insert_with(|| borrows.clone());
-                    sigs.entry(tail).or_insert_with(|| borrows.clone());
+                    upsert_mirror(sigs, mirror_owners, format!("{}::{}", mod_name, tail), &owner, &borrows);
+                    upsert_mirror(sigs, mirror_owners, tail, &owner, &borrows);
                     let origin = mod_name.replace('.', "_");
                     let flat = func.name.as_str().replace('.', "_");
                     let base = flat.strip_prefix(&format!("{}_", origin)).unwrap_or(&flat).to_string();
-                    sigs.entry(format!("almide_rt_{}_{}", origin, base)).or_insert_with(|| borrows.clone());
+                    upsert_mirror(sigs, mirror_owners, format!("almide_rt_{}_{}", origin, base), &owner, &borrows);
                 }
             }
             for (param, borrow) in func.params.iter_mut().zip(borrows) {
@@ -471,6 +505,8 @@ fn infer_program_module_borrows(program: &mut IrProgram, sigs: &mut HashMap<Stri
 
 pub fn infer_borrow_signatures(program: &mut IrProgram) -> HashMap<String, Vec<ParamBorrow>> {
     let mut sigs: HashMap<String, Vec<ParamBorrow>> = HashMap::new();
+    // Which fn (`mod::name`) first claimed each MIRROR key — see `upsert_mirror`.
+    let mut mirror_owners: HashMap<String, String> = HashMap::new();
 
     seed_record_names(program);
     seed_intrinsic_sigs(&mut sigs);
@@ -483,8 +519,15 @@ pub fn infer_borrow_signatures(program: &mut IrProgram) -> HashMap<String, Vec<P
 
         MOD_SCOPE.with(|m| *m.borrow_mut() = None);
         infer_program_fn_borrows(program, &mut sigs);
-        infer_program_module_borrows(program, &mut sigs);
+        infer_program_module_borrows(program, &mut sigs, &mut mirror_owners);
 
+        // ALMIDE_DBG_BORROW=<substr>: dump every matching sig key per
+        // fixed-point iteration (the probe that caught #1713's frozen mirrors).
+        if let Ok(filter) = std::env::var("ALMIDE_DBG_BORROW") {
+            for (k, v) in &sigs {
+                if k.contains(&filter) { eprintln!("[borrow iter {_iter}] {k} -> {v:?}"); }
+            }
+        }
         if sigs == prev_sigs {
             break;
         }

--- a/crates/almide-codegen/src/pass_borrow_inference_call_sites.rs
+++ b/crates/almide-codegen/src/pass_borrow_inference_call_sites.rs
@@ -55,6 +55,15 @@ fn wrap_call_args_for_target(args: Vec<IrExpr>, target: &CallTarget, sigs: &Hash
         _ => (None, false),
     };
     let Some(name) = callee_name else { return args; };
+    // ALMIDE_DBG_BORROW=<substr>: name the two keys this call site consults
+    // and what each resolved to (companion of the per-iteration sig dump).
+    if let Ok(filter) = std::env::var("ALMIDE_DBG_BORROW")
+        && name.contains(&filter)
+    {
+        let direct = sigs.get(&name).cloned();
+        let scoped = mod_scope.and_then(|m| sigs.get(&format!("{}::{}", m, name))).cloned();
+        eprintln!("[borrow callsite] name={name} scope={mod_scope:?} scoped={scoped:?} direct={direct:?}");
+    }
     // For module-scoped calls, look up with "module::func" key first
     let borrows = mod_scope
         .and_then(|m| sigs.get(&format!("{}::{}", m, name)))

--- a/tests/native_codec_option_decode_pin_test.rs
+++ b/tests/native_codec_option_decode_pin_test.rs
@@ -1,0 +1,110 @@
+//! NATIVE-leg regression pin for #1713 (0.60.0 regression, the "check green
+//! must build" class).
+//!
+//! A derived `Codec` type living in an imported module, with an Option-of-heap
+//! field (`Option[List[Record]] = none` is the reported shape), infers its
+//! decode's `&Value` borrow only in fixed-point round 1 — round 0 runs before
+//! the generated option workers' signatures exist. The MIRROR sig keys a
+//! cross-module call site resolves through (`Thing.decode` et al.) were
+//! `or_insert`-frozen at round 0's `Own`, so the definition emitted
+//! `decode(_v: &Value)` while the call site kept passing `Value` by value —
+//! rustc E0308 on a program `check` had accepted.
+//!
+//! The wasm leg never had the bug (`almide test` runs there — A/B-verified:
+//! the pre-fix 0.61.0 binary passes a spec/ fixture of this same shape), so
+//! per the tests/native_mut_param_pins_test.rs doctrine this pins at the
+//! compiler level on the NATIVE target; spec/stdlib/codec_field_matrix_test
+//! pins the cross-target field semantics.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+/// Write `files` under a temp package dir, `almide run` (NATIVE target) the
+/// first one, assert it prints `expected`.
+fn run_prints(name: &str, files: &[(&str, &str)], expected: &str) {
+    let dir = std::env::temp_dir().join(format!("almd_codec_opt_pin_{name}_{}", std::process::id()));
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("almide.toml"),
+        "[package]\nname = \"pins\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    for (rel, src) in files {
+        let file = dir.join(rel);
+        let mut f = std::fs::File::create(&file).unwrap();
+        f.write_all(src.as_bytes()).unwrap();
+    }
+    let entry = dir.join(files[0].0);
+    let out = Command::new(almide_bin())
+        .args(["run", entry.to_str().unwrap()])
+        .output()
+        .expect("failed to spawn almide");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    std::fs::remove_dir_all(&dir).ok();
+    assert!(
+        out.status.success(),
+        "[{name}] almide run (native) failed — the pinned native codegen bug is back?\n{stderr}"
+    );
+    assert_eq!(stdout.trim_end(), expected, "[{name}] wrong output");
+}
+
+#[test]
+fn cross_module_decode_with_option_list_record_field_builds_native() {
+    run_prints(
+        "opt_list_rec",
+        &[
+            (
+                "src/main.almd",
+                r#"import self.thing
+import json
+
+effect fn main() -> Unit = {
+  match thing.Thing.decode(json.parse("{\"schema\":\"s1\"}") ?? value.null()) {
+    Ok(t) => {
+      println(t.schema)
+      match t.extra {
+        some(_) => println("some"),
+        none => println("none"),
+      }
+    },
+    Err(e) => println("bad: " + e),
+  }
+  match thing.Thing.decode(json.parse("{\"schema\":\"s2\",\"extra\":[{\"name\":\"a\"},{\"name\":\"b\"}]}") ?? value.null()) {
+    Ok(t) => match t.extra {
+      some(items) => println(int.to_string(list.len(items))),
+      none => println("none"),
+    },
+    Err(e) => println("bad: " + e),
+  }
+}
+"#,
+            ),
+            (
+                "src/thing.almd",
+                r#"type Item: Codec = {
+  name: String,
+}
+
+type Thing: Codec = {
+  schema: String,
+  extra: Option[List[Item]] = none,
+}
+"#,
+            ),
+        ],
+        "s1\nnone\n2",
+    );
+}


### PR DESCRIPTION
Closes #1713.

**The regression (0.60.0):** a derived `Codec` type in an imported module with an Option-of-heap field (`Option[List[Record]] = none` is the reported shape — `Option[Record]` and `Option[List[String]]`, defaulted or not, all reproduce) generated `decode(_v: &Value)` while the cross-module call site kept passing `Value` by value. `check` green, native `build` dies with rustc E0308 — the class v0.59.1 was named after.

**Root cause** (probe-confirmed, per-iteration sig dump): borrow inference runs as a fixed point. A decode whose record has an Option-of-heap field infers its `&Value` borrow only in round 1 — round 0 runs before the generated option workers' signatures exist. The fn's canonical sig keys (`mod::name`, dotted) are `insert`-updated every round, but the four MIRROR keys (`Type.decode` bare tail, `mod::Type.method`, the fn-name key, the origin-stripped `almide_rt_*` symbol) were `or_insert`-frozen at round 0's `Own`. A cross-module call site resolves through the bare tail — so def said Ref, call site said Own. Simple shapes (`List[Record]`) prove Ref in round 0 because the list codec drivers are intrinsic-seeded upfront, which is why variants A/B/D in the issue build and C does not.

**Fix:** `upsert_mirror` — mirrors keep `or_insert`'s arbitration (first claimant wins the shared key; canonical entries are never clobbered) via an owner map keyed `mod::name`, but the claimant itself updates its own mirror every iteration instead of freezing.

**Evidence:**
- `tests/native_codec_option_decode_pin_test.rs` — the exact cross-module repro on the NATIVE target, A/B-verified: **fails on the released 0.61.0 binary, passes with the fix**. (The wasm leg never had the bug — `almide test` runs there, which is why a spec fixture alone pins nothing; same doctrine as `tests/native_mut_param_pins_test.rs`.)
- `ALMIDE_DBG_BORROW=<substr>` probes stay in: per-iteration sig dump + call-site key resolution, the probe pair that isolated this.
- `almide test` 426/426; full `cargo test --workspace --release` green; check/ast parity green.