### PR TITLE
almide test keys its scratch artifacts on a per-run directory and the absolute path, so same-named files and parallel runs cannot race

### DIFF
--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -1,6 +1,6 @@
 # CLI Specification
 
-> Last updated: 2026-08-14
+> Last updated: 2026-09-03
 
 ## Overview
 
@@ -85,6 +85,14 @@ almide test --json                      # 結果を JSONL (1行1ファイル) �
 | `--no-check` | 型チェックをスキップ |
 | `--json` | JSON 形式で結果出力 |
 | `--target wasm` | wasmtime で実行 |
+
+スクラッチ成果物（wasm レグが wasmtime に渡す `.wasm` モジュール）は実行ごとに固有の
+`$TMPDIR/almide-test-<pid>-<nonce>/` 配下に、ファイルの**絶対パス**のハッシュで命名して
+置かれ、終了時に削除される（`ALMIDE_KEEP_SCRATCH=1` で残し、場所を stderr に出す）。
+同名ファイルの並列実行や別ディレクトリの同名ファイルがパスを共有することはない（#1877）。
+ネイティブ fallback のビルドキャッシュは `$TMPDIR/almide-test/native/` に永続（同じく絶対パス鍵）。
+
+テスト: `tests/test_scratch_race_test.rs`
 
 失敗の報告は**構造化ブロック**（`FAILED: <file>` に続けて `test:` / `at:` /
 `hint:` / `diff:` または `expected:` `found:`）。複数行文字列・リスト・レコードは

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,5 +1,6 @@
 use crate::{parse_file, fmt, project, project_fetch, resolve, canonicalize, check, diagnostic, out, out_no_nl, err, err_no_nl};
 use super::{collect_test_files, incremental_cache_dir};
