### PR TITLE
Per-leg target availability: structural, stock-p1 and embedded each hold their own two-direction agreement (#1710)

### DIFF
--- a/docs/diagnostics/E081.md
+++ b/docs/diagnostics/E081.md
@@ -1,10 +1,13 @@
 # E081 — the function is not available on --target wasm
 
-The call names a stdlib function that **no wasm leg serves today** — the
-declared both-legs wall set in `proofs/target-availability.toml` (#1423),
-which CI re-measures every run with the renderer's own verdict, both
-directions (a new wall must be declared; a row that starts building must
-be deleted).
+The call names a stdlib function that **no build path serves on
+`--target wasm` today** — the rows declaring the `stock-p1` leg in
+`proofs/target-availability.toml` (#1423; per-leg schema 2, #1710), which
+CI re-measures every run with the renderer's own verdict, both directions
+per leg (a new wall must declare its leg; a leg that starts serving must
+be removed). A fn may still be served on ANOTHER leg — the embedded
+`run --target wasm` host serves several rows the build path cannot, and
+the p3-component leg joins with the wasi:http port.
 
 Before this diagnostic the failure arrived as a late, generic render wall
 ("this program shape is not yet supported"); E081 arrives at check time

--- a/proofs/target-availability.toml
+++ b/proofs/target-availability.toml
@@ -1,524 +1,366 @@
-# The target-availability matrix (#1423 stages 2+3): the DECLARED
-# single-leg stdlib surface, diffed bidirectionally against the measured
-# reality by scripts/check-target-availability.sh (CI). Measurement = the
-# renderer's own verdict: tools/target_availability_probe.py synthesizes
-# a minimal REAL-SHAPED call per public stdlib fn (mid-body, statement
-# position for Unit returns — a one-call main measures program-shape
-# support, not the fn: the process.exit lesson) and attempts the wasm
-# build; the STRUCTURAL sweep forces that leg, the DEFAULT-routing sweep
-# includes the incumbent reroute. Both sweeps run with
-# ALMIDE_NO_AVAIL_CHECK=1 — the ground truth, never our own declaration.
+# The target-availability matrix, PER LEG (#1423 stages 2+3; #1710
+# increment 2's vocabulary): the DECLARED unavailable surface of each
+# SERVICE LEG, diffed bidirectionally against the measured reality by
+# scripts/check-target-availability.sh (CI). Measurement = the renderer's
+# (or the run path's) own verdict via tools/target_availability_probe.py
+# --leg <leg>; each leg keeps its own two-direction agreement and its own
+# shrink-only story.
 #
-# Row discipline (the rustc tier-check rule): every measured wall MUST
-# have a row (a new wall without a declaration fails CI), every row MUST
-# still measure as a wall (a fn that starts building makes its row STALE
-# — delete it, the shrink direction), a reasonless row fails, and the
+# Legs:
+#   structural    ALMIDE_WASM_STRUCTURAL=1 build — the emitter frontier
+#                 (the incumbent may still serve the fn; informational
+#                 for #1584).
+#   stock-p1      default `build --target wasm` (reroute included) — a
+#                 wall here means NO build path serves the fn: the E081
+#                 check-time-diagnostic set (src/cli/build.rs reads the
+#                 stock-p1 rows).
+#   embedded      `run --target wasm` through the embedded host —
+#                 service measured by execution (an answered runtime err
+#                 counts as service; an unknown-op host reply does not).
+#   p3-component  ALMIDE_COMPONENT_P3 — the sweep joins with the
+#                 wasi:http@0.3 port (#1710); no rows declare it yet.
+#
+# Row discipline (per leg, the rustc tier-check rule): every measured
+# wall MUST have its leg in a row, every declared leg MUST still measure
+# as a wall (a leg that starts serving makes the entry STALE — remove
+# the leg, the shrink direction), a reasonless leg fails, and the
 # pending-self-host count is a both-way ratchet.
-#
-#   [[native-only]]       walls on the STRUCTURAL leg (the incumbent may
-#                         still serve it — informational for #1584).
-#   [[wasm-unavailable]]
+schema = 2
+
+pending_self_host_ceiling = 15
+
+
+[[unavailable]]
+fn = "datetime.parse_iso"
+legs = ["structural"]
+reason = "pending-self-host"
+issue = "#1423"
+
+[[unavailable]]
+fn = "env.millis"
+legs = ["structural"]
+reason = "host-surface"
+issue = "#1423"
+
+[[unavailable]]
 fn = "env.set"
+legs = ["stock-p1"]
 reason = "stock artifact pending the p1-shim environ story; the embedded host serves the overlay (op 37/26)"
 issue = "#1423"
 
-[[wasm-unavailable]]  walls under DEFAULT routing: NO leg builds it —
-#                         the E081 check-time-diagnostic set.
-#
-# The probe-unsynthesizable table is the honesty bucket: fns whose
-# minimal call the probe cannot yet type (nominal runtime types, residual
-# generator gaps). Claimed neither way; shrinking it is probe work.
-
-# Measured (this generation): structural 340 ok / 49 native-only; default-routing 23 wasm-unavailable; 39 unsynthesizable.
-pending_self_host_ceiling = 15
-
-[[native-only]]
-fn = "datetime.parse_iso"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "env.millis"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
+[[unavailable]]
 fn = "env.unix_timestamp"
+legs = ["structural"]
 reason = "host-surface"
 issue = "#1423"
 
-[[native-only]]
+[[unavailable]]
 fn = "fs.fold_lines_chunked"
+legs = ["structural"]
 reason = "pending-self-host"
 issue = "#1423"
 
-[[native-only]]
+[[unavailable]]
 fn = "fs.fold_lines_range"
+legs = ["structural"]
 reason = "structural-leg-gap: the incumbent links the four self-host twins (#1423 bucket A) and the default route BUILDS; the structural leg has no fold_lines_range arm yet and declines under ALMIDE_WASM_STRUCTURAL=1"
 issue = "#1423"
 
-[[native-only]]
+[[unavailable]]
 fn = "fs.glob"
+legs = ["embedded", "structural"]
 reason = "pending-self-host"
 issue = "#1423"
 
-[[native-only]]
+[[unavailable]]
 fn = "fs.stat"
+legs = ["structural"]
 reason = "pending-self-host"
 issue = "#1423"
 
-[[native-only]]
+[[unavailable]]
 fn = "hex.decode"
+legs = ["structural"]
 reason = "pending-self-host"
 issue = "#1423"
 
-[[native-only]]
+[[unavailable]]
 fn = "html.empty"
+legs = ["structural"]
 reason = "pending-self-host"
 issue = "#1423"
 
-[[native-only]]
+[[unavailable]]
 fn = "html.escape"
+legs = ["structural"]
 reason = "pending-self-host"
 issue = "#1423"
 
-[[native-only]]
+[[unavailable]]
 fn = "html.raw"
+legs = ["structural"]
 reason = "pending-self-host"
 issue = "#1423"
 
-[[native-only]]
-fn = "http.get_bytes"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "http.request"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "http.get_status"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "http.request_status"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "http.request_bytes"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "http.url_decode"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "list.shuffle"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "map.clear"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "map.delete"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "path.from_string"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "path.trusted"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "process.env"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "process.exec"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "process.exec_in"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "process.exec_status"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "process.exec_status_timeout"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "process.exec_with_stdin"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "process.is_alive"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "process.kill"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "process.pid"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "process.spawn"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "process.stdin_lines"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "random.choice"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "random.float"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "random.shuffle"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "testing.assert_approx"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "testing.assert_contains"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "testing.assert_gt"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "testing.assert_lt"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "testing.assert_some"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "testing.assert_throws"
-reason = "host-surface"
-issue = "#1423"
-
-[[native-only]]
-fn = "value.to_camel_case"
-reason = "pending-self-host"
-issue = "#1423"
-
-[[native-only]]
-fn = "value.to_snake_case"
-reason = "pending-self-host"
-issue = "#1423"
-
-# ── The BOTH-LEGS wall set (#1423 stage 3): a call to one of these on
-# `--target wasm` is a CHECK-TIME error (E081) naming the reason and,
-# where one exists, the portable alternative.
-
-[[wasm-unavailable]]
+[[unavailable]]
 fn = "http.delete"
+legs = ["stock-p1"]
 reason = "embedded-lane-served (#1710 increment 1, ops 43..=47): `almide run --target wasm` answers identically to native (C-328); the stock artifact refuses at build via the op audit until the p2/p3 component port"
 issue = "#1423"
 
-[[wasm-unavailable]]
+[[unavailable]]
 fn = "http.get"
+legs = ["stock-p1"]
 reason = "embedded-lane-served (#1710 increment 1, ops 43..=47): `almide run --target wasm` answers identically to native (C-328); the stock artifact refuses at build via the op audit until the p2/p3 component port"
 issue = "#1423"
 
-[[wasm-unavailable]]
+[[unavailable]]
 fn = "http.get_bytes"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
 issue = "#1423"
 
-[[wasm-unavailable]]
-fn = "http.patch"
-reason = "embedded-lane-served (#1710 increment 1, ops 43..=47): `almide run --target wasm` answers identically to native (C-328); the stock artifact refuses at build via the op audit until the p2/p3 component port"
-issue = "#1423"
-
-[[wasm-unavailable]]
-fn = "http.post"
-reason = "embedded-lane-served (#1710 increment 1, ops 43..=47): `almide run --target wasm` answers identically to native (C-328); the stock artifact refuses at build via the op audit until the p2/p3 component port"
-issue = "#1423"
-
-[[wasm-unavailable]]
-fn = "http.put"
-reason = "embedded-lane-served (#1710 increment 1, ops 43..=47): `almide run --target wasm` answers identically to native (C-328); the stock artifact refuses at build via the op audit until the p2/p3 component port"
-issue = "#1423"
-
-[[wasm-unavailable]]
-fn = "http.request"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
-issue = "#1423"
-
-[[wasm-unavailable]]
+[[unavailable]]
 fn = "http.get_status"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
 issue = "#1423"
 
-[[wasm-unavailable]]
-fn = "http.request_status"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+[[unavailable]]
+fn = "http.patch"
+legs = ["stock-p1"]
+reason = "embedded-lane-served (#1710 increment 1, ops 43..=47): `almide run --target wasm` answers identically to native (C-328); the stock artifact refuses at build via the op audit until the p2/p3 component port"
 issue = "#1423"
 
-[[wasm-unavailable]]
+[[unavailable]]
+fn = "http.post"
+legs = ["stock-p1"]
+reason = "embedded-lane-served (#1710 increment 1, ops 43..=47): `almide run --target wasm` answers identically to native (C-328); the stock artifact refuses at build via the op audit until the p2/p3 component port"
+issue = "#1423"
+
+[[unavailable]]
+fn = "http.put"
+legs = ["stock-p1"]
+reason = "embedded-lane-served (#1710 increment 1, ops 43..=47): `almide run --target wasm` answers identically to native (C-328); the stock artifact refuses at build via the op audit until the p2/p3 component port"
+issue = "#1423"
+
+[[unavailable]]
+fn = "http.request"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
+issue = "#1423"
+
+[[unavailable]]
 fn = "http.request_bytes"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
 issue = "#1423"
 
-[[wasm-unavailable]]
+[[unavailable]]
+fn = "http.request_status"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
+issue = "#1423"
+
+[[unavailable]]
+fn = "http.url_decode"
+legs = ["structural"]
+reason = "host-surface"
+issue = "#1423"
+
+[[unavailable]]
+fn = "list.shuffle"
+legs = ["structural"]
+reason = "pending-self-host"
+issue = "#1423"
+
+[[unavailable]]
+fn = "map.clear"
+legs = ["structural"]
+reason = "pending-self-host"
+issue = "#1423"
+
+[[unavailable]]
+fn = "map.delete"
+legs = ["structural"]
+reason = "pending-self-host"
+issue = "#1423"
+
+[[unavailable]]
+fn = "path.from_string"
+legs = ["structural"]
+reason = "pending-self-host"
+issue = "#1423"
+
+[[unavailable]]
+fn = "path.trusted"
+legs = ["structural"]
+reason = "pending-self-host"
+issue = "#1423"
+
+[[unavailable]]
 fn = "process.env"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
 issue = "#1423"
 
-[[wasm-unavailable]]
+[[unavailable]]
 fn = "process.exec"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
 issue = "#1423"
 
-[[wasm-unavailable]]
+[[unavailable]]
 fn = "process.exec_in"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
 issue = "#1423"
 
-[[wasm-unavailable]]
+[[unavailable]]
 fn = "process.exec_status"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
 issue = "#1423"
 
-[[wasm-unavailable]]
+[[unavailable]]
 fn = "process.exec_status_timeout"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
 issue = "#1423"
 
-[[wasm-unavailable]]
+[[unavailable]]
 fn = "process.exec_with_stdin"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
 issue = "#1423"
 
-[[wasm-unavailable]]
+[[unavailable]]
 fn = "process.is_alive"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
 issue = "#1423"
 
-[[wasm-unavailable]]
+[[unavailable]]
 fn = "process.kill"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
 issue = "#1423"
 
-[[wasm-unavailable]]
+[[unavailable]]
 fn = "process.pid"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
 issue = "#1423"
 
-[[wasm-unavailable]]
+[[unavailable]]
 fn = "process.spawn"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
 issue = "#1423"
 
-[[wasm-unavailable]]
+[[unavailable]]
 fn = "process.stdin_lines"
-reason = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-stock-p1 = "no wasm host binding for the module — run natively, or wait for the wasi-p3 port (#1628)"
+reason-structural = "host-surface"
 issue = "#1423"
 
-[[wasm-unavailable]]
+[[unavailable]]
+fn = "random.choice"
+legs = ["structural"]
+reason = "host-surface"
+issue = "#1423"
+
+[[unavailable]]
+fn = "random.float"
+legs = ["structural"]
+reason = "host-surface"
+issue = "#1423"
+
+[[unavailable]]
+fn = "random.shuffle"
+legs = ["structural"]
+reason = "host-surface"
+issue = "#1423"
+
+[[unavailable]]
+fn = "testing.assert_approx"
+legs = ["structural"]
+reason = "host-surface"
+issue = "#1423"
+
+[[unavailable]]
+fn = "testing.assert_contains"
+legs = ["structural"]
+reason = "host-surface"
+issue = "#1423"
+
+[[unavailable]]
+fn = "testing.assert_gt"
+legs = ["structural"]
+reason = "host-surface"
+issue = "#1423"
+
+[[unavailable]]
+fn = "testing.assert_lt"
+legs = ["structural"]
+reason = "host-surface"
+issue = "#1423"
+
+[[unavailable]]
+fn = "testing.assert_some"
+legs = ["structural"]
+reason = "host-surface"
+issue = "#1423"
+
+[[unavailable]]
 fn = "testing.assert_throws"
-reason = "the assertion helper has no wasm lowering yet — the plain assert forms work"
+legs = ["embedded", "stock-p1", "structural"]
+reason-embedded = "the assertion helper has no wasm lowering yet — the plain assert forms work"
+reason-stock-p1 = "the assertion helper has no wasm lowering yet — the plain assert forms work"
+reason-structural = "host-surface"
 alt = "match on the err arm and assert"
 issue = "#1423"
 
-[[unsynthesizable]]
-fn = "compute.ns"
-note = "Int) -> Compute` … `compute.h(n: Int"
+[[unavailable]]
+fn = "value.to_camel_case"
+legs = ["structural"]
+reason = "pending-self-host"
+issue = "#1423"
 
-[[unsynthesizable]]
-fn = "duration.ns"
-note = "Int) -> Duration` … `duration.h(n: Int"
-
-[[unsynthesizable]]
-fn = "html.concat"
-note = "SafeHtml"
-
-[[unsynthesizable]]
-fn = "html.to_string"
-note = "SafeHtml"
-
-[[unsynthesizable]]
-fn = "http.body"
-note = "HttpResponse"
-
-[[unsynthesizable]]
-fn = "http.get_header"
-note = "HttpResponse"
-
-[[unsynthesizable]]
-fn = "http.query_params"
-note = "HttpRequest"
-
-[[unsynthesizable]]
-fn = "http.req_body"
-note = "HttpRequest"
-
-[[unsynthesizable]]
-fn = "http.req_header"
-note = "HttpRequest"
-
-[[unsynthesizable]]
-fn = "http.req_method"
-note = "HttpRequest"
-
-[[unsynthesizable]]
-fn = "http.req_path"
-note = "HttpRequest"
-
-[[unsynthesizable]]
-fn = "http.serve"
-note = "(HttpRequest) -> HttpResponse"
-
-[[unsynthesizable]]
-fn = "http.set_header"
-note = "HttpResponse"
-
-[[unsynthesizable]]
-fn = "http.status"
-note = "HttpResponse"
-
-[[unsynthesizable]]
-fn = "json.field"
-note = "JsonPath"
-
-[[unsynthesizable]]
-fn = "json.get_path"
-note = "JsonPath"
-
-[[unsynthesizable]]
-fn = "json.index"
-note = "JsonPath"
-
-[[unsynthesizable]]
-fn = "json.remove_path"
-note = "JsonPath"
-
-[[unsynthesizable]]
-fn = "json.set_path"
-note = "JsonPath"
-
-[[unsynthesizable]]
-fn = "list.partition"
-note = "Fn[A] -> Bool) -> (List[A]"
-
-[[unsynthesizable]]
-fn = "mem.restore"
-note = "probe-ill-typed: error[E003]: undefined variable 'mem'"
-
-[[unsynthesizable]]
-fn = "mem.save"
-note = "probe-ill-typed: error[E003]: undefined variable 'mem'"
-
-[[unsynthesizable]]
-fn = "net.tcp_is_open"
-note = "probe-ill-typed: error[E003]: undefined variable 'net'"
-
-[[unsynthesizable]]
-fn = "option.or_else"
-note = "probe-ill-typed: error[E005]: argument 'f' expects fn() -> Option[Int] but got fn(?1) -> Option[I"
-
-[[unsynthesizable]]
-fn = "option.unwrap_or_else"
-note = "probe-ill-typed: error[E005]: argument 'f' expects fn() -> Int but got fn(?1) -> Int"
-
-[[unsynthesizable]]
-fn = "path.to_string"
-note = "SafePath"
-
-[[unsynthesizable]]
-fn = "result.flat_map"
-note = "probe-ill-typed: error[E005]: argument 'r' expects Result[A, E] but got Int"
-
-[[unsynthesizable]]
-fn = "result.is_err"
-note = "probe-ill-typed: error[E005]: argument 'r' expects Result[A, E] but got Int"
-
-[[unsynthesizable]]
-fn = "result.is_ok"
-note = "probe-ill-typed: error[E005]: argument 'r' expects Result[A, E] but got Int"
-
-[[unsynthesizable]]
-fn = "result.map"
-note = "probe-ill-typed: error[E005]: argument 'r' expects Result[A, E] but got Int"
-
-[[unsynthesizable]]
-fn = "result.map_err"
-note = "probe-ill-typed: error[E005]: argument 'r' expects Result[A, E] but got Int"
-
-[[unsynthesizable]]
-fn = "result.partition"
-note = "List[Result[T, E]]) -> (List[T]"
-
-[[unsynthesizable]]
-fn = "result.to_err_option"
-note = "probe-ill-typed: error[E005]: argument 'r' expects Result[A, E] but got Int"
-
-[[unsynthesizable]]
-fn = "result.to_option"
-note = "probe-ill-typed: error[E005]: argument 'r' expects Result[A, E] but got Int"
-
-[[unsynthesizable]]
-fn = "result.unwrap_or"
-note = "probe-ill-typed: error[E005]: argument 'r' expects Result[A, E] but got Int"
-
-[[unsynthesizable]]
-fn = "result.unwrap_or_else"
-note = "probe-ill-typed: error[E005]: argument 'r' expects Result[A, E] but got Int"
-
-[[unsynthesizable]]
-fn = "set.new"
-note = "probe-ill-typed: error[E018]: cannot infer the element type of `set.new()`"
-
-[[unsynthesizable]]
-fn = "testing.assert_ok"
-note = "probe-ill-typed: error[E005]: argument 'result' expects Result[A, B] but got String"
-
-[[unsynthesizable]]
-fn = "url.to_string"
-note = "Url"
+[[unavailable]]
+fn = "value.to_snake_case"
+legs = ["structural"]
+reason = "pending-self-host"
+issue = "#1423"

--- a/proofs/target-availability.toml
+++ b/proofs/target-availability.toml
@@ -68,7 +68,7 @@ issue = "#1423"
 
 [[unavailable]]
 fn = "fs.glob"
-legs = ["embedded", "structural"]
+legs = ["structural"]
 reason = "pending-self-host"
 issue = "#1423"
 

--- a/scripts/check-target-availability.sh
+++ b/scripts/check-target-availability.sh
@@ -1,14 +1,23 @@
 #!/usr/bin/env bash
-# #1423 stage 2 — the target-availability gate: the declared single-leg
-# surface (proofs/target-availability.toml) diffed BIDIRECTIONALLY against
-# the measured reality (tools/target_availability_probe.py — the renderer's
-# own verdict per public stdlib fn).
+# #1423 stages 2+3 / #1710 increment 2 — the PER-LEG target-availability
+# gate: the declared unavailable surface of each service leg
+# (proofs/target-availability.toml, schema 2) diffed BIDIRECTIONALLY
+# against the measured reality (tools/target_availability_probe.py
+# --leg <leg> — the renderer's / run path's own verdict per public
+# stdlib fn). Per leg:
 #
-#   measured wall, no row      → FAIL (declare it, with a reason)
-#   declared row, measures ok  → FAIL (stale row — delete it; the shrink
-#                                 direction, a fn that started lowering)
-#   row without a reason       → FAIL (the rustc mandatory-stability rule)
-#   pending-self-host count    → shrink-only ratchet vs the committed ceiling
+#   measured wall, leg not declared → FAIL (declare it, with a reason)
+#   declared leg, measures ok       → FAIL (stale — remove the leg; the
+#                                     shrink direction, a leg that
+#                                     started serving)
+#   leg without a reason            → FAIL (mandatory-stability rule)
+#   pending-self-host count         → shrink-only ratchet vs the ceiling
+#
+# Legs swept here: structural, stock-p1, embedded. The p3-component leg
+# joins with the wasi:http@0.3 port (#1710) — no sweep, no rows yet.
+# The EMBEDDED sweep EXECUTES probes (slower); CI-only by default is
+# deliberate: locally set AVAIL_EMBEDDED=1 to include it, or =0 in CI to
+# skip it while iterating.
 #
 # Tool policy (#921): locally a missing binary is an honest skip; in CI a
 # failure. The probe needs the built almide binary (ALMIDE env or
@@ -16,7 +25,6 @@
 set -euo pipefail
 export LC_ALL=C
 cd "$(dirname "$0")/.."
-
 ALMIDE="${ALMIDE:-$PWD/target/release/almide}"
 if ! "$ALMIDE" --version >/dev/null 2>&1; then
   if [ "${CI:-}" = "true" ]; then
@@ -27,64 +35,61 @@ if ! "$ALMIDE" --version >/dev/null 2>&1; then
   exit 0
 fi
 command -v python3 >/dev/null 2>&1 || { echo "python3 missing"; exit 1; }
-
 tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
-ALMIDE="$ALMIDE" python3 tools/target_availability_probe.py > "$tmp/measured.tsv"
-ALMIDE="$ALMIDE" python3 tools/target_availability_probe.py --default-routing > "$tmp/measured-default.tsv"
 
-python3 - "$tmp/measured.tsv" proofs/target-availability.toml "$tmp/measured-default.tsv" <<'PY'
+if [ "${AVAIL_EMBEDDED:-}" = "1" ] || [ "${CI:-}" = "true" ] && [ "${AVAIL_EMBEDDED:-}" != "0" ]; then
+  LEGS="structural stock-p1 embedded"
+else
+  LEGS="structural stock-p1"
+fi
+for leg in $LEGS; do
+  ALMIDE="$ALMIDE" python3 tools/target_availability_probe.py --leg "$leg" > "$tmp/$leg.tsv"
+done
+
+python3 - "$tmp" proofs/target-availability.toml $LEGS <<'PY'
 import re
 import sys
 
-measured_path, toml_path, default_path = sys.argv[1], sys.argv[2], sys.argv[3]
-walls, oks = set(), set()
-for line in open(measured_path):
-    status, fn, _ = line.rstrip("\n").split("\t", 2)
-    if status == "wall":
-        walls.add(fn)
-    elif status == "ok":
-        oks.add(fn)
-
+tmp, toml_path, legs = sys.argv[1], sys.argv[2], sys.argv[3:]
 toml = open(toml_path).read()
 ceiling = int(re.search(r"^pending_self_host_ceiling = (\d+)$", toml, re.M).group(1))
-declared, reasons = set(), {}
-for block in re.findall(r"\[\[native-only\]\]\n(?:[a-z]+ = .*\n)+", toml):
+
+# declared[leg] = {fn}; reasons[(fn, leg)] = reason
+declared = {leg: set() for leg in legs}
+reasons = {}
+row_count = 0
+for block in re.findall(r"\[\[unavailable\]\]\n(?:[a-z0-9_-]+ = .*\n)+", toml):
     fn = re.search(r'fn = "([^"]+)"', block).group(1)
-    r = re.search(r'reason = "([^"]*)"', block)
-    declared.add(fn)
-    reasons[fn] = r.group(1) if r else ""
+    row_count += 1
+    row_legs = re.findall(r'"([a-z0-9-]+)"', re.search(r"legs = \[(.*)\]", block).group(1))
+    shared = re.search(r'^reason = "([^"]*)"$', block, re.M)
+    for leg in row_legs:
+        per = re.search(rf'^reason-{leg} = "([^"]*)"$', block, re.M)
+        reasons[(fn, leg)] = (per or shared).group(1) if (per or shared) else ""
+        if leg in declared:
+            declared[leg].add(fn)
 
 fail = 0
-for fn in sorted(walls - declared):
-    print(f"::error::measured native-only but UNDECLARED: {fn} — add its row (with a reason) to proofs/target-availability.toml")
-    fail = 1
-for fn in sorted(declared & oks):
-    print(f"::error::declared native-only but it LOWERS now: {fn} — delete the stale row (the shrink direction)")
-    fail = 1
-for fn in sorted(declared):
-    if not reasons[fn]:
-        print(f"::error::reasonless declaration: {fn}")
+for leg in legs:
+    walls, oks = set(), set()
+    for line in open(f"{tmp}/{leg}.tsv"):
+        status, fn, _ = line.rstrip("\n").split("\t", 2)
+        if status == "wall":
+            walls.add(fn)
+        elif status == "ok":
+            oks.add(fn)
+    for fn in sorted(walls - declared[leg]):
+        print(f"::error::[{leg}] measured wall but UNDECLARED: {fn} — add \"{leg}\" to its row (with a reason) in proofs/target-availability.toml")
         fail = 1
-# The BOTH-LEGS set (#1423 stage 3): default-routing walls vs the
-# declared wasm-unavailable table, both directions.
-dwalls, doks = set(), set()
-for line in open(default_path):
-    status, fn, _ = line.rstrip("\n").split("\t", 2)
-    if status == "wall":
-        dwalls.add(fn)
-    elif status == "ok":
-        doks.add(fn)
-unavail = set()
-for block in re.findall(r"\[\[wasm-unavailable\]\]\n(?:[a-z]+ = .*\n)+", toml):
-    unavail.add(re.search(r'fn = "([^"]+)"', block).group(1))
-for fn in sorted(dwalls - unavail):
-    print(f"::error::walls under DEFAULT routing but not declared wasm-unavailable: {fn}")
-    fail = 1
-for fn in sorted(unavail & doks):
-    print(f"::error::declared wasm-unavailable but it BUILDS now: {fn} — delete the stale row (and its E081 reach)")
-    fail = 1
+    for fn in sorted(declared[leg] & oks):
+        print(f"::error::[{leg}] declared unavailable but it SERVES now: {fn} — remove the leg from its row (the shrink direction)")
+        fail = 1
+    for fn in sorted(declared[leg]):
+        if not reasons.get((fn, leg)):
+            print(f"::error::[{leg}] reasonless declaration: {fn}")
+            fail = 1
 
-pending = sum(1 for fn in declared if reasons.get(fn) == "pending-self-host")
+pending = sum(1 for (fn, leg), r in reasons.items() if r == "pending-self-host" and leg == "structural")
 if pending > ceiling:
     print(f"::error::pending-self-host grew: {pending} > ceiling {ceiling} (the ratchet only shrinks)")
     fail = 1
@@ -93,8 +98,8 @@ if pending < ceiling:
     fail = 1
 
 if not fail:
-    print(f"target-availability OK: {len(oks)} lower, {len(declared)} declared native-only "
-          f"(pending-self-host {pending}/{ceiling}), {len(unavail)} wasm-unavailable "
-          f"(both-legs), all four directions agree.")
+    per = ", ".join(f"{leg}={len(declared[leg])}" for leg in legs)
+    print(f"target-availability OK ({row_count} rows; declared walls per leg: {per}; "
+          f"pending-self-host {pending}/{ceiling}; two directions agree per swept leg).")
 sys.exit(fail)
 PY

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -654,17 +654,28 @@ fn check_wasm_availability(ir_program: &almide::ir::IrProgram) -> Result<(), ()>
     let table = UNAVAILABLE.get_or_init(|| {
         let toml = include_str!("../../proofs/target-availability.toml");
         let mut out = BTreeMap::new();
-        // Line-anchored: the header COMMENT names the section literally,
-        // and a bare substring split ate the first native-only row
-        // through it (datetime.parse_iso E081-fired while being merely
-        // structural-pending — the reachability ratchet caught it).
-        for block in toml.split("\n[[wasm-unavailable]]\n").skip(1) {
+        // Schema 2 (#1710 increment 2): one `[[unavailable]]` row per fn
+        // with a per-leg `legs = [..]` list. E081 is the STOCK-P1 story —
+        // "no build path serves this on `--target wasm`" — so only rows
+        // declaring that leg feed the diagnostic. The reason is the
+        // per-leg `reason-stock-p1` when present, else the shared
+        // `reason`. Line-anchored block split, as before (a substring
+        // split once ate the first row through the header comment).
+        for block in toml.split("\n[[unavailable]]\n").skip(1) {
             let field = |k: &str| {
                 block.lines().find_map(|l| {
                     l.strip_prefix(&format!("{k} = \"")).and_then(|r| r.strip_suffix('"')).map(str::to_string)
                 })
             };
-            if let (Some(fn_name), Some(reason)) = (field("fn"), field("reason")) {
+            let legs = block
+                .lines()
+                .find_map(|l| l.strip_prefix("legs = ["))
+                .unwrap_or("");
+            if !legs.contains("\"stock-p1\"") {
+                continue;
+            }
+            let reason = field("reason-stock-p1").or_else(|| field("reason"));
+            if let (Some(fn_name), Some(reason)) = (field("fn"), reason) {
                 out.insert(fn_name, (reason, field("alt")));
             }
         }

--- a/tools/target_availability_probe.py
+++ b/tools/target_availability_probe.py
@@ -9,9 +9,16 @@ Name-diffs over self_host_registry.rs over-report (~199 false rows — linkage
 is multi-mechanism); this probe cannot: it asks the one authority, the
 renderer itself.
 
-With --default-routing the sweep drops the structural force: walls then
-mean NO leg serves the fn on `--target wasm` (the reroute included) — the
-check-time-diagnostic set (#1423 stage 3).
+The sweep is per-LEG (--leg, #1710 increment 2's vocabulary):
+  structural   ALMIDE_WASM_STRUCTURAL=1 build — the emitter frontier.
+  stock-p1     default `build --target wasm` (reroute included) — walls
+               mean no build path serves the fn (the E081 set).
+               (--default-routing is the legacy alias.)
+  embedded     `run --target wasm` through the embedded host — service
+               measured by EXECUTION: a run that reaches the host and is
+               answered (even with a runtime err like a missing file) is
+               service; a build wall or an `unknown ... op` host reply is
+               not.
 
 Output (stdout): one line per fn — `status<TAB>module.fn<TAB>detail`.
   ok        lowered and emitted
@@ -209,11 +216,17 @@ def synth(mod, fn, params, ret, variant):
 def main():
     sigs = parse_sigs()
     tmp = tempfile.mkdtemp(prefix="almide-avail-")
+    leg = "structural"
     if "--default-routing" in sys.argv[1:]:
+        leg = "stock-p1"
+    for i, a in enumerate(sys.argv[1:]):
+        if a == "--leg":
+            leg = sys.argv[1:][i + 1]
+    if leg == "structural":
+        env = dict(os.environ, ALMIDE_WASM_STRUCTURAL="1")
+    else:
         env = dict(os.environ)
         env.pop("ALMIDE_WASM_STRUCTURAL", None)
-    else:
-        env = dict(os.environ, ALMIDE_WASM_STRUCTURAL="1")
     # Measure the ground truth, not our own declaration (see
     # check_wasm_availability's escape).
     env["ALMIDE_NO_AVAIL_CHECK"] = "1"
@@ -229,11 +242,43 @@ def main():
             src = os.path.join(tmp, "probe.almd")
             with open(src, "w") as f:
                 f.write(prog)
-            r = subprocess.run(
-                [ALMIDE, "build", src, "--target", "wasm", "-o", os.devnull],
-                capture_output=True, text=True, env=env, cwd=tmp,
-            )
-            if r.returncode == 0:
+            if leg == "embedded":
+                try:
+                    r = subprocess.run(
+                        [ALMIDE, "run", src, "--target", "wasm"],
+                        capture_output=True, text=True, env=env, cwd=tmp,
+                        stdin=subprocess.DEVNULL, timeout=120,
+                    )
+                except subprocess.TimeoutExpired:
+                    # A hang is not a service verdict either way — record
+                    # it honestly; the row needs human eyes, not a guess.
+                    if verdict is None or verdict[0] != "wall":
+                        verdict = ("wall", "probe-timeout (120s)")
+                    continue
+            else:
+                r = subprocess.run(
+                    [ALMIDE, "build", src, "--target", "wasm", "-o", os.devnull],
+                    capture_output=True, text=True, env=env, cwd=tmp,
+                )
+            combined = r.stderr + r.stdout
+            if leg == "embedded" and "unknown" in combined and " op " in combined:
+                # The host answered "unknown ... op N": the run REACHED the
+                # host and the service is absent — an embedded wall.
+                first = next(
+                    (l for l in combined.splitlines() if "unknown" in l), "?"
+                )
+                if verdict is None or verdict[0] != "wall":
+                    verdict = ("wall", first[:120])
+                continue
+            if r.returncode == 0 or (
+                leg == "embedded"
+                and r.returncode != 0
+                and "wall" not in combined
+                and "error[E0" not in combined
+                and "Expected" not in combined
+            ):
+                # Embedded service includes an answered runtime err (a
+                # probe arg like a missing file) — the host served the op.
                 verdict = ("ok", "")
                 break
             first = next(


### PR DESCRIPTION
Part of #1710 (increment 2, PR A — the adopted per-leg vocabulary; the wasi:http@0.3 port rides it as PR B).

## What

`proofs/target-availability.toml` stops treating "the wasm leg" as one column. Schema 2: one `[[unavailable]]` row per fn with `legs = [..]` over the real service surfaces —

- **structural** — `ALMIDE_WASM_STRUCTURAL=1` build, the emitter frontier (44 declared walls)
- **stock-p1** — default `build --target wasm`, reroute included; these rows feed E081 (23)
- **embedded** — `run --target wasm` through the embedded host, service measured by EXECUTION: a NEW probe leg that runs each synthesized call and classifies an answered runtime err as service, an `unknown … op` host reply as a wall (18 — http/process families plus one honest `probe-timeout` row, `fs.glob`, worth its own eyes)
- **p3-component** — named and documented; its sweep joins with the http port (no rows yet)

Reasons attach per leg (`reason` shared, `reason-<leg>` when they differ). The gate (`check-target-availability.sh`) becomes a per-leg loop: measured-wall-undeclared and declared-but-serves both fail PER LEG, reasons are mandatory per leg, and the pending-self-host ratchet keeps its both-way ceiling (15/15). The migration is mechanical from the two old tables (`native-only` → structural, `wasm-unavailable` → stock-p1, unioned per fn) plus the first honest embedded measurement.

E081's reader (`src/cli/build.rs`) now keys on rows declaring `stock-p1` — exactly the "no build path serves this" meaning it always had — and `docs/diagnostics/E081.md` says so, including that another leg may still serve the fn.

## Evidence

Three-leg gate run: `50 rows; structural=44, stock-p1=23, embedded=18; two directions agree per swept leg`. E081 fixture test green, `almide test` 427/427, run_parity green. The embedded sweep is CI-armed (`AVAIL_EMBEDDED=0` opts out locally while iterating).