### PR TITLE
The CI build job caches dependencies only and ships a stripped test archive, cutting the 4 GB cache and 3 GB artifact

### DIFF
--- a/.github/workflows/acceptance-ring.yml
+++ b/.github/workflows/acceptance-ring.yml
@@ -52,14 +52,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - uses: actions/cache@v6
+      # Dependencies only (see ci.yml `build`): rust-cache prunes the
+      # workspace's own artifacts on save; develop writes, PRs read.
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ring-cargo-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ring-cargo-${{ env.RUST_TOOLCHAIN }}-
+          shared-key: ring-build-${{ env.RUST_TOOLCHAIN }}
+          save-if: ${{ github.ref == 'refs/heads/develop' }}
+          cache-on-failure: true
       - run: cargo build --release
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci-cross-target.yml
+++ b/.github/workflows/ci-cross-target.yml
@@ -36,14 +36,13 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-      - uses: actions/cache@v6
+      # Dependencies only (see ci.yml `build`): rust-cache prunes the
+      # workspace's own artifacts on save; develop writes, PRs read.
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cross-cargo-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cross-cargo-${{ env.RUST_TOOLCHAIN }}-
+          shared-key: cross-target-${{ env.RUST_TOOLCHAIN }}
+          save-if: ${{ github.ref == 'refs/heads/develop' }}
+          cache-on-failure: true
 
       - name: Build
         run: cargo build --release

--- a/.github/workflows/ci-feature.yml
+++ b/.github/workflows/ci-feature.yml
@@ -40,14 +40,14 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-      - uses: actions/cache@v6
+      # Dependencies only (see ci.yml `build`). Feature branches only READ
+      # the shared entry (develop's ci-feature run never happens — the
+      # trigger is branch-pattern-gated), so every feature push writes its
+      # own key: keep it but let the branch pay for the workspace it built.
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: feature-cargo-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: feature-cargo-${{ env.RUST_TOOLCHAIN }}-
+          shared-key: feature-build-${{ env.RUST_TOOLCHAIN }}
+          cache-on-failure: true
 
       - name: Build
         run: cargo build --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,9 @@ jobs:
           name: almide-tests-archive
           path: /tmp/almide-tests.tar.zst
           retention-days: 1
+          # nextest already zstd-compressed the archive; a second gzip pass
+          # over incompressible bytes only costs upload-artifact time.
+          compression-level: 0
 
       # Wired to `build`, not `checks`: the ratchet compiles the workspace, and
       # `checks` downloads a prebuilt binary with no cargo toolchain. Runs after

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,19 +164,27 @@ jobs:
 
       - run: cargo build --release
 
-      # #1732: the workspace's dev-profile TEST build happens ONCE, here,
-      # and ships to the shards as a cargo-nextest archive — the four
-      # shard jobs stop compiling entirely (each used to repeat this
-      # ~10-minute build). The archive carries every test binary plus
-      # build-script outputs; shards replay it with `nextest run
-      # --archive-file` under the same target map and coverage gate.
+      # #1732: the workspace's TEST build happens ONCE, here, and ships to
+      # the shards as a cargo-nextest archive — the four shard jobs stop
+      # compiling entirely (each used to repeat this ~10-minute build). The
+      # archive carries every test binary plus build-script outputs; shards
+      # replay it with `nextest run --archive-file` under the same target map
+      # and coverage gate.
+      #
+      # `--cargo-profile ci-test` (Cargo.toml): the dev profile minus
+      # debuginfo. The dev-profile archive was 3.1 GB, took 164 s to pack and
+      # 86 s to upload, and every shard downloaded it (the `digest-mismatch`
+      # flake lived on that download). Test semantics are the dev profile's
+      # (debug_assertions on, so the release-only sweeps stay ignored here).
+      # The shards need no profile flag: the archive records its own layout
+      # and `--extract-to` recreates target/ci-test/*.
       - name: Install cargo-nextest
         run: |
           curl -LsSf https://get.nexte.st/latest/linux -o /tmp/nextest.tar.gz
           tar xzf /tmp/nextest.tar.gz -C /usr/local/bin
           cargo nextest --version
       - name: Archive the workspace test binaries
