### PR TITLE
Twelve pairs widen the thinnest diagnostic families (#1528)

### DIFF
--- a/tests/diagnostics/e058-map-key-tuple-float/broken.almd
+++ b/tests/diagnostics/e058-map-key-tuple-float/broken.almd
@@ -1,0 +1,4 @@
+fn main() -> Unit = {
+  let m: Map[(Int, Float), Int] = [:]
+  println(int.to_string(map.len(m)))
+}

--- a/tests/diagnostics/e058-map-key-tuple-float/fixed.almd
+++ b/tests/diagnostics/e058-map-key-tuple-float/fixed.almd
@@ -1,0 +1,4 @@
+fn main() -> Unit = {
+  let m: Map[(Int, Int), Int] = [:]
+  println(int.to_string(map.len(m)))
+}

--- a/tests/diagnostics/e058-map-key-tuple-float/meta.toml
+++ b/tests/diagnostics/e058-map-key-tuple-float/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E058"
+expects_error = "not hashable"
+hint_substring = "hashable"

--- a/tests/diagnostics/e059-for-in-result/broken.almd
+++ b/tests/diagnostics/e059-for-in-result/broken.almd
@@ -1,0 +1,6 @@
+fn main() -> Unit = {
+  let r = int.parse("3")
+  for x in r {
+    println(int.to_string(x))
+  }
+}

--- a/tests/diagnostics/e059-for-in-result/fixed.almd
+++ b/tests/diagnostics/e059-for-in-result/fixed.almd
@@ -1,0 +1,7 @@
+fn main() -> Unit = {
+  let r = int.parse("3")
+  match r {
+    ok(x) => println(int.to_string(x)),
+    err(_) => println("bad"),
+  }
+}

--- a/tests/diagnostics/e059-for-in-result/meta.toml
+++ b/tests/diagnostics/e059-for-in-result/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E059"
+expects_error = "cannot iterate"
+hint_substring = ""

--- a/tests/diagnostics/e059-for-in-tuple/broken.almd
+++ b/tests/diagnostics/e059-for-in-tuple/broken.almd
@@ -1,0 +1,6 @@
+fn main() -> Unit = {
+  let t = (1, 2)
+  for x in t {
+    println(int.to_string(x))
+  }
+}

--- a/tests/diagnostics/e059-for-in-tuple/fixed.almd
+++ b/tests/diagnostics/e059-for-in-tuple/fixed.almd
@@ -1,0 +1,6 @@
+fn main() -> Unit = {
+  let t = (1, 2)
+  for x in [t.0, t.1] {
+    println(int.to_string(x))
+  }
+}

--- a/tests/diagnostics/e059-for-in-tuple/meta.toml
+++ b/tests/diagnostics/e059-for-in-tuple/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E059"
+expects_error = "cannot iterate"
+hint_substring = ""

--- a/tests/diagnostics/e060-double-alias-import/broken.almd
+++ b/tests/diagnostics/e060-double-alias-import/broken.almd
@@ -1,0 +1,4 @@
+import regex as a
+import regex as b
+
+fn main() -> Unit = println(if a.is_match("x", "x") and b.is_match("y", "y") then "y" else "n")

--- a/tests/diagnostics/e060-double-alias-import/fixed.almd
+++ b/tests/diagnostics/e060-double-alias-import/fixed.almd
@@ -1,0 +1,3 @@
+import regex as a
+
+fn main() -> Unit = println(if a.is_match("x", "x") and a.is_match("y", "y") then "y" else "n")

--- a/tests/diagnostics/e060-double-alias-import/meta.toml
+++ b/tests/diagnostics/e060-double-alias-import/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E060"
+expects_error = "already imported"
+hint_substring = "duplicate import"

--- a/tests/diagnostics/e061-top-level-pipe-closure/broken.almd
+++ b/tests/diagnostics/e061-top-level-pipe-closure/broken.almd
@@ -1,0 +1,3 @@
+let shout = (s: String) => s + "!"
+
+fn main() -> Unit = println(shout("hey"))

--- a/tests/diagnostics/e061-top-level-pipe-closure/fixed.almd
+++ b/tests/diagnostics/e061-top-level-pipe-closure/fixed.almd
@@ -1,0 +1,3 @@
+fn shout(s: String) -> String = s + "!"
+
+fn main() -> Unit = println(shout("hey"))

--- a/tests/diagnostics/e061-top-level-pipe-closure/meta.toml
+++ b/tests/diagnostics/e061-top-level-pipe-closure/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E061"
+expects_error = "cannot be bound to a function value"
+hint_substring = "declare it as a function instead"

--- a/tests/diagnostics/e070-bounded-while-cond/broken.almd
+++ b/tests/diagnostics/e070-bounded-while-cond/broken.almd
@@ -1,0 +1,13 @@
+// ALS-B5: a while over a runtime condition has no static trip count.
+@bounded
+fn drain(n: Int) -> Int = {
+  var left = n
+  var steps = 0
+  while left > 0 {
+    left = left - 1
+    steps = steps + 1
+  }
+  steps
+}
+
+fn main() -> Unit = println("${drain(5)}")

--- a/tests/diagnostics/e070-bounded-while-cond/fixed.almd
+++ b/tests/diagnostics/e070-bounded-while-cond/fixed.almd
@@ -1,0 +1,11 @@
+// ALS-B5: the counted range is the admissible spelling.
+@bounded
+fn drain(n: Int) -> Int = {
+  var steps = 0
+  for i in 0..<100 {
+    if i < n then steps = steps + 1
+  }
+  steps
+}
+
+fn main() -> Unit = println("${drain(5)}")

--- a/tests/diagnostics/e070-bounded-while-cond/meta.toml
+++ b/tests/diagnostics/e070-bounded-while-cond/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E070"
+expects_error = ""
+hint_substring = ""

--- a/tests/diagnostics/e071-bounded-list-concat-in-loop/broken.almd
+++ b/tests/diagnostics/e071-bounded-list-concat-in-loop/broken.almd
@@ -1,0 +1,11 @@
+// ALS-B5: per-iteration list growth allocates inside the counted loop.
+@bounded
+fn build() -> Int = {
+  var xs: List[Int] = []
+  for i in 0..<8 {
+    xs = xs + [i]
+  }
+  list.len(xs)
+}
+
+fn main() -> Unit = println("${build()}")

--- a/tests/diagnostics/e071-bounded-list-concat-in-loop/fixed.almd
+++ b/tests/diagnostics/e071-bounded-list-concat-in-loop/fixed.almd
@@ -1,0 +1,11 @@
+// ALS-B5: carry the answer in a scalar accumulator.
+@bounded
+fn build() -> Int = {
+  var count = 0
+  for i in 0..<8 {
+    count = count + 1
+  }
+  count
+}
+
+fn main() -> Unit = println("${build()}")

--- a/tests/diagnostics/e071-bounded-list-concat-in-loop/meta.toml
+++ b/tests/diagnostics/e071-bounded-list-concat-in-loop/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E071"
+expects_error = ""
+hint_substring = ""

--- a/tests/diagnostics/e072-bounded-while-break/broken.almd
+++ b/tests/diagnostics/e072-bounded-while-break/broken.almd
@@ -1,0 +1,15 @@
+// ALS-B5: break inside a counted for weakens the trip count — a nested
+// early exit is the same violation one level down.
+@bounded
+fn seek(t: Int) -> Int = {
+  var hit = 0
+  for i in 0..<50 {
+    for j in 0..<50 {
+      if i * j == t then break
+      hit = j
+    }
+  }
+  hit
+}
+
+fn main() -> Unit = println("${seek(9)}")

--- a/tests/diagnostics/e072-bounded-while-break/fixed.almd
+++ b/tests/diagnostics/e072-bounded-while-break/fixed.almd
@@ -1,0 +1,13 @@
+// ALS-B5: run both counted ranges to completion.
+@bounded
+fn seek(t: Int) -> Int = {
+  var hit = 0
+  for i in 0..<50 {
+    for j in 0..<50 {
+      if i * j != t then hit = j
+    }
+  }
+  hit
+}
+
+fn main() -> Unit = println("${seek(9)}")

--- a/tests/diagnostics/e072-bounded-while-break/meta.toml
+++ b/tests/diagnostics/e072-bounded-while-break/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E072"
+expects_error = "not admissible in a @bounded function"
+hint_substring = ""

--- a/tests/diagnostics/e073-bounded-three-cycle/broken.almd
+++ b/tests/diagnostics/e073-bounded-three-cycle/broken.almd
@@ -1,0 +1,11 @@
+// ALS-B5: a three-fn call cycle is recursion the counted profile refuses.
+@bounded
+fn a(n: Int) -> Int = if n <= 0 then 0 else b(n - 1)
+
+@bounded
+fn b(n: Int) -> Int = if n <= 0 then 0 else c(n - 1)
+
+@bounded
+fn c(n: Int) -> Int = if n <= 0 then 0 else a(n - 1)
+
+fn main() -> Unit = println("${a(3)}")

--- a/tests/diagnostics/e073-bounded-three-cycle/fixed.almd
+++ b/tests/diagnostics/e073-bounded-three-cycle/fixed.almd
@@ -1,0 +1,11 @@
+// ALS-B5: the cycle unrolled into one counted loop.
+@bounded
+fn a(n: Int) -> Int = {
+  var left = 0
+  for i in 0..<100 {
+    if i < n then left = left + 1
+  }
+  left
+}
+
+fn main() -> Unit = println("${a(3)}")

--- a/tests/diagnostics/e073-bounded-three-cycle/meta.toml
+++ b/tests/diagnostics/e073-bounded-three-cycle/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E073"
+expects_error = ""
+hint_substring = ""

--- a/tests/diagnostics/e075-bounded-string-repeat-runtime/broken.almd
+++ b/tests/diagnostics/e075-bounded-string-repeat-runtime/broken.almd
@@ -1,0 +1,8 @@
+// ALS-B5: a run-time repeat count is a run-time-length heap value.
+@bounded
+fn pad(n: Int) -> Int = {
+  let s = string.repeat("x", n)
+  string.len(s)
+}
+
+fn main() -> Unit = println("${pad(4)}")

--- a/tests/diagnostics/e075-bounded-string-repeat-runtime/fixed.almd
+++ b/tests/diagnostics/e075-bounded-string-repeat-runtime/fixed.almd
@@ -1,0 +1,8 @@
+// ALS-B5: a literal count is a static footprint.
+@bounded
+fn pad() -> Int = {
+  let s = string.repeat("x", 4)
+  string.len(s)
+}
+
+fn main() -> Unit = println("${pad()}")

--- a/tests/diagnostics/e075-bounded-string-repeat-runtime/meta.toml
+++ b/tests/diagnostics/e075-bounded-string-repeat-runtime/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E075"
+expects_error = ""
+hint_substring = ""

--- a/tests/diagnostics/e076-bounded-env-effect/broken.almd
+++ b/tests/diagnostics/e076-bounded-env-effect/broken.almd
@@ -1,0 +1,10 @@
+import env
+
+// ALS-B5: an env read is an effect the bounded capability set must name.
+@bounded
+effect fn who() -> Int = {
+  let h = env.get("HOME") ?? ""
+  string.len(h)
+}
+
+fn main() -> Unit = println("ok")

--- a/tests/diagnostics/e076-bounded-env-effect/fixed.almd
+++ b/tests/diagnostics/e076-bounded-env-effect/fixed.almd
@@ -1,0 +1,5 @@
+// ALS-B5: keep the bounded body pure and pass the value in.
+@bounded
+fn who(h: String) -> Int = string.len(h)
+
+fn main() -> Unit = println("${who("x")}")

--- a/tests/diagnostics/e076-bounded-env-effect/meta.toml
+++ b/tests/diagnostics/e076-bounded-env-effect/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E076"
+expects_error = ""
+hint_substring = ""

--- a/tests/diagnostics/e077-bounded-float-division/broken.almd
+++ b/tests/diagnostics/e077-bounded-float-division/broken.almd
@@ -1,0 +1,8 @@
+// ALS-B7 (provisional): Float division inside the bounded profile.
+@bounded
+fn ratio(a: Int, b: Int) -> Int = {
+  let r = float.from_int(a) / float.from_int(b)
+  float.to_int(r)
+}
+
+fn main() -> Unit = println("${ratio(6, 3)}")

--- a/tests/diagnostics/e077-bounded-float-division/fixed.almd
+++ b/tests/diagnostics/e077-bounded-float-division/fixed.almd
@@ -1,0 +1,5 @@
+// ALS-B7: integer division stays in the profile.
+@bounded
+fn ratio(a: Int, b: Int) -> Int = a / b
+
+fn main() -> Unit = println("${ratio(6, 3)}")

--- a/tests/diagnostics/e077-bounded-float-division/meta.toml
+++ b/tests/diagnostics/e077-bounded-float-division/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E077"
+expects_error = ""
+hint_substring = ""


### PR DESCRIPTION
Part of #1528 (A1-3 — toward the ≥1,000-pair exit; 790 → 802).

Each of the twelve codes sitting at the tier-1 floor of three families gains a genuinely new shape, not a duplicate:

- **E058**: a Float nested inside a TUPLE key (`Map[(Int, Float), Int]`) — the reachability the flat-Float and record-Float variants don't probe. (A `List[Int]` key was probed too and turned out to be accepted — no fixture ships for a shape that does not fire.)
- **E059**: iterating a `Result` (the `int.parse` value a writer forgets to match) and a tuple.
- **E060**: the same module under TWO aliases (`import regex as a` / `as b`) — measured to warn; a literal bare re-import is silently deduped and deliberately has no fixture.
- **E061**: the closure-typed top-level `let` in its plainest one-arg form.
- **E070**: `while` over a runtime condition (the counted-`for` fix shown).
- **E071**: per-iteration LIST growth (`xs = xs + [i]`) — the sibling of the string-concat variant.
- **E072**: `break` in a NESTED counted loop.
- **E073**: a three-function call cycle (the two-fn mutual variant existed).
- **E075**: `string.repeat` with a runtime count.
- **E076**: an `env.get` effect inside `@bounded`.
- **E077**: Float DIVISION via `float.from_int` (the arithmetic/compare variants existed).

All twelve verified through the harness both ways: broken fires the exact code, fixed compiles clean. Coverage meter and `almide fix` suites green.