### PR TITLE
The signature index spells tuple, RawPtr, Never and Matrix[Float32] types: the doc-index renderer and the interface JSON stop emitting () and ?

### DIFF
--- a/crates/almide-tools/src/interface.rs
+++ b/crates/almide-tools/src/interface.rs
@@ -437,6 +437,10 @@ fn resolve_ty_scalar(ty: &Ty) -> Option<TypeRef> {
         Ty::UInt64 => named("UInt64"),
         Ty::Float32 => named("Float32"),
         Ty::Float64 => named("Float64"),
+        // #1832: the raw pointer and the bottom type used to fall through to
+        // `Unknown`, which the signature index rendered as `?`.
+        Ty::RawPtr => named("RawPtr"),
+        Ty::Never => named("Never"),
         _ => return None,
     })
 }

--- a/crates/almide-tools/src/interface.rs
+++ b/crates/almide-tools/src/interface.rs
@@ -464,6 +464,9 @@ fn resolve_ty_applied(ty: &Ty, records: &RecordLookup, variants: &VariantLookup)
             TypeRef::Map { key: one(&args[0]), value: one(&args[1]) }
         }
         TypeConstructorId::Tuple => TypeRef::Tuple { elements: each(args) },
+        // #1832: `Matrix[Float32]` is the applied matrix constructor; spell it as a
+        // named type with its element argument instead of `Unknown`.
+        TypeConstructorId::Matrix => TypeRef::Named { name: "Matrix".into(), args: each(args) },
         TypeConstructorId::UserDefined(name) => {
             TypeRef::Named { name: name.clone(), args: each(args) }
         }

--- a/docs/stdlib/bytes.md
+++ b/docs/stdlib/bytes.md
@@ -163,21 +163,21 @@ bytes.append_u16_le(b: Bytes, val: Int) -> Unit
 bytes.append_u32_be(b: Bytes, val: Int) -> Unit
 bytes.append_u32_le(b: Bytes, val: Int) -> Unit
 bytes.append_u8(b: Bytes, val: Int) -> Unit
-bytes.as_mut_ptr(b: Bytes) -> ?
-bytes.as_ptr(b: Bytes) -> ?
+bytes.as_mut_ptr(b: Bytes) -> RawPtr
+bytes.as_ptr(b: Bytes) -> RawPtr
 bytes.chunks(b: Bytes, size: Int) -> List[Bytes]
 bytes.clear(b: Bytes) -> Unit
 bytes.cmp(a: Bytes, b: Bytes) -> Int
 bytes.concat(a: Bytes, b: Bytes) -> Bytes
 bytes.contains(b: Bytes, pattern: Bytes) -> Bool
 bytes.copy_from(dst: Bytes, src: Bytes, dst_off: Int, src_off: Int, len: Int) -> Unit
-bytes.copy_to_ptr(b: Bytes, ptr: ?, cap: Int) -> Int
+bytes.copy_to_ptr(b: Bytes, ptr: RawPtr, cap: Int) -> Int
 bytes.data_ptr(b: Bytes) -> Int
 bytes.ends_with(b: Bytes, suffix: Bytes) -> Bool
 bytes.eof(b: Bytes, pos: Int) -> Bool
 bytes.fill(b: Bytes, val: Int) -> Unit
 bytes.from_list(xs: List[Int]) -> Bytes
-bytes.from_raw_ptr(ptr: ?, len: Int) -> Bytes
+bytes.from_raw_ptr(ptr: RawPtr, len: Int) -> Bytes
 bytes.from_string(s: String) -> Bytes
 bytes.get(b: Bytes, i: Int) -> Option[Int]
 bytes.get_or(b: Bytes, i: Int, default: Int) -> Int

--- a/docs/stdlib/bytes.md
+++ b/docs/stdlib/bytes.md
@@ -195,58 +195,58 @@ bytes.push(b: Bytes, val: Int) -> Unit
 bytes.set_at(b: Bytes, i: Int, val: Int) -> Unit
 bytes.copy_within(b: Bytes, src_start: Int, src_end: Int, dst: Int) -> Unit
 bytes.read_bool(b: Bytes, pos: Int) -> Bool
