### PR TITLE
math, float and json examples run: 52 fences promoted to executable doctests

### DIFF
--- a/docs/stdlib/float.md
+++ b/docs/stdlib/float.md
@@ -6,136 +6,228 @@ Floating-point operations. auto-imported.
 
 Convert a float to its string representation.
 
-```almd
-float.to_string(3.14) // => \"3.14\
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(3.14))
+}
+```
+```output
+3.14
 ```
 
 ### `float.to_int(n: Float) -> Int`
 
 Truncate a float to an integer (rounds toward zero).
 
-```almd
-float.to_int(3.9) // => 3
+```almd run
+fn main() -> Unit = {
+  println("${float.to_int(3.9)}")
+}
+```
+```output
+3
 ```
 
 ### `float.round(n: Float) -> Float`
 
 Round a float to the nearest integer value (as Float).
 
-```almd
-float.round(3.6) // => 4.0
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(float.round(3.6)))
+}
+```
+```output
+4.0
 ```
 
 ### `float.floor(n: Float) -> Float`
 
 Round a float down to the nearest integer value (as Float).
 
-```almd
-float.floor(3.9) // => 3.0
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(float.floor(3.9)))
+}
+```
+```output
+3.0
 ```
 
 ### `float.ceil(n: Float) -> Float`
 
 Round a float up to the nearest integer value (as Float).
 
-```almd
-float.ceil(3.1) // => 4.0
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(float.ceil(3.1)))
+}
+```
+```output
+4.0
 ```
 
 ### `float.abs(n: Float) -> Float`
 
 Return the absolute value of a float.
 
-```almd
-float.abs(-2.5) // => 2.5
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(float.abs(-2.5)))
+}
+```
+```output
+2.5
 ```
 
 ### `float.sqrt(n: Float) -> Float`
 
 Return the square root of a float.
 
-```almd
-float.sqrt(9.0) // => 3.0
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(float.sqrt(9.0)))
+}
+```
+```output
+3.0
 ```
 
 ### `float.parse(s: String) -> Result[Float, String]`
 
 Parse a string into a float. Returns err if the string is not a valid number.
 
-```almd
-float.parse(\"3.14\") // => ok(3.14)
+```almd run
+fn show(r: Result[Float, String]) -> String = match r {
+  ok(x) => "ok(${float.to_string(x)})",
+  err(e) => "err(${e})",
+}
+
+fn main() -> Unit = {
+  println(show(float.parse("3.14")))
+  println(show(float.parse("abc")))
+}
+```
+```output
+ok(3.14)
+err(invalid float literal)
 ```
 
 ### `float.from_int(n: Int) -> Float`
 
 Convert an integer to a float.
 
-```almd
-float.from_int(42) // => 42.0
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(float.from_int(42)))
+}
+```
+```output
+42.0
 ```
 
 ### `float.min(a: Float, b: Float) -> Float`
 
 Return the smaller of two floats.
 
-```almd
-float.min(1.5, 2.5) // => 1.5
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(float.min(1.5, 2.5)))
+}
+```
+```output
+1.5
 ```
 
 ### `float.max(a: Float, b: Float) -> Float`
 
 Return the larger of two floats.
 
-```almd
-float.max(1.5, 2.5) // => 2.5
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(float.max(1.5, 2.5)))
+}
+```
+```output
+2.5
 ```
 
 ### `float.to_fixed(n: Float, decimals: Int) -> String`
 
 Format a float with a fixed number of decimal places.
 
-```almd
-float.to_fixed(3.14159, 2) // => \"3.14\
+```almd run
+fn main() -> Unit = {
+  println(float.to_fixed(3.14159, 2))
+}
+```
+```output
+3.14
 ```
 
 ### `float.clamp(n: Float, lo: Float, hi: Float) -> Float`
 
 Clamp a float to the range [lo, hi].
 
-```almd
-float.clamp(15.0, 0.0, 10.0) // => 10.0
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(float.clamp(15.0, 0.0, 10.0)))
+}
+```
+```output
+10.0
 ```
 
 ### `float.sign(n: Float) -> Float`
 
 Return the sign of a float: -1.0, 0.0, or 1.0.
 
-```almd
-float.sign(-3.5) // => -1.0
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(float.sign(-3.5)))
+}
+```
+```output
+-1.0
 ```
 
 ### `float.is_nan(n: Float) -> Bool`
 
 Check if a float is NaN (not a number).
 
-```almd
-float.is_nan(0.0 / 0.0) // => true
+```almd run
+fn main() -> Unit = {
+  println("${float.is_nan(0.0 / 0.0)}")
+}
+```
+```output
+true
 ```
 
 ### `float.is_infinite(n: Float) -> Bool`
 
 Check if a float is positive or negative infinity.
 
