### PR TITLE
The negative-test corpus reaches 1,000 pairs: multi-file fixtures retire the E033/E420 exemptions, and opaque aliases become constructible

### DIFF
--- a/crates/almide-frontend/src/canonicalize/registration.rs
+++ b/crates/almide-frontend/src/canonicalize/registration.rs
@@ -638,9 +638,18 @@ fn register_type_decl_opaque_alias(env: &mut TypeEnv, name: &str, resolved: Ty, 
     // Register as nominal type (not transparent alias)
     let generic_args: Vec<Ty> = gnames.iter().map(|g| Ty::TypeVar(*g)).collect();
     let resolved = Ty::Named(sym(name), generic_args);
-    // Register constructor with visibility restriction
+    // Register constructor with visibility restriction. The OWNER is a
+    // definition-time identity captured once: the prefixed registration
+    // names it outright, and the per-module re-registration (which runs
+    // with prefix = None under `alias_owner_module`) must not overwrite it
+    // with "no module" — that read the defining module's own constructor
+    // call as foreign, so a `mod type` alias could never be built anywhere
+    // (the reference compilers key this privilege to the definition's
+    // module identity and never re-derive it: Rust's DefId parent, Gleam's
+    // opaque-type module, Roc's opaque wrap/unwrap scope).
     env.opaque_alias_visibility.insert(sym(name), visibility);
-    env.opaque_alias_module.insert(sym(name), prefix.map(|p| sym(p)));
+    let owner = prefix.map(|p| sym(p)).or(env.alias_owner_module);
+    env.opaque_alias_module.insert(sym(name), owner);
     resolved
 }
 /// Fix up a `Variant`'s registered name to the DECLARED name, and register each of its constructors. Verbatim text move out of [`register_type_decl`].

