### PR TITLE
CI shards stop compiling the workspace: one nextest archive, replayed (#1732)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,15 @@
+# nextest execution policy (#1732). cargo test runs a binary's #[test]s as
+# THREADS in one process, so suites that serialize shared on-disk fixtures
+# with in-process statics (a Mutex/OnceLock over the fs fixture files and
+# the shared build scratch) were safe. nextest runs each test in its OWN
+# process — those statics no longer serialize anything, and the fixture
+# suites raced (fs_preopen_resolve reading a sibling test's round marker,
+# wasm-opt parity seeing a vanished file — soak round 3). The test-group
+# pins them back to one-at-a-time; every other binary keeps full
+# process-parallelism.
+[test-groups]
+shared-fixture-serial = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'binary_id(=almide::wasm_runtime_test)'
+test-group = "shared-fixture-serial"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,25 @@ jobs:
 
       - run: cargo build --release
 
+      # #1732: the workspace's dev-profile TEST build happens ONCE, here,
+      # and ships to the shards as a cargo-nextest archive — the four
+      # shard jobs stop compiling entirely (each used to repeat this
+      # ~10-minute build). The archive carries every test binary plus
+      # build-script outputs; shards replay it with `nextest run
+      # --archive-file` under the same target map and coverage gate.
+      - name: Install cargo-nextest
+        run: |
+          curl -LsSf https://get.nexte.st/latest/linux -o /tmp/nextest.tar.gz
+          tar xzf /tmp/nextest.tar.gz -C /usr/local/bin
+          cargo nextest --version
+      - name: Archive the workspace test binaries
+        run: cargo nextest archive --workspace --archive-file /tmp/almide-tests.tar.zst
+      - uses: actions/upload-artifact@v7
+        with:
+          name: almide-tests-archive
+          path: /tmp/almide-tests.tar.zst
+          retention-days: 1
+
       # Wired to `build`, not `checks`: the ratchet compiles the workspace, and
       # `checks` downloads a prebuilt binary with no cargo toolchain. Runs after
       # the release build so the warning set is measured against the same
@@ -201,10 +220,10 @@ jobs:
       - name: Union of shards == full target set
         run: |
           set -euo pipefail
-          bash scripts/ci-test-shard.sh --list-all | sort > /tmp/all.txt
+          bash scripts/ci-test-shard.sh --list-all-archive /tmp/almide-archive/almide-tests.tar.zst | sort > /tmp/all.txt
           : > /tmp/union.txt
           for i in 0 1 2 3; do
-            bash scripts/ci-test-shard.sh --list "$i" 4 >> /tmp/union.txt
+            bash scripts/ci-test-shard.sh --list-archive "$i" 4 /tmp/almide-archive/almide-tests.tar.zst >> /tmp/union.txt
           done
           sort /tmp/union.txt > /tmp/union_sorted.txt
           dupes=$(sort /tmp/union.txt | uniq -d | wc -l | tr -d ' ')
@@ -223,7 +242,7 @@ jobs:
       - name: Balance report (informational — imbalance costs time, not coverage)
         run: |
           for i in 0 1 2 3; do
-            printf '  shard %s: %s target(s)\n' "$i" "$(bash scripts/ci-test-shard.sh --list "$i" 4 | wc -l | tr -d ' ')"
+            printf '  shard %s: %s target(s)\n' "$i" "$(bash scripts/ci-test-shard.sh --list-archive "$i" 4 /tmp/almide-archive/almide-tests.tar.zst | wc -l | tr -d ' ')"
           done
 
   test-rust:
@@ -271,20 +290,21 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-      # This job was the ONE heavy job with no cargo cache: every PR run
-      # downloaded the registry and cold-built the whole workspace's dev-profile
-      # test targets (~15 of its ~22 minutes) before a single test ran. Same
-      # shape as fuzz-nightly's cache — registry + git + target, keyed on
-      # Cargo.lock, prefix restore so a lockfile bump still warm-starts.
-      - uses: actions/cache@v6
+      # #1732: no compile here anymore — the build job ships the
+      # dev-profile test binaries as a nextest archive, and this job
+      # replays it. The big registry/target cache went with the compile;
+      # only the tool tarball caches below remain.
+      - name: Install cargo-nextest
+        if: env.DOCS_ONLY != 'true'
+        run: |
+          curl -LsSf https://get.nexte.st/latest/linux -o /tmp/nextest.tar.gz
+          tar xzf /tmp/nextest.tar.gz -C /usr/local/bin
+          cargo nextest --version
+      - uses: actions/download-artifact@v8
         if: env.DOCS_ONLY != 'true'
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: test-rust-cargo-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: test-rust-cargo-${{ env.RUST_TOOLCHAIN }}-
+          name: almide-tests-archive
+          path: /tmp/almide-archive
 
       - name: Cache wasmtime tarball
         if: env.DOCS_ONLY != 'true'
@@ -343,7 +363,7 @@ jobs:
         # and runs this shard's share. `shard-coverage` below proves the four
         # shards' union is the whole set, so a partition bug reads as a RED
         # build rather than a fast green one.
-        run: bash scripts/ci-test-shard.sh --run ${{ matrix.shard }} 4
+        run: bash scripts/ci-test-shard.sh --run-archive ${{ matrix.shard }} 4 /tmp/almide-archive/almide-tests.tar.zst
 
   almide-gates:
     # BRANCH PROTECTION: this job's name is a REQUIRED CHECK on develop. Renaming

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,17 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      # #1732: enumerate from the build job's nextest archive — this
+      # job's old enumerate compiled the workspace.
+      - name: Install cargo-nextest
+        run: |
+          curl -LsSf https://get.nexte.st/latest/linux -o /tmp/nextest.tar.gz
+          sudo tar xzf /tmp/nextest.tar.gz -C /usr/local/bin
+          cargo nextest --version
+      - uses: actions/download-artifact@v8
+        with:
+          name: almide-tests-archive
+          path: /tmp/almide-archive
       - name: Union of shards == full target set
         run: |
           set -euo pipefail

--- a/scripts/ci-test-shard.sh
+++ b/scripts/ci-test-shard.sh
@@ -59,7 +59,7 @@ for line in sorted(set(out)):
 
 partition() { # shard total  (empty shard = print every target)
   local shard="${1:-}" total="${2:-}"
-  enumerate | python3 -c '
+  { if [ "${ENUM:-}" = archive ]; then enumerate_archive; else enumerate; fi; } | python3 -c '
 import sys, os
 shard = os.environ.get("SHARD", "")
 total = os.environ.get("TOTAL", "")
@@ -92,8 +92,55 @@ for pkg, kind, name in bins[shard]:
 '
 }
 
+# Archive-sourced enumerate (#1732): the same pkg/kind/name rows, read
+# from a cargo-nextest archive instead of a fresh workspace compile. The
+# row format is IDENTICAL (diffed 213 == 213 at the refit), so the
+# partitioner, the weights file and the shard-coverage gate keep their
+# exact contract.
+enumerate_archive() {
+  cargo nextest list --archive-file "$ARCHIVE" --message-format json 2>/dev/null | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+rows = []
+for v in d["rust-suites"].values():
+    rows.append("%s\t%s\t%s" % (v["package-name"], v["kind"], v["binary-name"]))
+for line in sorted(set(rows)):
+    print(line)
+'
+}
+
 case "${1:-}" in
   --list-all) SHARD="" TOTAL="" DEFAULT_WEIGHT=$DEFAULT_WEIGHT WEIGHTS=$WEIGHTS partition ;;
