### PR TITLE
flat_map chunks and index writes stop retaining O(n^2) generations on the structural leg

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,13 @@ build. Regenerate with `almide run tools/almide-gates/src/main.almd -- bench`; t
 <!-- wasm-runtime:generated:start — rendered from docs/benchmarks/wasm-runtime.txt by scripts/gen-readme-stats.sh; DO NOT EDIT between the markers -->
 | Benchmark (`almide bench`, verify-then-time, median of 5) | wasm/native ratio |
 |---|---:|
-| nbody | **2.16×** |
-| spectralnorm | **2.25×** |
-| binarytrees | **0.81×** |
-| listbuild_append | **4.12×** |
+| nbody | **2.12×** |
+| spectralnorm | **1.94×** |
+| binarytrees | **1.15×** |
+| listbuild_append | **4.08×** |
+| listbuild_combinator | **4.33×** |
 
-Embedded wasm host (Perceus RC in linear memory) against the native binary, same machine, same run. Cross-engine ratios do NOT cancel hardware (a 2-core CI runner measures nbody ~10x worse), so the ratio verdict runs on the stamping machine class and CI gates the STATUS taxonomy below (`scripts/check-wasm-runtime-ratio.sh`). binarytrees runs its fan arms on the embedded host's thread pool, which is why wasm WINS there. The unmeasured corpus cells stay honest instead of estimated: 3 route to the incumbent artifact, 1 wall on the wasm build path, 4 exhaust the embedded heap (#1729) — each re-measured every gate run, so a cell that starts benching fails the gate until its row is promoted. Ledger: `docs/benchmarks/wasm-runtime.txt` (almide 0.61.0, 2026-09-01).
+Embedded wasm host (Perceus RC in linear memory) against the native binary, same machine, same run. Cross-engine ratios do NOT cancel hardware (a 2-core CI runner measures nbody ~10x worse), so the ratio verdict runs on the stamping machine class and CI gates the STATUS taxonomy below (`scripts/check-wasm-runtime-ratio.sh`). binarytrees runs its fan arms on the embedded host's thread pool, which is why wasm WINS there. The unmeasured corpus cells stay honest instead of estimated: 3 route to the incumbent artifact, 1 wall on the wasm build path, 3 exhaust the embedded heap (#1729) — each re-measured every gate run, so a cell that starts benching fails the gate until its row is promoted. Ledger: `docs/benchmarks/wasm-runtime.txt` (almide 0.61.0, 2026-09-01).
 <!-- wasm-runtime:generated:end -->
 
 ## How It Works

--- a/README.md
+++ b/README.md
@@ -170,13 +170,15 @@ build. Regenerate with `almide run tools/almide-gates/src/main.almd -- bench`; t
 <!-- wasm-runtime:generated:start — rendered from docs/benchmarks/wasm-runtime.txt by scripts/gen-readme-stats.sh; DO NOT EDIT between the markers -->
 | Benchmark (`almide bench`, verify-then-time, median of 5) | wasm/native ratio |
 |---|---:|
-| nbody | **2.12×** |
-| spectralnorm | **1.94×** |
-| binarytrees | **1.15×** |
-| listbuild_append | **4.08×** |
-| listbuild_combinator | **4.33×** |
+| nbody | **2.19×** |
+| spectralnorm | **2.06×** |
+| binarytrees | **0.86×** |
+| fft | **5.17×** |
+| listbuild_append | **4.20×** |
+| listbuild_combinator | **4.50×** |
+| listbuild_prealloc | **3.92×** |
 
