### PR TITLE
fmt reprints own-line comments inside list and map literals instead of refusing the file forever

### DIFF
--- a/crates/almide-syntax/src/parser/collections.rs
+++ b/crates/almide-syntax/src/parser/collections.rs
@@ -177,7 +177,11 @@ impl Parser {
         let span = Some(self.current_span());
         let open = self.current().clone();
         self.expect(TokenType::LBracket)?;
-        self.skip_newlines();
+        // #1714: own-line comments before an element introduce it — collect
+        // and bind them LEADING on the element's id so fmt can reprint them.
+        // Comments with no following element (before `]`) stay uncollected and
+        // the conservation verifier keeps refusing that shape.
+        let pending = self.skip_newlines_collecting();
 
         if self.check(TokenType::RBracket) {
             self.advance();
@@ -190,6 +194,7 @@ impl Parser {
         }
 
         let first = self.parse_expr()?;
+        self.attach_leading_comments(first.id, pending);
         self.skip_newlines();
 
         if self.check(TokenType::Colon) {
@@ -200,9 +205,11 @@ impl Parser {
         let mut elements = vec![first];
         while self.check(TokenType::Comma) {
             self.advance();
-            self.skip_newlines();
+            let pending = self.skip_newlines_collecting();
             if self.check(TokenType::RBracket) { break; }
-            elements.push(self.parse_expr()?);
+            let e = self.parse_expr()?;
+            self.attach_leading_comments(e.id, pending);
+            elements.push(e);
             self.skip_newlines();
         }
         if !self.check(TokenType::RBracket) && !self.check(TokenType::EOF) {
@@ -224,9 +231,12 @@ impl Parser {
         let mut entries = vec![(first_key, first_value)];
         while self.check(TokenType::Comma) {
             self.advance();
-            self.skip_newlines();
+            // #1714: same leading-comment collection as the list arm — a map
+            // entry's comments bind to its KEY expression.
+            let pending = self.skip_newlines_collecting();
             if self.check(TokenType::RBracket) { break; }
             let key = self.parse_expr()?;
+            self.attach_leading_comments(key.id, pending);
             self.skip_newlines();
             self.expect(TokenType::Colon)?;
             self.skip_newlines();

--- a/crates/almide-syntax/src/parser/helpers.rs
+++ b/crates/almide-syntax/src/parser/helpers.rs
@@ -458,6 +458,31 @@ impl Parser {
         }
     }
 
+    /// Bind `comments` as LEADING on `id` (the #1714 list/map-element path —
+    /// same table the #1404 inline machinery writes to, so fmt reads one map).
+    pub(crate) fn attach_leading_comments(&mut self, id: crate::ast::ExprId, comments: Vec<String>) {
+        if comments.is_empty() { return; }
+        self.expr_comments.entry(id).or_default().leading.extend(comments);
+    }
+
+    /// Like `skip_newlines`, but COLLECT the comment tokens skipped over: the
+    /// own-line comments inside a bracketed literal that introduce the element
+    /// that follows (#1714 — the `// ---- group ----` catalog idiom). The
+    /// caller attaches the result as LEADING on the next node it parses
+    /// (attach-to-following, #1326's ruling); a caller that finds no next node
+    /// leaves them uncollected-in-output and the conservation verifier keeps
+    /// refusing that shape honestly.
+    pub(crate) fn skip_newlines_collecting(&mut self) -> Vec<String> {
+        let mut collected = Vec::new();
+        while self.check(TokenType::Newline) || self.check(TokenType::Comment) {
+            if self.check(TokenType::Comment) {
+                collected.push(self.current().value.clone());
+            }
+            self.advance();
+        }
+        collected
+    }
+
     /// Skip newlines only if the next non-newline token matches `tt`.
     /// This allows multiline continuation for operators like `|>`.
     pub(crate) fn skip_newlines_if_followed_by(&mut self, tt: TokenType) {

--- a/crates/almide-tools/src/fmt_expr.rs
+++ b/crates/almide-tools/src/fmt_expr.rs
@@ -536,14 +536,50 @@ fn fmt_block(out: &mut String, stmts: &[Stmt], expr: &Option<Box<Expr>>, depth: 
     w!(out, "{}}}", ind(depth));
 }
 
+/// Does `id` carry LEADING comments (the #1714 own-line element-introducer
+/// shape)? Decides multi-line forcing for list/map literals: an own-line `//`
+/// comment has nowhere to go on one line — the record-type precedent
+/// (`fmt_record_type`).
+fn has_leading_comments(id: ExprId) -> bool {
+    comments_for(id).is_some_and(|a| !a.leading.is_empty())
+}
+
+/// Emit `id`'s leading comments on their own lines at `depth` — the element
+/// position their author wrote them in. The caller then renders the node via
+/// [`fmt_expr_sans_leading`] so the generic inline-leading printer in
+/// [`fmt_expr`] does not print them a second time.
+fn emit_leading_comment_lines(out: &mut String, id: ExprId, depth: usize) {
+    if let Some(a) = comments_for(id) {
+        for c in &a.leading {
+            out.push_str(&ind(depth));
+            out.push_str(c);
+            out.push('\n');
+        }
+    }
+}
+
+/// Render `expr` with its LEADING comments already emitted own-line by the
+/// caller; trailing stays inline exactly as [`fmt_expr`] prints it.
+fn fmt_expr_sans_leading(out: &mut String, expr: &Expr, depth: usize) {
+    fmt_expr_inner(out, expr, depth);
+    if let Some(a) = comments_for(expr.id) {
+        for c in &a.trailing {
+            out.push(' ');
+            out.push_str(c);
+        }
+    }
+}
+
 fn fmt_list(out: &mut String, elements: &[Expr], depth: usize) {
     if elements.is_empty() { out.push_str("[]"); return; }
-    if elements.len() <= 5 && elements.iter().all(is_short) {
+    let any_leading = elements.iter().any(|e| has_leading_comments(e.id));
+    if !any_leading && elements.len() <= 5 && elements.iter().all(is_short) {
         out.push('['); comma_sep(out, elements, |out, e| fmt_expr(out, e, depth)); out.push(']');
     } else {
         out.push_str("[\n");
         for (i, e) in elements.iter().enumerate() {
-            out.push_str(&ind(depth + 1)); fmt_expr(out, e, depth + 1);
+            emit_leading_comment_lines(out, e.id, depth + 1);
+            out.push_str(&ind(depth + 1)); fmt_expr_sans_leading(out, e, depth + 1);
             if i < elements.len() - 1 { out.push(','); } out.push('\n');
         }
         w!(out, "{}]", ind(depth));
@@ -551,13 +587,18 @@ fn fmt_list(out: &mut String, elements: &[Expr], depth: usize) {
 }
 
 fn fmt_map(out: &mut String, entries: &[(Expr, Expr)], depth: usize) {
-    let short = entries.len() <= 3 && entries.iter().all(|(k, v)| is_short(k) && is_short(v));
+    let any_leading = entries.iter().any(|(k, _)| has_leading_comments(k.id));
+    let short = !any_leading && entries.len() <= 3 && entries.iter().all(|(k, v)| is_short(k) && is_short(v));
     let (open, close, d) = if short { ("[", "]", depth) } else { ("[\n", "]", depth + 1) };
     out.push_str(open);
     for (i, (k, v)) in entries.iter().enumerate() {
         if short { if i > 0 { out.push_str(", "); } }
-        else { out.push_str(&ind(d)); }
-        fmt_expr(out, k, d); out.push_str(": "); fmt_expr(out, v, d);
+        else {
+            emit_leading_comment_lines(out, k.id, d);
+            out.push_str(&ind(d));
+        }
+        if short { fmt_expr(out, k, d); } else { fmt_expr_sans_leading(out, k, d); }
+        out.push_str(": "); fmt_expr(out, v, d);
         if !short { if i < entries.len() - 1 { out.push(','); } out.push('\n'); }
     }
     if !short { out.push_str(&ind(depth)); }

--- a/crates/almide-tools/src/fmt_tests.rs
+++ b/crates/almide-tools/src/fmt_tests.rs
@@ -223,6 +223,52 @@ mod attr_tests {
         assert_eq!(once, twice, "formatting is not idempotent for attached comments");
     }
 
+    /// #1714: own-line comments inside a LIST literal introduce the element
+    /// that follows (the `// ---- group ----` catalog idiom). They bind
+    /// LEADING on that element and reprint on their own lines above it; a
+    /// list that carries one is forced multi-line (an own-line `//` has
+    /// nowhere to go on one line — the record-type precedent). Before this,
+    /// such files could never be formatted: the conservation verifier
+    /// refused them (E054) forever.
+    #[test]
+    fn own_line_comments_in_a_list_literal_stay_above_their_elements() {
+        let src = "type Fix = { id: String, who: String }\n\nlet FIXES: List[Fix] = [\n  // ---- group 1 ----\n  Fix { id: \"A-01\", who: \"dev\" },\n  // ---- group 2 ----\n  Fix { id: \"B-01\", who: \"ops\" },\n]\n";
+        let out = roundtrip(src);
+        let g1 = out.find("// ---- group 1 ----").expect("group 1 comment lost");
+        let a01 = out.find("A-01").expect("element 1 lost");
+        let g2 = out.find("// ---- group 2 ----").expect("group 2 comment lost");
+        let b01 = out.find("B-01").expect("element 2 lost");
+        assert!(g1 < a01 && a01 < g2 && g2 < b01, "comments drifted off their groups:\n{out}");
+        // Own line, not joined onto the element's line.
+        assert!(out.contains("// ---- group 1 ----\n"), "comment not on its own line:\n{out}");
+        let twice = roundtrip(&out);
+        assert_eq!(out, twice, "list-comment formatting is not idempotent");
+    }
+
+    /// #1714, the forcing rule: a list short enough for one line goes
+    /// multi-line the moment an element carries a leading comment.
+    #[test]
+    fn a_leading_comment_forces_a_short_list_multiline() {
+        let src = "let XS: List[Int] = [\n  // the answer\n  42,\n]\n";
+        let out = roundtrip(src);
+        assert!(out.contains("[\n"), "short list with a comment must not collapse to one line:\n{out}");
+        assert!(out.contains("// the answer"), "comment lost:\n{out}");
+        assert_eq!(out, roundtrip(&out), "not idempotent");
+    }
+
+    /// #1714, the map arm: entry-introducing comments bind to the entry's KEY
+    /// and survive in place.
+    #[test]
+    fn own_line_comments_in_a_map_literal_stay_above_their_entries() {
+        let src = "let M: Map[String, Int] = [\n  // first\n  \"a\": 1,\n  // second\n  \"b\": 2,\n]\n";
+        let out = roundtrip(src);
+        let c1 = out.find("// first").expect("first comment lost");
+        let a = out.find("\"a\"").expect("entry a lost");
+        let c2 = out.find("// second").expect("second comment lost");
+        assert!(c1 < a && a < c2, "map comments drifted:\n{out}");
+        assert_eq!(out, roundtrip(&out), "map-comment formatting is not idempotent");
+    }
+
     /// Parse → format → parse round-trip: the second parse must
     /// produce the same attribute structure as the first. This is
     /// the formatter's idempotency contract, stricter than matching


### PR DESCRIPTION
Closes #1714.

**The report:** own-line comments inside a list literal (the `// ---- group ----` catalog idiom) had no printer slot, so the E054 conservation verifier refused the file — permanently. 9 files / 32 comments in one real 45-module project could never be formatted, and a `fmt` CI step can never go green there.

**Mechanism** (the attach-to-following half of #1326's ruling, adopted on the issue):
- Parser: `skip_newlines_collecting` gathers the comments the list/map element loops used to discard, and binds them LEADING on the following element's `ExprId` — the same #1404 side table the inline machinery writes, so fmt reads one map. Map entries bind to their KEY.
- Printer: a list/map with a commented element is forced multi-line (an own-line `//` has nowhere to go on one line — the `fmt_record_type` precedent), comments reprint on their own lines above their element, and `fmt_expr_sans_leading` keeps the generic inline printer from emitting them twice.
- Dangling comments with no following element (before `]`) stay uncollected → the verifier keeps refusing those shapes honestly. That residue is #1326's remit, not this PR's.

**Evidence:** three new fmt unit tests (list grouping + idempotency, short-list multi-line forcing, map arm); the issue's repro formats, round-trips byte-stable, and still runs; `fmt --check` over spec/ (1240), examples/, stdlib/ — zero drift; `almide test` 426/426; check/ast parity green.