--- a/crates/almide-frontend/src/check/calls_ufcs.rs
+++ b/crates/almide-frontend/src/check/calls_ufcs.rs
@@ -350,8 +350,14 @@ impl Checker {
             // Check if we're in the defining module
             let defining_module = self.env.opaque_alias_module.get(&sym(name))
                 .cloned().flatten();
-            let current_module = self.env.self_module_name
-                .or(self.current_module_prefix.as_ref().map(|p| sym(p)));
+            // The module whose body is being checked is the current one;
+            // `self_module_name` is the package's own identity and applies
+            // only to the entry file (no prefix). The reversed order made
+            // the DEFINING module's own constructor call read as foreign,
+            // so a `mod type` alias could never be built anywhere (#1528's
+            // multi-file E033 sweep found it).
+            let current_module = self.current_module_prefix.as_ref().map(|p| sym(p))
+                .or(self.env.self_module_name);
             let allowed = match (&defining_module, &current_module) {
                 (None, None) => true,       // defined in main, used in main
                 (Some(def), Some(cur)) => def == cur, // same module

--- a/scripts/check-diagnostic-code-coverage.sh
+++ b/scripts/check-diagnostic-code-coverage.sh
@@ -11,9 +11,10 @@
 # Known no-fixture codes, each with a reason the docs carry:
 #   E054 — fires only on an internal formatter defect (no committed source can
 #          trigger it deliberately; pinned by fmt_corpus_test instead).
-#   E033 — needs a multi-module project (opaque-type external construction);
-#          pinned by module-project tests, not single-file fixtures.
-#   E420 — needs a cross-module call (mod/local visibility); same.
+# E033 / E420 left this list in #1528's multi-file sweep: a fixture dir may
+# carry almide.toml + src/*.almd siblings, and `almide check broken.almd`
+# resolves `import self.x` against them — so the two cross-module codes
+# have real families now.
 #
 # Codes with fewer than 3 fixtures FAIL the gate: the tier-1 bar (>=3
 # families per code) was promoted from soft backlog to enforced when the
@@ -27,7 +28,7 @@ cd "$ROOT"
 # E081 fires in the BUILD path (--target wasm availability, #1423) — the
 # check-harness fixture format cannot reach it; its pin is
 # tests/wasm_availability_e081_test.rs (the E054 precedent).
-EXEMPT="E054 E033 E420 E081"
+EXEMPT="E054 E081"
 
 fail=0
 total=0

--- a/tests/diagnostic_coverage_test.rs
+++ b/tests/diagnostic_coverage_test.rs
@@ -29,11 +29,10 @@ const SOFT_GATE: bool = false;
 /// fixture harness can't express (E420 is cross-module visibility,
 /// which requires an `import` graph). Keep this list short — each
 /// entry is a gap the harness can't cover today.
+// E420 and E033 left this list in #1528's multi-file sweep: a fixture dir
+// may carry almide.toml + src/*.almd siblings, and the harness's
+// `almide check broken.almd` resolves `import self.x` against them.
 const FIXTURE_ALLOWLIST: &[&str] = &[
-    "E420",
-    // E033 (opaque-type construction outside its defining module) needs a
-    // two-module import graph the single-file harness can't express.
-    "E033",
     // E054 (fmt verification failed) fires on an INTERNAL formatter defect —
     // no committed source file can (or should) trigger it deliberately, and
     // the harness runs `almide check`, which never formats. The verifier

--- a/tests/diagnostics/e002-module-fn-undefined/almide.toml
+++ b/tests/diagnostics/e002-module-fn-undefined/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e002-module-fn-undefined/broken.almd
+++ b/tests/diagnostics/e002-module-fn-undefined/broken.almd
@@ -1,0 +1,5 @@
+// A qualified call into a self module names a fn the module does not
+// declare — E002 with the module-scoped spelling.
+import self.helper as h
+
+fn main() -> Unit = println(int.to_string(h.opne()))

--- a/tests/diagnostics/e002-module-fn-undefined/fixed.almd
+++ b/tests/diagnostics/e002-module-fn-undefined/fixed.almd
@@ -1,0 +1,5 @@
+// A qualified call into a self module names a fn the module does not
+// declare — E002 with the module-scoped spelling.
+import self.helper as h
+
+fn main() -> Unit = println(int.to_string(helper.open()))

--- a/tests/diagnostics/e002-module-fn-undefined/meta.toml
+++ b/tests/diagnostics/e002-module-fn-undefined/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E002"
+expects_error = "undefined function 'helper.opne'"
+hint_substring = ""

--- a/tests/diagnostics/e002-module-fn-undefined/src/helper.almd
+++ b/tests/diagnostics/e002-module-fn-undefined/src/helper.almd
@@ -1,0 +1,1 @@
+pub fn open() -> Int = 1

--- a/tests/diagnostics/e004-module-fn-arity/almide.toml
+++ b/tests/diagnostics/e004-module-fn-arity/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e004-module-fn-arity/broken.almd
+++ b/tests/diagnostics/e004-module-fn-arity/broken.almd
@@ -1,0 +1,5 @@
+// Arity is checked against the sibling's declaration: one argument for a
+// two-parameter module fn is E004.
+import self.calc as c
+
+fn main() -> Unit = println(int.to_string(c.add(1)))

--- a/tests/diagnostics/e004-module-fn-arity/fixed.almd
+++ b/tests/diagnostics/e004-module-fn-arity/fixed.almd
@@ -1,0 +1,5 @@
+// Arity is checked against the sibling's declaration: one argument for a
+// two-parameter module fn is E004.
+import self.calc as c
+
+fn main() -> Unit = println(int.to_string(c.add(1, 2)))

--- a/tests/diagnostics/e004-module-fn-arity/meta.toml
+++ b/tests/diagnostics/e004-module-fn-arity/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E004"
+expects_error = "expects 2 argument"
+hint_substring = ""

--- a/tests/diagnostics/e004-module-fn-arity/src/calc.almd
+++ b/tests/diagnostics/e004-module-fn-arity/src/calc.almd
@@ -1,0 +1,1 @@
+pub fn add(a: Int, b: Int) -> Int = a + b

--- a/tests/diagnostics/e005-module-fn-arg-type/almide.toml
+++ b/tests/diagnostics/e005-module-fn-arg-type/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e005-module-fn-arg-type/broken.almd
+++ b/tests/diagnostics/e005-module-fn-arg-type/broken.almd
@@ -1,0 +1,5 @@
+// The callee's declared param types cross the module boundary intact: a
+// String where the sibling's fn wants Int is E005 at the call.
+import self.calc as c
+
+fn main() -> Unit = println(int.to_string(c.add("one", 2)))

--- a/tests/diagnostics/e005-module-fn-arg-type/fixed.almd
+++ b/tests/diagnostics/e005-module-fn-arg-type/fixed.almd
@@ -1,0 +1,5 @@
+// The callee's declared param types cross the module boundary intact: a
+// String where the sibling's fn wants Int is E005 at the call.
+import self.calc as c
+
+fn main() -> Unit = println(int.to_string(c.add(1, 2)))

--- a/tests/diagnostics/e005-module-fn-arg-type/meta.toml
+++ b/tests/diagnostics/e005-module-fn-arg-type/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E005"
+expects_error = "expects Int"
+hint_substring = ""

--- a/tests/diagnostics/e005-module-fn-arg-type/src/calc.almd
+++ b/tests/diagnostics/e005-module-fn-arg-type/src/calc.almd
@@ -1,0 +1,1 @@
+pub fn add(a: Int, b: Int) -> Int = a + b

--- a/tests/diagnostics/e006-module-effect-fn-from-pure/almide.toml
+++ b/tests/diagnostics/e006-module-effect-fn-from-pure/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e006-module-effect-fn-from-pure/broken.almd
+++ b/tests/diagnostics/e006-module-effect-fn-from-pure/broken.almd
@@ -1,0 +1,5 @@
+// Effect-ness crosses the module boundary: a pure fn calling a sibling's
+// `effect fn` is E006 — mark the caller `effect fn`.
+import self.store as s
+
+fn main() -> Unit = println(int.to_string(s.load()))

--- a/tests/diagnostics/e006-module-effect-fn-from-pure/fixed.almd
+++ b/tests/diagnostics/e006-module-effect-fn-from-pure/fixed.almd
@@ -1,0 +1,5 @@
+// Effect-ness crosses the module boundary: a pure fn calling a sibling's
+// `effect fn` is E006 — mark the caller `effect fn`.
+import self.store as s
+
+effect fn main() -> Unit = println(int.to_string(s.load()!))

--- a/tests/diagnostics/e006-module-effect-fn-from-pure/meta.toml
+++ b/tests/diagnostics/e006-module-effect-fn-from-pure/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E006"
+expects_error = "cannot call effect function 'store.load'"
+hint_substring = "effect fn"

--- a/tests/diagnostics/e006-module-effect-fn-from-pure/src/store.almd
+++ b/tests/diagnostics/e006-module-effect-fn-from-pure/src/store.almd
@@ -1,0 +1,1 @@
+pub effect fn load() -> Int = 7

--- a/tests/diagnostics/e010-module-variant-nonexhaustive/almide.toml
+++ b/tests/diagnostics/e010-module-variant-nonexhaustive/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e010-module-variant-nonexhaustive/broken.almd
+++ b/tests/diagnostics/e010-module-variant-nonexhaustive/broken.almd
@@ -1,0 +1,10 @@
+// Exhaustiveness sees a sibling's variant definition: matching two of its
+// three cases is E010 naming the missing one.
+import self.color as c
+
+fn name(x: c.Color) -> String = match x {
+  c.Red => "red",
+  c.Green => "green",
+}
+
+fn main() -> Unit = println(name(c.red()))

--- a/tests/diagnostics/e010-module-variant-nonexhaustive/fixed.almd
+++ b/tests/diagnostics/e010-module-variant-nonexhaustive/fixed.almd
@@ -1,0 +1,11 @@
+// Exhaustiveness sees a sibling's variant definition: matching two of its
+// three cases is E010 naming the missing one.
+import self.color as c
+
+fn name(x: c.Color) -> String = match x {
+  c.Red => "red",
+  c.Green => "green",
+  c.Blue => "blue",
+}
+
+fn main() -> Unit = println(name(c.red()))

--- a/tests/diagnostics/e010-module-variant-nonexhaustive/meta.toml
+++ b/tests/diagnostics/e010-module-variant-nonexhaustive/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E010"
+expects_error = "missing"
+hint_substring = ""

--- a/tests/diagnostics/e010-module-variant-nonexhaustive/src/color.almd
+++ b/tests/diagnostics/e010-module-variant-nonexhaustive/src/color.almd
@@ -1,0 +1,3 @@
+type Color = | Red | Green | Blue
+
+pub fn red() -> Color = Red

--- a/tests/diagnostics/e013-module-record-unknown-field/almide.toml
+++ b/tests/diagnostics/e013-module-record-unknown-field/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e013-module-record-unknown-field/broken.almd
+++ b/tests/diagnostics/e013-module-record-unknown-field/broken.almd
@@ -1,0 +1,5 @@
+// Field access on a sibling's record checks against ITS definition: a
+// field the module never declared is E013 with the field list.
+import self.geo as g
+
+fn main() -> Unit = println(int.to_string(g.origin().z))

--- a/tests/diagnostics/e013-module-record-unknown-field/fixed.almd
+++ b/tests/diagnostics/e013-module-record-unknown-field/fixed.almd
@@ -1,0 +1,5 @@
+// Field access on a sibling's record checks against ITS definition: a
+// field the module never declared is E013 with the field list.
+import self.geo as g
+
+fn main() -> Unit = println(int.to_string(g.origin().x))

--- a/tests/diagnostics/e013-module-record-unknown-field/meta.toml
+++ b/tests/diagnostics/e013-module-record-unknown-field/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E013"
+expects_error = "no field 'z'"
+hint_substring = ""

--- a/tests/diagnostics/e013-module-record-unknown-field/src/geo.almd
+++ b/tests/diagnostics/e013-module-record-unknown-field/src/geo.almd
@@ -1,0 +1,3 @@
+type Point = { x: Int, y: Int }
+
+pub fn origin() -> Point = Point { x: 0, y: 0 }

--- a/tests/diagnostics/e016-module-record-fn-field-key/almide.toml
+++ b/tests/diagnostics/e016-module-record-fn-field-key/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e016-module-record-fn-field-key/broken.almd
+++ b/tests/diagnostics/e016-module-record-fn-field-key/broken.almd
@@ -1,0 +1,8 @@
+// The hash-blocker walk resolves the sibling's record and finds its fn
+// field: keying a Map by it is E016 with the closure wording (#1518).
+import self.handler as hd
+
+fn main() -> Unit = {
+  let m: Map[hd.Handler, Int] = map.new()
+  println(int.to_string(map.len(m)))
+}

--- a/tests/diagnostics/e016-module-record-fn-field-key/fixed.almd
+++ b/tests/diagnostics/e016-module-record-fn-field-key/fixed.almd
@@ -1,0 +1,8 @@
+// The hash-blocker walk resolves the sibling's record and finds its fn
+// field: keying a Map by it is E016 with the closure wording (#1518).
+import self.handler as hd
+
+fn main() -> Unit = {
+  let m: Map[String, hd.Handler] = map.new()
+  println(int.to_string(map.len(m)))
+}

--- a/tests/diagnostics/e016-module-record-fn-field-key/meta.toml
+++ b/tests/diagnostics/e016-module-record-fn-field-key/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E016"
+expects_error = "Handler"
+hint_substring = ""

--- a/tests/diagnostics/e016-module-record-fn-field-key/src/handler.almd
+++ b/tests/diagnostics/e016-module-record-fn-field-key/src/handler.almd
@@ -1,0 +1,3 @@
+type Handler = { name: String, run: (Int) -> Int }
+
+pub fn make(name: String) -> Handler = Handler { name: name, run: (n) => n + 1 }

--- a/tests/diagnostics/e029-module-type-unknown/almide.toml
+++ b/tests/diagnostics/e029-module-type-unknown/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e029-module-type-unknown/broken.almd
+++ b/tests/diagnostics/e029-module-type-unknown/broken.almd
@@ -1,0 +1,8 @@
+// A qualified type name the sibling does not declare is E029 at the
+// annotation — the module-scoped spelling is what the hint repeats.
+import self.geo as g
+
+fn main() -> Unit = {
+  let p: g.Piont = g.origin()
+  println(int.to_string(p.x))
+}

--- a/tests/diagnostics/e029-module-type-unknown/fixed.almd
+++ b/tests/diagnostics/e029-module-type-unknown/fixed.almd
@@ -1,0 +1,8 @@
+// A qualified type name the sibling does not declare is E029 at the
+// annotation — the module-scoped spelling is what the hint repeats.
+import self.geo as g
+
+fn main() -> Unit = {
+  let p: g.Point = g.origin()
+  println(int.to_string(p.x))
+}

--- a/tests/diagnostics/e029-module-type-unknown/meta.toml
+++ b/tests/diagnostics/e029-module-type-unknown/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E029"
+expects_error = "unknown type 'Piont'"
+hint_substring = ""

--- a/tests/diagnostics/e029-module-type-unknown/src/geo.almd
+++ b/tests/diagnostics/e029-module-type-unknown/src/geo.almd
@@ -1,0 +1,3 @@
+type Point = { x: Int, y: Int }
+
+pub fn origin() -> Point = Point { x: 0, y: 0 }

--- a/tests/diagnostics/e030-module-record-no-ord/almide.toml
+++ b/tests/diagnostics/e030-module-record-no-ord/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e030-module-record-no-ord/broken.almd
+++ b/tests/diagnostics/e030-module-record-no-ord/broken.almd
@@ -1,0 +1,8 @@
+// Ordering resolves the sibling's record: a module record without `: Ord`
+// cannot be sorted — E030 names the type by its module spelling.
+import self.geo as g
+
+fn main() -> Unit = {
+  let ps = list.sort([g.origin()])
+  println(int.to_string(list.len(ps)))
+}

--- a/tests/diagnostics/e030-module-record-no-ord/fixed.almd
+++ b/tests/diagnostics/e030-module-record-no-ord/fixed.almd
@@ -1,0 +1,8 @@
+// Ordering resolves the sibling's record: a module record without `: Ord`
+// cannot be sorted — E030 names the type by its module spelling.
+import self.geo as g
+
+fn main() -> Unit = {
+  let ps = list.sort_by([g.origin()], (p) => p.x)
+  println(int.to_string(list.len(ps)))
+}

--- a/tests/diagnostics/e030-module-record-no-ord/meta.toml
+++ b/tests/diagnostics/e030-module-record-no-ord/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E030"
+expects_error = "has no ordering"
+hint_substring = ""

--- a/tests/diagnostics/e030-module-record-no-ord/src/geo.almd
+++ b/tests/diagnostics/e030-module-record-no-ord/src/geo.almd
@@ -1,0 +1,3 @@
+type Point = { x: Int, y: Int }
+
+pub fn origin() -> Point = Point { x: 0, y: 0 }

--- a/tests/diagnostics/e033-opaque-ctor-from-sibling/almide.toml
+++ b/tests/diagnostics/e033-opaque-ctor-from-sibling/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e033-opaque-ctor-from-sibling/broken.almd
+++ b/tests/diagnostics/e033-opaque-ctor-from-sibling/broken.almd
@@ -1,0 +1,5 @@
+// The boundary is the DEFINING MODULE, not the entry file: a sibling module
+// constructing another sibling's opaque type is E033 just the same.
+import self.ledger as l
+
+fn main() -> Unit = println(int.to_string(l.open_balance()))

--- a/tests/diagnostics/e033-opaque-ctor-from-sibling/fixed.almd
+++ b/tests/diagnostics/e033-opaque-ctor-from-sibling/fixed.almd
@@ -1,0 +1,5 @@
+// The boundary is the DEFINING MODULE, not the entry file: a sibling module
+// constructing another sibling's opaque type is E033 just the same.
+import self.money as m
+
+fn main() -> Unit = println(int.to_string(m.value(m.from_int(100))))

--- a/tests/diagnostics/e033-opaque-ctor-from-sibling/meta.toml
+++ b/tests/diagnostics/e033-opaque-ctor-from-sibling/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E033"
+expects_error = "cannot construct opaque type 'Cents'"
+hint_substring = "public API"

--- a/tests/diagnostics/e033-opaque-ctor-from-sibling/src/ledger.almd
+++ b/tests/diagnostics/e033-opaque-ctor-from-sibling/src/ledger.almd
@@ -1,0 +1,3 @@
+import self.money as m
+
+pub fn open_balance() -> Int = m.value(Cents(100))

--- a/tests/diagnostics/e033-opaque-ctor-from-sibling/src/money.almd
+++ b/tests/diagnostics/e033-opaque-ctor-from-sibling/src/money.almd
@@ -1,0 +1,4 @@
+mod type Cents = Int
+
+pub fn from_int(n: Int) -> Cents = Cents(n)
+pub fn value(c: Cents) -> Int = 0

--- a/tests/diagnostics/e033-opaque-ctor-in-argument/almide.toml
+++ b/tests/diagnostics/e033-opaque-ctor-in-argument/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e033-opaque-ctor-in-argument/broken.almd
+++ b/tests/diagnostics/e033-opaque-ctor-in-argument/broken.almd
@@ -1,0 +1,5 @@
+// The foreign constructor call is refused wherever it sits — here inline
+// as a call argument, with an Int payload.
+import self.ident as id
+
+fn main() -> Unit = println(id.show(UserId(7)))

--- a/tests/diagnostics/e033-opaque-ctor-in-argument/fixed.almd
+++ b/tests/diagnostics/e033-opaque-ctor-in-argument/fixed.almd
@@ -1,0 +1,5 @@
+// The foreign constructor call is refused wherever it sits — here inline
+// as a call argument, with an Int payload.
+import self.ident as id
+
+fn main() -> Unit = println(id.show(id.of(7)))

--- a/tests/diagnostics/e033-opaque-ctor-in-argument/meta.toml
+++ b/tests/diagnostics/e033-opaque-ctor-in-argument/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E033"
+expects_error = "cannot construct opaque type 'UserId'"
+hint_substring = "Use the module's public API"

--- a/tests/diagnostics/e033-opaque-ctor-in-argument/src/ident.almd
+++ b/tests/diagnostics/e033-opaque-ctor-in-argument/src/ident.almd
@@ -1,0 +1,4 @@
+mod type UserId = Int
+
+pub fn of(n: Int) -> UserId = UserId(n)
+pub fn show(u: UserId) -> String = "user"

--- a/tests/diagnostics/e033-opaque-ctor-outside-module/almide.toml
+++ b/tests/diagnostics/e033-opaque-ctor-outside-module/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e033-opaque-ctor-outside-module/broken.almd
+++ b/tests/diagnostics/e033-opaque-ctor-outside-module/broken.almd
@@ -1,0 +1,9 @@
+// A `mod type` alias is a nominal newtype whose constructor belongs to its
+// defining module: building one from the entry file is E033 — go through
+// the module's public API instead.
+import self.token as tk
+
+fn main() -> Unit = {
+  let t = Token("raw")
+  println(tk.text(t))
+}

--- a/tests/diagnostics/e033-opaque-ctor-outside-module/fixed.almd
+++ b/tests/diagnostics/e033-opaque-ctor-outside-module/fixed.almd
@@ -1,0 +1,9 @@
+// A `mod type` alias is a nominal newtype whose constructor belongs to its
+// defining module: building one from the entry file is E033 — go through
+// the module's public API instead.
+import self.token as tk
+
+fn main() -> Unit = {
+  let t = tk.make("raw")
+  println(tk.text(t))
+}

--- a/tests/diagnostics/e033-opaque-ctor-outside-module/meta.toml
+++ b/tests/diagnostics/e033-opaque-ctor-outside-module/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E033"
+expects_error = "cannot construct opaque type 'Token' outside its defining module"
+hint_substring = "public API"

--- a/tests/diagnostics/e033-opaque-ctor-outside-module/src/token.almd
+++ b/tests/diagnostics/e033-opaque-ctor-outside-module/src/token.almd
@@ -1,0 +1,4 @@
+mod type Token = String
+
+pub fn make(raw: String) -> Token = Token(raw)
+pub fn text(t: Token) -> String = "token"

--- a/tests/diagnostics/e041-module-result-let/almide.toml
+++ b/tests/diagnostics/e041-module-result-let/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e041-module-result-let/broken.almd
+++ b/tests/diagnostics/e041-module-result-let/broken.almd
@@ -1,0 +1,8 @@
+// A sibling's fallible result bound by a plain `let` is E041: the Result
+// stays a value until `!` propagates it.
+import self.store as s
+
+effect fn main() -> Unit = {
+  let v = s.fetch()
+  println(int.to_string(v))
+}

--- a/tests/diagnostics/e041-module-result-let/fixed.almd
+++ b/tests/diagnostics/e041-module-result-let/fixed.almd
@@ -1,0 +1,8 @@
+// A sibling's fallible result bound by a plain `let` is E041: the Result
+// stays a value until `!` propagates it.
+import self.store as s
+
+effect fn main() -> Unit = {
+  let v = s.fetch()!
+  println(int.to_string(v))
+}

--- a/tests/diagnostics/e041-module-result-let/meta.toml
+++ b/tests/diagnostics/e041-module-result-let/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E041"
+expects_error = "implicit propagation"
+hint_substring = "propagate"

--- a/tests/diagnostics/e041-module-result-let/src/store.almd
+++ b/tests/diagnostics/e041-module-result-let/src/store.almd
@@ -1,0 +1,1 @@
+pub effect fn fetch() -> Result[Int, String] = ok(7)

--- a/tests/diagnostics/e042-module-result-discarded/almide.toml
+++ b/tests/diagnostics/e042-module-result-discarded/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e042-module-result-discarded/broken.almd
+++ b/tests/diagnostics/e042-module-result-discarded/broken.almd
@@ -1,0 +1,8 @@
+// A sibling's Result dropped in statement position is E042 (must-use)
+// — the module boundary does not launder a discarded error.
+import self.store as s
+
+effect fn main() -> Unit = {
+  s.save()
+  println("saved")
+}

--- a/tests/diagnostics/e042-module-result-discarded/fixed.almd
+++ b/tests/diagnostics/e042-module-result-discarded/fixed.almd
@@ -1,0 +1,8 @@
+// A sibling's Result dropped in statement position is E042 (must-use)
+// — the module boundary does not launder a discarded error.
+import self.store as s
+
+effect fn main() -> Unit = {
+  s.save()!
+  println("saved")
+}

--- a/tests/diagnostics/e042-module-result-discarded/meta.toml
+++ b/tests/diagnostics/e042-module-result-discarded/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E042"
+expects_error = "discards a Result"
+hint_substring = "expr!"

--- a/tests/diagnostics/e042-module-result-discarded/src/store.almd
+++ b/tests/diagnostics/e042-module-result-discarded/src/store.almd
@@ -1,0 +1,1 @@
+pub effect fn save() -> Result[Unit, String] = ok(())

--- a/tests/diagnostics/e058-module-record-float-key/almide.toml
+++ b/tests/diagnostics/e058-module-record-float-key/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e058-module-record-float-key/broken.almd
+++ b/tests/diagnostics/e058-module-record-float-key/broken.almd
@@ -1,0 +1,8 @@
+// Hashability resolves the sibling's record definition: a Float-carrying
+// module record as a Map key is E058.
+import self.geo as g
+
+fn main() -> Unit = {
+  let m: Map[g.Point, Int] = map.new()
+  println(int.to_string(map.len(m)))
+}

--- a/tests/diagnostics/e058-module-record-float-key/fixed.almd
+++ b/tests/diagnostics/e058-module-record-float-key/fixed.almd
@@ -1,0 +1,8 @@
+// Hashability resolves the sibling's record definition: a Float-carrying
+// module record as a Map key is E058.
+import self.geo as g
+
+fn main() -> Unit = {
+  let m: Map[String, g.Point] = map.new()
+  println(int.to_string(map.len(m)))
+}

--- a/tests/diagnostics/e058-module-record-float-key/meta.toml
+++ b/tests/diagnostics/e058-module-record-float-key/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E058"
+expects_error = "not hashable"
+hint_substring = "hashable"

--- a/tests/diagnostics/e058-module-record-float-key/src/geo.almd
+++ b/tests/diagnostics/e058-module-record-float-key/src/geo.almd
@@ -1,0 +1,1 @@
+type Point = { x: Float, y: Float }

--- a/tests/diagnostics/e060-duplicate-self-import/almide.toml
+++ b/tests/diagnostics/e060-duplicate-self-import/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e060-duplicate-self-import/broken.almd
+++ b/tests/diagnostics/e060-duplicate-self-import/broken.almd
@@ -1,0 +1,6 @@
+// Importing the same self module twice under two aliases is the duplicate
+// import E060 — one name is enough.
+import self.helper as h
+import self.helper as helper2
+
+fn main() -> Unit = println(int.to_string(h.open() + helper2.open()))

--- a/tests/diagnostics/e060-duplicate-self-import/fixed.almd
+++ b/tests/diagnostics/e060-duplicate-self-import/fixed.almd
@@ -1,0 +1,5 @@
+// Importing the same self module twice under two aliases is the duplicate
+// import E060 — one name is enough.
+import self.helper as h
+
+fn main() -> Unit = println(int.to_string(h.open() + h.open()))

--- a/tests/diagnostics/e060-duplicate-self-import/meta.toml
+++ b/tests/diagnostics/e060-duplicate-self-import/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E060"
+expects_error = "already imported"
+hint_substring = ""

--- a/tests/diagnostics/e060-duplicate-self-import/src/helper.almd
+++ b/tests/diagnostics/e060-duplicate-self-import/src/helper.almd
@@ -1,0 +1,1 @@
+pub fn open() -> Int = 1

--- a/tests/diagnostics/e080-module-ctor-or-binder/almide.toml
+++ b/tests/diagnostics/e080-module-ctor-or-binder/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e080-module-ctor-or-binder/broken.almd
+++ b/tests/diagnostics/e080-module-ctor-or-binder/broken.almd
@@ -1,0 +1,11 @@
+// Or-alternatives are binder-free even when the constructors come from a
+// sibling module: binding the payload inside `c.Circle(r) | c.Square(r)`
+// is E080.
+import self.shape as c
+
+fn size(s: c.Shape) -> Int = match s {
+  c.Circle(r) | c.Square(r) => r,
+  c.Dot => 0,
+}
+
+fn main() -> Unit = println(int.to_string(size(c.dot())))

--- a/tests/diagnostics/e080-module-ctor-or-binder/fixed.almd
+++ b/tests/diagnostics/e080-module-ctor-or-binder/fixed.almd
@@ -1,0 +1,12 @@
+// Or-alternatives are binder-free even when the constructors come from a
+// sibling module: binding the payload inside `c.Circle(r) | c.Square(r)`
+// is E080.
+import self.shape as c
+
+fn size(s: c.Shape) -> Int = match s {
+  c.Circle(r) => r,
+  c.Square(r) => r,
+  c.Dot => 0,
+}
+
+fn main() -> Unit = println(int.to_string(size(c.dot())))

--- a/tests/diagnostics/e080-module-ctor-or-binder/meta.toml
+++ b/tests/diagnostics/e080-module-ctor-or-binder/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E080"
+expects_error = "or-pattern alternative binds"
+hint_substring = "separate arms"

--- a/tests/diagnostics/e080-module-ctor-or-binder/src/shape.almd
+++ b/tests/diagnostics/e080-module-ctor-or-binder/src/shape.almd
@@ -1,0 +1,3 @@
+type Shape = | Dot | Circle(Int) | Square(Int)
+
+pub fn dot() -> Shape = Dot

--- a/tests/diagnostics/e420-local-fn-from-entry/almide.toml
+++ b/tests/diagnostics/e420-local-fn-from-entry/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e420-local-fn-from-entry/broken.almd
+++ b/tests/diagnostics/e420-local-fn-from-entry/broken.almd
@@ -1,0 +1,5 @@
+// A `local fn` is same-FILE only (#870): the entry file reaching a sibling's
+// local fn through `import self.helper` is E420 — the hint names the tier.
+import self.helper as h
+
+fn main() -> Unit = println(int.to_string(h.secret()))

--- a/tests/diagnostics/e420-local-fn-from-entry/fixed.almd
+++ b/tests/diagnostics/e420-local-fn-from-entry/fixed.almd
@@ -1,0 +1,5 @@
+// A `local fn` is same-FILE only (#870): the entry file reaching a sibling's
+// local fn through `import self.helper` is E420 — the hint names the tier.
+import self.helper as h
+
+fn main() -> Unit = println(int.to_string(h.open()))

--- a/tests/diagnostics/e420-local-fn-from-entry/meta.toml
+++ b/tests/diagnostics/e420-local-fn-from-entry/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E420"
+expects_error = "function 'helper.secret' is not accessible"
+hint_substring = "accessible only within the same file"

--- a/tests/diagnostics/e420-local-fn-from-entry/src/helper.almd
+++ b/tests/diagnostics/e420-local-fn-from-entry/src/helper.almd
@@ -1,0 +1,2 @@
+local fn secret() -> Int = 42
+pub fn open() -> Int = 1

--- a/tests/diagnostics/e420-local-fn-in-expression-position/almide.toml
+++ b/tests/diagnostics/e420-local-fn-in-expression-position/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e420-local-fn-in-expression-position/broken.almd
+++ b/tests/diagnostics/e420-local-fn-in-expression-position/broken.almd
@@ -1,0 +1,5 @@
+// The visibility check fires at the CALL, not the import: a local fn used
+// inside a larger expression (an argument, a pipe stage) is still E420.
+import self.math_bits as mb
+
+fn main() -> Unit = println(int.to_string(mb.twice(3) + 1))

--- a/tests/diagnostics/e420-local-fn-in-expression-position/fixed.almd
+++ b/tests/diagnostics/e420-local-fn-in-expression-position/fixed.almd
@@ -1,0 +1,5 @@
+// The visibility check fires at the CALL, not the import: a local fn used
+// inside a larger expression (an argument, a pipe stage) is still E420.
+import self.math_bits as mb
+
+fn main() -> Unit = println(int.to_string(mb.double(3) + 1))

--- a/tests/diagnostics/e420-local-fn-in-expression-position/meta.toml
+++ b/tests/diagnostics/e420-local-fn-in-expression-position/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E420"
+expects_error = "function 'math_bits.twice' is not accessible"
+hint_substring = "same file"

--- a/tests/diagnostics/e420-local-fn-in-expression-position/src/math_bits.almd
+++ b/tests/diagnostics/e420-local-fn-in-expression-position/src/math_bits.almd
@@ -1,0 +1,2 @@
+local fn twice(n: Int) -> Int = n * 2
+pub fn double(n: Int) -> Int = twice(n)

--- a/tests/diagnostics/e420-local-fn-unaliased-import/almide.toml
+++ b/tests/diagnostics/e420-local-fn-unaliased-import/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e420-local-fn-unaliased-import/broken.almd
+++ b/tests/diagnostics/e420-local-fn-unaliased-import/broken.almd
@@ -1,0 +1,5 @@
+// The same-file tier holds without an alias too: `import self.util` and a
+// qualified `util.scratch()` reach a local fn from another file.
+import self.util
+
+fn main() -> Unit = println(util.scratch())

--- a/tests/diagnostics/e420-local-fn-unaliased-import/fixed.almd
+++ b/tests/diagnostics/e420-local-fn-unaliased-import/fixed.almd
@@ -1,0 +1,5 @@
+// The same-file tier holds without an alias too: `import self.util` and a
+// qualified `util.scratch()` reach a local fn from another file.
+import self.util
+
+fn main() -> Unit = println(util.label())

--- a/tests/diagnostics/e420-local-fn-unaliased-import/meta.toml
+++ b/tests/diagnostics/e420-local-fn-unaliased-import/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E420"
+expects_error = "function 'util.scratch' is not accessible"
+hint_substring = "local fn"

--- a/tests/diagnostics/e420-local-fn-unaliased-import/src/util.almd
+++ b/tests/diagnostics/e420-local-fn-unaliased-import/src/util.almd
@@ -1,0 +1,2 @@
+local fn scratch() -> String = "internal"
+pub fn label() -> String = "public"


### PR DESCRIPTION
Fixes #1528. Fixes #1782.

## The multi-file fixture class

A fixture dir may now carry `almide.toml` + `src/*.almd` siblings; the harness's `almide check broken.almd` resolves `import self.x as h` against them (path-relative package resolution, verified harness-style from the repo root). That unlocks the two codes the corpus could never express — **E420** (cross-file `local fn` visibility) and **E033** (opaque construction outside the defining module) — each with three families, so both leave the EXEMPT list in `check-diagnostic-code-coverage.sh` and the FIXTURE_ALLOWLIST in `diagnostic_coverage_test.rs` (shrink direction). Fourteen more cross-module shapes join: E002/E004/E005 against a sibling's declaration, E006 effect-ness across the boundary, E041/E042 on a sibling's Result, E010 exhaustiveness over a sibling's variant, E058/E016/E030 type walks resolving sibling records, E080 or-binders with qualified ctors, E013/E029 on sibling record fields and types, the duplicate self-import E060. **1,000 fixture dirs exactly** (980 → 1,000); coverage gate 908 e-code dirs with the ≥3 bar held everywhere.

## The bug the sweep found (#1782)

`mod type Token = String` could not be constructed ANYWHERE — the module's own `Token(raw)` reported E033 "outside its defining module", so the E033 doc's own fix was impossible. Two halves: the per-module re-registration (`module_inference`, prefix = None) overwrote `opaque_alias_module`'s owner with "no module", and the check preferred `self_module_name` (the package identity) over the module actually being checked. Fixed by making the owner a captured-once identity (`prefix.or(alias_owner_module)`) and the current module `current_module_prefix.or(self_module_name)`. The reference compilers never re-derive this identity: Gleam registers an opaque type's constructors as private values of the defining module (`analyse.rs:1184`), MoonBit keys abstract types by package path. Pinned by the three `e033-opaque-ctor-*` families, whose fixed.almd builds the value through the module's public API.

## Gap recorded, not papered over

An unused `import self.x` is not flagged by E060 — filed as #1783; the fixture that could not be pinned was dropped rather than faked.

## Verification

`cargo test --release --test diagnostic_harness_test` 6/6 over all 1,000 dirs (fix-it apply gate included — two did-you-mean fixtures aligned to their applied form); `diagnostic_coverage_test` + `visibility_per_file_test` green (the E033 owner fix does not disturb the per-file visibility locks); `almide test` 427/427; `cargo test --workspace --release` green; clippy at the develop baseline (1423).

https://claude.ai/code/session_01Vq6t7fpBWLxGDL3NpHJei9