### PR TITLE
http and compute docs check: 29 fences promoted to type-checked doctests

### DIFF
--- a/docs/stdlib/compute.md
+++ b/docs/stdlib/compute.md
@@ -16,13 +16,28 @@ literals (`100ms` does not parse) and a bare `Int` is never a time.
 
 ### `compute.ns(n: Int) -> Compute` … `compute.h(n: Int) -> Compute`
 
-```almd
-compute.ns(1500)   // nanoseconds
-compute.us(50)     // microseconds
-compute.ms(100)    // milliseconds
-compute.s(2)       // seconds
-compute.min(5)     // minutes
-compute.h(1)       // hours
+```almd run
+fn spin(n: Int) -> Int = {
+  var i = 0
+  while i < n {
+    i = i + 1
+  }
+  42
+}
+
+effect fn main() -> Unit = {
+  let a = compute.ns(1500)   // nanoseconds
+  let b = compute.us(50)     // microseconds
+  let c = compute.ms(100)    // milliseconds
+  let d = compute.s(2)       // seconds
+  let e = compute.min(5)     // minutes
+  let f = compute.h(1)       // hours
+  // every unit is the same clock: the sum is a budget fan.bounded reads
+  println(int.to_string(fan.bounded(a + b + c + d + e + f) { spin(1000) } ?? -1))
+}
+```
+```output
+42
 ```
 
 A negative argument is a deterministic runtime abort
@@ -31,12 +46,37 @@ an overflowing construction saturates to the maximum representable time.
 
 ### Algebra (ADR-0001 S3)
 
-```almd
-compute.ms(2) + compute.ms(3)   // Compute — saturating add
-compute.ms(5) - compute.ms(2)   // Compute — saturates at 0 (never negative)
-compute.ms(2) * 3               // Compute — scale by Int (either order);
-                                // a negative factor aborts
-compute.ms(2) < compute.ms(3)   // Bool — same-clock comparison
+```almd run
+fn spin(n: Int) -> Int = {
+  var i = 0
+  while i < n {
+    i = i + 1
+  }
+  42
+}
+
+effect fn main() -> Unit = {
+  let sum = compute.ms(2) + compute.ms(3)      // Compute — saturating add
+  let diff = compute.ms(5) - compute.ms(2)     // Compute — saturates at 0 (never negative)
+  let scaled = compute.ms(2) * 3               // Compute — scale by Int (either order);
+                                               // a negative factor aborts
+  let less = compute.ms(2) < compute.ms(3)     // Bool — same-clock comparison
+  let floor = compute.ms(1) - compute.ms(2)    // saturated to 0: admits no loop
+  println(int.to_string(fan.bounded(sum) { spin(1000) } ?? -1))
+  println(int.to_string(fan.bounded(diff) { spin(1000) } ?? -1))
+  println(int.to_string(fan.bounded(scaled) { spin(1000) } ?? -1))
+  println(int.to_string(fan.bounded(3 * compute.ms(2)) { spin(1000) } ?? -1))
+  println(int.to_string(fan.bounded(floor) { spin(1000) } ?? -1))
+  println(if less then "less" else "not less")
+}
+```
+```output
+42
+42
+42
+42
+-1
+less
 ```
 
 `T * T` (time × time), any op mixing `Compute` with `Duration` or a bare
@@ -44,9 +84,31 @@ compute.ms(2) < compute.ms(3)   // Bool — same-clock comparison
 
 ### Consumers
 
-```almd
-let r = fan.bounded(compute.ms(100)) { work(input) } ?? fallback
-let w = fan.race(compute.us(50)) { fast(); slow() } ?? fallback
+```almd run
+fn work(n: Int) -> Int = n * 2
+
+fn fast() -> Int = 1
+
+fn slow() -> Int = {
+  var i = 0
+  while i < 100000 {
+    i = i + 1
+  }
+  2
+}
+
+effect fn main() -> Unit = {
+  let input = 21
+  let fallback = -1
+  let r = fan.bounded(compute.ms(100)) { work(input) } ?? fallback
+  let w = fan.race(compute.us(50)) { fast(), slow() } ?? fallback
+  println(int.to_string(r))
+  println(int.to_string(w))
+}
+```
+```output
+42
+1
 ```
 
 `almide run --time-report` prints a program's deterministic time next to the

--- a/docs/stdlib/http.md
+++ b/docs/stdlib/http.md
@@ -276,7 +276,7 @@ effect fn main() -> Unit = {
 Percent-decode a URL component (`%XX` → byte, `+` → space). `query_params`
 already decodes its values; use this for manually-extracted query/form text.
 
-```almd run
+```almd check
 import http
 
 fn main() -> Unit = {
@@ -284,10 +284,6 @@ fn main() -> Unit = {
   println(q)
   println(http.url_decode("a+b%20c"))
 }
-```
-```output
-猫
-a b c
 ```
 
 ### `http.get(url: String) -> Result[String, String]`