+  --list-all-archive)
+    ARCHIVE="$2"
+    SHARD="" TOTAL="" DEFAULT_WEIGHT=$DEFAULT_WEIGHT WEIGHTS=$WEIGHTS ENUM=archive partition ;;
+  --list-archive)
+    ARCHIVE="$4"
+    SHARD="$2" TOTAL="$3" DEFAULT_WEIGHT=$DEFAULT_WEIGHT WEIGHTS=$WEIGHTS ENUM=archive partition ;;
+  --run-archive)
+    # The no-compile shard run (#1732): partition from the archive, then
+    # ONE nextest invocation over the union filterset of this shard's
+    # binary ids (lib = the bare package id, test = pkg::name). Keeps
+    # per-test process isolation and --no-fail-fast parity with the
+    # per-package cargo loop below.
+    shard="$2"; total="$3"; ARCHIVE="$4"
+    mapfile -t rows < <(SHARD="$shard" TOTAL="$total" DEFAULT_WEIGHT=$DEFAULT_WEIGHT WEIGHTS=$WEIGHTS ENUM=archive partition)
+    if [ "${#rows[@]}" -eq 0 ]; then
+      echo "shard $shard/$total: no targets — a partition that runs nothing is a bug, not a fast build" >&2
+      exit 1
+    fi
+    echo "== shard $shard/$total: ${#rows[@]} target(s) (archive) =="
+    expr=""
+    for row in "${rows[@]}"; do
+      IFS=$'\t' read -r pkg kind name <<<"$row"
+      case "$kind" in
+        lib) bid="$pkg" ;;
+        *)   bid="$pkg::$name" ;;
+      esac
+      if [ -z "$expr" ]; then expr="binary_id(=$bid)"; else expr="$expr | binary_id(=$bid)"; fi
+    done
+    exec cargo nextest run --archive-file "$ARCHIVE" --workspace-remap . --no-fail-fast -E "$expr"
+    ;;
   --list)     SHARD="$2" TOTAL="$3" DEFAULT_WEIGHT=$DEFAULT_WEIGHT WEIGHTS=$WEIGHTS partition ;;
   --run)
     shard="$2"; total="$3"

