### PR TITLE
Angle-bracket generics steer fires in every position the mistake appears (#1736)

### DIFF
--- a/crates/almide-syntax/src/parser/hints/operator.rs
+++ b/crates/almide-syntax/src/parser/hints/operator.rs
@@ -29,10 +29,17 @@ pub fn check(ctx: &HintContext) -> Option<HintResult> {
             message: None,
             hint: "Use '->' for return type, not '='. Write: fn name() -> Type = body".into(),
         }),
-        // Generics: `<>` instead of `[]`
-        (TokenType::RParen, TokenType::LAngle, _) => Some(HintResult {
+        // Generics: `<>` instead of `[]` — three positions, one mistake
+        // (#1736). The DECLARATION head (`fn id<T>(x: T)` — the parser wants
+        // LParen) is the highest-frequency spelling in anything trained on
+        // Rust/TS/Java; the TYPE ANNOTATION (`let xs: List<Int> = []` — the
+        // parser wants Eq) is its sibling; the expression position
+        // (`f()<T>` — RParen) was the only one wired.
+        (TokenType::RParen, TokenType::LAngle, _)
+        | (TokenType::LParen, TokenType::LAngle, _)
+        | (TokenType::Eq, TokenType::LAngle, _) => Some(HintResult {
             message: None,
-            hint: "Use [] for generics, not <>. Example: List[String], Result[T, E]".into(),
+            hint: "Use [] for generics, not <>. Example: fn id[T](x: T) -> T, List[String], Result[T, E]".into(),
         }),
         _ => None,
     }

--- a/tests/generics_angle_hint_test.rs
+++ b/tests/generics_angle_hint_test.rs
@@ -1,0 +1,50 @@
+//! `<>` generics are the single most likely transcription slip for an LLM
+//! trained on Rust/TS/Java — and CHEATSHEET's "Common mistakes" block
+//! predicts exactly this spelling. The steer must fire in EVERY position the
+//! mistake appears (#1736): the declaration head (`fn id<T>(x: T)` — the
+//! highest-frequency form), the type annotation (`let xs: List<Int> = []`),
+//! and the expression position that was already wired. A generic
+//! "expected token" fallback names no fix and costs the writer a retry.
+
+use std::process::Command;
+
+fn almide() -> &'static str {
+    env!("CARGO_BIN_EXE_almide")
+}
+
+fn check_hint(name: &str, src: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = dir.path().join(name);
+    std::fs::write(&file, src).expect("write fixture");
+    let out = Command::new(almide())
+        .arg("check")
+        .arg(&file)
+        .output()
+        .expect("run almide check");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+#[test]
+fn declaration_head_angle_generics_steer_to_brackets() {
+    let text = check_hint("gd.almd", "fn id<T>(x: T) -> T = x\n");
+    assert!(
+        text.contains("Use [] for generics"),
+        "`fn id<T>` must steer to `[]`, got:\n{text}"
+    );
+}
+
+#[test]
+fn type_annotation_angle_generics_steer_to_brackets() {
+    let text = check_hint(
+        "ga.almd",
+        "fn main() -> Unit = {\n  let xs: List<Int> = []\n  println(int.to_string(list.len(xs)))\n}\n",
+    );
+    assert!(
+        text.contains("Use [] for generics"),
+        "`List<Int>` in an annotation must steer to `[]`, got:\n{text}"
+    );
+}


### PR DESCRIPTION
Closes #1736.

## What

The "Use [] for generics, not <>" hint existed only for the expression position (`(RParen, LAngle)`), so `fn id<T>(x: T)` — the highest-frequency form for anything trained on Rust/TS/Java, and one CHEATSHEET's "Common mistakes" block explicitly predicts — fell through to the generic expected-token fallback. The probe the issue suggested confirmed the type-annotation position (`let xs: List<Int> = []`, an `(Eq, LAngle)` pair) fell through too.

One catalog arm now covers all three pairs — `(RParen | LParen | Eq, LAngle)` — and the hint's example line gained the declaration form (`fn id[T](x: T) -> T`) so the steer names the exact rewrite for the shape that triggered it.

## Evidence

`tests/generics_angle_hint_test.rs` pins both previously-silent positions (declaration head, type annotation) on the `almide check` output. Diagnostic harness/coverage suites and the parser suite green; `almide test` 427/427. The hint fires only on parse-error paths, so a legal `x < y` comparison is untouched.