### PR TITLE
wasm-tools family 0.258 in lockstep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
  "tempfile",
  "toml 1.1.4+spec-1.1.0",
  "wasi-preview1-component-adapter-provider",
- "wasmparser 0.257.1",
+ "wasmparser 0.258.0",
  "wat",
- "wit-component 0.257.1",
+ "wit-component 0.258.0",
 ]
 
 [[package]]
@@ -87,7 +87,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml 1.1.4+spec-1.1.0",
- "wasmparser 0.256.0",
+ "wasmparser 0.258.0",
 ]
 
 [[package]]
@@ -253,8 +253,8 @@ dependencies = [
  "almide-wasm-run",
  "anyhow",
  "sha2",
- "wasm-encoder 0.257.1",
- "wasmparser 0.257.1",
+ "wasm-encoder 0.258.0",
+ "wasmparser 0.258.0",
  "wasmtime",
 ]
 
@@ -265,12 +265,12 @@ dependencies = [
  "almide-wasm",
  "anyhow",
  "rustls",
- "wasm-encoder 0.257.1",
- "wasmparser 0.257.1",
+ "wasm-encoder 0.258.0",
+ "wasmparser 0.258.0",
  "wasmtime",
  "webpki-roots",
- "wit-component 0.257.1",
- "wit-parser 0.257.1",
+ "wit-component 0.258.0",
+ "wit-parser 0.258.0",
 ]
 
 [[package]]
@@ -2323,16 +2323,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.257.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8ad9f0a39050867bda22e6486c316e2e52d20a42154d5bc433934bf738d085"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.257.1",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e974fe6821a8cf64575d51ea2194e2c8f77e7b66e9afe7419ce8a97f9ee0d251"
@@ -2355,14 +2345,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.257.1"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57460ad9bce753e8a80d47a445cb87c8724ea57f463d9c906a947c41032ce1ac"
+checksum = "18a11585adb92fe9b55ad1d760e8d8fb5d87e0d2e303cb8eed57f078d54293a2"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.257.1",
- "wasmparser 0.257.1",
+ "wasm-encoder 0.258.0",
+ "wasmparser 0.258.0",
 ]
 
 [[package]]
@@ -2392,39 +2382,15 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.256.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bd825ffedc6cba8a642924ba7ae424afbc47811cffbcb7b92031ec24e59b4c"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.17.1",
- "indexmap",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.257.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92fc335fb6d48f46bda1d8b26b69e28320c15ac3272208333833d6e217e2b4a"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.17.1",
- "indexmap",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9a61719f93a87b16d325921e251800c4833f8fab50fa21c7de73aed50086313"
 dependencies = [
  "bitflags 2.11.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "semver",
+ "serde",
 ]
 
 [[package]]
@@ -2928,9 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.257.1"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8b7d04a4c9491ffea354923ed70c8826d52c699fe20a52e8ceca95017dddb8"
+checksum = "481b5c47b2ecce0389b5e08a05557d6a190c9cd761773b8880a8017ee04dc7ef"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -2939,10 +2905,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.257.1",
- "wasm-metadata 0.257.1",
- "wasmparser 0.257.1",
- "wit-parser 0.257.1",
+ "wasm-encoder 0.258.0",
+ "wasm-metadata 0.258.0",
+ "wasmparser 0.258.0",
+ "wit-parser 0.258.0",
 ]
 
 [[package]]
@@ -2984,9 +2950,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.257.1"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f815340f0bb65d9775ae21e56b503b496683557b9b627b195d2766c25fb24ae"
+checksum = "ff4daaa3cd97ae49ecd0a99dc009d453f93e0f083dd3be38c0f24a83a93e37ac"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -2998,7 +2964,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-ident",
- "wasmparser 0.257.1",
+ "wasmparser 0.258.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ wat = "1"
 # Structural validation of the assembled v1 module: `wat` assembles without full stack-shape
 # validation, so the test harness validates before accepting a v1 module (invalid → the test
 # harness falls back to native execution; there is no v0 wasm emitter anymore).
-wasmparser = "0.257"
+wasmparser = "0.258"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -62,7 +62,7 @@ lsp-server = "0.10"
 # channel type (#1470) — same crate lsp-server itself uses.
 crossbeam-channel = "0.5"
 lsp-types = "0.97"
-wit-component = "0.257"
+wit-component = "0.258"
 wasi-preview1-component-adapter-provider = "48.0.1"
 
 # Cross-platform advisory file lock (flock / LockFileEx) for the shared build

