### PR TITLE
Stdlib docs state the accuracy and ordering they actually have: exp within 1 ulp, map in insertion order, json.set_path infallible

### DIFF
--- a/docs/stdlib/json.md
+++ b/docs/stdlib/json.md
@@ -282,7 +282,25 @@ none
 
 ### `json.set_path(j: Value, path: JsonPath, value: Value) -> Result[Value, String]`
 
-Set a value at a JSON path. Returns error if path is invalid.
+Set a value at a JSON path. Infallible: a missing object key is created, an index past the end of an array leaves the document unchanged, and a field step through a non-object value replaces that value with an object holding the field.
+
+```almd run
+import json
+
+fn show(r: Result[Value, String]) -> String = match r { ok(v) => json.stringify(v), err(e) => "err " + e }
+
+effect fn main() -> Unit = {
+  let doc = json.parse("{\"a\": {\"b\": 1}, \"xs\": [1, 2]}")!
+  println(show(json.set_path(doc, json.root() |> json.field("a") |> json.field("c"), value.int(5))))
+  println(show(json.set_path(doc, json.root() |> json.field("xs") |> json.index(7), value.int(5))))
+  println(show(json.set_path(doc, json.root() |> json.field("a") |> json.field("b") |> json.field("z"), value.int(5))))
+}
+```
+```output
+{"a":{"b":1,"c":5},"xs":[1,2]}
+{"a":{"b":1},"xs":[1,2]}
+{"a":{"b":{"z":5}},"xs":[1,2]}
+```
 
 ```almd run
 import json

--- a/docs/stdlib/map.md
+++ b/docs/stdlib/map.md
@@ -108,7 +108,7 @@ fn main() -> Unit = {
 
 ### `map.keys(m: Map[K, V]) -> List[K]`
 
-Get all keys as a sorted list.
+Get all keys as a list, in insertion order (the order the entries were first inserted; overwriting a key keeps its position).
 
 ```almd
 map.keys(m)
@@ -144,7 +144,7 @@ fn main() -> Unit = {
 
 ### `map.entries(m: Map[K, V]) -> List[(K, V)]`
 
-Get all key-value pairs as a list of tuples, sorted by key.
+Get all key-value pairs as a list of tuples, in insertion order.
 
 ```almd
 map.entries(m)

--- a/docs/stdlib/math.md
+++ b/docs/stdlib/math.md
@@ -134,10 +134,19 @@ fn main() -> Unit = {
 
 ### `math.exp(x: Float) -> Float`
 
-Return e raised to the given power.
+Return e raised to the given power. The vendored libm guarantees the result within 1 ulp of the true value and byte-identical across targets (C-305) — not correct rounding: `math.exp(1.0)` is one ulp above `math.e()`, which is the correctly rounded constant.
 
-```almd
-math.exp(1.0) // => 2.718281828459045
+```almd run
+fn main() -> Unit = {
+  println(float.to_string(math.exp(0.0)))
+  println(float.to_string(math.exp(1.0)))
+  println(float.to_string(math.e()))
+}
+```
+```output
+1.0
+2.7182818284590455
+2.718281828459045
 ```
 
 ### `math.sqrt(x: Float) -> Float`


### PR DESCRIPTION
Fixes #1796. Refs #1795 (the remaining ruling rows).

- `math.exp`: the example promised the correctly rounded e; the vendored libm's contract (C-305) promises within 1 ulp and byte-identity, and `exp(1.0)` sits one ulp above `math.e()`. The docs now say so and the example is an executable doctest pinning both values — the implementation is inside its contract, the doc was not.
- `map.keys` / `map.entries`: prose said sorted; the implementation (and `stdlib/map_core.almd`'s own comment) iterates in insertion order. Prose fixed; the existing doctests insert pre-sorted so they were already truthful.
- `json.set_path`: prose said "returns error if path is invalid"; the contract at C-031 (json get/set/remove_path) makes it infallible. The prose now describes the three edges (missing key created, index past the end ignored, field through a non-object replaces it) and a doctest pins them.

Still open on #1795: `path.extension(".gitignore")` — a code change following the documented rule, coming as its own PR with a contract.