### PR TITLE
Refresh the CI shard weights from a green run with the split wasm_runtime binaries

### DIFF
--- a/scripts/ci-test-weights.txt
+++ b/scripts/ci-test-weights.txt
@@ -14,70 +14,72 @@
 # RATIOS. Targets under 5s are omitted — they are within the default's noise.
 # Refresh by rerunning that command when the shard job's balance report drifts.
 # shard logs (Running/finished-in pairs, summed per target across shards).
+# shard logs (nextest per-test lines, or Running/finished-in pairs, summed per target across shards).
 # Refreshed 2026-09-03 by scripts/refresh-ci-test-weights.sh from a CI run's own
 # shard logs (nextest per-test lines, or Running/finished-in pairs, summed per target across shards).
-diagnostic_harness_test          1441
-eval_test                        518
-backend_parity                   381
-almide_mir                       303
-check_parity                     296
-run_parity                       234
-fuzz_differential                233
-surface_matrix                   219
-kernel_conformance_test          149
-bridge_test                      123
-fuzz_test                        110
-wasm_dispatch_coverage_test      103
-crossmod_matrix_test             93
-almide_egg_lab                   90
-charge_probe_test                79
-libm_trig_cross_target_test      77
-native_runtime_name_collision_pin_test 75
-fmt_test                         52
-native_v1_differential_test      48
-examples_parity_test             47
-http_close_notify_test           42
-native_fn_nested_derive_pin_test 38
-rc_placement_snapshot_test       34
+diagnostic_harness_test          1331
+wasm_runtime_interp_oracle       913
+run_parity                       746
+backend_parity                   568
+eval_test                        463
+surface_matrix                   451
+wasm_runtime_cross_target        446
+almide_mir                       285
+wasm_runtime_opt_parity          273
+check_parity                     186
+wasm_dispatch_coverage_test      171
+native_v1_differential_test      148
+kernel_conformance_test          134
+wasm_runtime_interp_ledger       125
+libm_trig_cross_target_test      122
+fuzz_test                        103
+fuzz_differential                101
+native_runtime_name_collision_pin_test 83
+almide_egg_lab                   82
+fmt_test                         73
+bridge_test                      73
+stdlib_type_owner_pull_test      64
+http_close_notify_test           57
+charge_probe_test                53
+crossmod_matrix_test             51
+wasm_runtime_inline              48
+native_codegen_walls_pin_test    42
+native_fn_nested_derive_pin_test 39
+http_timeout_native_test         36
 interp_spaced_globals_test       33
-libm_atan_tanh_cross_target_test 31
-run_target_flag_test             28
-semantic_laws_test               27
-bytes_unwrap_callarg_test        27
+libm_atan_tanh_cross_target_test 33
+semantic_laws_test               31
+examples_parity_test             30
 checker_test                     24
-crossmod_convention_key_test     23
 bytes_coalesce_call_arg_test     22
-heap_cap_test                    22
-regex_fuzz_test                  18
-http_timeout_native_test         18
-int_literal_domain_test          17
+rc_placement_snapshot_test       20
+crossmod_convention_key_test     19
+native_runtime_key_alias_pin_test 19
+nested_package_import_test       18
+list_pattern_test                17
+native_build_matrix_test         17
+int_literal_domain_test          16
 stdlib_examples_test             16
-gauntlet                         15
-tail_calls                       15
-alloc_count_gate_test            14
-value_match_unwrap_test          12
-io_print                         11
-dep_type_collision_test          11
+bytes_unwrap_callarg_test        15
+regex_fuzz_test                  15
+heap_cap_test                    15
+fan_arm_separator_test           13
+gauntlet                         13
+fmt_corpus_test                  12
 libm_explog_pow_cross_target_test 11
-alias_semantics                  10
-convention_extension_ruling_test 10
-lower_test                       9
-first_light                      9
-fmt_corpus_test                  9
+io_print                         10
+float_to_fixed_cross_target_test 10
+module_type_repr_test            10
 mut_param_mono                   9
-reimpl_lint_best_match_test      7
-io_read_all_test                 7
-deterministic_profile_test       6
-float_to_fixed_cross_target_test 5
-# The six wasm_runtime_* binaries (the former wasm_runtime_test, 1552 s on CI
-# run 33695667642): measured locally on 2026-09-03 with nextest, release,
-# sequential (41.1 / 350.3 / 345.1 / 351.9 / 7.5 / 3.9 s) and scaled to the
-# parent's 1552 so the ratios hold; the next refresh-ci-test-weights.sh run
-# replaces them with CI numbers (the ledger binary runs ~190 s under the dev
-# profile, so its scaled 11 is low until then).
-wasm_runtime_interp_oracle       497
-wasm_runtime_cross_target        494
-wasm_runtime_opt_parity          487
-wasm_runtime_inline              58
-wasm_runtime_interp_ledger       11
-wasm_runtime_fail_corpus         5
+tail_calls                       9
+first_light                      9
+fix_test                         9
+alias_semantics                  8
+alloc_count_gate_test            6
+exercise_corpus_check_test       6
+convention_extension_ruling_test 6
+almide_codegen                   6
+lsp_test                         6
+pkg_build_determinism_test       5
+io_read_all_test                 5
+lower_test                       5


### PR DESCRIPTION
Follow-up to #1846 and #1848. The six `wasm_runtime_*` binaries were weighted from a local measurement scaled to the parent's 1552 s; a real CI run (33735320646, green, all binaries present) measures them very differently (`wasm_runtime_interp_oracle` 913 s vs the scaled 497; `run_parity` 746 vs 234; `diagnostic_harness_test` 1331 vs 1441), and the packed shards on that run came out **1605 / 1612 / 1294 / 3416 s** — skew 2.6 against the weekly `shard-balance.yml` limit of 1.4.

This PR is `scripts/refresh-ci-test-weights.sh 33735320646`: 66 measured targets, nothing else. Expected effect: the four shards pack within a few minutes of each other, so the required path (Build ≈ 8 min + the slowest shard) drops from ~30 min toward ~22 min.