--- a/crates/almide-codegen/Cargo.toml
+++ b/crates/almide-codegen/Cargo.toml
@@ -11,7 +11,7 @@ almide-lang = { path = "../almide-lang" }
 almide-ir = { path = "../almide-ir" }
 almide-egg-lab = { path = "../almide-egg-lab" }
 egg = "0.11"
-wasmparser = "0.256"
+wasmparser = "0.258"
 toml = "1.1"
 serde_json = "1"
 

--- a/crates/almide-wasm-run/Cargo.toml
+++ b/crates/almide-wasm-run/Cargo.toml
@@ -16,11 +16,11 @@ almide-wasm = { path = "../almide-wasm" }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 webpki-roots = "1.0"
 anyhow = "1"
-wasmparser = "0.257"
-wasm-encoder = "0.257"
+wasmparser = "0.258"
+wasm-encoder = "0.258"
 wasmtime = "47"
-wit-component = "0.257"
-wit-parser = "0.257"
+wit-component = "0.258"
+wit-parser = "0.258"
 
 [lints]
 workspace = true

--- a/crates/almide-wasm/Cargo.toml
+++ b/crates/almide-wasm/Cargo.toml
@@ -11,8 +11,8 @@ almide-ir = { path = "../almide-ir" }
 almide-base = { path = "../almide-base" }
 almide-types = { path = "../almide-types" }
 almide-layout = { path = "../almide-layout" }
-wasm-encoder = { version = "0.257", features = ["wasmparser"] }
-wasmparser = "0.257"
+wasm-encoder = { version = "0.258", features = ["wasmparser"] }
+wasmparser = "0.258"
 
 [dev-dependencies]
 almide-corpus = { path = "../almide-corpus" }
@@ -20,7 +20,7 @@ anyhow = "1"
 almide-spine = { path = "../almide-spine" }
 almide-wasm-run = { path = "../almide-wasm-run" }
 almide = { path = "../.." }
-wasmparser = "0.257"
+wasmparser = "0.258"
 wasmtime = "47"
 sha2 = "0.10"
 

--- a/proofs/wasi-pin-policy.toml
+++ b/proofs/wasi-pin-policy.toml
@@ -38,8 +38,11 @@ ci = "v47.0.3"
 flags = "-W component-model-async=y,component-model-more-async-builtins=y -S p3=y"
 
 [wasm-tools]
-# The lockstep family version (workspace Cargo pins).
-family = "0.257"
+# The lockstep family version (workspace Cargo pins). 0.258 is the
+# 0.3.1-era toolchain (WIT `map<K,V>` / `implements` support) — the
+# coordinated bump #1759 landed the family as ONE change after the
+# per-crate dependabot PRs each failed on split-family version skew.
+family = "0.258"
 
 [sources]
 # Dated upstream evidence for the rows above.
@@ -47,4 +50,5 @@ evidence = [
   "WASI v0.3.0 release 2026-06-11; v0.3.1 2026-08-11 (github.com/WebAssembly/WASI/releases)",
   "wasmtime 46 release notes: wasi:cli@0.3.0 default-on (p3)",
   "wasmtime v47.0.2 vendored crates/wasi/src/p3/wit — the WIT shapes the almide p3 leg transcribed (2026-08-27/28 survey, ../almide-references/RESEARCH-component-model.md)",
+  "wasm-tools 0.258.0 release (wasmparser/wasm-encoder/wit-parser/wit-component lockstep, 2026-08; the 0.3.1 WIT-language train)",
 ]


### PR DESCRIPTION
First slice of #1759: wit-parser / wit-component / wasm-encoder / wasmparser all move 0.257 → 0.258 (almide-codegen's straggler 0.256 included) as ONE change — each per-crate dependabot PR (#1745/#1746/#1748) failed CI on split-family version skew, which is exactly the lockstep doctrine `proofs/wasi-pin-policy.toml` records; the policy's `family` row moves to 0.258 in the same change and `scripts/check-wasi-pins.sh` re-derives green. 0.258 is the WASI 0.3.1-era toolchain (WIT `map<K,V>` / `implements`), landed ahead of #1710 PR B so the http shim is written once against the surviving API.

No API breaks in our usage: workspace builds clean, `cargo test --workspace` green, `almide test` 427/427, the vendored p3 WIT resolves under the bumped wit-parser (the in-tree resolve tests), wasi-pins gate green.

Supersedes #1745, #1746, #1748.