-        run: cargo nextest archive --workspace --archive-file /tmp/almide-tests.tar.zst
+        run: cargo nextest archive --workspace --cargo-profile ci-test --archive-file /tmp/almide-tests.tar.zst
       - uses: actions/upload-artifact@v7
         with:
           name: almide-tests-archive
@@ -310,8 +318,8 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       # #1732: no compile here anymore — the build job ships the
-      # dev-profile test binaries as a nextest archive, and this job
-      # replays it. The big registry/target cache went with the compile;
+      # ci-test-profile test binaries (dev minus debuginfo) as a nextest
+      # archive, and this job replays it. The big registry/target cache went with the compile;
       # only the tool tarball caches below remain.
       - name: Install cargo-nextest
         if: env.DOCS_ONLY != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,14 +148,19 @@ jobs:
           # clippy rides this job's compile cache for its ratchet (#1462).
           components: clippy
 
-      - uses: actions/cache@v6
+      # Dependencies only. The old actions/cache entry (registry + git + the
+      # whole `target/`) had grown to 4.1 GB and took 143 s to restore — most
+      # of it the workspace's own artifacts, which every run recompiles anyway
+      # because the sources changed. rust-cache prunes workspace crates from
+      # `target/` on save and keeps the dependency artifacts (release,
+      # ci-test, and the check/clippy metadata the two ratchets below ride).
+      # `save-if`: develop writes, PRs and queue branches read — one warm
+      # entry per toolchain + lockfile instead of one per branch.
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: linux-cargo-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: linux-cargo-${{ env.RUST_TOOLCHAIN }}-
+          shared-key: ci-build-${{ env.RUST_TOOLCHAIN }}
+          save-if: ${{ github.ref == 'refs/heads/develop' }}
+          cache-on-failure: true
 
       - run: cargo build --release
 
@@ -628,14 +633,13 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-      - uses: actions/cache@v6
+      # Dependencies only (see the `build` job): rust-cache prunes the
+      # workspace's own artifacts on save; develop writes, PRs read.
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ env.RUST_TOOLCHAIN }}-
+          shared-key: ci-wasm-windows-${{ env.RUST_TOOLCHAIN }}
+          save-if: ${{ github.ref == 'refs/heads/develop' }}
+          cache-on-failure: true
 
       - run: cargo build --release
 
@@ -1305,14 +1309,13 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-      - uses: actions/cache@v6
+      # Dependencies only (see the `build` job): rust-cache prunes the
+      # workspace's own artifacts on save; develop writes, PRs read.
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ env.RUST_TOOLCHAIN }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ env.RUST_TOOLCHAIN }}-
+          shared-key: ci-cross-platform-${{ matrix.os }}-${{ env.RUST_TOOLCHAIN }}
+          save-if: ${{ github.ref == 'refs/heads/develop' }}
+          cache-on-failure: true
 
       - run: cargo build --release
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,16 @@ tempfile = "3"
 [profile.release]
 incremental = true
 
+
+# The CI test archive (ci.yml `build` → the four `Test Rust` shards). It is the
+# dev profile with the debuginfo left out: the shards replay these binaries from
+# a nextest archive, and debuginfo was most of the 3.1 GB that every shard
+# downloaded. Semantics are UNCHANGED — `inherits = "dev"` keeps
+# debug_assertions and overflow checks, so the `cfg_attr(debug_assertions,
+# ignore = "…release-only…")` sweeps stay ignored here exactly as they were.
+# Symbols are kept (`strip = "debuginfo"`, not "symbols") so a panic in a shard
+# still names its frames.
+[profile.ci-test]
+inherits = "dev"
+debug = 0
+strip = "debuginfo"


