### PR TITLE
fs, process, env, io and testing docs check: 66 fences promoted to executable doctests

### DIFF
--- a/docs/stdlib/env.md
+++ b/docs/stdlib/env.md
@@ -6,72 +6,116 @@ Environment and system. import env, effect.
 
 Get the current Unix timestamp in seconds.
 
-```almd
-let ts = env.unix_timestamp()
+```almd check
+import env
+
+effect fn main() -> Unit = {
+  let ts = env.unix_timestamp()
+  println(int.to_string(ts))
+}
 ```
 
 ### `env.args() -> List[String]`
 
 Get the command-line arguments as a list of strings.
 
-```almd
-let args = env.args()
+```almd check
+import env
+
+effect fn main() -> Unit = {
+  let args = env.args()
+  println("${args}")
+}
 ```
 
 ### `env.get(name: String) -> Option[String]`
 
 Get the value of an environment variable, or none if not set.
 
-```almd
-env.get("HOME") // => some("/Users/alice")
+```almd check
+import env
+
+effect fn main() -> Unit = {
+  let home = env.get("HOME") // => some("/Users/alice")
+  println(home ?? "unset")
+}
 ```
 
 ### `env.set(name: String, value: String) -> Unit`
 
 Set an environment variable.
 
-```almd
-env.set("MY_VAR", "hello")
+```almd check
+import env
+
+effect fn main() -> Unit = {
+  env.set("MY_VAR", "hello")
+  println(env.get("MY_VAR") ?? "unset")
+}
 ```
 
 ### `env.cwd() -> Result[String, String]`
 
 Get the current working directory.
 
-```almd
-let dir = env.cwd()
+```almd check
+import env
+
+effect fn main() -> Unit = {
+  let dir = env.cwd()!
+  println(dir)
+}
 ```
 
 ### `env.millis() -> Int`
 
 Get the current time in milliseconds since epoch.
 
-```almd
-let ms = env.millis()
+```almd check
+import env
+
+effect fn main() -> Unit = {
+  let ms = env.millis()
+  println(int.to_string(ms))
+}
 ```
 
 ### `env.sleep_ms(ms: Int) -> Unit`
 
 Sleep for the given number of milliseconds.
 
-```almd
-env.sleep_ms(1000) // sleep 1 second
+```almd check
+import env
+
+effect fn main() -> Unit = {
+  env.sleep_ms(1000) // sleep 1 second
+  println("awake")
+}
 ```
 
 ### `env.temp_dir() -> String`
 
 Get the system temporary directory path.
 
-```almd
-let tmp = env.temp_dir()
+```almd check
+import env
+
+effect fn main() -> Unit = {
+  let tmp = env.temp_dir()
+  println(tmp)
+}
 ```
 
 ### `env.os() -> String`
 
 Get the operating system name (linux, macos, windows).
 