-bytes.read_bool_at(b: Bytes, pos: Int) -> ()
+bytes.read_bool_at(b: Bytes, pos: Int) -> (Int, Option[Bool])
 bytes.read_f16_le(b: Bytes, pos: Int) -> Float
-bytes.read_f16_le_at(b: Bytes, pos: Int) -> ()
+bytes.read_f16_le_at(b: Bytes, pos: Int) -> (Int, Option[Float])
 bytes.read_f16_le_array(b: Bytes, pos: Int, count: Int) -> List[Float]
 bytes.read_f32_be(b: Bytes, pos: Int) -> Float
 bytes.read_f32_be_array(b: Bytes, pos: Int, count: Int) -> List[Float]
-bytes.read_f32_be_at(b: Bytes, pos: Int) -> ()
+bytes.read_f32_be_at(b: Bytes, pos: Int) -> (Int, Option[Float])
 bytes.read_f32_le(b: Bytes, pos: Int) -> Float
 bytes.read_f32_le_array(b: Bytes, pos: Int, count: Int) -> List[Float]
-bytes.read_f32_le_at(b: Bytes, pos: Int) -> ()
+bytes.read_f32_le_at(b: Bytes, pos: Int) -> (Int, Option[Float])
 bytes.read_f64_be(b: Bytes, pos: Int) -> Float
 bytes.read_f64_be_array(b: Bytes, pos: Int, count: Int) -> List[Float]
-bytes.read_f64_be_at(b: Bytes, pos: Int) -> ()
+bytes.read_f64_be_at(b: Bytes, pos: Int) -> (Int, Option[Float])
 bytes.read_f64_le(b: Bytes, pos: Int) -> Float
 bytes.read_f64_le_array(b: Bytes, pos: Int, count: Int) -> List[Float]
-bytes.read_f64_le_at(b: Bytes, pos: Int) -> ()
+bytes.read_f64_le_at(b: Bytes, pos: Int) -> (Int, Option[Float])
 bytes.read_i16_be(b: Bytes, pos: Int) -> Int
-bytes.read_i16_be_at(b: Bytes, pos: Int) -> ()
+bytes.read_i16_be_at(b: Bytes, pos: Int) -> (Int, Option[Int])
 bytes.read_i16_be_array(b: Bytes, pos: Int, count: Int) -> List[Int]
 bytes.read_i16_le(b: Bytes, pos: Int) -> Int
-bytes.read_i16_le_at(b: Bytes, pos: Int) -> ()
+bytes.read_i16_le_at(b: Bytes, pos: Int) -> (Int, Option[Int])
 bytes.read_i16_le_array(b: Bytes, pos: Int, count: Int) -> List[Int]
 bytes.read_i32_be(b: Bytes, pos: Int) -> Int
 bytes.read_i32_be_array(b: Bytes, pos: Int, count: Int) -> List[Int]
-bytes.read_i32_be_at(b: Bytes, pos: Int) -> ()
+bytes.read_i32_be_at(b: Bytes, pos: Int) -> (Int, Option[Int])
 bytes.read_i32_le(b: Bytes, pos: Int) -> Int
 bytes.read_i32_le_array(b: Bytes, pos: Int, count: Int) -> List[Int]
-bytes.read_i32_le_at(b: Bytes, pos: Int) -> ()
+bytes.read_i32_le_at(b: Bytes, pos: Int) -> (Int, Option[Int])
 bytes.read_i64_be(b: Bytes, pos: Int) -> Int
 bytes.read_i64_be_array(b: Bytes, pos: Int, count: Int) -> List[Int]
-bytes.read_i64_be_at(b: Bytes, pos: Int) -> ()
+bytes.read_i64_be_at(b: Bytes, pos: Int) -> (Int, Option[Int])
 bytes.read_i64_le(b: Bytes, pos: Int) -> Int
 bytes.read_i64_le_array(b: Bytes, pos: Int, count: Int) -> List[Int]
