### PR TITLE
The stock-wasmtime installer pins v27.0.0 so the release-shape gate stops failing on the GitHub API rate limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1469,7 +1469,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install wasmtime (stock CLI — the WASI gate's third-party runtime)
         run: |
-          curl https://wasmtime.dev/install.sh -sSf | bash
+          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v27.0.0
           echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
       - name: Carried gates in release shape
         run: cargo test --release --locked -p almide-wasm -p almide-wasm-run -p almide-spine -p almide-syntax -p almide-corpus -p almide-layout


### PR DESCRIPTION
`Commissioned wasm gates (structural leg, release)` installs the stock wasmtime CLI with `curl https://wasmtime.dev/install.sh -sSf | bash`. That installer asks `api.github.com/repos/bytecodealliance/wasmtime/releases/latest` for the version, unauthenticated; under the Team plan's 60 concurrent jobs the runner pool hits the API rate limit, the JSON error is parsed as the version and the step dies with:

```
Error: Could not download Wasmtime version '{'. See https://github.com/bytecodealliance/wasmtime/releases for a list of available releases
```

(PR #1831, run 33699756033, job "Carried gates in release shape": `corpus_reproduces_on_stock_wasmtime` then fails for want of the CLI.)

Fix: pass `--version v27.0.0` to the installer — the same version the other jobs pin by tarball URL — so the step never consults the releases API. The gate still runs a third-party stock wasmtime, now a reproducible one. `scripts/check-workflows.sh` clean.