### PR TITLE
Stdlib docs say what the compiler does: three examples become executable and three prose rows match the implementation

### DIFF
--- a/docs/stdlib/error.md
+++ b/docs/stdlib/error.md
@@ -38,10 +38,14 @@ oops
 
 ### `error.chain(outer: String, cause: String) -> String`
 
-Chain two error messages with a cause separator.
+Chain two error messages: the outer message on one line, the cause on the next, prefixed `caused by:`.
 
-```almd
-error.chain("load failed", "file not found") // => "load failed: file not found"
+```almd run
+fn main() -> Unit = println(error.chain("load failed", "file not found"))
+```
+```output
+load failed
+caused by: file not found
 ```
 
 <!-- BEGIN GENERATED SIGNATURE INDEX (make stdlib-docs) — do not edit by hand -->

--- a/docs/stdlib/fs.md
+++ b/docs/stdlib/fs.md
@@ -9,7 +9,7 @@ File system. import fs, effect.
 `ok(none)` when the path (or a parent) does not exist, `ok(some(content))`
 when readable, `err(msg)` for real failures (permission, a directory at the
 path, IO). Race-free — the classification happens inside the one read
-(unlike an `fs.exists` pre-check). Contract C-215; native-only today
+(unlike an `fs.exists` pre-check). Contract C-215; serves on native and both wasm legs
 (the wasm render walls honestly).
 
 ```almd run
@@ -454,7 +454,7 @@ false true
 
 ### `fs.walk(dir: String) -> Result[List[String], String]`
 
-Recursively list all files in a directory tree
+Recursively list every entry — files AND directories — in a directory tree
 
 ```almd run
 import fs

--- a/docs/stdlib/int.md
+++ b/docs/stdlib/int.md
@@ -53,8 +53,19 @@ err(invalid digit found in string)
 
 Parse a hexadecimal string into an integer. Returns err if the string is not valid hex.
 
-```almd
-int.parse_hex(\"ff\") // => ok(255)
+```almd run
+fn show(r: Result[Int, String]) -> String = match r { ok(n) => "ok " + int.to_string(n), err(e) => "err " + e }
+
+fn main() -> Unit = {
+  println(show(int.from_hex("ff")))
+  println(show(int.from_hex("FF")))
+  println(show(int.from_hex("zz")))
+}
+```
+```output
+ok 255
+ok 255
+err invalid digit found in string
 ```
 
 ### `int.abs(n: Int) -> Int`

--- a/docs/stdlib/list.md
+++ b/docs/stdlib/list.md
@@ -756,7 +756,7 @@ fn main() -> Unit = {
 
 ### `list.pop(xs: List[A]) -> Option[A]`
 
-Remove and discard the last element in place. Requires var binding.
+Remove the last element in place and return it (`some(x)`, or `none` when the list is empty). Requires var binding.
 
 ```almd run
 fn main() -> Unit = {

--- a/docs/stdlib/map.md
+++ b/docs/stdlib/map.md
@@ -201,8 +201,17 @@ fn main() -> Unit = {
 
 Transform all values in the map using a function, keeping keys unchanged.
 
-```almd
-map.map_values(m, fn(v) => v * 2)
+```almd run
+fn main() -> Unit = {
+  let m = map.from_list([("a", 1), ("b", 2), ("c", 3)])
+  let doubled = map.map(m, (v) => v * 2)
+  println("${map.get(doubled, "a") ?? 0} ${map.get(doubled, "b") ?? 0} ${map.get(doubled, "c") ?? 0}")
+  println(int.to_string(map.len(doubled)))
+}
+```
+```output
+2 4 6
+3
 ```
 
 ### `map.filter(m: Map[K, V], f: Fn[K, V] -> Bool) -> Map[K, V]`


### PR DESCRIPTION
The decision-free rows of #1795:

- `map.map` — the example called `map.map_values`, which does not exist; it is now an executable doctest of `map.map`.
- `int.from_hex` — the example called `int.parse_hex` (E002); now an executable doctest over lower/upper/invalid input.
- `error.chain` — the documented result `"load failed: file not found"` was never what the function returns; the doctest pins the two-line `caused by:` form and the prose says so.
- `fs.walk` prose said "list all files"; it lists files and directories.
- `fs.*_if_exists` prose said "native-only today"; the family serves on both wasm legs.
- `list.pop` prose said "remove and discard"; it returns the element as an Option.

Still open on #1795 (need a ruling, not a doc edit): `map.keys`/`map.entries` "sorted" vs insertion order, `json.set_path` never erring, `path.extension(".gitignore")`, and `math.exp(1.0)` (#1796). Refs #1795, #1490.