-bytes.read_i64_le_at(b: Bytes, pos: Int) -> ()
+bytes.read_i64_le_at(b: Bytes, pos: Int) -> (Int, Option[Int])
 bytes.read_length_prefixed_strings_le(b: Bytes, pos: Int, count: Int) -> List[String]
 bytes.read_string_at(b: Bytes, pos: Int, len: Int) -> String
 bytes.read_string_be(b: Bytes, pos: Int) -> String
-bytes.read_string_be_at(b: Bytes, pos: Int) -> ()
+bytes.read_string_be_at(b: Bytes, pos: Int) -> (Int, Option[String])
 bytes.read_u16_be(b: Bytes, pos: Int) -> Int
-bytes.read_u16_be_at(b: Bytes, pos: Int) -> ()
+bytes.read_u16_be_at(b: Bytes, pos: Int) -> (Int, Option[Int])
 bytes.read_u16_be_array(b: Bytes, pos: Int, count: Int) -> List[Int]
 bytes.read_u16_le(b: Bytes, pos: Int) -> Int
 bytes.read_u16_le_array(b: Bytes, pos: Int, count: Int) -> List[Int]
-bytes.read_u16_le_at(b: Bytes, pos: Int) -> ()
+bytes.read_u16_le_at(b: Bytes, pos: Int) -> (Int, Option[Int])
 bytes.read_u32_be(b: Bytes, pos: Int) -> Int
 bytes.read_u32_be_array(b: Bytes, pos: Int, count: Int) -> List[Int]
-bytes.read_u32_be_at(b: Bytes, pos: Int) -> ()
+bytes.read_u32_be_at(b: Bytes, pos: Int) -> (Int, Option[Int])
 bytes.read_u32_le(b: Bytes, pos: Int) -> Int
 bytes.read_u32_le_array(b: Bytes, pos: Int, count: Int) -> List[Int]
-bytes.read_u32_le_at(b: Bytes, pos: Int) -> ()
+bytes.read_u32_le_at(b: Bytes, pos: Int) -> (Int, Option[Int])
 bytes.read_u8(b: Bytes, pos: Int) -> Int
-bytes.read_u8_at(b: Bytes, pos: Int) -> ()
+bytes.read_u8_at(b: Bytes, pos: Int) -> (Int, Option[Int])
 bytes.remove_at(b: Bytes, pos: Int) -> Bytes
 bytes.repeat(b: Bytes, n: Int) -> Bytes
 bytes.reverse(b: Bytes) -> Bytes
@@ -271,7 +271,7 @@ bytes.skip_length_prefixed_le(b: Bytes, pos: Int, count: Int) -> Int
 bytes.slice(b: Bytes, start: Int, end: Int) -> Bytes
 bytes.split(b: Bytes, sep: Bytes) -> List[Bytes]
 bytes.starts_with(b: Bytes, prefix: Bytes) -> Bool
-bytes.take_at(b: Bytes, pos: Int, n: Int) -> ()
+bytes.take_at(b: Bytes, pos: Int, n: Int) -> (Int, Option[Bytes])
 bytes.to_list(b: Bytes) -> List[Int]
 bytes.to_string(b: Bytes) -> Result[String, String]
 bytes.to_string_lossy(b: Bytes) -> String

--- a/docs/stdlib/http.md
+++ b/docs/stdlib/http.md
@@ -487,8 +487,8 @@ effect http.put(url: String, body: String) -> String
 effect http.patch(url: String, body: String) -> String
 effect http.delete(url: String) -> String
 effect http.request(method: String, url: String, body: String, headers: Map[String, String]) -> String
-effect http.get_status(url: String) -> ()
-effect http.request_status(method: String, url: String, body: String, headers: Map[String, String]) -> ()
+effect http.get_status(url: String) -> (Int, String)
+effect http.request_status(method: String, url: String, body: String, headers: Map[String, String]) -> (Int, String)
 effect http.get_bytes(url: String) -> Bytes
 effect http.request_bytes(method: String, url: String, body: String, headers: Map[String, String]) -> Bytes
 effect http.request_stream(method: String, url: String, body: String, headers: Map[String, String], on_chunk: (String) -> Unit) -> Unit