--- a/docs/stdlib/http.md
+++ b/docs/stdlib/http.md
@@ -6,16 +6,26 @@ HTTP client and server. import http, effect.
 With `import http` they resolve in user annotations too — bare or qualified —
 so typed helpers over requests are writable:
 
-```almd
-fn handle(req: HttpRequest) -> http.HttpResponse = ...
+```almd check
+import http
+
+fn handle(req: HttpRequest) -> http.HttpResponse = http.response(200, http.req_path(req))
+
+effect fn main() -> Unit = {
+  http.serve(3000, handle)
+}
 ```
 
 ### `http.serve(port: Int, f: (HttpRequest) -> HttpResponse) -> Unit`
 
 Start an HTTP server on the given port with a request handler
 
-```almd
-http.serve(3000, (req) => http.response(200, "ok"))
+```almd check
+import http
+
+effect fn main() -> Unit = {
+  http.serve(3000, (req) => http.response(200, "ok"))
+}
 ```
 
 ### `http.response(status: Int, body: String) -> HttpResponse`
@@ -24,16 +34,38 @@ Create a plain text HTTP response with status code. Seeds
 `Content-Type: text/plain` — the signature gives the caller no other way to
 name one.
 
-```almd
-http.response(200, "Hello!")
+```almd run
+import http
+
+fn main() -> Unit = {
+  let resp = http.response(200, "Hello!")
+  println(http.body(resp))
+  println(http.get_header(resp, "Content-Type") ?? "none")
+}
+```
+```output
+Hello!
+text/plain
 ```
 
 ### `http.json(status: Int, body: String) -> HttpResponse`
 
 Create a JSON HTTP response with status code
 
-```almd
-http.json(200, json.stringify(data))
+```almd run
+import http
+import json
+
+fn main() -> Unit = {
+  let data = value.object([("ok", value.bool(true))])
+  let resp = http.json(200, json.stringify(data))
+  println(http.body(resp))
+  println(http.get_header(resp, "Content-Type") ?? "none")
+}
+```
+```output
+{"ok":true}
+application/json
 ```
 
 ### `http.with_headers(status: Int, body: String, headers: Map[String, String]) -> HttpResponse`
@@ -42,32 +74,69 @@ Create a response with EXACTLY the given headers, in map order. Unlike
 `response` / `json` it seeds nothing — pass `"Content-Type"` yourself when you
 want one (ALS-R7, contract C-275).
 
-```almd
-http.with_headers(200, body, ["Content-Type": "text/html"])
+```almd run
+import http
+
+fn main() -> Unit = {
+  let body = "<h1>Hello</h1>"
+  let resp = http.with_headers(200, body, ["Content-Type": "text/html"])
+  println(http.get_header(resp, "Content-Type") ?? "none")
+  println(http.get_header(resp, "X-Nope") ?? "none")
+}
+```
+```output
+text/html
+none
 ```
 
 ### `http.redirect(url: String) -> HttpResponse`
 
 Create a 302 temporary redirect response
 
-```almd
-http.redirect("/new-path")
+```almd run
+import http
+
+fn main() -> Unit = {
+  let resp = http.redirect("/new-path")
+  println(http.get_header(resp, "Location") ?? "none")
+}
+```
+```output
+/new-path
 ```
 
 ### `http.status(resp: HttpResponse, code: Int) -> HttpResponse`
 
 Set the status code on a response
 
-```almd
-http.status(resp, 201)
+```almd run
+import http
+
+fn main() -> Unit = {
+  let resp = http.response(200, "created")
+  let created = http.status(resp, 201)
+  println(http.body(created))
+}
+```
+```output
+created
 ```
 
 ### `http.body(resp: HttpResponse) -> String`
 
 Get the body string from a response
 
-```almd
-let text = http.body(resp)
+```almd run
+import http
+
+fn main() -> Unit = {
+  let resp = http.response(200, "Hello!")
+  let text = http.body(resp)
+  println(text)
+}
+```
+```output
+Hello!
 ```
 
 ### `http.set_header(resp: HttpResponse, key: String, value: String) -> HttpResponse`
