### PR TITLE
salsa 0.28 for the spine query layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,8 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -1082,11 +1084,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1127,11 +1129,17 @@ dependencies = [
 
 [[package]]
 name = "intrusive-collections"
-version = "0.9.7"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+checksum = "4275b20e6057cd7733fd8df8a5a31701e4fe44497dad0f3fa0e1c4fb971506be"
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
- "memoffset",
+ "rustversion",
 ]
 
 [[package]]
@@ -1303,15 +1311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,16 +1361,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "papaya"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2442474a9404698c42509b8967f437249dbc7b50493e83020333d3943ec0ae"
-dependencies = [
- "equivalent",
- "seize",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1750,18 +1739,18 @@ dependencies = [
 
 [[package]]
 name = "salsa"
-version = "0.23.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e235afdb8e510f38a07138fbe5a0b64691894358a9c0cbd813b1aade110efc9"
+checksum = "cf0e374215cd2db2b5c75d7b3a99cb0cc052c0595335dfdefc03d4eb08f4aa81"
 dependencies = [
  "boxcar",
  "crossbeam-queue",
  "crossbeam-utils",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "hashlink",
  "indexmap",
  "intrusive-collections",
- "papaya",
+ "inventory",
  "parking_lot",
  "portable-atomic",
  "rayon",
@@ -1771,24 +1760,24 @@ dependencies = [
  "smallvec",
  "thin-vec",
  "tracing",
+ "typeid",
 ]
 
 [[package]]
 name = "salsa-macro-rules"
-version = "0.23.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2edb86a7e9c91f6d30c9ce054312721dbe773a162db27bbfae834d16177b30ce"
+checksum = "85f4b7d4405540bbd6d4ffa52d4322d983f3781954d3073067ac1bdb028459b3"
 
 [[package]]
 name = "salsa-macros"
-version = "0.23.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0778d6e209051bc4e75acfe83bcd7848601ec3dbe9c3dbb982829020e9128af"
+checksum = "445be2bfbb2f67cb663225ecd7bc5a25370c0250fca30f9d8cbad9a913650370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "synstructure",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1796,16 +1785,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "seize"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "semver"
@@ -1976,17 +1955,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,6 +2109,12 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/crates/almide-spine/Cargo.toml
+++ b/crates/almide-spine/Cargo.toml
@@ -11,7 +11,7 @@ almide = { path = "../.." }
 almide-driver = { path = "../almide-driver" }
 almide-types = { path = "../almide-types" }
 almide-syntax = { path = "../almide-syntax" }
-salsa = "0.23"
+salsa = "0.28"
 serde_json = "1"
 
 [lints]

--- a/crates/almide-spine/src/bin/s2_bench.rs
+++ b/crates/almide-spine/src/bin/s2_bench.rs
@@ -76,7 +76,7 @@ fn main() {
     let t = Instant::now();
     let mut sink = 0u64;
     for k in &keys {
-        sink = sink.wrapping_add(check_decl(&db, *k));
+        sink = sink.wrapping_add(*check_decl(&db, *k));
     }
     let cold_ms = t.elapsed().as_secs_f64() * 1e3;
     println!(
@@ -102,7 +102,7 @@ fn main() {
     let mut db = db;
     let recheck_all = |db: &almide_spine::SpineDb, keys: &[DeclKey], sink: &mut u64| {
         for k in keys {
-            *sink = sink.wrapping_add(check_decl(db, *k));
+            *sink = sink.wrapping_add(*check_decl(db, *k));
         }
     };
 

--- a/crates/almide-spine/src/bin/spine_bench.rs
+++ b/crates/almide-spine/src/bin/spine_bench.rs
@@ -78,7 +78,7 @@ fn main() {
     let project = Project::new(&db, inputs.clone());
     PARSE_EXECUTIONS.store(0, Ordering::Relaxed);
     let t = Instant::now();
-    sink = sink.wrapping_add(project_digest(&db, project));
+    sink = sink.wrapping_add(*project_digest(&db, project));
     let cold = t.elapsed().as_secs_f64() * 1e3;
     let cold_execs = PARSE_EXECUTIONS.load(Ordering::Relaxed);
     let overhead = (cold / batch - 1.0) * 100.0;
@@ -93,7 +93,7 @@ fn main() {
         victim.set_text(&mut db).to(new_text);
         PARSE_EXECUTIONS.store(0, Ordering::Relaxed);
         let t = Instant::now();
-        sink = sink.wrapping_add(project_digest(&db, project));
+        sink = sink.wrapping_add(*project_digest(&db, project));
         warm_ms.push(t.elapsed().as_secs_f64() * 1e3);
         per_round_execs.push(PARSE_EXECUTIONS.load(Ordering::Relaxed));
     }
@@ -104,7 +104,7 @@ fn main() {
 
     // ── sanity: a memo hit round (no edit) must run 0 parses ────────────────
     PARSE_EXECUTIONS.store(0, Ordering::Relaxed);
-    sink = sink.wrapping_add(project_digest(&db, project));
+    sink = sink.wrapping_add(*project_digest(&db, project));
     let hit_execs = PARSE_EXECUTIONS.load(Ordering::Relaxed);
 
     let speedup = batch / warm;

--- a/crates/almide-spine/src/s2.rs
+++ b/crates/almide-spine/src/s2.rs
@@ -152,7 +152,7 @@ pub fn parse_decls(db: &dyn salsa::Database, file: SourceFile) -> Vec<DeclFp> {
 
 #[salsa::tracked]
 pub fn decl_fp(db: &dyn salsa::Database, key: DeclKey) -> Option<DeclFp> {
-    parse_decls(db, key.file(db)).get(key.index(db)).cloned()
+    parse_decls(db, *key.file(db)).get(*key.index(db)).cloned()
 }
 
 #[salsa::tracked]
@@ -170,7 +170,7 @@ pub fn project_symbols(db: &dyn salsa::Database, project: SProject) -> BTreeMap<
 
 #[salsa::tracked]
 pub fn symbol_fp(db: &dyn salsa::Database, sk: SymbolKey) -> Option<u64> {
-    project_symbols(db, sk.project(db)).get(sk.name(db)).copied()
+    project_symbols(db, *sk.project(db)).get(sk.name(db)).copied()
 }
 
 /// The stand-in sema query: depends on this decl's own fingerprint plus the
@@ -186,7 +186,7 @@ pub fn check_decl(db: &dyn salsa::Database, key: DeclKey) -> u64 {
     for dep in &fp.deps {
         if let Some(sk) = registry.get(dep) {
             if let Some(ifp) = symbol_fp(db, *sk) {
-                acc = acc.wrapping_mul(1_000_003).wrapping_add(ifp);
+                acc = acc.wrapping_mul(1_000_003).wrapping_add(*ifp);
             } else {
                 acc = acc.wrapping_mul(1_000_003).wrapping_add(0xDEAD);
             }

--- a/crates/almide-spine/tests/incremental_diag_test.rs
+++ b/crates/almide-spine/tests/incremental_diag_test.rs
@@ -23,7 +23,7 @@ use std::sync::atomic::Ordering;
 fn fresh(text: &str) -> CheckOutput {
     let db = SpineDb::default();
     let f = SourceFile::new(&db, "scenario.almd".to_string(), text.to_string());
-    check_file_json_v3(&db, f)
+    check_file_json_v3(&db, f).clone()
 }
 
 /// Run one edit script: apply each step to a persistent db (with an
@@ -44,7 +44,7 @@ fn run_scenario(name: &str, steps: &[&str]) {
             file.set_text(&mut db).to(text.to_string());
         }
         FILE_CHECK_EXECUTIONS.store(0, Ordering::Relaxed);
-        let inc = check_file_json_v3(&db, file);
+        let inc = check_file_json_v3(&db, file).clone();
         let ran = FILE_CHECK_EXECUTIONS.load(Ordering::Relaxed);
         // Memoization witness: the edited file re-checks (k>0), the neighbor
         // never does.


### PR DESCRIPTION
Third slice of #1759: salsa 0.23 → 0.28 (major). The API move: tracked-struct field getters and tracked-query returns now come back by REFERENCE — call sites deref scalar copies (`*key.file(db)`, `*check_decl(...)`) or clone where an owned value crosses a db lifetime (the incremental-diag test's from-scratch comparison). No query-shape or memoization-semantics change: the incremental-diag scenarios still witness ≤1 re-check per edit and 0 neighbor re-checks, spine parity suites green, workspace green, `almide test` 427/427.

Supersedes #1744.