--- a/docs/stdlib/list.md
+++ b/docs/stdlib/list.md
@@ -833,8 +833,8 @@ list.swap(xs: List[A], i: Int, j: Int) -> List[A]
 list.sort(xs: List[A]) -> List[A]
 list.reverse(xs: List[A]) -> List[A]
 list.contains(xs: List[A], x: A) -> Bool
-list.enumerate(xs: List[A]) -> List[()]
-list.zip(xs: List[A], ys: List[B]) -> List[()]
+list.enumerate(xs: List[A]) -> List[(Int, A)]
+list.zip(xs: List[A], ys: List[B]) -> List[(A, B)]
 list.flatten(xss: List[List[T]]) -> List[T]
 list.take(xs: List[A], n: Int) -> List[A]
 list.drop(xs: List[A], n: Int) -> List[A]
@@ -862,7 +862,7 @@ list.fold(xs: List[A], init: B, f: (B, A) -> B) -> B
 list.sort_by(xs: List[A], f: (A) -> B) -> List[A]
 list.take_while(xs: List[A], f: (A) -> Bool) -> List[A]
 list.drop_while(xs: List[A], f: (A) -> Bool) -> List[A]
-list.partition(xs: List[A], f: (A) -> Bool) -> ()
+list.partition(xs: List[A], f: (A) -> Bool) -> (List[A], List[A])
 list.reduce(xs: List[A], f: (A, A) -> A) -> Option[A]
 list.group_by(xs: List[A], f: (A) -> B) -> Map[B, List[A]]
 list.find_index(xs: List[A], f: (A) -> Bool) -> Option[Int]
@@ -888,7 +888,7 @@ list.with_capacity(cap: Int) -> List[A]
 list.pop(xs: List[A]) -> Option[A]
 list.clear(xs: List[A]) -> Unit
 list.bundled_probe(n: Int) -> Int
-list.split_at(xs: List[T], n: Int) -> ()
+list.split_at(xs: List[T], n: Int) -> (List[T], List[T])
 list.iterate(seed: T, f: (T) -> T, n: Int) -> List[T]
 ```
 

--- a/docs/stdlib/map.md
+++ b/docs/stdlib/map.md
@@ -378,17 +378,17 @@ map.remove(m: Map[K, V], key: K) -> Map[K, V]
 map.keys(m: Map[K, V]) -> List[K]
 map.values(m: Map[K, V]) -> List[V]
 map.len(m: Map[K, V]) -> Int
-map.entries(m: Map[K, V]) -> List[()]
+map.entries(m: Map[K, V]) -> List[(K, V)]
 map.merge(a: Map[K, V], b: Map[K, V]) -> Map[K, V]
 map.is_empty(m: Map[K, V]) -> Bool
-map.from_list(pairs: List[()]) -> Map[K, V]
+map.from_list(pairs: List[(K, V)]) -> Map[K, V]
 map.map(m: Map[K, V], f: (V) -> B) -> Map[K, B]
 map.filter(m: Map[K, V], f: (K, V) -> Bool) -> Map[K, V]
 map.fold(m: Map[K, V], init: A, f: (A, K, V) -> A) -> A
 map.any(m: Map[K, V], f: (K, V) -> Bool) -> Bool
 map.all(m: Map[K, V], f: (K, V) -> Bool) -> Bool
 map.count(m: Map[K, V], f: (K, V) -> Bool) -> Int
-map.find(m: Map[K, V], f: (K, V) -> Bool) -> Option[()]
+map.find(m: Map[K, V], f: (K, V) -> Bool) -> Option[(K, V)]
 map.update(m: Map[K, V], key: K, f: (V) -> V) -> Map[K, V]
 map.upsert(m: Map[K, V], key: K, init: V, f: (V) -> V) -> Map[K, V]
 map.insert(m: Map[K, V], key: K, value: V) -> Unit

--- a/docs/stdlib/matrix.md
+++ b/docs/stdlib/matrix.md
@@ -119,7 +119,7 @@ information and survives (C-269).
 ```
 matrix.zeros(rows: Int, cols: Int) -> Matrix
 matrix.ones(rows: Int, cols: Int) -> Matrix