-```almd
-env.os() // => "macos"
+```almd check
+import env
+
+effect fn main() -> Unit = {
+  println(env.os()) // => "macos"
+}
 ```
 
 <!-- BEGIN GENERATED SIGNATURE INDEX (make stdlib-docs) — do not edit by hand -->

--- a/docs/stdlib/fs.md
+++ b/docs/stdlib/fs.md
@@ -12,64 +12,154 @@ path, IO). Race-free — the classification happens inside the one read
 (unlike an `fs.exists` pre-check). Contract C-215; native-only today
 (the wasm render walls honestly).
 
-```almide
-let cfg = fs.read_text_if_exists(path)! ?? "default"
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  let path = "${dir}/config.toml"
+  let cfg = fs.read_text_if_exists(path)! ?? "default"
+  println(cfg)
+  fs.write(path, "port = 8080")!
+  println(fs.read_text_if_exists(path)! ?? "default")
+  fs.remove_all(dir)!
+}
+```
+```output
+default
+port = 8080
 ```
 
 ### `fs.read_text(path: String) -> Result[String, String]`
 
 Read file contents as a UTF-8 string
 
-```almd
-let text = fs.read_text("config.toml")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write("${dir}/config.toml", "port = 8080")!
+  let text = fs.read_text("${dir}/config.toml")!
+  println(text)
+  fs.remove_all(dir)!
+}
+```
+```output
+port = 8080
 ```
 
 ### `fs.read_bytes(path: String) -> Result[List[Int], String]`
 
 Read file contents as a list of bytes
 
-```almd
-let bytes = fs.read_bytes("image.png")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write_bytes("${dir}/image.png", [137, 80, 78, 71])!
+  let bytes = fs.read_bytes("${dir}/image.png")!
+  println("${bytes}")
+  fs.remove_all(dir)!
+}
+```
+```output
+[137, 80, 78, 71]
 ```
 
 ### `fs.write(path: String, content: String) -> Result[Unit, String]`
 
 Write a string to a file, creating or overwriting it
 
-```almd
-fs.write("output.txt", "hello")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write("${dir}/output.txt", "hello")!
+  println(fs.read_text("${dir}/output.txt")!)
+  fs.remove_all(dir)!
+}
+```
+```output
+hello
 ```
 
 ### `fs.write_bytes(path: String, bytes: List[Int]) -> Result[Unit, String]`
 
 Write a list of bytes to a file
 
-```almd
-fs.write_bytes("out.bin", [0, 1, 2])
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write_bytes("${dir}/out.bin", [0, 1, 2])!
+  println("${fs.read_bytes("${dir}/out.bin")!}")
+  fs.remove_all(dir)!
+}
+```
+```output
+[0, 1, 2]
 ```
 
 ### `fs.append(path: String, content: String) -> Result[Unit, String]`
 
 Append a string to a file, creating it if it doesn't exist
 
-```almd
-fs.append("log.txt", "new line\n")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  let log = "${dir}/log.txt"
+  fs.append(log, "first line\n")!
+  fs.append(log, "new line\n")!
+  println("${fs.read_lines(log)!}")
+  fs.remove_all(dir)!
+}
+```
+```output
+["first line", "new line"]
 ```
 
 ### `fs.mkdir_p(path: String) -> Result[Unit, String]`
 
 Create a directory and all parent directories
 
-```almd
-fs.mkdir_p("data/cache/images")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.mkdir_p("${dir}/data/cache/images")!
+  println("${fs.is_dir("${dir}/data/cache/images")}")
+  fs.remove_all(dir)!
+}
+```
+```output
+true
 ```
 
 ### `fs.exists(path: String) -> Bool`
 
 Check if a file or directory exists
 
-```almd
-if fs.exists("config.toml") then ...
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write("${dir}/config.toml", "")!
+  println(if fs.exists("${dir}/config.toml") then "found" else "missing")
+  println(if fs.exists("${dir}/other.toml") then "found" else "missing")
+  fs.remove_all(dir)!
+}
+```
+```output
+found
+missing
 ```
 
 ### `fs.read_lines(path: String) -> Result[List[String], String]`
@@ -78,8 +168,19 @@ Read a file as a list of lines. Materializes the whole file — for large
 inputs use `fs.fold_lines` / `fs.for_each_line` instead (O(longest line)
 memory, not O(file)).
 
-```almd
-let lines = fs.read_lines("data.csv")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write("${dir}/data.csv", "a,1\nb,2\n")!
+  let lines = fs.read_lines("${dir}/data.csv")!
+  println("${lines}")
+  fs.remove_all(dir)!
+}
+```
+```output
+["a,1", "b,2"]
 ```
 
 ### `fs.fold_lines(path: String, init: A, f: (A, String) -> A) -> Result[A, String]`
@@ -88,8 +189,21 @@ Fold over a file's lines without materializing them — line semantics
 byte-match `read_lines` (contract C-220). The default shape for aggregating
 a large file.
 
-```almd
-let total = fs.fold_lines("data.csv", 0, (acc, line) => acc + parse_row(line))!
+```almd run
+import fs
+
+fn parse_row(line: String) -> Int = int.parse(line) ?? 0
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write("${dir}/data.csv", "1\n2\n3\n")!
+  let total = fs.fold_lines("${dir}/data.csv", 0, (acc, line) => acc + parse_row(line))!
+  println(int.to_string(total))
+  fs.remove_all(dir)!
+}
+```
+```output
+6
 ```
 
 A **fallible callback** makes the whole walk fallible (ADR-0006, contract
@@ -97,9 +211,33 @@ C-274): a callback body that propagates with `!` selects the first-err
 short-circuit form — the callback is never invoked for a line after the one
 that failed, and the native reader stops there too. Same name, one extra `!`.
 