-Embedded wasm host (Perceus RC in linear memory) against the native binary, same machine, same run. Cross-engine ratios do NOT cancel hardware (a 2-core CI runner measures nbody ~10x worse), so the ratio verdict runs on the stamping machine class and CI gates the STATUS taxonomy below (`scripts/check-wasm-runtime-ratio.sh`). binarytrees runs its fan arms on the embedded host's thread pool, which is why wasm WINS there. The unmeasured corpus cells stay honest instead of estimated: 3 route to the incumbent artifact, 1 wall on the wasm build path, 3 exhaust the embedded heap (#1729) — each re-measured every gate run, so a cell that starts benching fails the gate until its row is promoted. Ledger: `docs/benchmarks/wasm-runtime.txt` (almide 0.61.0, 2026-09-01).
+Embedded wasm host (Perceus RC in linear memory) against the native binary, same machine, same run. Cross-engine ratios do NOT cancel hardware (a 2-core CI runner measures nbody ~10x worse), so the ratio verdict runs on the stamping machine class and CI gates the STATUS taxonomy below (`scripts/check-wasm-runtime-ratio.sh`). binarytrees runs its fan arms on the embedded host's thread pool, which is why wasm WINS there. The unmeasured corpus cells stay honest instead of estimated: 3 route to the incumbent artifact, 1 wall on the wasm build path, 1 exhaust the embedded heap (#1729) — each re-measured every gate run, so a cell that starts benching fails the gate until its row is promoted. Ledger: `docs/benchmarks/wasm-runtime.txt` (almide 0.61.0, 2026-09-01).
 <!-- wasm-runtime:generated:end -->
 
 ## How It Works

--- a/crates/almide-wasm/src/list.rs
+++ b/crates/almide-wasm/src/list.rs
@@ -359,9 +359,44 @@ impl Emitter<'_> {
         let SliceTy::List(bi) = got else {
             return unsup(&format!("flat-map-body:{got:?}"));
         };
-        self.f.instructions().local_set(hs);
-        self.f.instructions().local_get(hacc).local_get(hs).call(F_CONCAT);
-        self.f.instructions().local_set(hacc);
+        if matches!(self.types.el(bi), SliceTy::Scalar(Scalar::Int | Scalar::Float)) {
+            // 8-byte scalar chunks ride the amortized push window (#1729):
+            // the per-element $concat re-copied the WHOLE accumulator and
+            // freed neither side, so n chunks retained O(n²) bytes — 2^16
+            // elements OOM'd where the append row's working set fits. A
+            // borrowed chunk (a callback returning a captured list) takes
+            // inc-before-dec, so the per-iteration dec balances fresh and
+            // aliased alike; the move is by 8-byte bits, so Int and Float
+            // share one loop and $dec_flat (shallow) is a full free.
+            if !crate::rc_ownership::rc_certainly_fresh(&crate::rc_ownership::rc_tail(body).kind)
+            {
+                self.rc_inc_top();
+            }
+            self.f.instructions().local_set(hs);
+            let hj = self.hold_i32()?;
+            let he = self.hold_i32()?;
+            self.f.instructions().local_get(hs).i32_load(len_memarg()).local_set(he);
+            self.f.instructions().i32_const(0).local_set(hj);
+            self.f.instructions().block(BlockType::Empty).loop_(BlockType::Empty);
+            self.f.instructions().local_get(hj).local_get(he).i32_ge_u().br_if(1);
+            self.f.instructions().local_get(hacc);
+            self.f.instructions().local_get(hs).local_get(hj).i32_add();
+            self.f.instructions().i64_load(slot_memarg(0));
+            self.f.instructions().call(F_LIST_PUSH_8).local_set(hacc);
+            self.f.instructions().local_get(hj).i32_const(8).i32_add().local_set(hj);
+            self.f.instructions().br(0).end().end();
+            self.f.instructions().local_get(hs).call(F_DEC_FLAT);
+            self.release_i32();
+            self.release_i32();
+        } else {
+            // Handle-element chunks keep the concat merge: their interiors
+            // are co-owned by the chunk, and freeing after a raw byte copy
+            // needs the Dup discipline (the C-186 trap) — outside this
+            // window, as in the assign-site append gate.
+            self.f.instructions().local_set(hs);
+            self.f.instructions().local_get(hacc).local_get(hs).call(F_CONCAT);
+            self.f.instructions().local_set(hacc);
+        }
         self.hof_step(ih);
         self.f.instructions().local_get(hacc);
         for _ in 0..5 {

--- a/crates/almide-wasm/src/stmts.rs
+++ b/crates/almide-wasm/src/stmts.rs
@@ -557,9 +557,16 @@ impl Emitter<'_> {
                 }
                 self.emit_error_frame_abort();
                 self.f.instructions().end();
