### PR TITLE
Interface JSON reads @deprecated and doc comments survive attribute lines (#1735 follow-up)

### DIFF
--- a/crates/almide-tools/src/interface.rs
+++ b/crates/almide-tools/src/interface.rs
@@ -705,7 +705,35 @@ fn collect_preceding_doc(lines: &[&str], i: usize) -> DocInfo {
                     doc_lines.push(c.to_string());
                 }
             }
-            None => break,
+            None => {
+                // Attribute lines sit BETWEEN the doc comments and the
+                // declaration (`@intrinsic(..)`, `@deprecated(..)`) —
+                // skip through them so the comments above still attach,
+                // and read the `@deprecated` attribute itself (#1735):
+                // the interface JSON's `deprecated` field is what the
+                // doc-index generator annotates from.
+                if prev.starts_with('@') {
+                    if let Some(args) = prev
+                        .strip_prefix("@deprecated(")
+                        .and_then(|r| r.strip_suffix(')'))
+                    {
+                        let field = |k: &str| {
+                            args.split(',').find_map(|p| {
+                                p.trim()
+                                    .strip_prefix(k)
+                                    .map(|r| r.trim_start_matches([' ', '=']).trim_matches('"').to_string())
+                            })
+                        };
+                        deprecated = Some(match (field("use"), field("note")) {
+                            (Some(u), _) => format!("use {u}"),
+                            (None, Some(n)) => n,
+                            (None, None) => String::new(),
+                        });
+                    }
+                    continue;
+                }
+                break;
+            }
         }
     }
     doc_lines.reverse();
@@ -720,4 +748,39 @@ fn extract_decl_name(rest: &str) -> Option<std::string::String> {
         .take_while(|c| c.is_alphanumeric() || *c == '_')
         .collect();
     if name.is_empty() { None } else { Some(name) }
+}
+
+#[cfg(test)]
+mod attr_doc_tests {
+    use super::extract_docs;
+
+    /// #1735 follow-up: attribute lines (`@intrinsic(..)`, `@deprecated(..)`)
+    /// sit between a declaration and its doc comment. The doc walk skips
+    /// THROUGH them (previously every attributed fn silently lost its doc
+    /// comment in the interface JSON), and the `@deprecated` attribute
+    /// itself feeds the `deprecated` field the doc-index annotates from.
+    #[test]
+    fn docs_attach_through_attributes_and_deprecated_reads_the_attr() {
+        let src = "\
+// The old spelling.
+@deprecated(since = 3, use = \"m.shout\")
+fn yell(s: String) -> String = shout(s)
+
+// Doc above an intrinsic.
+@intrinsic(\"almide_rt_x\")
+fn direct(s: String) -> String = _
+
+@deprecated(since = 2, note = \"removed with the v2 surface\")
+fn gone() -> Unit = ()
+";
+        let docs = extract_docs(src);
+        let yell = &docs["yell"];
+        assert_eq!(yell.doc.as_deref(), Some("The old spelling."));
+        assert_eq!(yell.deprecated.as_deref(), Some("use m.shout"));
+        let direct = &docs["direct"];
+        assert_eq!(direct.doc.as_deref(), Some("Doc above an intrinsic."));
+        assert_eq!(direct.deprecated, None);
+        let gone = &docs["gone"];
+        assert_eq!(gone.deprecated.as_deref(), Some("removed with the v2 surface"));
+    }
 }

--- a/docs/stdlib/string.md
+++ b/docs/stdlib/string.md
@@ -364,7 +364,7 @@ string.split(s: String, sep: String) -> List[String]
 string.split_once(s: String, sep: String) -> Option[()]
 string.join(list: List[String], sep: String) -> String
 string.len(s: String) -> Int
-string.length(s: String) -> Int
+string.length(s: String) -> Int   (deprecated — use string.len)
 string.contains(s: String, sub: String) -> Bool
 string.starts_with(s: String, prefix: String) -> Bool
 string.ends_with(s: String, suffix: String) -> Bool

--- a/tools/gen-stdlib-doc-index.py
+++ b/tools/gen-stdlib-doc-index.py
@@ -70,7 +70,10 @@ def render_ty(t: dict) -> str:
 def signature(module: str, f: dict) -> str:
     params = ", ".join(f"{p['name']}: {render_ty(p['type'])}" for p in f.get("params", []))
     eff = "effect " if f.get("effect") else ""
-    return f"{eff}{module}.{f['name']}({params}) -> {render_ty(f['return'])}"
+    # #1735: a deprecated fn carries its steer inline, so the generated
+    # index and the E052 warning tell one story.
+    dep = f"   (deprecated — {f['deprecated']})" if f.get("deprecated") else ""
+    return f"{eff}{module}.{f['name']}({params}) -> {render_ty(f['return'])}{dep}"
 
 
 def module_block(module: str) -> str:


### PR DESCRIPTION
The follow-up named in #1741: the generated signature index (`make stdlib-docs`) reads `almide compile --json`, which never carried the `@deprecated` attribute.

## What

- **A real pre-existing loss, fixed**: the doc-comment walk stopped at the first non-comment line above a declaration — and attribute lines (`@intrinsic(..)`, `@deprecated(..)`) sit exactly there, so EVERY attributed fn (most of the stdlib) silently lost its doc comment in the interface JSON. The walk now skips through attribute lines; docs attach.
- The `@deprecated` attribute itself feeds the JSON's existing `deprecated` field (`use = ".."` → `use <name>`, else the `note`), which previously populated only from a `// deprecated:` comment convention.
- `tools/gen-stdlib-doc-index.py` renders the steer inline: `string.length(s: String) -> Int   (deprecated — use string.len)`.
- A unit test pins all three behaviors (doc-through-attribute, attr-fed deprecation, note fallback).

## Sequencing

NOT armed for auto-merge yet: once #1741 (the `string.length` deprecation) merges, this branch gets a rebase + `make stdlib-docs` regen in one push so the committed index and the freshness gate (`--check`) agree — merging the two independently would leave whichever lands second with a stale index.