-matrix.shape(m: Matrix) -> ()
+matrix.shape(m: Matrix) -> (Int, Int)
 matrix.transpose(m: Matrix) -> Matrix
 matrix.from_lists(rows: List[List[Float]]) -> Matrix
 matrix.from_q1_0_bytes(data: Bytes, offset: Int, rows: Int, cols: Int) -> Matrix
@@ -130,14 +130,14 @@ matrix.select_rows_q1_0(data: Bytes, offset: Int, cols: Int, row_ids: List[Int])
 matrix.rope_rotate(x: Matrix, n_heads: Int, head_dim: Int, theta_base: Float) -> Matrix
 matrix.rope_rotate_at(x: Matrix, n_heads: Int, head_dim: Int, theta_base: Float, start_pos: Int) -> Matrix
 matrix.append_rows(base: Matrix, extra: Matrix) -> Matrix
-matrix.qwen3_block_q1_0_kv(h: Matrix, k_cache: Matrix, v_cache: Matrix, w: Bytes, gamma_offs: List[Int], weight_offs: List[Int], start_pos: Int, n_q_heads: Int, n_kv_heads: Int, head_dim: Int, ffn_hidden: Int, rope_theta: Float, eps: Float) -> ()
+matrix.qwen3_block_q1_0_kv(h: Matrix, k_cache: Matrix, v_cache: Matrix, w: Bytes, gamma_offs: List[Int], weight_offs: List[Int], start_pos: Int, n_q_heads: Int, n_kv_heads: Int, head_dim: Int, ffn_hidden: Int, rope_theta: Float, eps: Float) -> (Matrix, Matrix, Matrix)
 matrix.linear_f32_row_no_bias(x: Matrix, w_bytes: Bytes, w_offset: Int, w_rows: Int, w_cols: Int) -> Matrix
 matrix.select_rows_f32(data: Bytes, offset: Int, cols: Int, row_ids: List[Int]) -> Matrix
 matrix.rope_rotate_neox_at(x: Matrix, n_heads: Int, head_dim: Int, theta_base: Float, start_pos: Int) -> Matrix
-matrix.qwen3_block_f32_kv(h: Matrix, k_cache: Matrix, v_cache: Matrix, w: Bytes, gamma_offs: List[Int], weight_offs: List[Int], start_pos: Int, n_q_heads: Int, n_kv_heads: Int, head_dim: Int, ffn_hidden: Int, rope_theta: Float, eps: Float) -> ()
+matrix.qwen3_block_f32_kv(h: Matrix, k_cache: Matrix, v_cache: Matrix, w: Bytes, gamma_offs: List[Int], weight_offs: List[Int], start_pos: Int, n_q_heads: Int, n_kv_heads: Int, head_dim: Int, ffn_hidden: Int, rope_theta: Float, eps: Float) -> (Matrix, Matrix, Matrix)
 matrix.linear_q8_0_row_no_bias(x: Matrix, w_bytes: Bytes, w_offset: Int, w_rows: Int, w_cols: Int) -> Matrix
 matrix.select_rows_q8_0_dq(data: Bytes, offset: Int, cols: Int, row_ids: List[Int]) -> Matrix
-matrix.qwen3_block_q8_0_kv(h: Matrix, k_cache: Matrix, v_cache: Matrix, w: Bytes, gamma_offs: List[Int], weight_offs: List[Int], start_pos: Int, n_q_heads: Int, n_kv_heads: Int, head_dim: Int, ffn_hidden: Int, rope_theta: Float, eps: Float) -> ()
+matrix.qwen3_block_q8_0_kv(h: Matrix, k_cache: Matrix, v_cache: Matrix, w: Bytes, gamma_offs: List[Int], weight_offs: List[Int], start_pos: Int, n_q_heads: Int, n_kv_heads: Int, head_dim: Int, ffn_hidden: Int, rope_theta: Float, eps: Float) -> (Matrix, Matrix, Matrix)
 matrix.to_lists(m: Matrix) -> List[List[Float]]
 matrix.get(m: Matrix, row: Int, col: Int) -> Float
 matrix.rows(m: Matrix) -> Int