### PR DESCRIPTION
## Problem (run 33735320646, job "Build (Linux)", ~9 min)

Compile is cheap; the bytes are the cost. The `actions/cache` entry (registry + git + the whole `target/`) had grown to 4.1 GB, and the dev-profile nextest archive that every one of the four `Test Rust` shards downloads was 3.1 GB (the `digest-mismatch` flake seen twice on 2026-09-02 was on that download).

## Change

1. **Cache — dependencies only.** The `build` job (and the other jobs that cached `target/`: the Windows/macOS legs in `ci.yml`, `acceptance-ring`, `ci-cross-target`, `ci-feature`) move from `actions/cache@v6` to `Swatinem/rust-cache@v2` with a `shared-key` per job+toolchain, `save-if` on develop only (PRs and queue branches read, do not write) and `cache-on-failure`. rust-cache prunes the workspace's own artifacts on save and keeps the dependency artifacts — including the check/clippy metadata the two warning ratchets ride.
2. **Archive — `[profile.ci-test]`** (`Cargo.toml`): `inherits = "dev"`, `debug = 0`, `strip = "debuginfo"`. Test semantics are unchanged: it is the dev profile, so `debug_assertions` stays on and the `cfg_attr(debug_assertions, ignore = "…release-only…")` sweeps stay ignored in the shards exactly as before. Symbols are kept so a shard panic still names its frames. The shards need no flag — the archive records its own layout and `--extract-to` recreates `target/ci-test/*`; `shard-coverage` enumerates from the same archive.
3. **Upload — `compression-level: 0`** on the archive artifact: nextest already zstd-compressed it.

Nothing about what is tested changes: no spec fixtures, no ledgers, no shard partition.

## Measured — before (run 33735320646, develop) vs after (run 33745328800, this PR)

| | before | after | note |
|---|---|---|---|
| `almide-tests-archive` artifact | **3.1 GB** | **576 MB** | −81 % |
| Archive the workspace test binaries | 164 s | 148 s | cold deps in the after-run (see cache row) |
| upload-artifact (archive) | 86 s | **4 s** | `compression-level: 0` |
| download-artifact (archive, shard 0) | 62 s | **6 s** | ×4 shards + shard-coverage |
| cargo cache restore | 143 s (4.1 GB entry) | 1 s — **miss** | PRs read only; develop has not saved a `ci-build-1.94.0` entry yet, so this run built cold |
| `cargo build --release` | 100 s (warm) | 353 s (cold) | returns to ~100 s once develop saves the entry; the `almide-gates` job's rust-cache entry (release deps, same shape) is 473 MB vs the old 4098 MB |
| Build (Linux) job | 563 s | 632 s | cold-cache run; expected warm ≈ 563 − 143 − 82 ≈ 340 s |
| Test shards cover every target | 456 s | 112 s | |
| slowest shard | 1280 s (shard 2) | 1343 s (shard 3) | test execution, runner noise; shards 0/1/2 all faster (685→456, 638→415, 1280→832) |
| tests enumerated per shard (nextest `(n/N)` counter; run incl. skipped) | 274 · 975 · 539 · 624 = 2412 (run 33742315928, develop @ merge base) | 274 · 975 · 539 · 624 = 2412 (13 skipped, as before: the release-only sweeps stay ignored) | identical per-shard counts — same targets, same tests, same partition |
| shard-coverage | 229 targets | 229 targets | |

Local (macOS, cargo 1.96): dev archive 654 MB vs ci-test 594 MB — a small delta only because macOS keeps debuginfo in the `.o` files rather than linking it into the binaries; Linux links it in, which is where the 3.1 GB → 576 MB comes from.

`bash scripts/check-workflows.sh`: 16 workflow files parse strictly.

What this run could NOT show: the warm-cache restore time and the saved entry's size, because `save-if` is develop-only by design — the first develop run after merge writes it; the next develop push measures it.
