### PR TITLE
The E060 usage walk descends through as-patterns: an alias used only inside x @ c.Red is used

### DIFF
--- a/crates/almide-frontend/src/check/mod.rs
+++ b/crates/almide-frontend/src/check/mod.rs
@@ -1346,12 +1346,11 @@ fn qualified_import_heads(program: &mut ast::Program) -> std::collections::HashS
             ast::Pattern::Or { alts } => for a in alts { walk_pat(a, heads); },
             ast::Pattern::Wildcard | ast::Pattern::Ident { .. } | ast::Pattern::None
             | ast::Pattern::Literal { .. } => {}
-            // A pattern form this walker does not know (the #1461 as-pattern
-            // lands separately) contributes no heads — an unmarked alias
-            // there surfaces as a false E060, which the multi-file corpus
-            // would catch; extend the walk when the form lands.
-            #[allow(unreachable_patterns)]
-            _ => {}
+            // `x @ c.Red` (#1461): the binder names nothing qualified; the
+            // inner pattern may. Exhaustive on purpose — a new pattern form
+            // must be walked here, or an alias used only inside it is a
+            // false E060 the multi-file corpus would catch.
+            ast::Pattern::As { inner, .. } => walk_pat(inner, heads),
         }
     }
     fn walk_generics(gs: &Option<Vec<ast::GenericParam>>, heads: &mut HashSet<Sym>) {

--- a/tests/diagnostics/e060-unused-self-import-as-pattern-used/almide.toml
+++ b/tests/diagnostics/e060-unused-self-import-as-pattern-used/almide.toml
@@ -1,0 +1,3 @@
+[package]
+name = "diagfx"
+version = "0.1.0"

--- a/tests/diagnostics/e060-unused-self-import-as-pattern-used/broken.almd
+++ b/tests/diagnostics/e060-unused-self-import-as-pattern-used/broken.almd
@@ -1,0 +1,13 @@
+// A self import referenced ONLY inside an as-pattern's inner pattern
+// (`x @ c.Red`) is USED — the syntactic usage walk must descend through the
+// binder (#1783 walker, extended for #1461's as-patterns). This broken file
+// adds a second, genuinely unused import beside it.
+import self.color as c
+import self.color as unused_color
+
+fn name(v: c.Color) -> String = match v {
+  x @ c.Red => "red",
+  _ => "other",
+}
+
+fn main() -> Unit = println(name(c.Red))

--- a/tests/diagnostics/e060-unused-self-import-as-pattern-used/fixed.almd
+++ b/tests/diagnostics/e060-unused-self-import-as-pattern-used/fixed.almd
@@ -1,0 +1,13 @@
+// A self import referenced ONLY inside an as-pattern's inner pattern
+// (`x @ c.Red`) is USED — the syntactic usage walk must descend through the
+// binder (#1783 walker, extended for #1461's as-patterns). This broken file
+// adds a second, genuinely unused import beside it.
+import self.color as c
+
+
+fn name(v: c.Color) -> String = match v {
+  x @ c.Red => "red",
+  _ => "other",
+}
+
+fn main() -> Unit = println(name(c.Red))

--- a/tests/diagnostics/e060-unused-self-import-as-pattern-used/meta.toml
+++ b/tests/diagnostics/e060-unused-self-import-as-pattern-used/meta.toml
@@ -1,0 +1,3 @@
+expects_code = "E060"
+expects_error = "unused_color"
+hint_substring = ""

--- a/tests/diagnostics/e060-unused-self-import-as-pattern-used/src/color.almd
+++ b/tests/diagnostics/e060-unused-self-import-as-pattern-used/src/color.almd
@@ -1,0 +1,1 @@
+type Color = Red | Green


### PR DESCRIPTION
Follow-up to #1785 (the E060 self-import fix) now that #1781 (as-patterns, #1461) has landed: the syntactic usage walker left a `_ => {}` fallback for pattern forms it did not know, which would have reported a false E060 for an alias used only inside an as-pattern's inner pattern (`x @ c.Red`). The walk now descends through the binder, and the match is exhaustive again — a future pattern form is a compile error here, not a silent false warning.

Evidence: `tests/diagnostics/e060-unused-self-import-as-pattern-used` — two self imports, one used only in `x @ c.Red`; the other is the E060.