### PR TITLE
The LLM-facing surface rule is written down and the checked-fence floor rises to 11

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,24 @@ differential fuzz, an emit-time Σ-probe, or a Lean theorem. The index is
   vocabulary is shared with the rt-oracle-registry via
   `scripts/lib/contract-classes.txt`.
 
+## The LLM-Facing Surface Is the Stable Surface (#1483)
+
+`docs/CHEATSHEET.md` and `llms.txt` are what models read as training and
+context data — **anything that appears there is a promise**, and anything not
+intended as a promise must not appear there. Our primary reader cannot notice
+a doc/reality gap, so the gap is gated:
+
+- A fence labeled ```` ```almide check ```` asserts "this is a complete,
+  checkable program" and `scripts/check-llm-surface.sh` (CI) runs
+  `almide check` on every one — a rotted example is a CI failure, not a
+  training-corpus bug. Plain ```` ```almide ```` stays a highlighting label
+  for fragments and deliberate ✗-examples.
+- Growing coverage means COMPLETING an example and promoting its marker,
+  one fence at a time. The gate's allowlist is shrink-only.
+- New language surface documented in the cheatsheet lands with its spec
+  coverage in the same change — the contract-ledger rule above, applied to
+  prose.
+
 ## Documentation
 
 - 言語仕様: `docs/specs/` — ルールは [docs/specs/CLAUDE.md](./docs/specs/CLAUDE.md)

--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -56,7 +56,7 @@ type Handler = (String) -> String                    // function type alias
 ```
 
 ### Conventions
-```
+```almide check
 type Color: Eq, Repr = Red | Green | Blue   // convention after type name with :
 ```
 
@@ -67,7 +67,7 @@ instead of hand-writing `match` ladders. The derived Codec is
 externally tagged — the ctor name is the single key; a record payload
 keeps its field names, a tuple payload is a positional array, a unit
 case is `null`:
-```
+```almide check
 type Event: Codec = | Click(Int, Int) | Scroll{dy: Int} | Quit
 // Event.encode(Click(10, 20))    → {"Click": [10, 20]}
 // Event.encode(Scroll { dy: 5 }) → {"Scroll": {"dy": 5}}
@@ -397,7 +397,7 @@ m["key"] = value           // index write (var only)
 A malformed numeric escape (e.g. `\xzz`, `\u{}`) is left literal.
 
 ### Heredoc (multi-line strings)
-```
+```almide check
 let sql = """
   SELECT *
   FROM users
@@ -410,7 +410,7 @@ let sql = """
 ## Statements
 
 ### Top-level let (module-scope constant)
-```
+```almide check
 let PI = 3.14159265358979323846
 let MAX_RETRIES = 3
 let GREETING = "Hello"
@@ -632,7 +632,7 @@ assert(cond)               // assert true
 `eprintln` is for debug/internal errors only — user-facing messages MUST use `println`.
 
 ### Stdin & parsing
-```
+```almide check
 import io                                     // io is NOT auto-imported
 effect fn main() -> Unit = {
   let line = io.read_line()                   // plain String — NOT a Result. Do not add ! or ?

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,10 @@
 > on the [almide-dojo](https://github.com/almide/almide-dojo) MSR benchmark.
 
 If you are an LLM writing Almide code, read this file first. It is
-concise on purpose. Follow the link map for depth.
+concise on purpose. Follow the link map for depth. This file and
+docs/CHEATSHEET.md are the STABLE surface (#1483): every example fence
+labeled `almide check` is compiled by CI on every change, so what you
+read here is what the current compiler accepts.
 
 ## Fast facts
 


### PR DESCRIPTION
Closes #1483 — the definition of done's last open item.

The gate (`scripts/check-llm-surface.sh`, CI-wired) and the `proofs/gate-verification.toml` row with its reality-paid negative control landed earlier (2026-08-17); what was missing was **the written rule**. It now sits in CLAUDE.md next to the contract discipline:

> `docs/CHEATSHEET.md` and `llms.txt` are what models read as training and context data — anything that appears there is a promise, and anything not intended as a promise must not appear there.

with the three operating clauses: `almide check`-labeled fences are compiled by CI (a rotted example is a CI failure, not a training-corpus bug); coverage grows by completing-and-promoting one fence at a time under a shrink-only allowlist; new documented surface lands with its spec coverage in the same change.

**Coverage raised in the same change:** five bare cheatsheet fences that already check clean promote to `almide check` (the convention-clause Color, the Codec Event wire-format example, the heredoc SQL block, the top-level constants, the io import block) — the gate's floor goes 6 → 11 labeled fences. `llms.txt` now tells its LLM reader the surface is CI-compiled, which is both true and the kind of claim that keeps itself true.

The issue's aspirational items beyond the DoD — a construct-level extractor resolving every cheatsheet construct to a spec fixture, and an experimental marker — remain the promotion arc the script header describes; the floor form plus the written rule is the gate the DoD defined.