### PR TITLE
The statement/expression boundary is diagnosed by rule, not by token

### DIFF
--- a/crates/almide-syntax/src/parser/collections.rs
+++ b/crates/almide-syntax/src/parser/collections.rs
@@ -81,6 +81,23 @@ impl Parser {
         let mut stmts = initial_comments;
         let mut final_expr: Option<Box<Expr>> = None;
         while !self.check(TokenType::RBrace) && !self.check(TokenType::EOF) {
+            // #1677: a nested `fn` declaration — reflexive for writers from
+            // Rust/TS/Swift, unsupported here. The old path fell into
+            // "Expected expression … got Fn" plus E003s from the orphaned
+            // body. Name the rule, consume the WHOLE declaration (so its body
+            // does not re-parse as statements), and suppress the undefined-
+            // function cascade at its call sites. Braced blocks only: at
+            // top level a stray `fn` is the next declaration, not a nesting.
+            if self.check(TokenType::Fn)
+                || (self.check(TokenType::Effect)
+                    && self.peek_at(1).map(|t| &t.token_type) == Some(&TokenType::Fn))
+            {
+                let err_span = Some(self.current_span());
+                self.nested_fn_decl_error();
+                stmts.push(Stmt::Error { span: err_span });
+                self.skip_newlines();
+                continue;
+            }
             let pre_err_len = self.errors.len();
             match self.parse_stmt() {
                 Ok(stmt) => {

--- a/crates/almide-syntax/src/parser/fn_decls.rs
+++ b/crates/almide-syntax/src/parser/fn_decls.rs
@@ -11,6 +11,34 @@ use crate::lexer::TokenType;
 use super::Parser;
 
 impl Parser {
+    /// #1677: a `fn` (or `effect fn`) declaration at STATEMENT position inside
+    /// a braced block. Emits the boundary-naming diagnostic, consumes the
+    /// whole declaration through its body (recovery that leaves the body
+    /// behind re-parses it as statements and floods E003 on the parameters),
+    /// and records the name in `failed_fn_names` so call sites below do not
+    /// cascade "undefined function".
+    pub(crate) fn nested_fn_decl_error(&mut self) {
+        let tok = self.current().clone();
+        let diag = self.diag_error(
+            "`fn` cannot be declared inside a function body",
+            "Move it to the top level (thread any captured locals as parameters), or bind a lambda: `let row = (label, ns) => ...`",
+            "nested fn",
+        ).with_try("fn row(label: String, ns: Int, total: Int) -> Unit =\n    println(\"${label}: ${ns / total}\")");
+        self.errors.push(diag);
+        let _ = tok;
+        match self.parse_fn_decl() {
+            Ok(Decl::Fn { name, .. }) => {
+                self.failed_fn_names.insert(name.to_string());
+            }
+            Ok(_) => {}
+            Err(_) => {
+                // parse_fn_decl already recorded the name and its own error;
+                // skip to a statement boundary so the loop can continue.
+                self.recover_to_sync_point(true);
+            }
+        }
+    }
+
     pub(crate) fn parse_fn_decl(&mut self) -> Result<Decl, String> {
         let span = self.current_span();
         if self.check(TokenType::Pub) { self.advance(); }

--- a/crates/almide-syntax/src/parser/patterns.rs
+++ b/crates/almide-syntax/src/parser/patterns.rs
@@ -176,6 +176,12 @@ impl Parser {
         let tok = self.current();
         let hint: String = match (&tok.token_type, tok.value.as_str()) {
             (_, "=>") => "\n  Hint: Missing pattern before '=>'. Use '_' for wildcard, or a variable name".into(),
+            // #1677: `ok(_) => c = c + 1` — the arm body parsed as `c`, the
+            // parser moved on to the next arm, and `=` is where it noticed.
+            // The broken rule is the statement/expression boundary, not
+            // pattern syntax — name it, or the hint sends the reader to
+            // enumerate patterns (the one thing that was right).
+            (TokenType::Eq, _) => "\n  Hint: assignment is a statement, not an expression — a match arm that assigns needs a block body:\n    ok(_) => { c = c + 1 }".into(),
             (TokenType::DotDotDot, _) | (TokenType::DotDot, _) => {
                 "\n  Hint: rest/spread patterns `[h, ...t]` / `[h, ..t]` are not supported in Almide list patterns.\n\
                   Use recursion with list.first / list.drop:\n\

--- a/tests/diagnostics/parse-match-arm-assign/broken.almd
+++ b/tests/diagnostics/parse-match-arm-assign/broken.almd
@@ -1,0 +1,8 @@
+// #1677: assignment in a match arm — the parser commits to reading the next
+// arm and the old hint enumerated pattern syntax (the one thing that was
+// right). The statement/expression boundary is the rule; name it.
+fn main() -> Unit = {
+  var c = 0
+  match int.parse("3") { ok(_) => c = c + 1, err(_) => c = c }
+  println("${c}")
+}

--- a/tests/diagnostics/parse-match-arm-assign/fixed.almd
+++ b/tests/diagnostics/parse-match-arm-assign/fixed.almd
@@ -1,0 +1,13 @@
+// The fix the hint teaches: an arm body that assigns is a block.
+fn main() -> Unit = {
+  var c = 0
+  match int.parse("3") {
+    ok(_) => {
+      c = c + 1
+    },
+    err(_) => {
+      c = c
+    },
+  }
+  println("${c}")
+}

--- a/tests/diagnostics/parse-match-arm-assign/meta.toml
+++ b/tests/diagnostics/parse-match-arm-assign/meta.toml
@@ -1,0 +1,2 @@
+expects_error = "Expected pattern"
+hint_substring = "assignment is a statement, not an expression"

--- a/tests/diagnostics/parse-nested-fn/broken.almd
+++ b/tests/diagnostics/parse-nested-fn/broken.almd
@@ -1,0 +1,8 @@
+// #1677: a nested `fn` declaration — reflexive for writers from Rust/TS/Swift.
+// The old diagnostic named the token ("Expected expression ... got Fn") and the
+// orphaned body flooded E003 on the parameters; the rule is what broke.
+effect fn main() -> Unit = {
+  let total = 1000
+  fn row(label: String, ns: Int) -> Unit = println("${label}: ${ns / total}")
+  row("a", 5)
+}

--- a/tests/diagnostics/parse-nested-fn/fixed.almd
+++ b/tests/diagnostics/parse-nested-fn/fixed.almd
@@ -1,0 +1,7 @@
+// The fix the hint teaches: top-level fn, captured local threaded as a parameter.
+fn row(label: String, ns: Int, total: Int) -> Unit = println("${label}: ${ns / total}")
+
+effect fn main() -> Unit = {
+  let total = 1000
+  row("a", 5, total)
+}

--- a/tests/diagnostics/parse-nested-fn/meta.toml
+++ b/tests/diagnostics/parse-nested-fn/meta.toml
@@ -1,0 +1,2 @@
+expects_error = "`fn` cannot be declared inside a function body"
+hint_substring = "bind a lambda"


### PR DESCRIPTION
Closes #1677.

Two reflexive shapes from Rust/TS/Swift writers got confident, specific, wrongly-aimed diagnostics:

**1. Assignment in a match arm** (`ok(_) => c = c + 1`): the parser had committed to the next arm and reported \"Expected pattern … (got Eq '=')\" with a pattern-syntax enumeration — the one thing that was right. The `Eq`-at-pattern-position case now names the boundary:
> assignment is a statement, not an expression — a match arm that assigns needs a block body: `ok(_) => { c = c + 1 }`

(The derived top-level error after the aborted match remains — statement-granular recovery inside match arms is a separate shape.)

**2. Nested `fn` declaration**: fell into \"Expected expression … (got Fn 'fn')\" whose generic hint (\"check the token just BEFORE\") was actively wrong, then flooded E003 on the orphaned body's parameters. Braced-block statement position now intercepts `fn`/`effect fn`:
> `fn` cannot be declared inside a function body — move it to the top level (thread any captured locals as parameters), or bind a lambda: `let row = (label, ns) => ...`

The whole declaration is consumed (its body no longer re-parses as statements → zero E003s) and the name joins `failed_fn_names` (call sites below no longer cascade E002). The repro now produces exactly ONE error. Braced blocks only, deliberately: at top level a stray `fn` is the next declaration, and `parse_braceless_block` treats it as a block terminator — intercepting there would eat a real top-level fn after a missing body.

**Evidence:** two new `tests/diagnostics/` pairs (`parse-nested-fn`, `parse-match-arm-assign`) pinning message + hint substrings through the harness; syntax suite green; `almide test` 426/426.