-```almd
-float.is_infinite(1.0 / 0.0) // => true
+```almd run
+fn main() -> Unit = {
+  println("${float.is_infinite(1.0 / 0.0)}")
+}
+```
+```output
+true
 ```
 
 ### `float.to_bits(f: Float) -> Int`
 
 Reinterpret a float as its IEEE 754 bit representation (i64).
 
-```almd
-float.to_bits(1.0) // => 4607182418800017408
+```almd run
+fn main() -> Unit = {
+  println("${float.to_bits(1.0)}")
+}
+```
+```output
+4607182418800017408
 ```
 
 <!-- BEGIN GENERATED SIGNATURE INDEX (make stdlib-docs) — do not edit by hand -->

--- a/docs/stdlib/json.md
+++ b/docs/stdlib/json.md
@@ -16,120 +16,326 @@ in user annotations whenever `json` is imported — bare or `json.JsonPath`.
 
 Parse a JSON string into a Value.
 
-```almd
-let v = json.parse("{\"name\": \"Alice\"}")
+```almd run
+import json
+
+fn main() -> Unit = {
+  let v = json.parse("{\"name\": \"Alice\"}")
+  match v {
+    ok(j) => println(json.stringify(j)),
+    err(e) => println("parse error: ${e}"),
+  }
+}
+```
+```output
+{"name":"Alice"}
 ```
 
 ### `json.stringify(v: Value) -> String`
 
 Convert a Value to a JSON string.
 
-```almd
-json.stringify(person.encode())
+```almd run
+import json
+
+type Person: Codec = { name: String, age: Int }
+
+fn main() -> Unit = {
+  let person = Person { name: "Alice", age: 30 }
+  println(json.stringify(person.encode()))
+}
+```
+```output
+{"name":"Alice","age":30}
 ```
 
 ### `json.stringify_pretty(j: Value) -> String`
 
 Convert a Json value to a pretty-printed JSON string with indentation.
 
-```almd
-json.stringify_pretty(j)
+```almd run
+import json
+
+fn main() -> Unit = {
+  let j = json.parse("{\"name\": \"Alice\", \"tags\": [\"a\", \"b\"]}") ?? value.null()
+  println(json.stringify_pretty(j))
+}
+```
+```output
+{
+  "name": "Alice",
+  "tags": [
+    "a",
+    "b"
+  ]
+}
 ```
 
 ### `json.get_string(j: Value, key: String) -> Option[String]`
 
 Get a string value by key. Returns none if key doesn't exist or value is not a string.
 
-```almd
-json.get_string(j, "name")
+```almd run
+import json
+
+fn main() -> Unit = {
+  let j = json.parse("{\"name\": \"Alice\", \"age\": 30, \"price\": 9.5, \"active\": true, \"items\": [1, 2, 3]}") ?? value.null()
+  match json.get_string(j, "name") {
+    some(x) => println("some(${x})"),
+    none => println("none"),
+  }
+  match json.get_string(j, "age") {
+    some(x) => println("some(${x})"),
+    none => println("none"),
+  }
+}
+```
+```output
+some(Alice)
+none
 ```
 
 ### `json.get_int(j: Value, key: String) -> Option[Int]`
 
 Get an integer value by key. Returns none if key doesn't exist or value is not an integer.
 
-```almd
-json.get_int(j, "age")
+```almd run
+import json
+
+fn main() -> Unit = {
+  let j = json.parse("{\"name\": \"Alice\", \"age\": 30, \"price\": 9.5, \"active\": true, \"items\": [1, 2, 3]}") ?? value.null()
+  match json.get_int(j, "age") {
+    some(x) => println("some(${x})"),
+    none => println("none"),
+  }
+  match json.get_int(j, "name") {
+    some(x) => println("some(${x})"),
+    none => println("none"),
+  }
+}
+```
+```output
+some(30)
+none
 ```
 
 ### `json.get_float(j: Value, key: String) -> Option[Float]`
 
 Get a float value by key. Returns none if key doesn't exist or value is not a number.
 
-```almd
-json.get_float(j, "price")
+```almd run
+import json
+
+fn main() -> Unit = {
+  let j = json.parse("{\"name\": \"Alice\", \"age\": 30, \"price\": 9.5, \"active\": true, \"items\": [1, 2, 3]}") ?? value.null()
+  match json.get_float(j, "price") {
+    some(x) => println("some(${float.to_string(x)})"),
+    none => println("none"),
+  }
+  match json.get_float(j, "name") {
+    some(x) => println("some(${float.to_string(x)})"),
+    none => println("none"),
+  }
+}
+```
+```output
+some(9.5)
+none
 ```
 
 ### `json.get_bool(j: Value, key: String) -> Option[Bool]`
 
 Get a boolean value by key. Returns none if key doesn't exist or value is not a boolean.
 