-                // COW: the binding gets a fresh block, then the store.
+                // RC-5: the COW judge, not an unconditional copy — a
+                // uniquely-held list takes the store IN PLACE, a shared one
+                // copies and releases one source ref. The old
+                // $block_copy-per-write materialized a fresh generation on
+                // EVERY index write and never freed the outgrown one, so n
+                // writes into a preallocated list retained O(n²) bytes
+                // (#1729: the prealloc/fft rows OOM'd at 2^16 writes where
+                // the live payload is 512 KiB).
                 get_target(self.f, self.locals, self.globals);
-                self.f.instructions().call(F_BLOCK_COPY).local_set(hb);
+                self.f.instructions().call(F_COW).local_set(hb);
                 if is_local {
                     let idx = self.locals[target].0;
                     self.f.instructions().local_get(hb).local_set(idx);

--- a/crates/almide-wasm/tests/golden/alloc-baseline.txt
+++ b/crates/almide-wasm/tests/golden/alloc-baseline.txt
@@ -284,7 +284,7 @@
 66176	spec/wasm_cross/list_call_element.almd
 66688	spec/wasm_cross/list_chunk_windows.almd
 65920	spec/wasm_cross/list_chunk_zero.almd
-70720	spec/wasm_cross/list_comprehensive.almd
+70512	spec/wasm_cross/list_comprehensive.almd
 81504	spec/wasm_cross/list_count_index_truncation.almd
 70224	spec/wasm_cross/list_cross_module_variant.almd
 66096	spec/wasm_cross/list_element_hof_chain.almd

--- a/crates/almide-wasm/tests/golden/alloc-baseline.txt
+++ b/crates/almide-wasm/tests/golden/alloc-baseline.txt
@@ -97,7 +97,7 @@
 68592	spec/wasm_cross/edge_int_boundaries.almd
 67504	spec/wasm_cross/edge_map_order.almd
 113792	spec/wasm_cross/edge_string_unicode.almd
-66656	spec/wasm_cross/effect_assign_unwrap.almd
+66624	spec/wasm_cross/effect_assign_unwrap.almd
 67232	spec/wasm_cross/effect_fn_value.almd
 65872	spec/wasm_cross/effect_main_guard_err.almd
 66336	spec/wasm_cross/effect_main_guard_ok.almd
@@ -206,7 +206,7 @@
 70000	spec/wasm_cross/grouping_unary.almd
 66288	spec/wasm_cross/guard_let_statement.almd
 65840	spec/wasm_cross/guard_statement.almd
-7097840	spec/wasm_cross/gzip_inflate_members.almd
+782832	spec/wasm_cross/gzip_inflate_members.almd
 92752	spec/wasm_cross/hash_digests.almd
 68768	spec/wasm_cross/heap_arena.almd
 65936	spec/wasm_cross/heap_result_err_interp.almd
@@ -227,10 +227,10 @@
 65872	spec/wasm_cross/if_block_forms.almd
 65808	spec/wasm_cross/if_let_forms.almd
 66400	spec/wasm_cross/if_let_guard_let.almd
-66192	spec/wasm_cross/index_bounds.almd
-66144	spec/wasm_cross/index_bounds_i64.almd
-66128	spec/wasm_cross/index_bounds_write_heap.almd
-66048	spec/wasm_cross/index_bounds_write_only_var.almd
+66128	spec/wasm_cross/index_bounds.almd
+66080	spec/wasm_cross/index_bounds_i64.almd
+66096	spec/wasm_cross/index_bounds_write_heap.almd
+66016	spec/wasm_cross/index_bounds_write_only_var.almd
 66240	spec/wasm_cross/inplace_mutator_statement.almd
 65808	spec/wasm_cross/int8_div_overflow.almd
 65904	spec/wasm_cross/int_clamp_inverted.almd
@@ -284,7 +284,7 @@
 66176	spec/wasm_cross/list_call_element.almd
 66688	spec/wasm_cross/list_chunk_windows.almd
 65920	spec/wasm_cross/list_chunk_zero.almd
-70512	spec/wasm_cross/list_comprehensive.almd
+70448	spec/wasm_cross/list_comprehensive.almd
 81504	spec/wasm_cross/list_count_index_truncation.almd
 70224	spec/wasm_cross/list_cross_module_variant.almd
 66096	spec/wasm_cross/list_element_hof_chain.almd
@@ -364,10 +364,10 @@
 106304	spec/wasm_cross/matrix_select_rows.almd
 148080	spec/wasm_cross/matrix_select_rows_oob.almd
 172016	spec/wasm_cross/matrix_softmax_fastexp.almd
-147440	spec/wasm_cross/memory_stress.almd
+122352	spec/wasm_cross/memory_stress.almd
 75072	spec/wasm_cross/mg_rebuild_two_phase.almd
 65936	spec/wasm_cross/module_global_const.almd
-74528	spec/wasm_cross/module_var_alias_cow.almd
+74464	spec/wasm_cross/module_var_alias_cow.almd
 69200	spec/wasm_cross/mut_heap_param.almd
 66992	spec/wasm_cross/mut_map_param.almd
 65904	spec/wasm_cross/mut_param_branch_forward.almd
@@ -420,8 +420,8 @@
 65760	spec/wasm_cross/pipe_chain_scalar_bind.almd
 65968	spec/wasm_cross/pipe_compose_forms.almd
 65792	spec/wasm_cross/pipe_lambda_block_value.almd
-66576	spec/wasm_cross/place_assign_ascription.almd
-66672	spec/wasm_cross/place_mutation.almd
+66512	spec/wasm_cross/place_assign_ascription.almd
+66576	spec/wasm_cross/place_mutation.almd
 76576	spec/wasm_cross/playground_default.almd
 65856	spec/wasm_cross/pop_heap_element.almd
 ~	spec/wasm_cross/process_args.almd

--- a/docs/benchmarks/wasm-runtime.txt
+++ b/docs/benchmarks/wasm-runtime.txt
@@ -21,15 +21,15 @@ version = almide 0.61.0
 date    = 2026-09-01
 machine = arm64 Darwin (local stamp; ratios are the gated quantity)
 
-nbody                 | measured         | 1.22  | 2.64 | 2.16
-spectralnorm          | measured         | 1.34  | 3.01 | 2.25
-binarytrees           | measured         | 3.22  | 2.61 | 0.81
-fasta                 | routed-incumbent | 1.33  | -    | -
-fannkuchredux         | routed-incumbent | 1.39  | -    | -
-mandelbrot            | routed-incumbent | 2.50  | -    | -
-onebrc                | walled           | 1.85  | -    | -
-fft                   | oom-embedded     | 39.80 | -    | -
-strchurn              | oom-embedded     | 54.81 | -    | -
-listbuild_append      | measured         | 21.04 | 86.77 | 4.12
-listbuild_combinator  | oom-embedded     | 21.52 | -    | -
-listbuild_prealloc    | oom-embedded     | 20.22 | -    | -
+nbody                 | measured         | 1.36  | 2.89 | 2.12
+spectralnorm          | measured         | 1.55  | 3.01 | 1.94
+binarytrees           | measured         | 3.24  | 3.72 | 1.15
+fasta                 | routed-incumbent | 1.41  | -    | -
+fannkuchredux         | routed-incumbent | 1.44  | -    | -
+mandelbrot            | routed-incumbent | 2.48  | -    | -
+onebrc                | walled           | 2.02  | -    | -
+fft                   | oom-embedded     | 39.91 | -    | -
+strchurn              | oom-embedded     | 51.42 | -    | -
+listbuild_append      | measured         | 21.15 | 86.26 | 4.08
+listbuild_combinator  | measured         | 21.33 | 92.33 | 4.33
+listbuild_prealloc    | oom-embedded     | 21.09 | -    | -

--- a/docs/benchmarks/wasm-runtime.txt
+++ b/docs/benchmarks/wasm-runtime.txt
@@ -21,15 +21,15 @@ version = almide 0.61.0
 date    = 2026-09-01
 machine = arm64 Darwin (local stamp; ratios are the gated quantity)
 
-nbody                 | measured         | 1.36  | 2.89 | 2.12
-spectralnorm          | measured         | 1.55  | 3.01 | 1.94
-binarytrees           | measured         | 3.24  | 3.72 | 1.15
-fasta                 | routed-incumbent | 1.41  | -    | -
-fannkuchredux         | routed-incumbent | 1.44  | -    | -
-mandelbrot            | routed-incumbent | 2.48  | -    | -
-onebrc                | walled           | 2.02  | -    | -
-fft                   | oom-embedded     | 39.91 | -    | -
-strchurn              | oom-embedded     | 51.42 | -    | -
-listbuild_append      | measured         | 21.15 | 86.26 | 4.08
-listbuild_combinator  | measured         | 21.33 | 92.33 | 4.33
-listbuild_prealloc    | oom-embedded     | 21.09 | -    | -
+nbody                 | measured         | 1.29  | 2.82 | 2.19
+spectralnorm          | measured         | 1.54  | 3.17 | 2.06
+binarytrees           | measured         | 3.14  | 2.70 | 0.86
+fasta                 | routed-incumbent | 1.46  | -    | -
+fannkuchredux         | routed-incumbent | 1.41  | -    | -
+mandelbrot            | routed-incumbent | 2.64  | -    | -
+onebrc                | walled           | 1.69  | -    | -
+fft                   | measured         | 39.65 | 205.05 | 5.17
+strchurn              | oom-embedded     | 53.94 | -    | -
+listbuild_append      | measured         | 20.54 | 86.20 | 4.20
+listbuild_combinator  | measured         | 21.37 | 96.23 | 4.50
+listbuild_prealloc    | measured         | 21.09 | 82.62 | 3.92

--- a/tests/static_memory_test.rs
+++ b/tests/static_memory_test.rs
@@ -163,6 +163,57 @@ fn fixed_heap_budget_suffices_and_is_enforced() {
 }
 
 #[test]
+fn flat_map_chunks_recycle_under_fixed_budget() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    if !wasmtime_available() {
+        return;
+    }
+    let dir = std::env::temp_dir().join("almide-static-memory");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+
+    // The flat_map merge window (#1729, increment 2): 50k fresh scalar
+    // chunks push into the accumulator and each chunk is freed per
+    // iteration, and 50k pushes of an ALIASED chunk (the callback
+    // returning its captured list) take inc-before-dec, so the shared
+    // list survives its own consumption. Live payload ≈ 2 MiB; the old
+    // per-element $concat retained the outgrown accumulator every
+    // iteration (O(n²) bytes), which no fixed budget survives.
+    let fm = dir.join("flatmap-recycle.almd");
+    std::fs::write(
+        &fm,
+        "import int\n\neffect fn main() -> Unit = {\n  let shared = [7, 8, 9]\n  let big = list.range(0, 50000) |> list.flat_map((i) => [i, i + 1])\n  let echo = list.range(0, 50000) |> list.flat_map((i) => shared)\n  println(int.to_string(list.len(big)))\n  println(int.to_string(list.len(echo)))\n  println(int.to_string(list.sum(shared)))\n}\n",
+    )
+    .expect("write");
+    let fm_wasm = dir.join("flatmap-recycle.wasm");
+    let out = Command::new(almide_bin())
+        .args([
+            "build",
+            fm.to_str().unwrap(),
+            "--target",
+            "wasm",
+            "--heap-cap",
+            "8388608",
+            "-o",
+            fm_wasm.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn almide build");
+    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+    let run = Command::new("wasmtime")
+        .args(["run", fm_wasm.to_str().unwrap()])
+        .output()
+        .expect("spawn wasmtime");
+    assert!(run.status.success(), "{}", String::from_utf8_lossy(&run.stderr));
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "100000\n150000\n24\n",
+        "flat_map under the budget must answer the native trace"
+    );
+}
+
+#[test]
 fn artifact_is_partition_shaped() {
     if Command::new(almide_bin()).arg("--version").output().is_err() {
         return;

--- a/tests/static_memory_test.rs
+++ b/tests/static_memory_test.rs
@@ -214,6 +214,56 @@ fn flat_map_chunks_recycle_under_fixed_budget() {
 }
 
 #[test]
+fn index_writes_stay_in_place_under_fixed_budget() {
+    if Command::new(almide_bin()).arg("--version").output().is_err() {
+        return;
+    }
+    if !wasmtime_available() {
+        return;
+    }
+    let dir = std::env::temp_dir().join("almide-static-memory");
+    std::fs::create_dir_all(&dir).expect("mkdir");
+
+    // The index-write COW judge (#1729): 100k writes into a preallocated
+    // 100k-element list run IN PLACE when the list is uniquely held —
+    // the old $block_copy-per-write materialized a fresh generation on
+    // every write (O(n²) retained), which no fixed budget survives. The
+    // snapshot taken before the loop pins the value-semantics half: the
+    // shared holder forces ONE copy and keeps its zeros.
+    let iw = dir.join("index-writes.almd");
+    std::fs::write(
+        &iw,
+        "import int\n\neffect fn main() -> Unit = {\n  var data: List[Int] = list.repeat(0, 100000)\n  let snap = data\n  for i in 0..<100000 {\n    data[i] = 1\n  }\n  println(int.to_string(list.sum(snap)))\n  println(int.to_string(list.sum(data)))\n}\n",
+    )
+    .expect("write");
+    let iw_wasm = dir.join("index-writes.wasm");
+    let out = Command::new(almide_bin())
+        .args([
+            "build",
+            iw.to_str().unwrap(),
+            "--target",
+            "wasm",
+            "--heap-cap",
+            "8388608",
+            "-o",
+            iw_wasm.to_str().unwrap(),
+        ])
+        .output()
+        .expect("spawn almide build");
+    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+    let run = Command::new("wasmtime")
+        .args(["run", iw_wasm.to_str().unwrap()])
+        .output()
+        .expect("spawn wasmtime");
+    assert!(run.status.success(), "{}", String::from_utf8_lossy(&run.stderr));
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "0\n100000\n",
+        "the snapshot must keep its zeros and the writes must land"
+    );
+}
+
+#[test]
 fn artifact_is_partition_shaped() {
     if Command::new(almide_bin()).arg("--version").output().is_err() {
         return;


### PR DESCRIPTION
## Summary
Increment 2 of #1729: the `listbuild_combinator` row (`list.range |> list.flat_map`, the CHEATSHEET-recommended idiom) OOM'd on the structural embedded leg at 2^16 elements where its true working set is ~1.5 MiB.

**Root cause** — `lower_list_flat_map` merged every callback chunk with a per-element `$concat`: the whole accumulator was re-copied each iteration and **neither the outgrown accumulator nor the chunk was ever freed**, so n chunks retained O(n²) bytes. The self-hosted two-pass `list_flatmap.almd` never runs for this shape — the inline HOF path is the only path.

**Fix** — 8-byte scalar chunks (Int/Float, the same gate as increment 1's assign-site append window) now push element-by-element into the accumulator via the amortized `$list_push_8` and the chunk is freed per iteration (`$dec_flat` is a full free for flat blocks). A borrowed chunk — a callback returning its captured list — takes inc-before-dec, so fresh and aliased chunks balance identically. Handle-element chunks keep the concat merge (freeing after a raw byte copy needs the Dup discipline, the C-186 trap — same boundary as the append gate).

## Evidence
- `listbuild_combinator` flips **oom-embedded → measured**: 92.33 ms embedded vs 21.33 ms native (ratio 4.33; the append row is 4.08). Checksum byte-identical to native at 2^20.
- Aliased-chunk / empty-chunk / string-chunk probes agree native == structural leg.
- New `flat_map_chunks_recycle_under_fixed_budget` in `tests/static_memory_test.rs`: 100k fresh-chunk pushes + 50k aliased-chunk pushes complete under a fixed 8 MiB `--heap-cap` and the shared list survives — no fixed budget survives the old quadratic retention.
- `almide test` 427/427; `cargo test --workspace` green; alloc ledger ratified (one row, smaller).

Remaining #1729 shapes: `listbuild_prealloc`/`fft` (index writes), `strchurn` (over-512KiB block churn).