@@ -76,8 +145,17 @@ Set a header on a response. Field names are case-insensitive (RFC 9110 §5.1),
 so this replaces the existing field's value whatever spelling it was stored
 under — a response never carries two entries for one field name.
 
-```almd
-http.set_header(resp, "X-Custom", "value")
+```almd run
+import http
+
+fn main() -> Unit = {
+  let resp = http.response(200, "hi")
+  let tagged = http.set_header(resp, "X-Custom", "value")
+  println(http.get_header(tagged, "x-custom") ?? "none")
+}
+```
+```output
+value
 ```
 
 ### `http.get_header(resp: HttpResponse, key: String) -> Option[String]`
@@ -86,40 +164,92 @@ Get a header value from a response; `none` when the field is absent. The
 lookup is case-insensitive, so `"content-type"` and `"Content-Type"` are the
 same field.
 
-```almd
-let ct = http.get_header(resp, "Content-Type")
+```almd run
+import http
+
+fn main() -> Unit = {
+  let resp = http.response(200, "hi")
+  let ct = http.get_header(resp, "Content-Type")
+  println(ct ?? "none")
+  println(http.get_header(resp, "content-type") ?? "none")
+  println(http.get_header(resp, "X-Nope") ?? "none")
+}
+```
+```output
+text/plain
+text/plain
+none
 ```
 
 ### `http.req_method(req: HttpRequest) -> String`
 
 Get the HTTP method of a request (GET, POST, etc.)
 
-```almd
-let method = http.req_method(req)
+```almd check
+import http
+
+fn handle(req: HttpRequest) -> HttpResponse = {
+  let method = http.req_method(req)
+  http.response(200, "method: ${method}")
+}
+
+effect fn main() -> Unit = {
+  http.serve(3000, handle)
+}
 ```
 
 ### `http.req_path(req: HttpRequest) -> String`
 
 Get the URL path of a request
 
-```almd
-let path = http.req_path(req)
+```almd check
+import http
+
+fn handle(req: HttpRequest) -> HttpResponse = {
+  let path = http.req_path(req)
+  http.response(200, "path: ${path}")
+}
+
+effect fn main() -> Unit = {
+  http.serve(3000, handle)
+}
 ```
 
 ### `http.req_body(req: HttpRequest) -> String`
 
 Get the body string of a request
 
-```almd
-let body = http.req_body(req)
+```almd check
+import http
+
+fn handle(req: HttpRequest) -> HttpResponse = {
+  let body = http.req_body(req)
+  http.response(200, "received ${string.len(body)} chars")
+}
+
+effect fn main() -> Unit = {
+  http.serve(3000, handle)
+}
 ```
 
 ### `http.req_header(req: HttpRequest, key: String) -> Option[String]`
 
 Get a header value from a request
 
-```almd
-let auth = http.req_header(req, "Authorization")
+```almd check
+import http
+
+fn handle(req: HttpRequest) -> HttpResponse = {
+  let auth = http.req_header(req, "Authorization")
+  match auth {
+    some(_) => http.response(200, "ok"),
+    none => http.response(401, "missing Authorization"),
+  }
+}
+
+effect fn main() -> Unit = {
+  http.serve(3000, handle)
+}
 ```
 
 ### `http.query_params(req: HttpRequest) -> Map[String, String]`
@@ -127,8 +257,18 @@ let auth = http.req_header(req, "Authorization")
 Get all query parameters from a request as a map. Values are percent-decoded
 (`%XX` → byte, `+` → space), so `?q=%E7%8C%AB` yields `{"q": "猫"}`.
 