+use super::test_scratch::TestScratch;
 
 pub fn cmd_init() {
     if std::path::Path::new("almide.toml").exists() {
@@ -96,7 +97,7 @@ fn discover_test_files(file: &str, fallback_dirs: &[&str]) -> Vec<String> {
 /// CPU count), each in its own scratch dir so cold rustc builds parallelize
 /// instead of serializing on the shared dir's BUILD_LOCK. Extracted
 /// verbatim.
-fn compile_test_files_parallel(test_files: &[String], no_check: bool) -> Vec<(String, Result<std::path::PathBuf, String>)> {
+fn compile_test_files_parallel(test_files: &[String], no_check: bool, scratch: &std::sync::Arc<TestScratch>) -> Vec<(String, Result<std::path::PathBuf, String>)> {
     let cpus = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4);
     let (tx, rx) = std::sync::mpsc::channel();
     let (sem_tx, sem_rx) = std::sync::mpsc::sync_channel::<()>(cpus);
@@ -108,13 +109,13 @@ fn compile_test_files_parallel(test_files: &[String], no_check: bool) -> Vec<(St
         let tx = tx.clone();
         let sem_rx = sem_rx.clone();
         let sem_tx = sem_tx.clone();
+        let scratch = scratch.clone();
         handles.push(std::thread::spawn(move || {
             let _ = sem_rx.lock().unwrap().recv();
             // Per-file scratch dir so cold rustc builds parallelize instead
-            // of serializing on the shared dir's BUILD_LOCK.
-            let worker_dir = std::env::temp_dir()
-                .join("almide-test")
-                .join(test_file.replace('/', "_").replace('.', "_"));
+            // of serializing on the shared dir's BUILD_LOCK; keyed on the
+            // absolute path (#1877).
+            let worker_dir = scratch.native_worker_dir(&test_file);
             let result = super::run::compile_to_binary(&test_file, no_check, true, false, Some(&worker_dir));
             let _ = sem_tx.send(());
             let _ = tx.send((test_file, result));
@@ -167,9 +168,10 @@ pub fn cmd_test(file: &str, no_check: bool, run_filter: Option<&str>) {
     let test_files: Vec<String> = discover_test_files(file, &["spec", "exercises"]);
 
     let program_args = test_harness_args(run_filter);
+    let scratch = std::sync::Arc::new(TestScratch::new());
 
     // Phase 1: Compile all test files in parallel (bounded by CPU count)
-    let compiled = compile_test_files_parallel(&test_files, no_check);
+    let compiled = compile_test_files_parallel(&test_files, no_check, &scratch);
 
     // Phase 2: Execute test binaries in parallel (bounded by CPU count)
     let results = run_test_binaries_parallel(compiled, &program_args);
@@ -183,9 +185,11 @@ pub fn cmd_test(file: &str, no_check: bool, run_filter: Option<&str>) {
     }
     if failed > 0 {
         err(&format!("\n{}/{} test file(s) failed", failed, test_files.len()));
+        scratch.finish();
         std::process::exit(1);
     }
     err(&format!("\nAll {} test file(s) passed", test_files.len()));
+    scratch.finish();
 }
 
 enum WasmTestOutcome {
@@ -345,14 +349,11 @@ fn lower_wasm_test_modules(program: &almide_lang::ast::Program, checker: &mut ch
     Ok(ir_program)
 }
 
-fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> WasmTestOutcome {
+fn compile_and_run_wasm_test(test_file: &str, wasm_path: std::path::PathBuf) -> WasmTestOutcome {
     let skip = |reason: String| WasmTestOutcome::Skip { file: test_file.to_string(), reason };
     let compile_error = |detail: String| WasmTestOutcome::CompileError { file: test_file.to_string(), detail };
     let prof = std::env::var_os("ALMIDE_PROFILE").is_some();
     let mut marks: Vec<(&'static str, std::time::Instant)> = vec![("start", std::time::Instant::now())];
-
-    let wasm_name = test_file.replace('/', "_").replace('.', "_") + ".wasm";
-    let wasm_path = tmp_dir.join(&wasm_name);
 
     let (mut program, source_text, parse_errors) = parse_file(test_file);
     mark(prof, &mut marks, "parse");
@@ -504,13 +505,11 @@ fn compile_and_run_wasm_test(test_file: &str, tmp_dir: &std::path::Path) -> Wasm
 pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
     let test_files: Vec<String> = discover_test_files(file, &[]);
 
-    let tmp_dir = std::env::temp_dir().join("almide-wasm-test");
-    std::fs::create_dir_all(&tmp_dir).ok();
+    let scratch = std::sync::Arc::new(TestScratch::new());
 
     // Parallel: each file's compile+run is independent and rustc/cargo-free,
     // so there's no global build lock to serialize on (unlike the native path).
     let cpus = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4);
-    let tmp_dir = std::sync::Arc::new(tmp_dir);
     let (tx, rx) = std::sync::mpsc::channel();
     let (sem_tx, sem_rx) = std::sync::mpsc::sync_channel::<()>(cpus);
     for _ in 0..cpus { let _ = sem_tx.send(()); }
@@ -519,12 +518,12 @@ pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
     let mut handles = Vec::new();
     for test_file in test_files.clone() {
         let tx = tx.clone();
-        let tmp_dir = tmp_dir.clone();
+        let scratch = scratch.clone();
         let sem_rx = sem_rx.clone();
         let sem_tx = sem_tx.clone();
         handles.push(std::thread::spawn(move || {
             let _ = sem_rx.lock().unwrap().recv();
-            let outcome = compile_and_run_wasm_test(&test_file, &tmp_dir);
+            let outcome = compile_and_run_wasm_test(&test_file, scratch.wasm_module_path(&test_file));
             let _ = sem_tx.send(());
             let _ = tx.send(outcome);
         }));
@@ -576,6 +575,7 @@ pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
         err(&format!("{} passed, {} failed (of {} files)",
             passed, failed, test_files.len()));
     }
+    scratch.finish();
     if failed > 0 {
         std::process::exit(1);
     }
@@ -583,7 +583,7 @@ pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
 
 /// `cmd_test_fast`'s Phase 1: run every file on the fast rustc-free WASM
 /// path, in parallel (bounded by `cpus`). Extracted verbatim.
-fn run_wasm_test_phase(test_files: &[String], tmp_dir: &std::sync::Arc<std::path::PathBuf>, cpus: usize) -> Vec<WasmTestOutcome> {
+fn run_wasm_test_phase(test_files: &[String], scratch: &std::sync::Arc<TestScratch>, cpus: usize) -> Vec<WasmTestOutcome> {
     let (tx, rx) = std::sync::mpsc::channel();
     let (sem_tx, sem_rx) = std::sync::mpsc::sync_channel::<()>(cpus);
     for _ in 0..cpus { let _ = sem_tx.send(()); }
@@ -592,12 +592,12 @@ fn run_wasm_test_phase(test_files: &[String], tmp_dir: &std::sync::Arc<std::path
     let mut handles = Vec::new();
     for tf in test_files.to_vec() {
         let tx = tx.clone();
-        let td = tmp_dir.clone();
+        let scratch = scratch.clone();
         let sr = sem_rx.clone();
         let st = sem_tx.clone();
         handles.push(std::thread::spawn(move || {
             let _ = sr.lock().unwrap().recv();
-            let o = compile_and_run_wasm_test(&tf, &td);
+            let o = compile_and_run_wasm_test(&tf, scratch.wasm_module_path(&tf));
             let _ = st.send(());
             let _ = tx.send(o);
         }));
@@ -611,7 +611,7 @@ fn run_wasm_test_phase(test_files: &[String], tmp_dir: &std::sync::Arc<std::path
 /// `cmd_test_fast`'s Phase 2: native rustc fallback (authoritative) for
 /// everything the WASM path didn't pass, parallel with per-file scratch
 /// dirs. Output is captured — see [`run_test_binaries_parallel`].
-fn run_native_fallback_phase(fallback: &[String], program_args: &std::sync::Arc<Vec<String>>, no_check: bool, cpus: usize) -> Vec<TestRun> {
+fn run_native_fallback_phase(fallback: &[String], program_args: &std::sync::Arc<Vec<String>>, no_check: bool, cpus: usize, scratch: &std::sync::Arc<TestScratch>) -> Vec<TestRun> {
     let (tx, rx) = std::sync::mpsc::channel();
     let (sem_tx, sem_rx) = std::sync::mpsc::sync_channel::<()>(cpus);
     for _ in 0..cpus { let _ = sem_tx.send(()); }
@@ -623,11 +623,10 @@ fn run_native_fallback_phase(fallback: &[String], program_args: &std::sync::Arc<
         let args = program_args.clone();
         let sr = sem_rx.clone();
         let st = sem_tx.clone();
+        let scratch = scratch.clone();
         handles.push(std::thread::spawn(move || {
             let _ = sr.lock().unwrap().recv();
-            let worker_dir = std::env::temp_dir()
-                .join("almide-test")
-                .join(tf.replace('/', "_").replace('.', "_"));
+            let worker_dir = scratch.native_worker_dir(&tf);
             let (code, out) = match super::run::compile_to_binary(&tf, no_check, true, false, Some(&worker_dir)) {
                 Ok(bin) => super::run::run_binary_captured(&bin, &args),
                 Err(e) => (1, format!("Compile error for {}:\n{}", tf, e)),
@@ -651,11 +650,10 @@ pub fn cmd_test_fast(file: &str, no_check: bool, run_filter: Option<&str>) {
     let test_files: Vec<String> = discover_test_files(file, &["spec", "exercises"]);
 
     let cpus = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(4);
-    let tmp_dir = std::sync::Arc::new(std::env::temp_dir().join("almide-wasm-test"));
-    std::fs::create_dir_all(&*tmp_dir).ok();
+    let scratch = std::sync::Arc::new(TestScratch::new());
 
     // Phase 1: WASM (fast, rustc-free), parallel.
-    let wasm_outcomes = run_wasm_test_phase(&test_files, &tmp_dir, cpus);
+    let wasm_outcomes = run_wasm_test_phase(&test_files, &scratch, cpus);
 
     let mut wasm_pass = 0usize;
     let mut fallback: Vec<String> = Vec::new();
@@ -689,7 +687,7 @@ pub fn cmd_test_fast(file: &str, no_check: bool, run_filter: Option<&str>) {
     // path didn't pass, parallel with per-file scratch dirs.
     let program_args = test_harness_args(run_filter);
 
-    let native_results = run_native_fallback_phase(&fallback, &program_args, no_check, cpus);
+    let native_results = run_native_fallback_phase(&fallback, &program_args, no_check, cpus, &scratch);
 
     let mut failed = 0;
     for (file, code, output) in &native_results {
@@ -729,6 +727,7 @@ pub fn cmd_test_fast(file: &str, no_check: bool, run_filter: Option<&str>) {
     };
     err(&format!("\n{} via WASM, {} via native fallback{}, {} failed (of {} files)",
         wasm_pass, fallback.len().saturating_sub(failed), trap_note, failed, test_files.len()));
+    scratch.finish();
     if failed > 0 {
         std::process::exit(1);
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@ mod emit;
 mod check;
 mod dialect_stamp;
 mod commands;
+mod test_scratch;
 pub mod test_report;
 mod install;
 mod selfupdate;

--- a/src/cli/test_scratch.rs
+++ b/src/cli/test_scratch.rs
@@ -1,0 +1,134 @@
+//! Per-invocation scratch root for `almide test` (#1877).
+//!
+//! The harness used to key its scratch artifacts — the wasm module it hands
+//! to wasmtime and the native worker's cargo/rustc project dir — on the test
+//! file's RELATIVE path, under one shared `$TMPDIR/almide-wasm-test` /
+//! `$TMPDIR/almide-test`. Two invocations on same-named files from different
+//! directories (`cd a && almide test x_test.almd` racing `cd b && almide test
+//! x_test.almd`, or two parallel runs on copies of one file) therefore wrote
+//! the SAME `x_test_almd.wasm`: whichever wrote first launched wasmtime on the
+//! other's module and reported the other file's verdict — a failing file
+//! printed "All 1 test file(s) passed" (reproduced 1/30 rounds on 0.61.1).
+//!
+//! Every artifact is now named by the hash of the file's ABSOLUTE path, so
+//! a same-named sibling can never share a path, and the wasm module lives
+//! under a root unique to this process (`almide-test-<pid>-<nonce>`), so
+//! neither can another invocation. That root is removed when the command
+//! finishes — including the `process::exit(1)` failure paths, which skip
+//! destructors — unless `ALMIDE_KEEP_SCRATCH=1`, which keeps it and prints
+//! where it is.
+//!
+//! The native worker dir stays PERSISTENT (`$TMPDIR/almide-test/native/`):
+//! it is a build cache — its content-hashed binary names and per-dir flock
+//! already make concurrent use of one dir correct (`build_native_cached`) —
+//! and moving it under the per-run root cold-builds every native-fallback
+//! file on every run: measured 14 s → 31 s for a warm `almide test spec/`.
+
+use std::path::{Path, PathBuf};
+
+pub(crate) struct TestScratch {
+    /// Per-run root: `<temp>/almide-test-<pid>-<nonce>/`, removed on finish.
+    root: PathBuf,
+    /// Persistent native build cache: `<temp>/almide-test/native/`.
+    native_cache: PathBuf,
+    keep: bool,
+}
+
+impl TestScratch {
+    pub(crate) fn new() -> Self {
+        // pid + wall clock + an in-process counter: distinct across parallel
+        // processes AND across two roots created in one process.
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let nonce = {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            super::hash64(format!("{}:{}:{}", std::process::id(), nanos, seq).as_bytes())
+        };
+        let root = std::env::temp_dir().join(format!("almide-test-{}-{:016x}", std::process::id(), nonce));
+        std::fs::create_dir_all(root.join("wasm")).ok();
+        let native_cache = std::env::temp_dir().join("almide-test").join("native");
+        let keep = std::env::var_os("ALMIDE_KEEP_SCRATCH").is_some_and(|v| !v.is_empty() && v != "0");
+        TestScratch { root, native_cache, keep }
+    }
+
+    /// The scratch `.wasm` module for one test file on the wasm leg:
+    /// `<root>/wasm/<stem>-<abs-path hash>.wasm`.
+    pub(crate) fn wasm_module_path(&self, test_file: &str) -> PathBuf {
+        self.root.join("wasm").join(format!("{}.wasm", Self::file_key(test_file)))
+    }
+
+    /// The native worker's project dir for one test file (its own
+    /// `src/main.rs`, so cold rustc builds parallelize instead of serializing
+    /// on the shared dir's build lock), in the persistent cache:
+    /// `<temp>/almide-test/native/<stem>-<abs-path hash>`.
+    pub(crate) fn native_worker_dir(&self, test_file: &str) -> PathBuf {
+        self.native_cache.join(Self::file_key(test_file))
+    }
+
+    /// `<stem>-<hash of the absolute path>`: the stem keeps a kept scratch
+    /// dir readable, the hash is what makes two same-named files distinct.
+    fn file_key(test_file: &str) -> String {
+        let path = Path::new(test_file);
+        let abs = std::fs::canonicalize(path)
+            .unwrap_or_else(|_| std::env::current_dir().map(|cwd| cwd.join(path)).unwrap_or_else(|_| path.to_path_buf()));
+        let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("test");
+        format!("{}-{:016x}", stem, super::hash64(abs.to_string_lossy().as_bytes()))
+    }
+
+    /// Remove the per-run root (or report it when kept). Idempotent; called
+    /// explicitly before every `process::exit`, and again from `Drop` on the
+    /// normal return path.
+    pub(crate) fn finish(&self) {
+        if self.keep {
+            crate::err(&format!(
+                "scratch kept (ALMIDE_KEEP_SCRATCH): {} (native build cache: {})",
+                self.root.display(),
+                self.native_cache.display()
+            ));
+        } else {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+}
+
+impl Drop for TestScratch {
+    fn drop(&mut self) {
+        if !self.keep {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TestScratch;
+
+    #[test]
+    fn same_name_different_directories_never_share_a_path() {
+        let s = TestScratch::new();
+        let a = s.wasm_module_path("a/x_test.almd");
+        let b = s.wasm_module_path("b/x_test.almd");
+        assert_ne!(a, b);
+        assert_ne!(s.native_worker_dir("a/x_test.almd"), s.native_worker_dir("b/x_test.almd"));
+        assert!(a.starts_with(s.root.join("wasm")));
+        // The native worker dir is the persistent cache, keyed on the
+        // absolute path — the same across two runs of one file.
+        let t = TestScratch::new();
+        assert_eq!(s.native_worker_dir("a/x_test.almd"), t.native_worker_dir("a/x_test.almd"));
+        assert!(!s.native_worker_dir("a/x_test.almd").starts_with(&s.root));
+    }
+
+    #[test]
+    fn two_runs_never_share_a_root() {
+        let a = TestScratch::new();
+        let b = TestScratch::new();
+        assert_ne!(a.root, b.root);
+        assert!(a.root.is_dir() && b.root.is_dir());
+        let root = a.root.clone();
+        a.finish();
+        assert!(!root.exists());
+    }
+}

--- a/tests/test_scratch_race_test.rs
+++ b/tests/test_scratch_race_test.rs
@@ -1,0 +1,160 @@
+//! #1877: `almide test` keyed its scratch wasm module and native worker dir
+//! on the test file's RELATIVE path under one shared temp dir, so two
+//! invocations on same-named files from different directories wrote the same
+//! `x_test_almd.wasm` and whichever wrote first ran wasmtime on the OTHER
+//! file's module — a failing file printed "All 1 test file(s) passed".
+//!
+//! The race window is the gap between the write and wasmtime opening the
+//! file, a few milliseconds, so one pair of processes hits it a few percent
+//! of the time; eight processes over eight rounds make a wrong verdict near
+//! certain on the pre-fix binary while the fixed binary (per-run root, keyed
+//! on the absolute path) can never share a path and is deterministically
+//! green.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn almide_bin() -> String {
+    env!("CARGO_BIN_EXE_almide").to_string()
+}
+
+const PASSING: &str = "test \"same name\" {\n  assert_eq(1 + 1, 2)\n}\n";
+const FAILING: &str = "test \"same name\" {\n  assert_eq(1 + 1, 3)\n}\n";
+
+fn fresh_root(tag: &str) -> PathBuf {
+    let root = std::env::temp_dir().join(format!("almide-1877-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).expect("temp root");
+    root
+}
+
+/// Write `x_test.almd` with `body` into `dir` and return the dir.
+fn case_dir(root: &Path, name: &str, body: &str) -> PathBuf {
+    let dir = root.join(name);
+    std::fs::create_dir_all(&dir).expect("case dir");
+    std::fs::write(dir.join("x_test.almd"), body).expect("write case");
+    dir
+}
+
+/// Run `almide test x_test.almd` from inside `dir` (the RELATIVE name is
+/// what the pre-fix harness keyed on), returning (success, stderr).
+fn run_test_in(dir: &Path) -> (bool, String) {
+    let out = Command::new(almide_bin())
+        .args(["test", "x_test.almd"])
+        .current_dir(dir)
+        .output()
+        .expect("spawn almide test");
+    (out.status.success(), String::from_utf8_lossy(&out.stderr).into_owned())
+}
+
+/// Every verdict from `rounds` rounds of `pairs` concurrent (passing,
+/// failing) same-named pairs, as (expected_pass, actual_pass, stderr).
+fn race(root: &Path, rounds: usize, pairs: usize) -> Vec<(bool, bool, String)> {
+    let mut verdicts = Vec::new();
+    for _ in 0..rounds {
+        let handles: Vec<_> = (0..pairs)
+            .flat_map(|j| {
+                let p = case_dir(root, &format!("p{j}"), PASSING);
+                let f = case_dir(root, &format!("f{j}"), FAILING);
+                [(true, p), (false, f)]
+            })
+            .map(|(expected, dir)| std::thread::spawn(move || {
+                let (ok, err) = run_test_in(&dir);
+                (expected, ok, err)
+            }))
+            .collect();
+        for h in handles {
+            verdicts.push(h.join().expect("race thread"));
+        }
+    }
+    verdicts
+}
+
+fn assert_all_right(verdicts: &[(bool, bool, String)]) {
+    let wrong: Vec<String> = verdicts
+        .iter()
+        .filter(|(expected, actual, _)| expected != actual)
+        .map(|(expected, _, err)| format!("expected {}: {err}", if *expected { "PASS" } else { "FAIL" }))
+        .collect();
+    assert!(
+        wrong.is_empty(),
+        "{} of {} verdicts wrong — the scratch artifacts of same-named files are shared:\n{}",
+        wrong.len(),
+        verdicts.len(),
+        wrong.join("\n")
+    );
+}
+
+#[test]
+fn same_named_files_in_different_directories_get_their_own_verdicts_under_parallel_runs() {
+    let root = fresh_root("pair");
+    let verdicts = race(&root, 8, 4);
+    let _ = std::fs::remove_dir_all(&root);
+    assert_eq!(verdicts.len(), 64);
+    assert_all_right(&verdicts);
+}
+
+#[test]
+fn the_same_file_run_twice_in_parallel_passes_both_times() {
+    let root = fresh_root("same");
+    let dir = case_dir(&root, "one", PASSING);
+    let handles: Vec<_> = (0..4)
+        .map(|_| {
+            let dir = dir.clone();
+            std::thread::spawn(move || run_test_in(&dir))
+        })
+        .collect();
+    let results: Vec<(bool, String)> = handles.into_iter().map(|h| h.join().expect("thread")).collect();
+    let _ = std::fs::remove_dir_all(&root);
+    for (ok, err) in &results {
+        assert!(ok, "a parallel run of one passing file failed:\n{err}");
+    }
+}
+
+#[test]
+fn same_named_files_in_one_invocation_get_their_own_verdicts() {
+    let root = fresh_root("one-run");
+    case_dir(&root, "a", PASSING);
+    case_dir(&root, "b", FAILING);
+    let out = Command::new(almide_bin())
+        .args(["test", "."])
+        .current_dir(&root)
+        .output()
+        .expect("spawn almide test");
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    let _ = std::fs::remove_dir_all(&root);
+    assert!(!out.status.success(), "b/x_test.almd must fail the run:\n{stderr}");
+    assert!(stderr.contains("FAILED: ./b/x_test.almd"), "the failing file is b/x_test.almd:\n{stderr}");
+    assert!(!stderr.contains("FAILED: ./a/x_test.almd"), "a/x_test.almd must pass:\n{stderr}");
+}
+
+#[test]
+fn scratch_root_is_removed_on_exit_and_kept_under_the_flag() {
+    let root = fresh_root("keep");
+    let dir = case_dir(&root, "one", PASSING);
+    let out = Command::new(almide_bin())
+        .args(["test", "x_test.almd"])
+        .env("ALMIDE_KEEP_SCRATCH", "1")
+        .current_dir(&dir)
+        .output()
+        .expect("spawn almide test");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "{stderr}");
+    let kept = stderr
+        .lines()
+        .find_map(|l| l.strip_prefix("scratch kept (ALMIDE_KEEP_SCRATCH): "))
+        .unwrap_or_else(|| panic!("no scratch-kept line:\n{stderr}"))
+        .split(" (native build cache: ")
+        .next()
+        .unwrap()
+        .trim()
+        .to_string();
+    let kept = PathBuf::from(kept);
+    assert!(kept.join("wasm").is_dir(), "kept root has no wasm/: {}", kept.display());
+    let _ = std::fs::remove_dir_all(&kept);
+
+    let (ok, stderr) = run_test_in(&dir);
+    assert!(ok, "{stderr}");
+    assert!(!stderr.contains("scratch kept"), "the root must be removed without the flag:\n{stderr}");
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
Fixes #1877

## Cause

`almide test` derived its scratch artifacts from the test file's **relative** path under one shared temp dir: the wasm leg wrote `$TMPDIR/almide-wasm-test/<relpath-mangled>.wasm` and then launched `wasmtime` on that path (`compile_and_run_wasm_test`), and the native worker used `$TMPDIR/almide-test/<relpath-mangled>/`. Two invocations on same-named files from different directories (`cd a && almide test x_test.almd` racing `cd b && almide test x_test.almd`, or parallel runs on copies of one file) therefore wrote the same `x_test_almd.wasm`; whichever wrote first ran wasmtime on the **other** file's module and reported the other file's verdict. The window is the few milliseconds between `fs::write` and wasmtime opening the file.

The native worker dir was not the racy artifact: `build_native_cached` names the binary by a content hash and holds a per-dir flock across write→build→copy, so two processes sharing one dir serialize and each gets its own binary.

## Repro (release build of develop, 46aabc3e6)

`a/x_test.almd` (passes) and `b/x_test.almd` (fails, `assert_eq(1 + 1, 3)`), run concurrently as `almide test x_test.almd` from inside each directory:

```
rounds=30  a(pass file) reported FAIL: 0   b(fail file) reported PASS: 1
```

The failing file printed `1 via WASM, 0 via native fallback, 0 failed (of 1 files) / All 1 test file(s) passed`. With 8 concurrent processes (4 pass + 4 fail copies) the wrong-verdict rate is ~5% per process.

## Fix

`src/cli/test_scratch.rs` — a `TestScratch` handle created once per `cmd_test` / `cmd_test_fast` / `cmd_test_wasm`:

- wasm modules go under a per-run root `$TMPDIR/almide-test-<pid>-<nonce>/wasm/<stem>-<hash of absolute path>.wasm`; the root is removed on finish (explicitly before every `process::exit`, since that skips destructors, and from `Drop` on the return path) unless `ALMIDE_KEEP_SCRATCH=1`, which keeps it and prints the location.
- the native worker dir is keyed on the absolute path too, but stays in the persistent build cache `$TMPDIR/almide-test/native/<stem>-<hash>/`. Moving it under the per-run root was measured: a warm `almide test spec/` went 14 s → 31 s because the 12 native-fallback files cold-build rustc every run. Its flock + content-hashed binary names already make concurrent use correct, so the cache stays.

The scratch location was not documented; `docs/specs/cli.md` now describes it.

## Pin

`tests/test_scratch_race_test.rs` (spawns the binary, like `pkg_build_determinism_test.rs`):

- `same_named_files_in_different_directories_get_their_own_verdicts_under_parallel_runs` — 8 rounds × 4 concurrent (pass, fail) same-named pairs, all 64 verdicts must be right
- `the_same_file_run_twice_in_parallel_passes_both_times` — 4 parallel runs of one file
- `same_named_files_in_one_invocation_get_their_own_verdicts` — `a/x_test.almd` + `b/x_test.almd` in one run
- `scratch_root_is_removed_on_exit_and_kept_under_the_flag`

## A/B

Same test executable, binary swapped:

| binary | race test | keep-flag test |
|---|---|---|
| develop (46aabc3e6) | **FAILED — 11 of 64 verdicts wrong** | FAILED (no scratch-kept line) |
| this branch | ok | ok |

## Gates

- `almide test spec/` — All 431 test file(s) passed (lang / stdlib / integration each run separately as well); warm wall time 14.7 s, same as develop
- `cargo test --release --test test_scratch_race_test` — 4 passed; `test_scratch` unit tests 2 passed
- clippy: no warnings on the new file, the new test, or any touched line (the six in `commands.rs` are pre-existing `to_vec` / `useless format!` / `sort_by_key` lines)
- codopsy `src/`: B (86/100) before and after