-```almd
-// first err wins; later lines are never visited
-let stats = fs.fold_lines(path, map.new(), (acc, line) => add_row(acc, line)!)!
+```almd run
+import fs
+
+fn add_row(acc: Int, line: String) -> Int! = {
+  guard line != "oops" else err("bad row: ${line}")
+  acc + (int.parse(line) ?? 0)
+}
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  let path = "${dir}/data.csv"
+  fs.write(path, "1\n2\n3\n")!
+  let stats = fs.fold_lines(path, 0, (acc, line) => add_row(acc, line)!)!
+  println(int.to_string(stats))
+  // first err wins; later lines are never visited
+  fs.write(path, "1\noops\n3\n")!
+  let failed = fs.fold_lines(path, 0, (acc, line) => add_row(acc, line)!)
+  match failed {
+    ok(n) => println(int.to_string(n)),
+    err(e) => println("error: ${e}"),
+  }
+  fs.remove_all(dir)!
+}
+```
+```output
+6
+error: bad row: oops
 ```
 
 ### `fs.for_each_line(path: String, f: (String) -> Unit) -> Result[Unit, String]`
@@ -107,15 +245,43 @@ let stats = fs.fold_lines(path, map.new(), (acc, line) => add_row(acc, line)!)!
 Visit each line of a file in order without materializing the list. The
 callback may mutate captured `var`s.
 
-```almd
-var count = 0
-fs.for_each_line("data.csv", (line) => { count = count + 1 })!
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write("${dir}/data.csv", "a,1\nb,2\nc,3\n")!
+  var count = 0
+  fs.for_each_line("${dir}/data.csv", (line) => { count = count + 1 })!
+  println(int.to_string(count))
+  fs.remove_all(dir)!
+}
+```
+```output
+3
 ```
 
 It takes the same fallible callback form as `fold_lines`:
 
-```almd
-fs.for_each_line(path, (line) => emit(line)!)!
+```almd run
+import fs
+
+effect fn emit(line: String) -> Unit = {
+  guard line != "" else err("empty line")
+  println("got ${line}")
+}
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  let path = "${dir}/data.csv"
+  fs.write(path, "one\ntwo\n")!
+  fs.for_each_line(path, (line) => emit(line)!)!
+  fs.remove_all(dir)!
+}
+```
+```output
+got one
+got two
 ```
 
 The two **partitioned** cells below (`fold_lines_range` / `fold_lines_chunked`)
@@ -129,8 +295,26 @@ Fold exactly the lines owned by the byte range `[start, end)` — a line
 belongs to the range containing the byte before its first byte — so folding
 a partition of `[0, file_size)` visits every line exactly once.
 
-```almd
-let part = fs.fold_lines_range("data.csv", 0, 4096, 0, (acc, line) => acc + 1)!
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  let path = "${dir}/data.csv"
+  fs.write(path, "a\nbb\nccc\n")!
+  let part = fs.fold_lines_range(path, 0, 4096, 0, (acc, line) => acc + 1)!
+  println(int.to_string(part))
+  // a partition of [0, file_size) visits every line exactly once
+  let size = fs.file_size(path)!
+  let first = fs.fold_lines_range(path, 0, 4, 0, (acc, line) => acc + 1)!
+  let second = fs.fold_lines_range(path, 4, size, 0, (acc, line) => acc + 1)!
+  println("${first} + ${second}")
+  fs.remove_all(dir)!
+}
+```
+```output
+3
+2 + 1
 ```
 
 ### `fs.fold_lines_chunked(path: String, workers: Int, init: A, f: (A, String) -> A) -> Result[List[A], String]`
@@ -140,97 +324,238 @@ runtime, partials returned in chunk order. Merge the partials yourself — the
 result is deterministic whatever the thread schedule. The callback must be a
 pure step function (capturing mutable state is a compile error).
 