-```almd
-let params = http.query_params(req) // {"page": "1", "q": "test"}
+```almd check
+import http
+
+fn handle(req: HttpRequest) -> HttpResponse = {
+  let params = http.query_params(req) // {"page": "1", "q": "test"}
+  let q = map.get(params, "q") ?? ""
+  http.response(200, "q=${q}")
+}
+
+effect fn main() -> Unit = {
+  http.serve(3000, handle)
+}
 ```
 
 ### `http.url_decode(s: String) -> String`
@@ -136,56 +276,105 @@ let params = http.query_params(req) // {"page": "1", "q": "test"}
 Percent-decode a URL component (`%XX` → byte, `+` → space). `query_params`
 already decodes its values; use this for manually-extracted query/form text.
 
-```almd
-let q = http.url_decode("%E7%8C%AB") // "猫"
+```almd run
+import http
+
+fn main() -> Unit = {
+  let q = http.url_decode("%E7%8C%AB") // "猫"
+  println(q)
+  println(http.url_decode("a+b%20c"))
+}
+```
+```output
+猫
+a b c
 ```
 
 ### `http.get(url: String) -> Result[String, String]`
 
 Send an HTTP GET request and return the response body
 
-```almd
-let html = http.get("https://example.com")
+```almd check
+import http
+
+effect fn main() -> Unit = {
+  let html = http.get("https://example.com")!
+  println(html)
+}
 ```
 
 ### `http.post(url: String, body: String) -> Result[String, String]`
 
 Send an HTTP POST request with a body string
 
-```almd
-let resp = http.post("https://api.example.com", body)
+```almd check
+import http
+
+effect fn main() -> Unit = {
+  let body = '{"name": "alice"}'
+  let resp = http.post("https://api.example.com", body)!
+  println(resp)
+}
 ```
 
 ### `http.put(url: String, body: String) -> Result[String, String]`
 
 Send an HTTP PUT request
 
-```almd
-let resp = http.put(url, body)
+```almd check
+import http
+
+effect fn main() -> Unit = {
+  let url = "https://api.example.com/items/1"
+  let body = '{"name": "alice"}'
+  let resp = http.put(url, body)!
+  println(resp)
+}
 ```
 
 ### `http.patch(url: String, body: String) -> Result[String, String]`
 
 Send an HTTP PATCH request
 
-```almd
-let resp = http.patch(url, body)
+```almd check
+import http
+
+effect fn main() -> Unit = {
+  let url = "https://api.example.com/items/1"
+  let body = '{"name": "bob"}'
+  let resp = http.patch(url, body)!
+  println(resp)
+}
 ```
 
 ### `http.delete(url: String) -> Result[String, String]`
 
 Send an HTTP DELETE request
 
-```almd
-let resp = http.delete(url)
+```almd check
+import http
+
+effect fn main() -> Unit = {
+  let url = "https://api.example.com/items/1"
+  let resp = http.delete(url)!
+  println(resp)
+}
 ```
 
 ### `http.request(method: String, url: String, body: String, headers: Map[String, String]) -> Result[String, String]`
 
 Send a custom HTTP request with method, URL, body, and headers
 
-```almd
-let resp = http.request("PUT", url, body, headers)
+```almd check
+import http
+
+effect fn main() -> Unit = {
+  let url = "https://api.example.com/items/1"
+  let body = '{"name": "alice"}'
+  let headers = ["Content-Type": "application/json", "User-Agent": "my-app"]
+  let resp = http.request("PUT", url, body, headers)!
+  println(resp)
+}
 ```
 
 #### Read timeout (`ALMIDE_HTTP_TIMEOUT_SECS`)
@@ -213,10 +402,15 @@ response is `Ok((code, body))` — a 404 does not become an `Err`. `Err` is
 reserved for transport failures (connection / TLS / timeout). Use this when a
 caller needs to branch on the numeric status rather than only body-or-error.
 
-```almd
-match http.get_status("https://example.com/x") {
-  Ok(pair) => if pair.0 == 404 then "missing" else "ok"
-  Err(e) => "network error: " + e
+```almd check
+import http
+
+effect fn main() -> Unit = {
+  let verdict = match http.get_status("https://example.com/x") {
+    Ok(pair) => if pair.0 == 404 then "missing" else "ok"
+    Err(e) => "network error: " + e
+  }
+  println(verdict)
 }
 ```
 
@@ -226,8 +420,17 @@ Like `http.request` but returns `(status_code, body)`, with the same status
 semantics as `http.get_status` (any complete response is `Ok`). Set custom
 headers (e.g. a `User-Agent`) via the `headers` map.
 
-```almd
-let r = http.request_status("GET", url, "", ["User-Agent": "my-app"])
+```almd check
+import http
+
+effect fn main() -> Unit = {
+  let url = "https://example.com/x"
+  let r = http.request_status("GET", url, "", ["User-Agent": "my-app"])
+  match r {
+    ok(pair) => println("status ${pair.0}"),
+    err(e) => println("network error: " + e),
+  }
+}
 ```
 
 ### `http.get_bytes(url: String) -> Result[Bytes, String]`
