### PR TITLE
A type transitively containing a function value drops Debug/PartialEq/AlmideRepr like a direct one

### DIFF
--- a/crates/almide-codegen/src/walker/declarations.rs
+++ b/crates/almide-codegen/src/walker/declarations.rs
@@ -85,7 +85,7 @@ pub fn render_type_decl(ctx: &RenderContext, td: &IrTypeDecl) -> String {
 /// Named/Record split and `TyChecker::check_ty`'s Named/Variant split).
 fn render_type_decl_record(ctx: &RenderContext, td: &IrTypeDecl, generics_str: &str, decl_attrs: &[&str]) -> String {
     let IrTypeDeclKind::Record { fields } = &td.kind else { unreachable!() };
-    let has_fn_fields = fields.iter().any(|f| matches!(&f.ty, Ty::Fn { .. }));
+    let has_fn_fields = fields.iter().any(|f| ty_has_fn_with(&f.ty, &ctx.ann.fn_blocked_types));
     // Matrix / Fn / transitively-blocking types prevent PartialEq derive.
     // Uses the precomputed `eq_blocked_types` set so Named references
     // to other blocked user types propagate correctly.
@@ -188,8 +188,8 @@ fn render_type_decl_variant(ctx: &RenderContext, td: &IrTypeDecl, generics_str: 
     // `Rc<dyn Fn>`, which is neither Debug nor PartialEq → derive Clone only.
     let has_fn_fields = cases.iter().any(|v| match &v.kind {
         IrVariantKind::Unit => false,
-        IrVariantKind::Tuple { fields } => fields.iter().any(ty_has_fn),
-        IrVariantKind::Record { fields } => fields.iter().any(|f| ty_has_fn(&f.ty)),
+        IrVariantKind::Tuple { fields } => fields.iter().any(|t| ty_has_fn_with(t, &ctx.ann.fn_blocked_types)),
+        IrVariantKind::Record { fields } => fields.iter().any(|f| ty_has_fn_with(&f.ty, &ctx.ann.fn_blocked_types)),
     });
     let has_ord = td.deriving.as_ref().map_or(false, |d| d.iter().any(|s| s.as_str() == "Ord"));
     let mut enum_attrs = decl_attrs.to_vec();
@@ -221,13 +221,13 @@ fn render_type_decl_variant(ctx: &RenderContext, td: &IrTypeDecl, generics_str: 
 /// whose fields/payloads are all `AlmideRepr` (no closure field). The interp
 /// router (`ty_needs_repr`) and the impl emitter share this predicate so the
 /// "this Named type is repr-backed" decision is made in exactly one place.
-pub fn type_has_repr_impl(td: &IrTypeDecl) -> bool {
+pub fn type_has_repr_impl(td: &IrTypeDecl, fn_blocked: &HashSet<String>) -> bool {
     match &td.kind {
-        IrTypeDeclKind::Record { fields } => !fields.iter().any(|f| ty_has_fn(&f.ty)),
+        IrTypeDeclKind::Record { fields } => !fields.iter().any(|f| ty_has_fn_with(&f.ty, fn_blocked)),
         IrTypeDeclKind::Variant { cases, .. } => !cases.iter().any(|v| match &v.kind {
             IrVariantKind::Unit => false,
-            IrVariantKind::Tuple { fields } => fields.iter().any(ty_has_fn),
-            IrVariantKind::Record { fields } => fields.iter().any(|f| ty_has_fn(&f.ty)),
+            IrVariantKind::Tuple { fields } => fields.iter().any(|t| ty_has_fn_with(t, fn_blocked)),
+            IrVariantKind::Record { fields } => fields.iter().any(|f| ty_has_fn_with(&f.ty, fn_blocked)),
         }),
         _ => false,
     }
@@ -235,7 +235,7 @@ pub fn type_has_repr_impl(td: &IrTypeDecl) -> bool {
 
 fn render_repr_impl(ctx: &RenderContext, td: &IrTypeDecl) -> Option<String> {
     // Records/variants without a closure field back a repr; skip everything else.
-    if !type_has_repr_impl(td) { return None; }
+    if !type_has_repr_impl(td, &ctx.ann.fn_blocked_types) { return None; }
 
     // Generic header + target. The impl GENERICS carry every param's bounds; the
     // impl TARGET uses BARE params. For a generic type these MUST differ:
@@ -375,6 +375,13 @@ pub fn take_anon_fn_keys() -> HashSet<Vec<String>> {
 
 pub fn collect_anon_records(program: &IrProgram, named: &HashMap<Vec<String>, String>) -> HashMap<Vec<String>, String> {
     ANON_FN_KEYS.with(|s| s.borrow_mut().clear());
+    // The same transitive fn-blocked set the derive gate uses (#1674): an anon
+    // record whose field is a fn-BLOCKED named type must also derive Clone only.
+    let all_decls: Vec<IrTypeDecl> = program.type_decls.iter()
+        .chain(program.modules.iter().flat_map(|m| m.type_decls.iter()))
+        .cloned()
+        .collect();
+    ANON_FN_BLOCKED.with(|s| *s.borrow_mut() = compute_fn_blocked_types(&all_decls));
     let named_set: HashSet<Vec<String>> = named.keys().cloned().collect();
     let mut seen: HashSet<Vec<String>> = HashSet::new();
 
@@ -577,11 +584,66 @@ fn collect_anon_from_stmt(stmt: &IrStmt, named: &HashSet<Vec<String>>, seen: &mu
     }
 }
 
-/// True if `ty` mentions a function type anywhere (directly or nested in a
-/// container/tuple/record). Such a type lowers to `Rc<dyn Fn>` (or a container
-/// thereof), which is neither `Debug` nor `PartialEq`.
-fn ty_has_fn(ty: &Ty) -> bool {
-    matches!(ty, Ty::Fn { .. }) || ty.children().iter().any(|c| ty_has_fn(c))
+/// True if `ty` mentions a function type anywhere — directly, nested in a
+/// container/tuple/record, or through a fn-blocked NAMED type from the
+/// precomputed transitive set. Such a type lowers to `Rc<dyn Fn>` (or a
+/// container thereof), which is neither `Debug` nor `PartialEq`.
+///
+/// This is `ty_has_fn` widened by a precomputed transitive set: a `Named` reference to
+/// a fn-blocked user type counts as holding a function value (#1674 — the
+/// analysis was one level deep, so `type Schema = | Str(Check)` over a
+/// closure-carrying `Check` still derived Debug/PartialEq and the generated
+/// Rust did not compile). Mirror of `ty_blocks_eq_with`.
+pub(super) fn ty_has_fn_with(ty: &Ty, fn_blocked: &HashSet<String>) -> bool {
+    match ty {
+        Ty::Fn { .. } => true,
+        Ty::Named(name, args) => {
+            fn_blocked.contains(name.as_str())
+                || args.iter().any(|t| ty_has_fn_with(t, fn_blocked))
+        }
+        Ty::Tuple(elems) => elems.iter().any(|t| ty_has_fn_with(t, fn_blocked)),
+        Ty::Applied(_, args) => args.iter().any(|t| ty_has_fn_with(t, fn_blocked)),
+        Ty::Record { fields } | Ty::OpenRecord { fields } => {
+            fields.iter().any(|(_, t)| ty_has_fn_with(t, fn_blocked))
+        }
+        _ => false,
+    }
+}
+
+/// Precompute the user-defined type names that transitively contain a function
+/// value — fixed point over the whole decl set, exactly like
+/// `compute_eq_blocked_types`.
+pub(super) fn compute_fn_blocked_types(type_decls: &[IrTypeDecl]) -> HashSet<String> {
+    let mut blocked: HashSet<String> = HashSet::new();
+    loop {
+        let mut changed = false;
+        for td in type_decls {
+            if blocked.contains(td.name.as_str()) { continue }
+            let blocks = match &td.kind {
+                IrTypeDeclKind::Record { fields } => {
+                    fields.iter().any(|f| ty_has_fn_with(&f.ty, &blocked))
+                }
+                IrTypeDeclKind::Variant { cases, .. } => {
+                    cases.iter().any(|c| match &c.kind {
+                        IrVariantKind::Unit => false,
+                        IrVariantKind::Tuple { fields } => {
+                            fields.iter().any(|t| ty_has_fn_with(t, &blocked))
+                        }
+                        IrVariantKind::Record { fields } => {
+                            fields.iter().any(|f| ty_has_fn_with(&f.ty, &blocked))
+                        }
+                    })
+                }
+                _ => false,
+            };
+            if blocks {
+                blocked.insert(td.name.to_string());
+                changed = true;
+            }
+        }
+        if !changed { break }
+    }
+    blocked
 }
 
 /// Does this type transitively hold a value that doesn't implement `PartialEq`
@@ -693,6 +755,11 @@ thread_local! {
     /// does not affect host-deterministic emit. (Closure codegen cross-target gaps.)
     static ANON_FN_KEYS: std::cell::RefCell<HashSet<Vec<String>>> =
         std::cell::RefCell::new(HashSet::new());
+    /// Fn-blocked named types for the CURRENT `collect_anon_records` run
+    /// (#1674) — consulted by `collect_anon_from_ty` so an anon record whose
+    /// field is a fn-blocked NAMED type also lands in `ANON_FN_KEYS`.
+    static ANON_FN_BLOCKED: std::cell::RefCell<HashSet<String>> =
+        std::cell::RefCell::new(HashSet::new());
 }
 
 fn collect_anon_from_ty(ty: &Ty, named: &HashSet<Vec<String>>, seen: &mut HashSet<Vec<String>>) {
@@ -705,7 +772,7 @@ fn collect_anon_from_ty(ty: &Ty, named: &HashSet<Vec<String>>, seen: &mut HashSe
             // `Map[_, Fn]`, `(Fn, _)`, …) lowers to a type that is neither `Debug`
             // nor `PartialEq`, so the generated struct must derive `Clone` only.
             // Matching `Ty::Fn` alone missed boxed-closure containers.
-            if fields.iter().any(|(_, t)| ty_has_fn(t)) {
+            if fields.iter().any(|(_, t)| ANON_FN_BLOCKED.with(|b| ty_has_fn_with(t, &b.borrow()))) {
                 ANON_FN_KEYS.with(|s| { s.borrow_mut().insert(names.clone()); });
             }
             seen.insert(names);

--- a/crates/almide-codegen/src/walker/program_render.rs
+++ b/crates/almide-codegen/src/walker/program_render.rs
@@ -33,10 +33,15 @@ fn collect_type_aliases_and_generics(program: &IrProgram) -> (
 /// Gate mirrors `render_repr_impl` (closure-bearing types are excluded).
 fn collect_repr_named_types(program: &IrProgram) -> std::collections::HashSet<almide_base::intern::Sym> {
     let mut repr_named_types = std::collections::HashSet::new();
-    for td in program.type_decls.iter()
+    let all: Vec<_> = program.type_decls.iter()
         .chain(program.modules.iter().flat_map(|m| m.type_decls.iter()))
-    {
-        if declarations::type_has_repr_impl(td) {
+        .cloned()
+        .collect();
+    // Same transitive fn-blocked set the derive gate uses (#1674): a type
+    // whose field CONTAINS a closure through another named type has no repr.
+    let fn_blocked = declarations::compute_fn_blocked_types(&all);
+    for td in &all {
+        if declarations::type_has_repr_impl(td, &fn_blocked) {
             repr_named_types.insert(td.name);
         }
     }
@@ -58,6 +63,7 @@ fn build_program_ann(ctx: &RenderContext, program: &IrProgram) -> CodegenAnnotat
         .cloned()
         .collect();
     ann.eq_blocked_types = super::walker::declarations::compute_eq_blocked_types(&all_type_decls);
+    ann.fn_blocked_types = super::walker::declarations::compute_fn_blocked_types(&all_type_decls);
     ann.phantom_param_structs = super::walker::declarations::compute_phantom_param_structs(&all_type_decls);
     // §4 endgame: the legacy pre-index (lazy_top_let_names /
     // eager_force_top_lets / const_top_let_vars) and the mutable-storage

--- a/crates/almide-ir/src/annotations.rs
+++ b/crates/almide-ir/src/annotations.rs
@@ -63,6 +63,14 @@ pub struct CodegenAnnotations {
     /// derive `PartialEq` (a field transitively blocks equality — e.g.
     /// contains a Matrix or a function pointer).
     pub eq_blocked_types: HashSet<String>,
+    /// User-defined record/enum names that transitively CONTAIN a function
+    /// value (directly, in a container, or through another fn-blocked named
+    /// type). Such a type lowers to `Rc<dyn Fn>` somewhere inside, so its
+    /// struct/enum derives `Clone` only — no `Debug`, no `PartialEq`, no
+    /// generated `AlmideRepr` impl. One level deep was #1674: a type
+    /// containing a fn-carrying type still derived Debug and rustc refused
+    /// the generated Rust.
+    pub fn_blocked_types: HashSet<String>,
     /// Record types ALL of whose generic params are phantom (declared but used
     /// by no field). Rust rejects an unused type param (`error[E0392]`), so the
     /// Rust struct is emitted WITHOUT generics and every `Ty::Named` reference to

--- a/tests/native_fn_nested_derive_pin_test.rs
+++ b/tests/native_fn_nested_derive_pin_test.rs
@@ -1,0 +1,103 @@
+//! NATIVE-leg regression pins for #1674: derive suppression for closure-
+//! carrying types is TRANSITIVE.
+//!
+//! A type whose payload is a function value already dropped
+//! `Debug`/`PartialEq`/`AlmideRepr` — but the analysis was one level deep, so
+//! any type CONTAINING that type (variant payload, `List[...]`, record field,
+//! or a two-hop chain) still derived them and the generated Rust failed rustc
+//! (E0277 `Check: Debug`, E0369 `==` on `&Check`, E0599 `almide_repr`). This
+//! is the representation every schema/validation library reaches for: nodes
+//! carrying user predicates, trees built from those nodes.
+//!
+//! Native pins per the tests/native_mut_param_pins_test.rs doctrine (the wasm
+//! leg does not share this derive machinery; `almide run` here is the NATIVE
+//! target). A/B-verified: each shape fails the generated-Rust build on the
+//! pre-fix compiler.
+
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+/// Write `src` as a single-file program, `almide run` (NATIVE) it, assert it
+/// prints `expected`.
+fn run_prints(name: &str, src: &str, expected: &str) {
+    let dir = std::env::temp_dir().join(format!("almd_fn_derive_pin_{name}_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("main.almd");
+    let mut f = std::fs::File::create(&file).unwrap();
+    f.write_all(src.as_bytes()).unwrap();
+    let out = Command::new(almide_bin())
+        .args(["run", file.to_str().unwrap()])
+        .output()
+        .expect("failed to spawn almide");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    std::fs::remove_dir_all(&dir).ok();
+    assert!(
+        out.status.success(),
+        "[{name}] almide run (native) failed — transitive fn-derive suppression regressed?\n{stderr}"
+    );
+    assert_eq!(stdout.trim_end(), expected, "[{name}] wrong output");
+}
+
+#[test]
+fn variant_containing_fn_carrying_type_builds_native() {
+    run_prints(
+        "variant",
+        "type Check = | Email | Refine((Int) -> Bool)\n\
+         type Schema = | Str(Check)\n\
+         fn main() -> Unit = println(match Str(Refine((n) => n > 0)) { Str(_) => \"ok\" })\n",
+        "ok",
+    );
+}
+
+#[test]
+fn list_of_fn_carrying_type_in_payload_builds_native() {
+    run_prints(
+        "list",
+        "type Check = | Email | Refine((Int) -> Bool)\n\
+         type Schema = | Str(List[Check])\n\
+         fn main() -> Unit = println(match Str([Refine((n) => n > 0)]) { Str(_) => \"ok\" })\n",
+        "ok",
+    );
+}
+
+#[test]
+fn record_field_of_fn_carrying_type_builds_native() {
+    run_prints(
+        "record",
+        "type Check = | Email | Refine((Int) -> Bool)\n\
+         type Schema = { checks: List[Check] }\n\
+         fn main() -> Unit = {\n\
+           let s = Schema { checks: [Refine((n) => n > 0)] }\n\
+           println(int.to_string(list.len(s.checks)))\n\
+         }\n",
+        "1",
+    );
+}
+
+#[test]
+fn two_hop_chain_through_named_types_builds_native() {
+    run_prints(
+        "two_hop",
+        "type Check = | Email | Refine((Int) -> Bool)\n\
+         type Node = | Leaf(Check) | Empty\n\
+         type Tree = { root: Node, tag: String }\n\
+         fn main() -> Unit = {\n\
+           let t = Tree { root: Leaf(Refine((n) => n > 0)), tag: \"t\" }\n\
+           println(t.tag)\n\
+         }\n",
+        "t",
+    );
+}


### PR DESCRIPTION
Closes #1674.

**The bug:** the fn-payload derive suppression was one level deep. `type Check = | Email | Refine((Int) -> Bool)` correctly derived `Clone` only — but `type Schema = | Str(Check)` (and `List[Check]`, and a record field) still got `#[derive(Clone, Debug, PartialEq)]` plus a generated `AlmideRepr` impl, and the generated Rust failed rustc (E0277/E0369/E0599) behind the codegen-bug wall. This is the schema-tree-with-user-predicates representation every validation library reaches for.

**Fix:** a precomputed transitive set, exactly the `eq_blocked_types` machinery next to it: `compute_fn_blocked_types` reaches a fixed point over all type decls; `ty_has_fn_with` treats a `Named` reference to a blocked type as fn-carrying. Consumers now sharing one verdict:
- record and variant derive gates (`has_fn_fields`),
- `type_has_repr_impl` (the single predicate behind both the `AlmideRepr` impl emitter and the interp router's `repr_named_types`),
- the anonymous-record `ANON_FN_KEYS` Clone-only path (an anon record whose field is a fn-blocked named type had the same hole).

The shallow `ty_has_fn` is gone — every caller consults the transitive set.

**Evidence:** `tests/native_fn_nested_derive_pin_test.rs` — all four shapes from the issue (variant payload, List payload, record field, two-hop chain), A/B-verified: 4/4 fail on the pre-fix binary, 4/4 pass with the fix. `almide test` 426/426; codegen suite green.