### PR TITLE
sha2 0.11 across all consumers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
  "almide-types",
  "salsa",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -216,7 +216,7 @@ dependencies = [
  "almide-corpus",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -252,7 +252,7 @@ dependencies = [
  "almide-types",
  "almide-wasm-run",
  "anyhow",
- "sha2",
+ "sha2 0.11.0",
  "wasm-encoder 0.258.0",
  "wasmparser 0.258.0",
  "wasmtime",
@@ -395,6 +395,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "boxcar"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cpp_demangle"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +522,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -575,7 +599,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
  "wasmtime-internal-core",
@@ -720,6 +744,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,8 +781,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1096,6 +1140,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "id-arena"
@@ -1866,8 +1919,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2452,7 +2516,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
  "wasm-encoder 0.252.0",
@@ -2475,7 +2539,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.10.9",
  "toml 0.9.12+spec-1.1.0",
  "wasmtime-environ",
  "windows-sys 0.61.2",

--- a/crates/almide-spine/Cargo.toml
+++ b/crates/almide-spine/Cargo.toml
@@ -19,4 +19,4 @@ workspace = true
 
 [dev-dependencies]
 almide-corpus = { path = "../almide-corpus" }
-sha2 = "0.10"
+sha2 = "0.11"

--- a/crates/almide-spine/tests/check_parity.rs
+++ b/crates/almide-spine/tests/check_parity.rs
@@ -17,7 +17,7 @@ fn workspace_root() -> PathBuf {
 }
 
 fn sha(s: &str) -> String {
-    format!("{:x}", Sha256::digest(s.as_bytes()))
+    Sha256::digest(s.as_bytes()).iter().map(|b| format!("{b:02x}")).collect::<String>()
 }
 
 #[test]

--- a/crates/almide-spine/tests/run_parity.rs
+++ b/crates/almide-spine/tests/run_parity.rs
@@ -22,7 +22,7 @@ fn normalized_hash(stdout: &str) -> String {
     let no_nul: String = stdout.chars().filter(|c| *c != '\0').collect();
     let trimmed = no_nul.trim_end_matches('\n');
     let text = if trimmed.is_empty() { String::new() } else { format!("{trimmed}\n") };
-    format!("{:x}", Sha256::digest(text.as_bytes()))
+    Sha256::digest(text.as_bytes()).iter().map(|b| format!("{b:02x}")).collect::<String>()
 }
 
 #[test]

--- a/crates/almide-syntax/Cargo.toml
+++ b/crates/almide-syntax/Cargo.toml
@@ -12,4 +12,4 @@ serde_json = "1"
 
 [dev-dependencies]
 almide-corpus = { path = "../almide-corpus" }
-sha2 = "0.10"
+sha2 = "0.11"

--- a/crates/almide-syntax/tests/ast_parity.rs
+++ b/crates/almide-syntax/tests/ast_parity.rs
@@ -68,7 +68,10 @@ fn spec_corpus_ast_matches_oracle_hashes() {
             .unwrap_or_else(|e| panic!("{rel}: oracle parsed this but greenfield failed: {e}"));
         assert!(parser.errors.is_empty(), "{rel}: oracle emitted AST but greenfield has parse errors: {:?}", parser.errors[0]);
         let json = serde_json::to_string_pretty(&prog).unwrap();
-        let got = format!("{:x}", Sha256::digest(format!("{json}\n").as_bytes()));
+        let got = Sha256::digest(format!("{json}\n").as_bytes())
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>();
         if got != *want {
             mismatches.push(rel.clone());
         }

--- a/crates/almide-wasm/Cargo.toml
+++ b/crates/almide-wasm/Cargo.toml
@@ -22,7 +22,7 @@ almide-wasm-run = { path = "../almide-wasm-run" }
 almide = { path = "../.." }
 wasmparser = "0.258"
 wasmtime = "47"
-sha2 = "0.10"
+sha2 = "0.11"
 
 [lints]
 workspace = true

--- a/crates/almide-wasm/tests/backend_parity.rs
+++ b/crates/almide-wasm/tests/backend_parity.rs
@@ -25,7 +25,7 @@ fn normalized_hash(stdout: &str) -> String {
     let no_nul: String = stdout.chars().filter(|c| *c != '\0').collect();
     let trimmed = no_nul.trim_end_matches('\n');
     let text = if trimmed.is_empty() { String::new() } else { format!("{trimmed}\n") };
-    format!("{:x}", Sha256::digest(text.as_bytes()))
+    Sha256::digest(text.as_bytes()).iter().map(|b| format!("{b:02x}")).collect::<String>()
 }
 
 #[test]

--- a/crates/almide-wasm/tests/wasi_gate.rs
+++ b/crates/almide-wasm/tests/wasi_gate.rs
@@ -24,7 +24,7 @@ fn normalized_hash(stdout: &[u8]) -> String {
     let no_nul: String = text.chars().filter(|c| *c != '\0').collect();
     let trimmed = no_nul.trim_end_matches('\n');
     let text = if trimmed.is_empty() { String::new() } else { format!("{trimmed}\n") };
-    format!("{:x}", Sha256::digest(text.as_bytes()))
+    Sha256::digest(text.as_bytes()).iter().map(|b| format!("{b:02x}")).collect::<String>()
 }
 
 fn wasmtime_bin() -> String {


### PR DESCRIPTION
Replaces #1767 (same content, linear history — the #1771→#1775 queue class: a branch carrying merge commits gets dequeued with merge_conflict before CI by the rebase-based queue).

sha2 moves 0.10 → 0.11 in the three consumers at once (almide-spine, almide-wasm, almide-syntax — the family-lockstep doctrine that closed the dependabot singles); digest 0.11's output array drops LowerHex, so the parity harness hexes bytes explicitly. The lockfile carries sha2 0.11 for our crates beside the 0.10 wasmtime-cache still requires transitively.

Verification: `cargo test --release` on the three consumer crates green; lock re-resolved by build on top of current develop.