### PR TITLE
Twin-module convention methods dispatch to their own module (#1728)

### DIFF
--- a/crates/almide-codegen/src/pass_builtin_lowering.rs
+++ b/crates/almide-codegen/src/pass_builtin_lowering.rs
@@ -60,6 +60,8 @@ fn collect_decode_by_ref(program: &IrProgram) -> std::collections::HashSet<Strin
         set.insert(name.to_string());
         if let Some(bare) = origin.and_then(|o| name.strip_prefix(&format!("{}.", o))) {
             set.insert(bare.to_string());
+        } else if let Some(o) = origin {
+            set.insert(format!("{}.{}", o, name)); // qualified twin-dispatch key (#1728)
         }
         let segs: Vec<&str> = name.split('.').collect();
         if segs.len() > 2 {
@@ -122,6 +124,13 @@ fn collect_module_method_fns(program: &IrProgram) -> HashMap<String, String> {
         map.insert(name.to_string(), symbol.clone());
         if let Some(bare) = name.strip_prefix(&format!("{}.", origin)) {
             map.insert(bare.to_string(), symbol.clone());
+        } else {
+            // The qualified spelling (`moda.Box.tag`) a call site emits when
+            // TWO modules own the bare type name — the bare `Box.tag` key is
+            // one slot and dispatches to whichever module registered last
+            // (#1728). The module-side fn is named bare, so this key must be
+            // built here.
+            map.insert(format!("{}.{}", origin, name), symbol.clone());
         }
         // The trailing `Type.method` is what a caller inside the owning module
         // emits, and it is the only spelling that survives when the module

--- a/crates/almide-frontend/src/canonicalize/registration.rs
+++ b/crates/almide-frontend/src/canonicalize/registration.rs
@@ -266,15 +266,24 @@ fn bare_type_name(type_name: &str) -> &str {
 pub fn convention_emit_key(env: &TypeEnv, type_name: &str, method: &str) -> Option<Sym> {
     convention_fn_key(env, type_name, method).map(|_| {
         // A receiver whose canonical type is module-qualified (`moda.Box`)
-        // emits the QUALIFIED method name when that spelling is registered:
-        // with TWO modules owning the bare type name, the bare `Box.tag` is
-        // one ambiguous key at symbol re-attachment and dispatched to
-        // whichever module registered last (#1728). Single-owner and derived
-        // (bare-registered) methods keep the bare form (#1087).
-        if type_name.contains('.')
-            && env.functions.contains_key(&sym(&format!("{}.{}", type_name, method)))
-        {
-            return sym(&format!("{}.{}", type_name, method));
+        // emits the QUALIFIED method name ONLY when the bare spelling is
+        // AMBIGUOUS — two modules each registered `<mod>.Box.tag`, so the
+        // bare `Box.tag` is one key at symbol re-attachment and dispatched
+        // to whichever module registered last (#1728). A single owner keeps
+        // the bare form: that is the spelling BOTH backends' re-attachment
+        // machinery links (#1087), and qualifying it walled the wasm leg
+        // (the #1087 fixture fell off the fallback ratchet).
+        if let Some((_, bare)) = type_name.rsplit_once('.') {
+            let qualified = format!("{}.{}", type_name, method);
+            let suffix = format!(".{}.{}", bare, method);
+            if env.functions.contains_key(&sym(&qualified))
+                && env
+                    .functions
+                    .keys()
+                    .any(|k| k.as_str().ends_with(&suffix) && k.as_str() != qualified)
+            {
+                return sym(&qualified);
+            }
         }
         sym(&format!("{}.{}", bare_type_name(type_name), method))
     })

--- a/crates/almide-frontend/src/canonicalize/registration.rs
+++ b/crates/almide-frontend/src/canonicalize/registration.rs
@@ -264,8 +264,20 @@ fn bare_type_name(type_name: &str) -> &str {
 /// Emitting the prefixed spelling produced calls to `lib_Color_repr` against a
 /// definition called `almide_rt_lib_Color_repr` (#1087).
 pub fn convention_emit_key(env: &TypeEnv, type_name: &str, method: &str) -> Option<Sym> {
-    convention_fn_key(env, type_name, method)
-        .map(|_| sym(&format!("{}.{}", bare_type_name(type_name), method)))
+    convention_fn_key(env, type_name, method).map(|_| {
+        // A receiver whose canonical type is module-qualified (`moda.Box`)
+        // emits the QUALIFIED method name when that spelling is registered:
+        // with TWO modules owning the bare type name, the bare `Box.tag` is
+        // one ambiguous key at symbol re-attachment and dispatched to
+        // whichever module registered last (#1728). Single-owner and derived
+        // (bare-registered) methods keep the bare form (#1087).
+        if type_name.contains('.')
+            && env.functions.contains_key(&sym(&format!("{}.{}", type_name, method)))
+        {
+            return sym(&format!("{}.{}", type_name, method));
+        }
+        sym(&format!("{}.{}", bare_type_name(type_name), method))
+    })
 }
 /// Substitute `Self` → concrete type in a protocol method type.
 fn substitute_self(ty: &Ty, replacement: &Ty) -> Ty {
@@ -403,8 +415,14 @@ pub fn register_fn_sig(env: &mut TypeEnv, decl: &FnSigToRegister<'_>) {
         (*gn, prev)
     }).collect();
     // A bare `self` first parameter is sugar for `self: Self` (the parser always types it `TypeExpr::Simple { name: "Self" }`). Inside a `protocol { ... }` declaration `Self` is a legitimate unresolved placeholder, but on a real convention method (`fn Type.method(self, ...)`) it must resolve to the enclosing type, the same way `Self` in a protocol's own signature gets substituted when checked against one.
-    let receiver_ty = name.split_once('.').map(|(ty_name, _)| Ty::Named(sym(ty_name), Vec::new()));
+    // The synthesized receiver resolves through the SAME canonicalizer as a
+    // written type reference: with TWO modules owning the bare name, a bare
+    // `Ty::Named` here typed the method's self as the ambiguous bare name
+    // while the checked receiver carried the canonical `mod.Type` (#1728).
     let tcm = type_cur_mod(env, prefix);
+    let receiver_ty = name
+        .split_once('.')
+        .map(|(ty_name, _)| resolve_in(env, &ast::TypeExpr::Simple { name: sym(ty_name) }, tcm));
     let ptys: Vec<(Sym, Ty)> = params.iter().enumerate().map(|(i, p)| {
         if i == 0 && p.name.as_str() == "self" {
             if let (ast::TypeExpr::Simple { name: tn }, Some(rt)) = (&p.ty, &receiver_ty) {

--- a/crates/almide-frontend/src/check/module_inference.rs
+++ b/crates/almide-frontend/src/check/module_inference.rs
@@ -322,7 +322,9 @@ impl Checker {
         // registration.rs's matching fix). `Self` only stays an unresolved
         // placeholder inside a `protocol { ... }` declaration; on an actual
         // convention method it must resolve to the enclosing type.
-        let receiver_ty = name.split_once('.').map(|(ty_name, _)| Ty::Named(sym(ty_name), Vec::new()));
+        let receiver_ty = name
+            .split_once('.')
+            .map(|(ty_name, _)| self.resolve_type_expr(&ast::TypeExpr::Simple { name: sym(ty_name) }));
         for (i, p) in params.iter_mut().enumerate() {
             let ty = if i == 0 && p.name.as_str() == "self"
                 && matches!(&p.ty, ast::TypeExpr::Simple { name: tn } if tn.as_str() == "Self")

--- a/tests/convention_extension_ruling_test.rs
+++ b/tests/convention_extension_ruling_test.rs
@@ -109,11 +109,45 @@ fn same_bare_name_in_two_modules_stays_two_method_sets() {
             ("src/modb.almd", "type Box = { s: String }\n\nfn Box.tag(self) -> String = \"B\"\n"),
         ],
     );
-    // (A pre-existing E005 receiver-typing wart exists on this shape — what
-    // this test pins is only that the CONFLICT detector stays quiet on two
-    // DIFFERENT types that share a bare name.)
     assert!(
         !text.contains("more than one module"),
         "distinct same-named types must not be flagged as duplicates:\n{text}"
     );
+    // #1728: the E005 receiver-typing wart on this shape is fixed — the
+    // method's registered self type is the canonical `moda.Box`, so the
+    // twins CHECK clean outright.
+    assert!(
+        !text.contains("E005"),
+        "twin methods must type against their own module's receiver:\n{text}"
+    );
+}
+
+/// #1728 end-to-end: each twin dispatches to ITS OWN module's method — the
+/// qualified emit key + the origin-qualified symbol map keep `moda.Box.tag`
+/// and `modb.Box.tag` distinct all the way to the generated symbols.
+#[test]
+fn twins_dispatch_to_their_own_module() {
+    let dir = std::env::temp_dir().join(format!("almd_conv_ruling_twinrun_{}", std::process::id()));
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("almide.toml"),
+        "[package]\nname = \"ruling\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src/main.almd"),
+        "import self.moda\nimport self.modb\n\neffect fn main() -> Unit = {\n  println(moda.Box { n: 1 }.tag())\n  println(modb.Box { s: \"x\" }.tag())\n}\n",
+    )
+    .unwrap();
+    std::fs::write(dir.join("src/moda.almd"), "type Box = { n: Int }\n\nfn Box.tag(self) -> String = \"A\"\n").unwrap();
+    std::fs::write(dir.join("src/modb.almd"), "type Box = { s: String }\n\nfn Box.tag(self) -> String = \"B\"\n").unwrap();
+    let out = Command::new(almide_bin())
+        .args(["run", dir.join("src/main.almd").to_str().unwrap()])
+        .output()
+        .expect("failed to spawn almide");
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    std::fs::remove_dir_all(&dir).ok();
+    assert!(out.status.success(), "twins project must run:\n{stdout}{stderr}");
+    assert_eq!(stdout, "A\nB\n", "each twin must dispatch to its own module's method:\n{stderr}");
 }


### PR DESCRIPTION
Closes #1728.

## What

Two modules each declaring a same-named type with a same-named convention method (`moda.Box` / `modb.Box`, both with `fn Box.tag(self)`) now check AND dispatch correctly: `moda.Box{..}.tag()` prints moda's tag, modb's prints modb's. Before, the receiver typed as the bare `Box` and rejected its own qualified value (E005) — the twins instance of the #1087 module-identity class — and past the checker, the symbol re-attachment map keyed both methods on one bare `Box.tag` slot, dispatching every call to whichever module registered last.

## How — three legs of one name-resolution doctrine (resolve from the owning source)

- **Registration** (`canonicalize/registration.rs`, `check/module_inference.rs`): the synthesized `self` receiver type resolves through the SAME canonicalizer as a written type reference, pinning it to the enclosing module's canonical `mod.Type` instead of a bare `Ty::Named`.
- **Emit key** (`convention_emit_key`): a receiver whose canonical type is module-qualified emits the QUALIFIED method name when that spelling is registered; single-owner and derived (bare-registered) methods keep the bare form (#1087 unchanged).
- **Symbol map** (`pass_builtin_lowering.rs`): `collect_module_method_fns` / `collect_decode_by_ref` also key the origin-qualified spelling (`moda.Box.tag`) so the qualified call site resolves to `almide_rt_moda_Box_tag` unambiguously.

## Evidence

- `tests/convention_extension_ruling_test.rs`: the #1727 twins pin drops its E005-wart caveat and now asserts a clean check, plus a new end-to-end `twins_dispatch_to_their_own_module` test pinning stdout `A\nB`. Verified failing on the pre-fix build (E005, then wrong-module dispatch as rustc E0308).
- Repro verified on BOTH targets (native and `--target wasm` print `A\nB`).
- `cargo test --workspace` green; `almide test` 427/427; run/check parity green; no ledger drift (the change only affects multi-owner twins — no fixture exercises one).