-```almd
-json.get_bool(j, "active")
+```almd run
+import json
+
+fn main() -> Unit = {
+  let j = json.parse("{\"name\": \"Alice\", \"age\": 30, \"price\": 9.5, \"active\": true, \"items\": [1, 2, 3]}") ?? value.null()
+  match json.get_bool(j, "active") {
+    some(x) => println("some(${x})"),
+    none => println("none"),
+  }
+  match json.get_bool(j, "missing") {
+    some(x) => println("some(${x})"),
+    none => println("none"),
+  }
+}
+```
+```output
+some(true)
+none
 ```
 
 ### `json.get_array(j: Value, key: String) -> Option[List[Value]]`
 
 Get an array value by key. Returns none if key doesn't exist or value is not an array.
 
-```almd
-json.get_array(j, "items")
+```almd run
+import json
+
+fn main() -> Unit = {
+  let j = json.parse("{\"name\": \"Alice\", \"age\": 30, \"price\": 9.5, \"active\": true, \"items\": [1, 2, 3]}") ?? value.null()
+  match json.get_array(j, "items") {
+    some(xs) => println(xs |> list.map((x) => json.stringify(x)) |> list.join(",")),
+    none => println("none"),
+  }
+  match json.get_array(j, "name") {
+    some(xs) => println(xs |> list.map((x) => json.stringify(x)) |> list.join(",")),
+    none => println("none"),
+  }
+}
+```
+```output
+1,2,3
+none
 ```
 
 ### `json.root() -> JsonPath`
 
 Create a root JSON path for traversal.
 
-```almd
-json.root()
+```almd run
+import json
+
+fn show(o: Option[Value]) -> String = match o {
+  some(v) => json.stringify(v),
+  none => "none",
+}
+
+fn main() -> Unit = {
+  let j = json.parse("{\"user\": {\"name\": \"Alice\"}}") ?? value.null()
+  let path = json.root()
+  println(show(json.get_path(j, path)))
+}
+```
+```output
+{"user":{"name":"Alice"}}
 ```
 
 ### `json.field(path: JsonPath, name: String) -> JsonPath`
 
 Extend a JSON path with a field name.
 
-```almd
-json.field(json.root(), "user")
+```almd run
+import json
+
+fn show(o: Option[Value]) -> String = match o {
+  some(v) => json.stringify(v),
+  none => "none",
+}
+
+fn main() -> Unit = {
+  let j = json.parse("{\"user\": {\"name\": \"Alice\"}}") ?? value.null()
+  let path = json.field(json.root(), "user")
+  println(show(json.get_path(j, path)))
+}
+```
+```output
+{"name":"Alice"}
 ```
 
 ### `json.index(path: JsonPath, i: Int) -> JsonPath`
 
 Extend a JSON path with an array index.
 
-```almd
-json.index(json.field(json.root(), "items"), 0)
+```almd run
+import json
+
+fn show(o: Option[Value]) -> String = match o {
+  some(v) => json.stringify(v),
+  none => "none",
+}
+
+fn main() -> Unit = {
+  let j = json.parse("{\"items\": [10, 20, 30]}") ?? value.null()
+  let path = json.index(json.field(json.root(), "items"), 0)
+  println(show(json.get_path(j, path)))
+}
+```
+```output
+10
 ```
 
 ### `json.get_path(j: Value, path: JsonPath) -> Option[Value]`
 
 Get a value at a JSON path. Returns none if path doesn't exist.
 
-```almd
-json.get_path(j, json.field(json.root(), "name"))
+```almd run
+import json
+
+fn show(o: Option[Value]) -> String = match o {
+  some(v) => json.stringify(v),
+  none => "none",
+}
+
+fn main() -> Unit = {
+  let j = json.parse("{\"name\": \"Alice\"}") ?? value.null()
+  println(show(json.get_path(j, json.field(json.root(), "name"))))
+  println(show(json.get_path(j, json.field(json.root(), "missing"))))
+}
+```
+```output
+"Alice"
+none
 ```
 
 ### `json.set_path(j: Value, path: JsonPath, value: Value) -> Result[Value, String]`
 
 Set a value at a JSON path. Returns error if path is invalid.
 
