### PR TITLE
Constant-factor quick wins: 1 of the #1232 ledger's small items lands, the other 12 are audited as already landed

### DIFF
--- a/crates/almide-mir/src/lower/desugar_nested_unwrap.rs
+++ b/crates/almide-mir/src/lower/desugar_nested_unwrap.rs
@@ -27,6 +27,12 @@ pub(crate) fn desugar_stmt_value_nested_unwrap(
     body: &IrExpr,
     next_var: &mut u32,
 ) -> Option<IrExpr> {
+    // Search first, clone only on a candidate (the `desugar_let_unwrap`
+    // shape, #1232): a body `has_candidate_unwrap` rejects can never be
+    // rewritten below, so it is declined without the whole-body clone.
+    if !has_candidate_unwrap(body) {
+        return None;
+    }
     let mut out = body.clone();
     if nested_unwrap_rewrite_expr(&mut out, next_var) {
         return Some(out);
@@ -171,6 +177,56 @@ fn nested_unwrap_rewrite_stmts(
     false
 }
 
+/// A scalar-typed `Unwrap` whose operand is a Result/Option — the node class
+/// every nested hoist below targets.
+fn is_hoistable_unwrap(e: &IrExpr) -> bool {
+    use almide_ir::IrExprKind;
+    matches!(
+        &e.kind,
+        IrExprKind::Unwrap { expr: inner }
+            if !crate::lower::is_heap_ty(&e.ty)
+                && matches!(
+                    &inner.ty,
+                    almide_lang::types::Ty::Applied(
+                        almide_lang::types::constructor::TypeConstructorId::Result
+                            | almide_lang::types::constructor::TypeConstructorId::Option,
+                        _
+                    )
+                )
+    )
+}
+
+/// Read-only SUPERSET of what the mutable search can hoist: an
+/// `is_hoistable_unwrap` node anywhere, or an `Unwrap` at an Assign's value
+/// root (the root-Assign case hoists regardless of type). Position rules are
+/// ignored here, so a `true` may still decline later — never the reverse.
+fn has_candidate_unwrap(body: &IrExpr) -> bool {
+    use almide_ir::visit::{walk_expr, walk_stmt, IrVisitor};
+    use almide_ir::{IrExprKind, IrStmt, IrStmtKind};
+    struct V(bool);
+    impl IrVisitor for V {
+        fn visit_expr(&mut self, e: &IrExpr) {
+            if self.0 || is_hoistable_unwrap(e) {
+                self.0 = true;
+                return;
+            }
+            walk_expr(self, e);
+        }
+        fn visit_stmt(&mut self, s: &IrStmt) {
+            if let IrStmtKind::Assign { value, .. } = &s.kind {
+                if matches!(value.kind, IrExprKind::Unwrap { .. }) {
+                    self.0 = true;
+                    return;
+                }
+            }
+            walk_stmt(self, s);
+        }
+    }
+    let mut v = V(false);
+    v.visit_expr(body);
+    v.0
+}
+
 /// Find a hoistable nested scalar Result/Option `Unwrap` strictly BELOW the
 /// given expression's root; replace it with a fresh Var and return the Bind
 /// stmt kind that hoists it.
@@ -193,22 +249,6 @@ fn take_innermost_scalar_unwrap(
     next_var: &mut u32,
 ) -> Option<(almide_ir::IrStmtKind, Option<almide_ir::Span>)> {
     use almide_ir::{IrExpr, IrExprKind, IrStmtKind, Mutability, VarId};
-
-    fn is_hoistable_unwrap(e: &IrExpr) -> bool {
-        matches!(
-            &e.kind,
-            IrExprKind::Unwrap { expr: inner }
-                if !crate::lower::is_heap_ty(&e.ty)
-                    && matches!(
-                        &inner.ty,
-                        almide_lang::types::Ty::Applied(
-                            almide_lang::types::constructor::TypeConstructorId::Result
-                                | almide_lang::types::constructor::TypeConstructorId::Option,
-                            _
-                        )
-                    )
-        )
-    }
 
     fn hoist_here(e: &mut IrExpr, next_var: &mut u32) -> (IrStmtKind, Option<almide_ir::Span>) {
         let ty = e.ty.clone();


### PR DESCRIPTION
Audit of the #1232 "Quick wins" and "New-code small fixes" checkboxes against current develop. Twelve of the thirteen were already landed (the boxes were never ticked); this PR lands the one remaining half and records the rest.

**Quick wins**
- `pass_borrow_inference_ownership.rs` operand swap + per-(module, fn) borrow table — N/A, landed in 2aa94adcd
- `bundled_sigs.rs` projection under the read guard — N/A, landed in cc6d06a63
- `check/mod.rs` `instantiate_ty` identity deep copy — N/A, landed in f5760aa23 (the fn is gone)
- `mono/varid_remap.rs` `collect_var_id` contains check — N/A, landed in baaccde82
- `pass_auto_parallel.rs` `mem::take` instead of `body.clone()` — N/A, landed in bb91d37ed
- `mono/mod.rs` `record_flattened_call` precomputed flat names — N/A, landed in 04aed36b6
- `lower/calls_target.rs` UFCS needle hoist — N/A, landed in 383726af1
- interp `dispatch.rs` `variant_ctor` registry — N/A, landed in 5cbd22d6f
- `pipeline.rs` duplicate `program_uses_*` calls — N/A, landed in 3ec4a8950 (the twelve walks fused into one `measure_program_usage` scan, which also closes the medium-backlog "fuse into one flag-struct scan" row)

**New-code small fixes**
- `lower/desugar_nested_unwrap.rs` — the `AnyUnwrap` trigger half landed in 810d84956; the search-first-then-clone half lands HERE (d85f8f300): a read-only `has_candidate_unwrap` visitor (a superset of what the mutable search can hoist: an `is_hoistable_unwrap` node anywhere, or an `Unwrap` at an Assign's value root) declines the body before the whole-body clone. `is_hoistable_unwrap` moves verbatim to module level so both searches share the one definition.
- `lower/continuation_lift.rs` empty-chain early-continue — N/A, landed in 810d84956
- interp trampoline `cur.ty.clone()` per hop — N/A, landed in 452ee5fa3 (carries the one Option-identity bit)
- `runtime/rs/fs.rs` per-line `buf.clone()` — N/A, MEASURED as a 4-6% regression (`take` steals the String's capacity, so `read_line` regrows every line); the rejection is recorded in-code at each site (810d84956). Do not re-apply without re-measuring.

**Verification** (baseline = develop 59536419b binary vs this branch, same worktree)
- Emitted Rust over all 1251 `spec/**/*.almd`: 1251/1251 byte-identical
- Built wasm modules over the same 1251: 1250/1251 byte-identical; the one diff, `spec/wasm_cross_pkg/main.almd`, is PRE-EXISTING nondeterminism — 8 builds with the baseline binary alone yield the same two distinct modules (5/3) that 8 builds with this branch's binary do (2/6). Not caused here; noted for a separate issue (the host-determinism gate defaults to `spec/wasm_cross`, not `_pkg`).
- `cargo test --release -p almide-mir`: 631 + the small suites, all passed
- `almide test spec/lang/`: 207/207 files passed; full `almide test`: 428/428 files passed
- `cargo clippy --release -p almide-mir`: the touched file's 12 warnings are all pre-existing (`Option<Span>` clone, doc-list indentation) at lines outside the diff; `check-clippy-warnings.sh` ran under the non-pinned 1.96.1 toolchain (informational)
- `check-file-discipline.sh`: OK
- codopsy `almide-mir`: before B (88/100), 55 warnings / 86 info — after B (88/100), 55 warnings / 86 info (unchanged; the crate was already at 88 on develop)

Refs #1232.

https://claude.ai/code/session_01QPHbSjT155tPW3gQVT1Sbb