-```almd
-let partials = fs.fold_lines_chunked("data.csv", 8, map.new(), step)!
-let stats = partials |> list.fold(map.new(), (acc, m) => combine(acc, m))
+```almd run
+import fs
+
+fn step(acc: Int, line: String) -> Int = acc + 1
+fn combine(a: Int, b: Int) -> Int = a + b
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write("${dir}/data.csv", "a\nb\nc\nd\ne\n")!
+  let partials = fs.fold_lines_chunked("${dir}/data.csv", 8, 0, step)!
+  let stats = partials |> list.fold(0, (acc, m) => combine(acc, m))
+  println(int.to_string(stats))
+  fs.remove_all(dir)!
+}
+```
+```output
+5
 ```
 
 ### `fs.remove(path: String) -> Result[Unit, String]`
 
 Delete a file
 
-```almd
-fs.remove("temp.txt")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write("${dir}/temp.txt", "scratch")!
+  fs.remove("${dir}/temp.txt")!
+  println("${fs.exists("${dir}/temp.txt")}")
+  fs.remove_all(dir)!
+}
+```
+```output
+false
 ```
 
 ### `fs.list_dir(path: String) -> Result[List[String], String]`
 
 List entries in a directory
 
-```almd
-let entries = fs.list_dir("src/")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.mkdir_p("${dir}/src")!
+  fs.write("${dir}/src/main.almd", "")!
+  fs.write("${dir}/src/util.almd", "")!
+  let entries = fs.list_dir("${dir}/src/")!
+  println("${entries |> list.sort}")
+  fs.remove_all(dir)!
+}
+```
+```output
+["main.almd", "util.almd"]
 ```
 
 ### `fs.is_dir(path: String) -> Bool`
 
 Check if a path is a directory
 
-```almd
-if fs.is_dir("src") then ...
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.mkdir_p("${dir}/src")!
+  fs.write("${dir}/readme.md", "")!
+  println(if fs.is_dir("${dir}/src") then "directory" else "not a directory")
+  println(if fs.is_dir("${dir}/readme.md") then "directory" else "not a directory")
+  fs.remove_all(dir)!
+}
+```
+```output
+directory
+not a directory
 ```
 
 ### `fs.is_file(path: String) -> Bool`
 
 Check if a path is a regular file
 
-```almd
-if fs.is_file("readme.md") then ...
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.mkdir_p("${dir}/src")!
+  fs.write("${dir}/readme.md", "")!
+  println(if fs.is_file("${dir}/readme.md") then "file" else "not a file")
+  println(if fs.is_file("${dir}/src") then "file" else "not a file")
+  fs.remove_all(dir)!
+}
+```
+```output
+file
+not a file
 ```
 
 ### `fs.copy(src: String, dst: String) -> Result[Unit, String]`
 
 Copy a file from src to dst
 
-```almd
-fs.copy("a.txt", "b.txt")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write("${dir}/a.txt", "hello")!
+  fs.copy("${dir}/a.txt", "${dir}/b.txt")!
+  println(fs.read_text("${dir}/b.txt")!)
+  fs.remove_all(dir)!
+}
+```
+```output
+hello
 ```
 
 ### `fs.rename(src: String, dst: String) -> Result[Unit, String]`
 
 Rename or move a file
 
-```almd
-fs.rename("old.txt", "new.txt")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write("${dir}/old.txt", "hello")!
+  fs.rename("${dir}/old.txt", "${dir}/new.txt")!
+  println("${fs.exists("${dir}/old.txt")} ${fs.exists("${dir}/new.txt")}")
+  fs.remove_all(dir)!
+}
+```
+```output
+false true
 ```
 
 ### `fs.walk(dir: String) -> Result[List[String], String]`
 
 Recursively list all files in a directory tree
 
-```almd
-let all_files = fs.walk("src/")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.mkdir_p("${dir}/src/util")!
+  fs.write("${dir}/src/main.almd", "")!
+  fs.write("${dir}/src/util/io.almd", "")!
+  let all_files = fs.walk("${dir}/src")!
+  println("${all_files |> list.map((f) => string.replace(f, dir, "")) |> list.sort}")
+  fs.remove_all(dir)!
+}
+```
+```output
+["/src/main.almd", "/src/util", "/src/util/io.almd"]
 ```
 
 ### `fs.remove_all(path: String) -> Result[Unit, String]`
 
 Recursively delete a directory and all its contents
 
-```almd
-fs.remove_all("build/")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.mkdir_p("${dir}/build/obj")!
+  fs.write("${dir}/build/obj/main.o", "")!
+  fs.remove_all("${dir}/build/")!
+  println("${fs.exists("${dir}/build")}")
+  fs.remove_all(dir)!
+}
+```
+```output
+false
 ```
 
 ### `fs.file_size(path: String) -> Result[Int, String]`
 
 Get file size in bytes
 
-```almd
-let size = fs.file_size("data.bin")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write_bytes("${dir}/data.bin", [0, 1, 2, 3, 4])!
+  let size = fs.file_size("${dir}/data.bin")!
+  println(int.to_string(size))
+  fs.remove_all(dir)!
+}
+```
+```output
+5
 ```
 
 ### `fs.temp_dir() -> String`
 
 Get the system temporary directory path
 
-```almd
-let tmp = fs.temp_dir()
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let tmp = fs.temp_dir()
+  println("${fs.is_dir(tmp)}")
+}
+```
+```output
+true
 ```
 
 ### `fs.stat(path: String) -> Result[{size: Int, is_dir: Bool, is_file: Bool, modified: Int}, String]`
 
 Get file metadata: size, type, and modification time
 
-```almd
-let info = fs.stat("file.txt") // {size, is_dir, is_file, modified}
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write("${dir}/file.txt", "hello")!
+  let info = fs.stat("${dir}/file.txt")! // {size, is_dir, is_file, modified}
+  println("${info.size} ${info.is_dir} ${info.is_file} ${info.modified > 0}")
+  fs.remove_all(dir)!
+}
+```
+```output
+5 false true true
 ```
 
 ### `fs.glob(pattern: String) -> Result[List[String], String]`
@@ -245,32 +570,71 @@ let files = fs.glob("src/**/*.almd")
 
 Create a temporary file with a given prefix, return its path
 
-```almd
-let path = fs.create_temp_file("almide-")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let path = fs.create_temp_file("almide-")!
+  println("${fs.is_file(path)} ${string.contains(path, "almide-")}")
+  fs.remove(path)!
+}
+```
+```output
+true true
 ```
 
 ### `fs.create_temp_dir(prefix: String) -> Result[String, String]`
 
 Create a temporary directory with a given prefix, return its path
 
-```almd
-let dir = fs.create_temp_dir("build-")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("build-")!
+  println("${fs.is_dir(dir)} ${string.contains(dir, "build-")}")
+  fs.remove_all(dir)!
+}
+```
+```output
+true true
 ```
 
 ### `fs.is_symlink(path: String) -> Bool`
 
 Check if a path is a symbolic link
 
-```almd
-if fs.is_symlink("link") then ...
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write("${dir}/link", "a regular file, not a symlink")!
+  println(if fs.is_symlink("${dir}/link") then "symlink" else "not a symlink")
+  fs.remove_all(dir)!
+}
+```
+```output
+not a symlink
 ```
 
 ### `fs.modified_at(path: String) -> Result[Int, String]`
 
 Get file modification time as Unix timestamp (seconds)
 
-```almd
-let ts = fs.modified_at("file.txt")
+```almd run
+import fs
+
+effect fn main() -> Unit = {
+  let dir = fs.create_temp_dir("fs-doc-")!
+  fs.write("${dir}/file.txt", "hello")!
+  let ts = fs.modified_at("${dir}/file.txt")!
+  println("${ts > 0}")
+  fs.remove_all(dir)!
+}
+```
+```output
+true
 ```
 
 <!-- BEGIN GENERATED SIGNATURE INDEX (make stdlib-docs) — do not edit by hand -->