--- a/docs/stdlib/matrix.md
+++ b/docs/stdlib/matrix.md
@@ -181,12 +181,12 @@ matrix.conv1d(input: Matrix, weight: Matrix, bias: List[Float], kernel: Int, str
 matrix.gather_rows(m: Matrix, indices: List[Int]) -> Matrix
 matrix.dot_row(m: Matrix, r: Int, vec: List[Float]) -> Float
 matrix.row_dot(m: Matrix, r: Int, vec: List[Float]) -> Float
-matrix.zeros_f32(rows: Int, cols: Int) -> ?
-matrix.ones_f32(rows: Int, cols: Int) -> ?
-matrix.mul_f32(a: ?, b: ?) -> ?
-matrix.mul_f32_scaled(a: ?, alpha: Float, b: ?) -> ?
-matrix.mul_f32_t(a: ?, b: ?) -> ?
-matrix.mul_f32_t_scaled(a: ?, alpha: Float, b: ?) -> ?
+matrix.zeros_f32(rows: Int, cols: Int) -> Matrix[Float32]
+matrix.ones_f32(rows: Int, cols: Int) -> Matrix[Float32]
+matrix.mul_f32(a: Matrix[Float32], b: Matrix[Float32]) -> Matrix[Float32]
+matrix.mul_f32_scaled(a: Matrix[Float32], alpha: Float, b: Matrix[Float32]) -> Matrix[Float32]
+matrix.mul_f32_t(a: Matrix[Float32], b: Matrix[Float32]) -> Matrix[Float32]
+matrix.mul_f32_t_scaled(a: Matrix[Float32], alpha: Float, b: Matrix[Float32]) -> Matrix[Float32]
 matrix.mul_scaled(a: Matrix, alpha: Float, b: Matrix) -> Matrix
 ```
 

--- a/docs/stdlib/option.md
+++ b/docs/stdlib/option.md
@@ -223,7 +223,7 @@ option.is_some(o: Option[A]) -> Bool
 option.is_none(o: Option[A]) -> Bool
 option.to_result(o: Option[A], e: E) -> Result[A, E]
 option.filter(o: Option[A], f: (A) -> Bool) -> Option[A]
-option.zip(a: Option[A], b: Option[B]) -> Option[()]
+option.zip(a: Option[A], b: Option[B]) -> Option[(A, B)]
 option.or_else(o: Option[A], f: () -> Option[A]) -> Option[A]
 option.to_list(o: Option[A]) -> List[A]
 option.collect(xs: List[Option[T]]) -> Option[List[T]]

--- a/docs/stdlib/process.md
+++ b/docs/stdlib/process.md
@@ -188,7 +188,7 @@ effect fn main() -> Unit = {
 
 ```
 effect process.exec(cmd: String, args: List[String]) -> String
-effect process.exit(code: Int) -> ?
+effect process.exit(code: Int) -> Never
 process.args() -> List[String]
 effect process.stdin_lines() -> List[String]
 effect process.exec_in(dir: String, cmd: String, args: List[String]) -> String

--- a/docs/stdlib/result.md
+++ b/docs/stdlib/result.md
@@ -190,10 +190,10 @@ result.is_ok(r: Result[A, E]) -> Bool
 result.is_err(r: Result[A, E]) -> Bool
 result.to_option(r: Result[A, E]) -> Option[A]
 result.to_err_option(r: Result[A, E]) -> Option[E]
-result.partition(rs: List[Result[T, E]]) -> ()
+result.partition(rs: List[Result[T, E]]) -> (List[T], List[E])
 result.flatten(r: Result[Result[A, E], E]) -> Result[A, E]
 result.to_list(r: Result[A, E]) -> List[A]
-result.zip(a: Result[A, E], b: Result[B, E]) -> Result[(), E]
+result.zip(a: Result[A, E], b: Result[B, E]) -> Result[(A, B), E]
 result.or_else(r: Result[A, E], f: (E) -> Result[A, F]) -> Result[A, F]
 result.filter(r: Result[A, E], pred: (A) -> Bool, err_val: E) -> Result[A, E]
 ```

--- a/docs/stdlib/string.md
+++ b/docs/stdlib/string.md
@@ -637,7 +637,7 @@ hel
 ```
 string.trim(s: String) -> String
 string.split(s: String, sep: String) -> List[String]
-string.split_once(s: String, sep: String) -> Option[()]
+string.split_once(s: String, sep: String) -> Option[(String, String)]
 string.join(list: List[String], sep: String) -> String
 string.len(s: String) -> Int
 string.length(s: String) -> Int   (deprecated — use string.len)
@@ -681,7 +681,7 @@ string.take(s: String, n: Int) -> String
 string.take_end(s: String, n: Int) -> String
 string.drop(s: String, n: Int) -> String
 string.drop_end(s: String, n: Int) -> String
-string.run_length_encode(s: String) -> List[()]
+string.run_length_encode(s: String) -> List[(String, Int)]
 string.push(s: String, suffix: String) -> Unit
 string.clear(s: String) -> Unit
 ```

--- a/docs/stdlib/url.md
+++ b/docs/stdlib/url.md
@@ -97,8 +97,8 @@ url.encode_component(s: String) -> String
 url.decode_component(s: String) -> Result[String, String]
 url.parse(s: String) -> Result[Url, String]
 url.to_string(u: Url) -> String
-url.query_pairs(query: String) -> List[()]
-url.build_query(pairs: List[()]) -> String
+url.query_pairs(query: String) -> List[(String, String)]
+url.build_query(pairs: List[(String, String)]) -> String
 ```
 
 <!-- END GENERATED SIGNATURE INDEX -->

--- a/docs/stdlib/value.md
+++ b/docs/stdlib/value.md
@@ -106,7 +106,7 @@ value.float(f: Float) -> Value
 value.int(n: Int) -> Value
 value.merge(a: Value, b: Value) -> Value
 value.null() -> Value
-value.object(pairs: List[()]) -> Value
+value.object(pairs: List[(String, Value)]) -> Value
 value.omit(v: Value, keys: List[String]) -> Value
 value.pick(v: Value, keys: List[String]) -> Value
 value.str(s: String) -> Value

--- a/tools/gen-stdlib-doc-index.py
+++ b/tools/gen-stdlib-doc-index.py
@@ -48,7 +48,9 @@ def render_ty(t: dict) -> str:
         params = ", ".join(render_ty(p) for p in t.get("params", []))
         return f"({params}) -> {render_ty(t['return'])}"
     if k == "tuple":
-        return "(" + ", ".join(render_ty(p) for p in t.get("items", t.get("elems", []))) + ")"
+        # The interface JSON spells tuple members `elements` (#1832); the
+        # old `items`/`elems` lookups rendered every tuple as `()`.
+        return "(" + ", ".join(render_ty(p) for p in t.get("elements", t.get("items", t.get("elems", [])))) + ")"
     if k in ("named", "type_var"):
         name = t.get("name", "?")
         args = t.get("args", [])


### PR DESCRIPTION
Refs #1832 (the tuple half). `tools/gen-stdlib-doc-index.py` looked up tuple members under `items`/`elems`; the interface JSON emits `elements`, so every tuple-typed signature in docs/stdlib rendered as `()` (`bytes.read_bool_at(b, pos) -> ()`, `string.split_once(s, sep) -> ()?`). Ten module docs regenerated; nothing else changes.

The other half of #1832 lands here too: `resolve_ty_scalar` maps `RawPtr` and `Never`, and `resolve_ty_applied` maps `Matrix[Float32]`, to named types instead of `Unknown`, so the interface JSON and the index spell them.

Note for the release: `scripts/check-interface-diff.sh` compares the committed indexes, so the next run will classify these lines as changed — the SPELLING moved, not the surface.

Fixes #1832.