-```almd
-json.set_path(j, json.field(json.root(), "name"), json.s("Bob"))
+```almd run
+import json
+
+fn main() -> Unit = {
+  let j = json.parse("{\"name\": \"Alice\"}") ?? value.null()
+  match json.set_path(j, json.field(json.root(), "name"), value.str("Bob")) {
+    ok(v) => println(json.stringify(v)),
+    err(e) => println("error: ${e}"),
+  }
+}
+```
+```output
+{"name":"Bob"}
 ```
 
 ### `json.remove_path(j: Value, path: JsonPath) -> Value`
 
 Remove a value at a JSON path. Returns the Json with the value removed.
 
-```almd
-json.remove_path(j, json.field(json.root(), "temp"))
+```almd run
+import json
+
+fn main() -> Unit = {
+  let j = json.parse("{\"name\": \"Alice\", \"temp\": 1}") ?? value.null()
+  println(json.stringify(json.remove_path(j, json.field(json.root(), "temp"))))
+}
+```
+```output
+{"name":"Alice"}
 ```
 
 ### `json.to_map(j: Value) -> Option[Map[String, String]]`
 
 Convert a JSON object to a Map[String, String]. Values are stringified. Returns none if not an object.
 
-```almd
-let m = json.to_map(obj) ?? map.new()
+```almd run
+import json
+
+fn main() -> Unit = {
+  let obj = json.parse("{\"name\": \"Alice\", \"age\": 30, \"tags\": [1, 2]}") ?? value.null()
+  let m = json.to_map(obj) ?? map.new()
+  println("${map.len(m)}")
+  println(map.get_or(m, "name", "?"))
+  println(map.get_or(m, "age", "?"))
+  println(map.get_or(m, "tags", "?"))
+}
+```
+```output
+3
+Alice
+30
+[1,2]
 ```
 
 <!-- BEGIN GENERATED SIGNATURE INDEX (make stdlib-docs) — do not edit by hand -->

--- a/docs/stdlib/math.md
+++ b/docs/stdlib/math.md
@@ -6,80 +6,130 @@ Mathematical functions. import math.
 
 Return the smaller of two integers.
 
-```almd
-math.min(3, 7) // => 3
+```almd run
+fn main() -> Unit = {
+  println("${math.min(3, 7)}")
+}
+```
+```output
+3
 ```
 
 ### `math.max(a: Int, b: Int) -> Int`
 
 Return the larger of two integers.
 
-```almd
-math.max(3, 7) // => 7
+```almd run
+fn main() -> Unit = {
+  println("${math.max(3, 7)}")
+}
+```
+```output
+7
 ```
 
 ### `math.abs(n: Int) -> Int`
 
 Return the absolute value of an integer.
 
-```almd
-math.abs(-5) // => 5
+```almd run
+fn main() -> Unit = {
+  println("${math.abs(-5)}")
+}
+```
+```output
+5
 ```
 
 ### `math.pow(base: Int, exp: Int) -> Int`
 
 Raise an integer base to an integer exponent.
 
-```almd
-math.pow(2, 10) // => 1024
+```almd run
+fn main() -> Unit = {
+  println("${math.pow(2, 10)}")
+}
+```
+```output
+1024
 ```
 
 ### `math.pi() -> Float`
 
 Return the mathematical constant pi (3.14159...).
 
-```almd
-math.pi() // => 3.141592653589793
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(math.pi()))
+}
+```
+```output
+3.141592653589793
 ```
 
 ### `math.e() -> Float`
 
 Return Euler's number e (2.71828...).
 
-```almd
-math.e() // => 2.718281828459045
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(math.e()))
+}
+```
+```output
+2.718281828459045
 ```
 
 ### `math.sin(x: Float) -> Float`
 
 Return the sine of an angle in radians.
 
-```almd
-math.sin(0.0) // => 0.0
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(math.sin(0.0)))
+}
+```
+```output
+0.0
 ```
 
 ### `math.cos(x: Float) -> Float`
 
 Return the cosine of an angle in radians.
 
-```almd
-math.cos(0.0) // => 1.0
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(math.cos(0.0)))
+}
+```
+```output
+1.0
 ```
 
 ### `math.tan(x: Float) -> Float`
 
 Return the tangent of an angle in radians.
 
-```almd
-math.tan(0.0) // => 0.0
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(math.tan(0.0)))
+}
+```
+```output
+0.0
 ```
 
 ### `math.log(x: Float) -> Float`
 
 Return the natural logarithm (base e) of a float.
 
-```almd
-math.log(1.0) // => 0.0
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(math.log(1.0)))
+}
+```
+```output
+0.0
 ```
 
 ### `math.exp(x: Float) -> Float`
@@ -94,80 +144,130 @@ math.exp(1.0) // => 2.718281828459045
 
 Return the square root of a float.
 
-```almd
-math.sqrt(16.0) // => 4.0
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(math.sqrt(16.0)))
+}
+```
+```output
+4.0
 ```
 
 ### `math.log10(x: Float) -> Float`
 
 Return the base-10 logarithm of a float.
 
-```almd
-math.log10(100.0) // => 2.0
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(math.log10(100.0)))
+}
+```
+```output
+2.0
 ```
 
 ### `math.log2(x: Float) -> Float`
 
 Return the base-2 logarithm of a float.
 
-```almd
-math.log2(8.0) // => 3.0
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(math.log2(8.0)))
+}
+```
+```output
+3.0
 ```
 
 ### `math.sign(n: Int) -> Int`
 
 Return the sign of an integer: -1, 0, or 1.
 
-```almd
-math.sign(-42) // => -1
+```almd run
+fn main() -> Unit = {
+  println("${math.sign(-42)}")
+}
+```
+```output
+-1
 ```
 
 ### `math.fmin(a: Float, b: Float) -> Float`
 
 Return the smaller of two floats.
 