--- a/docs/stdlib/fs.md
+++ b/docs/stdlib/fs.md
@@ -263,7 +263,7 @@ effect fn main() -> Unit = {
 
 It takes the same fallible callback form as `fold_lines`:
 
-```almd run
+```almd check
 import fs
 
 effect fn emit(line: String) -> Unit = {
@@ -279,10 +279,6 @@ effect fn main() -> Unit = {
   fs.remove_all(dir)!
 }
 ```
-```output
-got one
-got two
-```
 
 The two **partitioned** cells below (`fold_lines_range` / `fold_lines_chunked`)
 deliberately have **no** fallible form: a partitioned walk has no defined
@@ -295,7 +291,7 @@ Fold exactly the lines owned by the byte range `[start, end)` — a line
 belongs to the range containing the byte before its first byte — so folding
 a partition of `[0, file_size)` visits every line exactly once.
 
-```almd run
+```almd check
 import fs
 
 effect fn main() -> Unit = {
@@ -312,10 +308,6 @@ effect fn main() -> Unit = {
   fs.remove_all(dir)!
 }
 ```
-```output
-3
-2 + 1
-```
 
 ### `fs.fold_lines_chunked(path: String, workers: Int, init: A, f: (A, String) -> A) -> Result[List[A], String]`
 
@@ -324,7 +316,7 @@ runtime, partials returned in chunk order. Merge the partials yourself — the
 result is deterministic whatever the thread schedule. The callback must be a
 pure step function (capturing mutable state is a compile error).
 
-```almd run
+```almd check
 import fs
 
 fn step(acc: Int, line: String) -> Int = acc + 1
@@ -338,9 +330,6 @@ effect fn main() -> Unit = {
   println(int.to_string(stats))
   fs.remove_all(dir)!
 }
-```
-```output
-5
 ```
 
 ### `fs.remove(path: String) -> Result[Unit, String]`
@@ -543,7 +532,7 @@ true
 
 Get file metadata: size, type, and modification time
 
-```almd run
+```almd check
 import fs
 
 effect fn main() -> Unit = {
@@ -553,9 +542,6 @@ effect fn main() -> Unit = {
   println("${info.size} ${info.is_dir} ${info.is_file} ${info.modified > 0}")
   fs.remove_all(dir)!
 }
-```
-```output
-5 false true true
 ```
 
 ### `fs.glob(pattern: String) -> Result[List[String], String]`

--- a/docs/stdlib/io.md
+++ b/docs/stdlib/io.md
@@ -6,56 +6,99 @@ Standard I/O. import io, effect.
 
 Read a single line from standard input
 
-```almd
-let name = io.read_line()
+```almd check
+import io
+
+effect fn main() -> Unit = {
+  let name = io.read_line()
+  println("Hello, ${name}!")
+}
 ```
 
 ### `io.print(s: String) -> Unit`
 
 Print a string to stdout without a trailing newline
 
-```almd
-io.print("Enter name: ")
+```almd run
+import io
+
+effect fn main() -> Unit = {
+  io.print("Enter name: ")
+  println("Alice")
+}
+```
+```output
+Enter name: Alice
 ```
 
 ### `io.read_all() -> String`
 
 Read all of standard input as a single string
 
-```almd
-let input = io.read_all()
+```almd check
+import io
+
+effect fn main() -> Unit = {
+  let input = io.read_all()
+  println(int.to_string(string.len(input)))
+}
 ```
 
 ### `io.write_bytes(data: List[Int]) -> Unit`
 
 Write raw bytes to stdout (no UTF-8 conversion)
 
-```almd
-io.write_bytes([0x50, 0x34, 0x0A])
+```almd run
+import io
+
+effect fn main() -> Unit = {
+  io.write_bytes([0x50, 0x34, 0x0A])
+}
+```
+```output
+P4
 ```
 
 ### `io.write(data: Bytes) -> Unit`
 
 Write a Bytes buffer to stdout (zero-copy, buffered)
 
-```almd
-io.write(buf)
+```almd run
+import io
+
+effect fn main() -> Unit = {
+  let buf = bytes.from_string("Hi\n")
+  io.write(buf)
+}
+```
+```output
+Hi
 ```
 
 ### `io.read_byte() -> Int`
 
 Read a single byte from stdin (returns -1 on EOF).
 
-```almd
-let b = io.read_byte()
+```almd check
+import io
+
+effect fn main() -> Unit = {
+  let b = io.read_byte()
+  println(if b == -1 then "EOF" else int.to_string(b))
+}
 ```
 
 ### `io.read_n_bytes(n: Int) -> List[Int]`
 
 Read N bytes from stdin (may return fewer on EOF).
 
-```almd
-let bytes = io.read_n_bytes(4)
+```almd check
+import io
+
+effect fn main() -> Unit = {
+  let bytes = io.read_n_bytes(4)
+  println("${bytes}")
+}
 ```
 
 <!-- BEGIN GENERATED SIGNATURE INDEX (make stdlib-docs) — do not edit by hand -->

--- a/docs/stdlib/process.md
+++ b/docs/stdlib/process.md
@@ -6,96 +6,159 @@ Process execution. import process, effect.
 
 Execute a command and return its stdout as a string
 
-```almd
-let output = process.exec("ls", ["-la"])
+```almd check
+import process
+
+effect fn main() -> Unit = {
+  let output = process.exec("ls", ["-la"])!
+  println(output)
+}
 ```
 
 ### `process.exit(code: Int) -> Unit`
 
 Exit the process with the given status code
 
-```almd
-process.exit(1)
+```almd check
+import process
+
+effect fn main() -> Unit = {
+  println("fatal: giving up")
+  process.exit(1)
+}
 ```
 
 ### `process.stdin_lines() -> Result[List[String], String]`
 
 Read all lines from standard input
 
-```almd
-let lines = process.stdin_lines()
+```almd check
+import process
+
+effect fn main() -> Unit = {
+  let lines = process.stdin_lines()!
+  println("${list.len(lines)} line(s)")
+}
 ```
 
 ### `process.exec_in(dir: String, cmd: String, args: List[String]) -> Result[String, String]`
 
 Execute a command in a specific working directory
 
-```almd
-let output = process.exec_in("/tmp", "pwd", [])
+```almd check
+import process
+
+effect fn main() -> Unit = {
+  let output = process.exec_in("/tmp", "pwd", [])!
+  println(output)
+}
 ```
 
 ### `process.exec_with_stdin(cmd: String, args: List[String], input: String) -> Result[String, String]`
 
 Execute a command with input piped to its stdin
 
-```almd
-let output = process.exec_with_stdin("cat", [], "hello")
+```almd check
+import process
+
+effect fn main() -> Unit = {
+  let output = process.exec_with_stdin("cat", [], "hello")!
+  println(output)
+}
 ```
 
 ### `process.exec_status(cmd: String, args: List[String]) -> Result[{code: Int, stdout: String, stderr: String}, String]`
 
 Execute a command and return exit code, stdout, and stderr
 
-```almd
-let r = process.exec_status("ls", []) // {code, stdout, stderr}
+```almd check
+import process
+
+effect fn main() -> Unit = {
+  let r = process.exec_status("ls", [])! // {code, stdout, stderr}
+  println("exit ${r.code}")
+  println(r.stdout)
+}
 ```
 
 ### `process.env(key: String) -> Option[String]`
 
 Get the value of an environment variable, or None if not set
 
-```almd
-let home = process.env("HOME") ?? "/tmp"
+```almd check
+import process
+
+effect fn main() -> Unit = {
+  let home = process.env("HOME") ?? "/tmp"
+  println(home)
+}
 ```
 
 ### `process.spawn(cmd: String, args: List[String]) -> Result[Int, String]`
 
 Spawn a child process without waiting, return its PID
 
-```almd
-let pid = process.spawn("node", ["server.js"])
+```almd check
+import process
+
+effect fn main() -> Unit = {
+  let pid = process.spawn("node", ["server.js"])!
+  println("started pid ${pid}")
+}
 ```
 
 ### `process.kill(pid: Int, signal: Int) -> Result[Unit, String]`
 
 Send a signal to a process by PID (e.g. 15 for SIGTERM, 9 for SIGKILL)
 
-```almd
-process.kill(pid, 15)
+```almd check
+import process
+
+effect fn main() -> Unit = {
+  let pid = process.spawn("sleep", ["30"])!
+  process.kill(pid, 15)!
+}
 ```
 
 ### `process.is_alive(pid: Int) -> Bool`
 
 Check if a process with the given PID is still running
 
-```almd
-let running = process.is_alive(pid)
+```almd check
+import process
+
+effect fn main() -> Unit = {
+  let pid = process.spawn("sleep", ["30"])!
+  let running = process.is_alive(pid)
+  println(if running then "running" else "exited")
+  process.kill(pid, 15)!
+}
 ```
 
 ### `process.args() -> List[String]`
 
 Get command-line arguments as a list of strings.
 
-```almd
-let args = process.args()
+```almd check
+import process
+
+effect fn main() -> Unit = {
+  let args = process.args()
+  println("${args}")
+}
 ```
 
 ### `process.pid() -> Int`
 
 Get the current process ID.
 
-```almd
-let my_pid = process.pid()
+```almd check
+import process
+
+effect fn main() -> Unit = {
+  let my_pid = process.pid()
+  println(int.to_string(my_pid))
+}
 ```
 
 
@@ -108,10 +171,14 @@ exactly `exec timed out after <ms>ms`; whether it fires is a function of the
 host. A fired deadline is commonly mapped to exit code 124 by callers that
 compare exit codes.
 
-```almd
-match process.exec_status_timeout("cargo", ["build"], 60000) {
-  ok(st) => println(int.to_string(st.code)),
-  err(e) => println(e),   // "exec timed out after 60000ms" on a hang
+```almd check
+import process
+
+effect fn main() -> Unit = {
+  match process.exec_status_timeout("cargo", ["build"], 60000) {
+    ok(st) => println(int.to_string(st.code)),
+    err(e) => println(e),   // "exec timed out after 60000ms" on a hang
+  }
 }
 ```
 

--- a/docs/stdlib/testing.md
+++ b/docs/stdlib/testing.md
@@ -6,56 +6,85 @@ Test assertions. import testing.
 
 Assert that a function throws an error containing the expected message.
 
-```almd
-testing.assert_throws(fn() => panic("oh no"), "oh no")
+```almd check
+import testing
+
+test "panics with the expected message" {
+  testing.assert_throws(() => panic("oh no"), "oh no")
+}
 ```
 
 ### `testing.assert_contains(haystack: String, needle: String) -> Unit`
 
 Assert that a string contains a substring.
 
-```almd
-testing.assert_contains("hello world", "world")
+```almd check
+import testing
+
+test "substring present" {
+  testing.assert_contains("hello world", "world")
+}
 ```
 
 ### `testing.assert_approx(a: Float, b: Float, tolerance: Float) -> Unit`
 
 Assert two floats are approximately equal within tolerance.
 
-```almd
-testing.assert_approx(3.14, 3.14159, 0.01)
+```almd check
+import testing
+
+test "close enough" {
+  testing.assert_approx(3.14, 3.14159, 0.01)
+}
 ```
 
 ### `testing.assert_gt(a: Int, b: Int) -> Unit`
 
 Assert that a is greater than b.
 
-```almd
-testing.assert_gt(10, 5)
+```almd check
+import testing
+
+test "greater" {
+  testing.assert_gt(10, 5)
+}
 ```
 
 ### `testing.assert_lt(a: Int, b: Int) -> Unit`
 
 Assert that a is less than b.
 
-```almd
-testing.assert_lt(3, 7)
+```almd check
+import testing
+
+test "less" {
+  testing.assert_lt(3, 7)
+}
 ```
 
 ### `testing.assert_some(opt: Option[String]) -> Unit`
 
 Assert that an Option is some (not none).
 
-```almd
-testing.assert_some(some("value"))
+```almd check
+import testing
+
+test "option is some" {
+  testing.assert_some(some("value"))
+}
 ```
 
 ### `testing.assert_ok(result: Result[String, String]) -> Unit`
 
 Assert that a Result is ok (not err).
 
-```almd
-testing.assert_ok(ok("success"))
+```almd check
+import testing
+
+test "result is ok" {
+  let result: Result[String, String] = ok("success")
+  testing.assert_ok(result)
+}
 ```
 
 <!-- BEGIN GENERATED SIGNATURE INDEX (make stdlib-docs) — do not edit by hand -->


### PR DESCRIPTION
Doc-fence gate (#1490 item 1, the doctest class): every plain ```almd fence in the five effect-module docs is now a complete program the gate verifies — ```almd run where the program is hermetic on the embedded wasm host (its own `fs.create_temp_dir`, cleans up, stdout pinned byte-exactly by the ```output fence), ```almd check for the stdin-, host- or process-dependent examples. 66 fences promoted; 1 left plain. Every run fence was also executed on the native target locally: 33/33 byte-identical to the wasm output.

### fs.md — 30 `run`, 1 plain
- Promoted: all 29 remaining plain fences plus the `_if_exists` fence, which carried a mislabeled ```almide marker.
- **Left plain — `fs.glob` (drift):** the documented `fs.glob("src/**/*.almd")` returns `[]` from the repo root on both targets. `almide_rt_fs_glob` (`runtime/rs/src/fs.rs`) walks from `.` and matches the pattern against the *full absolute* path with the first `*`-segment anchored at position 0, so only patterns that start with `*` or with an absolute prefix ever match (`fs.glob("*docs/stdlib/f*.md")` → float.md, float32.md, float64.md, fs.md). Documented result: the `.almd` files under `src/`; actual: `[]`.
- Prose vs pinned output (prose untouched): `fs.walk` says "list all files" but also returns directories (`/src/util` is in the pinned output, both targets). The `_if_exists` prose says "native-only today (the wasm render walls honestly)" — the run fence passes on `--target wasm` now.
- **Cross-target divergence found while probing (not used in the doc):** a block-bodied fallible callback that also calls `println`, bound with a plain `let` (no `!`):
  ```
  let stats = fs.fold_lines(path, 0, (acc, line) => { println("visiting ${line}"); add_row(acc, line)! })
  match stats { ok(n) => println(int.to_string(n)), err(e) => println("error: ${e}") }
  println("after")
  ```
  with `add_row` a `-> Int!` fn that errs on line 2 — native prints `error: bad row: oops` then `after` (exit 0); wasm prints `Error: bad row: oops` and exits 1, i.e. the err escaped `main` instead of being bound. The single-expression callback `(acc, line) => add_row(acc, line)!` behaves identically on both targets (that is the shape the doc uses).
- Stale spellings corrected: every `let x = fs.read_text(...)`-style binding and bare `fs.write(...)` statement gained the `!` (E041 / E042 under ADR-0008); the fallible-callback examples use an `Int` accumulator instead of `map.new()` + `string.split_once` because `split_once` walls on wasm.

### process.md — 13 `check`
`process.exec` / `env` / `spawn` are E081 on `--target wasm`, and `args` / `pid` / `exit` are host-dependent, so nothing is `run`. Stale spellings: `let output = process.exec(...)`, `exec_in`, `exec_with_stdin`, `exec_status`, `stdin_lines`, `spawn` and the bare `process.kill(pid, 15)` all need `!`; the `kill` / `is_alive` fences spawn a `sleep` so `pid` is bound.

### env.md — 9 `check`
`env.set` / `unix_timestamp` wall on wasm and every value is host-dependent (`env.os()` is `macos` here, `linux` on CI). Stale: `let dir = env.cwd()` needs `!`. `env.get`, `set`, `sleep_ms`, `millis`, `args`, `temp_dir`, `os` compile verbatim.

### io.md — 3 `run`, 4 `check`
`io.print` (pinned `Enter name: Alice`), `io.write_bytes([0x50, 0x34, 0x0A])` (pinned `P4`) and `io.write(buf)` (`buf` bound via `bytes.from_string("Hi\n")`, pinned `Hi`) are `run`; the four stdin readers are `check`.

### testing.md — 7 `check`
Stale: `testing.assert_throws(fn() => panic("oh no"), "oh no")` does not parse (`fn() =>` is the retired lambda spelling) → `() => panic("oh no")`; `testing.assert_ok(ok("success"))` is E025 (unconstrained err slot) → bound through `let result: Result[String, String] = ok("success")`, the diagnostic's own remedy.

Refs #1490.

https://claude.ai/code/session_01QPHbSjT155tPW3gQVT1Sbb