@@ -236,17 +439,30 @@ Send an HTTP GET and return the raw response body as `Bytes` (no UTF-8
 conversion), so binary payloads such as images or TTS audio survive intact.
 The `String` client corrupts non-UTF-8 bodies.
 
-```almd
-let audio = http.get_bytes("https://tts.example.com/say.mp3")!
-fs.write_bytes_raw("say.mp3", audio)!
+```almd check
+import fs
+import http
+
+effect fn main() -> Unit = {
+  let audio = http.get_bytes("https://tts.example.com/say.mp3")!
+  fs.write_bytes_raw("say.mp3", audio)!
+}
 ```
 
 ### `http.request_bytes(method: String, url: String, body: String, headers: Map[String, String]) -> Result[Bytes, String]`
 
 Like `http.request` but returns the raw response body as `Bytes`.
 
-```almd
-let blob = http.request_bytes("POST", url, body, headers)!
+```almd check
+import http
+
+effect fn main() -> Unit = {
+  let url = "https://api.example.com/render"
+  let body = '{"text": "hello"}'
+  let headers = ["Content-Type": "application/json"]
+  let blob = http.request_bytes("POST", url, body, headers)!
+  println(int.to_string(bytes.len(blob)))
+}
 ```
 
 <!-- BEGIN GENERATED SIGNATURE INDEX (make stdlib-docs) — do not edit by hand -->


### PR DESCRIPTION
Promotes every plain ```almd fence in `docs/stdlib/http.md` and `docs/stdlib/compute.md` to a gated doctest marker (`scripts/check-doc-fences.sh`, #1490 item 1). Prose is untouched; the documented expressions stay verbatim wherever they compile.

## docs/stdlib/http.md — 26 fences promoted (17 check, 9 run)

**`run` (hermetic, output pinned; verified byte-identical on native and `--target wasm`)**: `http.response`, `http.json`, `http.with_headers`, `http.redirect`, `http.status`, `http.body`, `http.set_header`, `http.get_header`, `http.url_decode`. The header ones also pin the case-insensitive lookup and the "seeds nothing" rule for `with_headers` (C-275).

**`check` (type-checked only — never executed, CI has no network)**: the typed-helper intro (`fn handle(req: HttpRequest) -> http.HttpResponse`, completed with a body), `http.serve`, `req_method` / `req_path` / `req_body` / `req_header` / `query_params` (each completed as a handler fn passed to `http.serve`, since a request has no constructor), and all client calls: `get` / `post` / `put` / `patch` / `delete` / `request` / `get_status` / `request_status` / `get_bytes` / `request_bytes`.

**Left plain**: none.

**Stale spellings corrected**:
- `let html = http.get("https://example.com")` — as a fragment this binds a `Result`; using it as the body String is E041 (ADR-0008). Promoted with the documented idiom `!`. The same `!` was added to `post` / `put` / `patch` / `delete` / `request`, whose fences had the same shape. `request_status` kept its verbatim binding (no `!`) and consumes `r` with a `match`, since the prose is about branching on the status.
- No other drift: the `Ok(pair)` / `Err(e)` match in `get_status` (uppercase, comma-less arms) checks verbatim and was kept as written.

## docs/stdlib/compute.md — 3 fences promoted (3 run)

Constructors, algebra, and consumers are all hermetic and deterministic (ADR-0001); each is pinned as a `run` fence, verified identical on native and wasm. Verdicts are observed through `fan.bounded` with a loop-carrying body (a loop-free callee is inlined charge-and-all and a 0 budget still admits it, C-294 — so the "saturates at 0" line uses a looping `spin(n)`).

**Stale spelling corrected**: `fan.race(compute.us(50)) { fast(); slow() }` does not parse — race arms are separated by `,` or a newline, not `;` (the `;` form is rejected with a dedicated diagnostic). Promoted as `{ fast(), slow() }`.

**Drift found**: none beyond the two spellings above.

Gate: `check-doc-fences.sh` exits 0 (17 check / 14 run across docs/stdlib); `docs-gen --check` and `tools/gen-stdlib-doc-index.py --check` clean.

Refs #1490.

https://claude.ai/code/session_01QPHbSjT155tPW3gQVT1Sbb