--- a/scripts/ci-test-shard.sh
+++ b/scripts/ci-test-shard.sh
@@ -98,7 +98,7 @@ for pkg, kind, name in bins[shard]:
 # partitioner, the weights file and the shard-coverage gate keep their
 # exact contract.
 enumerate_archive() {
-  cargo nextest list --archive-file "$ARCHIVE" --message-format json 2>/dev/null | python3 -c '
+  cargo nextest list --archive-file "$ARCHIVE" --message-format json | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
 rows = []
@@ -135,6 +135,7 @@ case "${1:-}" in
       IFS=$'\t' read -r pkg kind name <<<"$row"
       case "$kind" in
         lib) bid="$pkg" ;;
+        bin) bid="$pkg::bin/$name" ;;
         *)   bid="$pkg::$name" ;;
       esac
       if [ -z "$expr" ]; then expr="binary_id(=$bid)"; else expr="$expr | binary_id(=$bid)"; fi

--- a/scripts/ci-test-shard.sh
+++ b/scripts/ci-test-shard.sh
@@ -140,7 +140,11 @@ case "${1:-}" in
       esac
       if [ -z "$expr" ]; then expr="binary_id(=$bid)"; else expr="$expr | binary_id(=$bid)"; fi
     done
-    exec cargo nextest run --archive-file "$ARCHIVE" --workspace-remap . --no-fail-fast -E "$expr"
+    # --extract-to .: the archive recreates ./target/debug/* in the
+    # workspace, so the CARGO_BIN_EXE_* paths the test helpers baked at
+    # compile time resolve on a checkout that never ran cargo (the
+    # binding_diag "No such file or directory" class, soak round 2).
+    exec cargo nextest run --archive-file "$ARCHIVE" --extract-to . --workspace-remap . --no-fail-fast -E "$expr"
     ;;
   --list)     SHARD="$2" TOTAL="$3" DEFAULT_WEIGHT=$DEFAULT_WEIGHT WEIGHTS=$WEIGHTS partition ;;
   --run)


### PR DESCRIPTION
Closes #1732 (the archive lever; the merge-queue lever already landed separately).

## What

The four `Test Rust` shards each rebuilt the workspace's dev-profile test targets (~10 min × 4, every run). Now:

- **Build (Linux)** additionally runs `cargo nextest archive --workspace` and uploads `almide-tests-archive` next to the compiler binary (the established artifact pattern).
- **Shards** stop compiling: nextest + the archive download replace the registry/target cache, and `ci-test-shard.sh --run-archive <shard> 4 <archive>` replays this shard's share as ONE `cargo nextest run --archive-file … -E '<union of binary_id()>'` invocation. Env (`ALMIDE_BIN`, `ALMIDE_EXPECT_TOOLS`), wasmtime/wasm-opt installs, and the flock discipline are unchanged; `--no-fail-fast` matches the old per-package `|| rc=1` loop's keep-going behavior.
- **Test shards cover every target** enumerates from the SAME archive (`--list-all-archive` / `--list-archive`) — its old enumerate compiled the workspace too. The row format is byte-identical (diffed 213 == 213 at the refit), so the committed weights file and the union/disjointness assertions keep their exact contract — target-list sharding, not count partitioning.

The old `--run`/`--list`/`--list-all` modes stay in the script for local use and as the fallback.

## Semantics deltas, named

- nextest runs each test in its own process (MORE isolation; the repo's tests are parallel-safe by design — the almide build scratch is flock-serialized, and no suite pins `--test-threads`).
- nextest does not run doctests — the shard enumerate never listed them (compiler-artifact targets only), so no coverage change.

## Expected effect

Shard wall 14-17 min → ~5-7 min; ~35-40 min less runner time per run; the queue under a PR burst drains ~2× faster. The build job grows by the one archive build. This PR's own CI run is the first soak — the queue only merges it green.