-```almd
-math.fmin(1.5, 2.5) // => 1.5
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(math.fmin(1.5, 2.5)))
+}
+```
+```output
+1.5
 ```
 
 ### `math.fmax(a: Float, b: Float) -> Float`
 
 Return the larger of two floats.
 
-```almd
-math.fmax(1.5, 2.5) // => 2.5
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(math.fmax(1.5, 2.5)))
+}
+```
+```output
+2.5
 ```
 
 ### `math.fpow(base: Float, exp: Float) -> Float`
 
 Raise a float base to a float exponent.
 
-```almd
-math.fpow(2.0, 0.5) // => 1.4142135623730951
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(math.fpow(2.0, 0.5)))
+}
+```
+```output
+1.4142135623730951
 ```
 
 ### `math.factorial(n: Int) -> Int`
 
 Return the factorial of a non-negative integer.
 
-```almd
-math.factorial(5) // => 120
+```almd run
+fn main() -> Unit = {
+  println("${math.factorial(5)}")
+}
+```
+```output
+120
 ```
 
 ### `math.choose(n: Int, k: Int) -> Int`
 
 Return the binomial coefficient C(n, k) = n! / (k! * (n-k)!).
 
-```almd
-math.choose(5, 2) // => 10
+```almd run
+fn main() -> Unit = {
+  println("${math.choose(5, 2)}")
+}
+```
+```output
+10
 ```
 
 ### `math.log_gamma(x: Float) -> Float`
 
 Return the natural logarithm of the gamma function at x.
 
-```almd
-math.log_gamma(5.0) // => 3.178...
+```almd run
+fn main() -> Unit = {
+  println(float.to_fixed(math.log_gamma(5.0), 3))
+}
+```
+```output
+3.178
 ```
 
 <!-- BEGIN GENERATED SIGNATURE INDEX (make stdlib-docs) — do not edit by hand -->


### PR DESCRIPTION
Promotes the plain ```almd example fences in three stdlib docs to ```almd run + ```output doctests, checked by `scripts/check-doc-fences.sh` (54 run fences verified, up from 2). Native and wasm printed identical values for every example probed.

**math.md — 20 of 21 promoted.** Int results print via interpolation, Float results via `float.to_string` (so `4.0` stays `4.0`). `math.log_gamma(5.0)` is pinned through `float.to_fixed(_, 3)` = `3.178`, matching the documented `3.178...` precision rather than the approximation's trailing digits. **Left plain: `math.exp(1.0)`** — documented `2.718281828459045`, compiler prints `2.7182818284590455` on both targets (doc/impl drift, not papered over; `math.e()` does print `2.718281828459045`).

**float.md — 17 of 17 promoted.** The three fences with garbled `\"3.14\` escape artifacts (`to_string`, `parse`, `to_fixed`) are now real programs; `float.parse` also shows the documented err branch (`err(invalid float literal)`).

**json.md — 15 of 15 promoted.** `json.root` / `json.field` / `json.index` are demonstrated through `json.get_path` since a `JsonPath` is opaque. The `json.set_path` example called `json.s("Bob")`, which does not exist (retired in #1078); the doctest uses `value.str("Bob")`. Observation for a follow-up: `json.set_path` never returned `err` in probes (missing key, out-of-range index, field on a string root all return `ok`), while the prose says "Returns error if path is invalid".

Refs #1490.

https://claude.ai/code/session_01QPHbSjT155tPW3gQVT1Sbb