### PR TITLE
The interp oracle evaluates opaque-alias constructors, in-place writers on temporaries, and the html/path/url bodies: four of the five #1844 abstentions become real votes

### DIFF
--- a/crates/almide-interp/interp-abstain-ledger.txt
+++ b/crates/almide-interp/interp-abstain-ledger.txt
@@ -13,7 +13,6 @@
 alias_combinator_rc  out-of-interp-scope capability: prim.handle of a Option (outside the slice-2 heap family)
 availability_pure_batch  out-of-interp-scope capability: html.escape
 bytes_rawptr  out-of-interp-scope capability: prim.int_to_ptr
-bytes_temp_receiver  out-of-interp-scope capability: in-place container mutation `bytes.append_i16_be` through a non-variable receiver (a record field / index / temporary has no single binding to write back to)
 count_domain_nonbytes  out-of-interp-scope capability: prim.read_n_bytes
 effect_tco_err_rewrap  interp fuel/recursion budget exhausted
 env_set_overlay  out-of-interp-scope capability: env.set

--- a/crates/almide-interp/interp-abstain-ledger.txt
+++ b/crates/almide-interp/interp-abstain-ledger.txt
@@ -39,6 +39,5 @@ negative_offset_and_width_totality  out-of-interp-scope capability: prim.int_to_
 range_bind_huge  interp fuel/recursion budget exhausted
 range_materialize_oom  out-of-interp-scope capability: range materialization beyond the interp cap (both backends take the C-197 resource path)
 set_index_order  out-of-interp-scope capability: prim.load64 outside this heap's arena — the backends read real memory here, so a guessed value would be a wrong vote
-stdlib_opaque_shadow  out-of-interp-scope capability: named call `self.Value`
 stdlib_type_shadow  out-of-interp-scope capability: url.parse
 string_from_bytes  out-of-interp-scope capability: prim.load64 outside this heap's arena — the backends read real memory here, so a guessed value would be a wrong vote

--- a/crates/almide-interp/interp-abstain-ledger.txt
+++ b/crates/almide-interp/interp-abstain-ledger.txt
@@ -11,7 +11,6 @@
 # (bridge.rs / hofs.rs / dispatch.rs — see crates/almide-interp/CLAUDE.md).
 
 alias_combinator_rc  out-of-interp-scope capability: prim.handle of a Option (outside the slice-2 heap family)
-availability_pure_batch  out-of-interp-scope capability: html.escape
 bytes_rawptr  out-of-interp-scope capability: prim.int_to_ptr
 count_domain_nonbytes  out-of-interp-scope capability: prim.read_n_bytes
 effect_tco_err_rewrap  interp fuel/recursion budget exhausted
@@ -38,5 +37,4 @@ negative_offset_and_width_totality  out-of-interp-scope capability: prim.int_to_
 range_bind_huge  interp fuel/recursion budget exhausted
 range_materialize_oom  out-of-interp-scope capability: range materialization beyond the interp cap (both backends take the C-197 resource path)
 set_index_order  out-of-interp-scope capability: prim.load64 outside this heap's arena — the backends read real memory here, so a guessed value would be a wrong vote
-stdlib_type_shadow  out-of-interp-scope capability: url.parse
 string_from_bytes  out-of-interp-scope capability: prim.load64 outside this heap's arena — the backends read real memory here, so a guessed value would be a wrong vote

--- a/crates/almide-interp/src/dispatch.rs
+++ b/crates/almide-interp/src/dispatch.rs
@@ -122,6 +122,17 @@ impl<'a> Interpreter<'a> {
             return self.eval_expr(&args[0], scope);
         }
 
+        // 2d. Inside a LOWERED MODULE body, a bare sibling call resolves
+        //     against the executing module FIRST (#1844) — the scope the
+        //     checker bound it in — before the flat table and before the
+        //     unique-definer rule of step 4: `to_string(a)` inside
+        //     `html.concat` is html's own, however many loaded modules (or
+        //     the program) spell a `to_string`. The program root (space 0)
+        //     has no owner and keeps the flat-table order below.
+        if let Some(func) = self.own_module_sibling(name) {
+            return self.eval_lowered_fn_call(func, args, scope);
+        }
+
         // 3. A user / stdlib free function lowered into the program. A stdlib
         //    IMPL name (`string_slice` — how a lowered MODULE body spells
         //    `string.slice`) first tries the SAME native bridge a
@@ -189,6 +200,15 @@ impl<'a> Interpreter<'a> {
         }
 
         Flow::Unsupported(format!("named call `{}`", n))
+    }
+
+    /// Step 2d of [`Self::eval_named_call`]: the executing module's own
+    /// definition of `name`, when a module body is executing (`cur_space`)
+    /// and its module defines the name.
+    fn own_module_sibling(&self, name: Sym) -> Option<&'a almide_ir::IrFunction> {
+        let space = self.cur_space.get();
+        let owner = self.program.modules.get(space.checked_sub(1)? as usize)?.name;
+        self.module_fns.get(&(owner, name)).copied()
     }
 
     /// Step 2 of [`Self::eval_named_call`]: build the variant value a Unit- or

--- a/crates/almide-interp/src/dispatch.rs
+++ b/crates/almide-interp/src/dispatch.rs
@@ -13,7 +13,7 @@
 use std::rc::Rc;
 
 use almide_base::intern::Sym;
-use almide_ir::{CallTarget, IrExpr};
+use almide_ir::{CallTarget, IrExpr, IrExprKind};
 use almide_lang::types::Ty;
 
 use crate::env::Scope;
@@ -568,10 +568,7 @@ impl<'a> Interpreter<'a> {
             ));
         }
         let Some(recv) = args.first().and_then(crate::inplace::receiver_var) else {
-            return Flow::Unsupported(format!(
-                "in-place container mutation `{m}.{f}` through a non-variable receiver \
-                 (a record field / index / temporary has no single binding to write back to)"
-            ));
+            return self.eval_inplace_on_temporary(m, f, args, scope);
         };
         // A `mut`-PARAMETER receiver is fine now: the write lands on the
         // callee frame's binding, and `eval_named_call`'s mut-param copy-out
@@ -589,6 +586,52 @@ impl<'a> Interpreter<'a> {
             Some(Some(out)) => Flow::val(out),
             Some(None) => Flow::Abort(format!("internal: malformed `{m}.{f}` receiver or args")),
             None => Flow::Abort(format!("internal: `{m}.{f}` on an unbound receiver")),
+        }
+    }
+
+    /// [`Self::eval_inplace_mutation`] for a receiver that is not a variable.
+    /// A TEMPORARY — a call result (`bytes.append_u8(bytes.new(2), 7)`,
+    /// #1849) — has no binding to write back to, and none is needed: both
+    /// backends evaluate the arguments in order, mutate the temporary and
+    /// drop it, so the statement observes nothing but its own argument
+    /// evaluation. The mutation runs on the evaluated value here (through
+    /// the same `inplace::apply`, so a temporary that ALIASES a live
+    /// binding's `Rc` takes the COW copy and the binding is untouched —
+    /// the fixture's `same(x)` probe) and the value is dropped with the
+    /// call. A record field or an index is a different shape: the backends
+    /// write THROUGH it, and this frame has no single slot for it — that
+    /// shape still abstains under its own name.
+    fn eval_inplace_on_temporary(
+        &mut self,
+        m: &str,
+        f: &str,
+        args: &[IrExpr],
+        scope: &Scope,
+    ) -> Flow {
+        let Some(recv) = args.first() else {
+            return Flow::Abort(format!("internal: `{m}.{f}` with no receiver"));
+        };
+        let shape = match &recv.kind {
+            IrExprKind::Call { .. } => None,
+            IrExprKind::Member { .. } => Some("a record field"),
+            IrExprKind::IndexAccess { .. } | IrExprKind::TupleIndex { .. } => Some("an index"),
+            _ => Some("a non-call expression"),
+        };
+        if let Some(shape) = shape {
+            return Flow::Unsupported(format!(
+                "in-place container mutation `{m}.{f}` through {shape} receiver \
+                 (the backends write through it; this frame has no single binding \
+                 to write back to)"
+            ));
+        }
+        let mut temp = val!(self.eval_expr(recv, scope));
+        let mut rest = Vec::with_capacity(args.len().saturating_sub(1));
+        for a in &args[1..] {
+            rest.push(val!(self.eval_expr(a, scope)));
+        }
+        match crate::inplace::apply(m, f, &mut temp, rest) {
+            Some(out) => Flow::val(out),
+            None => Flow::Abort(format!("internal: malformed `{m}.{f}` receiver or args")),
         }
     }
 

--- a/crates/almide-interp/src/dispatch.rs
+++ b/crates/almide-interp/src/dispatch.rs
@@ -113,6 +113,15 @@ impl<'a> Interpreter<'a> {
             });
         }
 
+        // 2c. An opaque NEWTYPE's constructor (`SafeHtml(s)`, `Value(s)` under
+        //     its `self.Value` identity, #1835): both backends erase the
+        //     wrapper — the value IS its payload — so the call is an identity
+        //     on its one argument. Registered by name from the program's
+        //     Alias decls; an arity other than one is not a newtype call.
+        if args.len() == 1 && self.newtype_ctors.contains(&name) {
+            return self.eval_expr(&args[0], scope);
+        }
+
         // 3. A user / stdlib free function lowered into the program. A stdlib
         //    IMPL name (`string_slice` — how a lowered MODULE body spells
         //    `string.slice`) first tries the SAME native bridge a

--- a/crates/almide-interp/src/dispatch.rs
+++ b/crates/almide-interp/src/dispatch.rs
@@ -94,43 +94,10 @@ impl<'a> Interpreter<'a> {
             return flow;
         }
 
-        // 2. Variant constructor (Unit / Tuple). Record-variant ctors arrive
-        //    as `Record` nodes, handled in eval. Look up in the registry.
-        if let Some((ty_name, kind)) = self.variant_ctor(name) {
-            return self.eval_variant_ctor_call(ty_name, name, kind, args, scope);
-        }
-
-        // 2b. The stdlib's only BUNDLED variant type (bytes.Endian): its decl
-        //     lives in the bundled module, never in the program, so the ctor
-        //     registry above misses it. The checker already typed the ctor —
-        //     build the variant value directly (the same value the inplace
-        //     tier's `endian_is_big` and the bytes read bridge dispatch on).
-        if args.is_empty() && matches!(n, "LittleEndian" | "BigEndian") {
-            return Flow::val(Value::Variant {
-                ty: None,
-                ctor: name,
-                payload: VariantPayload::Unit,
-            });
-        }
-
-        // 2c. An opaque NEWTYPE's constructor (`SafeHtml(s)`, `Value(s)` under
-        //     its `self.Value` identity, #1835): both backends erase the
-        //     wrapper — the value IS its payload — so the call is an identity
-        //     on its one argument. Registered by name from the program's
-        //     Alias decls; an arity other than one is not a newtype call.
-        if args.len() == 1 && self.newtype_ctors.contains(&name) {
-            return self.eval_expr(&args[0], scope);
-        }
-
-        // 2d. Inside a LOWERED MODULE body, a bare sibling call resolves
-        //     against the executing module FIRST (#1844) — the scope the
-        //     checker bound it in — before the flat table and before the
-        //     unique-definer rule of step 4: `to_string(a)` inside
-        //     `html.concat` is html's own, however many loaded modules (or
-        //     the program) spell a `to_string`. The program root (space 0)
-        //     has no owner and keeps the flat-table order below.
-        if let Some(func) = self.own_module_sibling(name) {
-            return self.eval_lowered_fn_call(func, args, scope);
+        // 2. Constructors and the executing module's own sibling — the pure
+        //    lookups between the builtins and the flat fn table.
+        if let Some(flow) = self.eval_named_ctor_or_sibling(name, args, scope) {
+            return flow;
         }
 
         // 3. A user / stdlib free function lowered into the program. A stdlib
@@ -202,17 +169,57 @@ impl<'a> Interpreter<'a> {
         Flow::Unsupported(format!("named call `{}`", n))
     }
 
-    /// Step 2d of [`Self::eval_named_call`]: the executing module's own
-    /// definition of `name`, when a module body is executing (`cur_space`)
-    /// and its module defines the name.
+    /// Step 2 of [`Self::eval_named_call`]: the pure lookups between the
+    /// builtins and the flat fn table. `None` = none of them claims `name`.
+    fn eval_named_ctor_or_sibling(&mut self, name: Sym, args: &[IrExpr], scope: &Scope) -> Option<Flow> {
+        let n = name.as_str();
+        // 2a. Variant constructor (Unit / Tuple). Record-variant ctors arrive
+        //     as `Record` nodes, handled in eval. Look up in the registry.
+        if let Some((ty_name, kind)) = self.variant_ctor(name) {
+            return Some(self.eval_variant_ctor_call(ty_name, name, kind, args, scope));
+        }
+        // 2b. The stdlib's only BUNDLED variant type (bytes.Endian): its decl
+        //     lives in the bundled module, never in the program, so the ctor
+        //     registry above misses it. The checker already typed the ctor —
+        //     build the variant value directly (the same value the inplace
+        //     tier's `endian_is_big` and the bytes read bridge dispatch on).
+        if args.is_empty() && matches!(n, "LittleEndian" | "BigEndian") {
+            return Some(Flow::val(Value::Variant {
+                ty: None,
+                ctor: name,
+                payload: VariantPayload::Unit,
+            }));
+        }
+        // 2c. An opaque NEWTYPE's constructor (`SafeHtml(s)`, `Value(s)` under
+        //     its `self.Value` identity, #1835): both backends erase the
+        //     wrapper — the value IS its payload — so the call is an identity
+        //     on its one argument. Registered by name from the program's
+        //     Alias decls; an arity other than one is not a newtype call.
+        if args.len() == 1 && self.newtype_ctors.contains(&name) {
+            return Some(self.eval_expr(&args[0], scope));
+        }
+        // 2d. Inside a LOWERED MODULE body, a bare sibling call resolves
+        //     against the executing module FIRST (#1844) — the scope the
+        //     checker bound it in — before the flat table and before the
+        //     unique-definer rule of step 4: `to_string(a)` inside
+        //     `html.concat` is html's own, however many loaded modules (or
+        //     the program) spell a `to_string`. The program root (space 0)
+        //     has no owner and keeps the flat-table order below.
+        let func = self.own_module_sibling(name)?;
+        Some(self.eval_lowered_fn_call(func, args, scope))
+    }
+
+    /// Step 2d of [`Self::eval_named_ctor_or_sibling`]: the executing
+    /// module's own definition of `name`, when a module body is executing
+    /// (`cur_space`) and its module defines the name.
     fn own_module_sibling(&self, name: Sym) -> Option<&'a almide_ir::IrFunction> {
         let space = self.cur_space.get();
         let owner = self.program.modules.get(space.checked_sub(1)? as usize)?.name;
         self.module_fns.get(&(owner, name)).copied()
     }
 
-    /// Step 2 of [`Self::eval_named_call`]: build the variant value a Unit- or
-    /// Tuple-payload constructor names.
+    /// Step 2a of [`Self::eval_named_ctor_or_sibling`]: build the variant
+    /// value a Unit- or Tuple-payload constructor names.
     fn eval_variant_ctor_call(
         &mut self,
         ty_name: Sym,

--- a/crates/almide-interp/src/eval_match.rs
+++ b/crates/almide-interp/src/eval_match.rs
@@ -169,7 +169,10 @@ impl<'a> Interpreter<'a> {
     }
 
     /// `try_match`'s `Constructor` arm: the ctor name must agree, and the
-    /// payload arity must match the sub-pattern count.
+    /// payload arity must match the sub-pattern count. An opaque NEWTYPE's
+    /// pattern (`SafeHtml(s)`, `Value(s)` under its `self.Value` identity)
+    /// is a pass-through to the payload sub-pattern: the subject IS the
+    /// payload, the way `eval_named_call` built it (#1835).
     fn try_match_ctor(
         &mut self,
         name: &str,
@@ -177,6 +180,11 @@ impl<'a> Interpreter<'a> {
         value: &Value,
         binds: &mut Vec<(VarId, Value)>,
     ) -> bool {
+        if let [inner] = args
+            && self.newtype_ctors.contains(&almide_base::intern::sym(name))
+        {
+            return self.try_match(inner, value, binds);
+        }
         let Value::Variant { ctor, payload, .. } = value else { return false };
         if ctor.as_str() != name {
             return false;

--- a/crates/almide-interp/src/lib.rs
+++ b/crates/almide-interp/src/lib.rs
@@ -191,6 +191,12 @@ pub struct Interpreter<'a> {
     /// (0 = root, i+1 = `modules[i]`). Pool fns are absent (their bodies are
     /// self-contained — the pool has no top-lets) and default to space 0.
     pub(crate) fn_space: HashMap<usize, u32>,
+    /// The space of the lowered fn currently EXECUTING (set per trampoline
+    /// hop, restored on return; 0 = the program root, i+1 = `modules[i]`).
+    /// A module body's bare sibling call (`to_string(a)` inside `html.concat`)
+    /// resolves against this module first — the scope the checker bound it
+    /// in — so two loaded modules sharing a fn name are not ambiguous (#1844).
+    pub(crate) cur_space: Cell<u32>,
     pub(crate) globals_ready: Cell<bool>,
     pub(crate) stdout: String,
     pub(crate) stderr: String,
@@ -488,6 +494,7 @@ impl<'a> Interpreter<'a> {
             globals: env::Scope::root(),
             module_globals: program.modules.iter().map(|_| env::Scope::root()).collect(),
             fn_space,
+            cur_space: Cell::new(0),
             globals_ready: Cell::new(false),
             stdout: String::new(),
             stderr: String::new(),
@@ -1000,6 +1007,7 @@ impl<'a> Interpreter<'a> {
         }
         self.depth.set(d + 1);
         let det_was_user = self.det_in_user.get();
+        let space_was = self.cur_space.get();
         // C-320: the meter's region depth at call entry — if the callee
         // leaves it HIGHER, a det cut skipped a region's budget_exit and
         // the exit bookkeeping runs here (exhausted ⇒ Err, never stale).
@@ -1023,7 +1031,11 @@ impl<'a> Interpreter<'a> {
             // different table. Closures keep their captured chain (which was
             // built under this rule at creation).
             let fn_base = match &callee {
-                TailCallee::Fn(f) => self.space_scope(self.fn_space_of(f)).clone(),
+                TailCallee::Fn(f) => {
+                    let space = self.fn_space_of(f);
+                    self.cur_space.set(space);
+                    self.space_scope(space).clone()
+                }
                 TailCallee::Clo(_) => base.clone(),
             };
             let (frame, fn_body, clo_body) = bind_hop_frame(&callee, &mut args, &fn_base);
@@ -1089,6 +1101,7 @@ impl<'a> Interpreter<'a> {
         let result = normalize_option_fn_return(&callee, result);
         let result = self.fold_pending_try(result, &pending);
         self.det_in_user.set(det_was_user);
+        self.cur_space.set(space_was);
         self.depth.set(self.depth.get() - 1);
         (result, first_frame.unwrap_or_else(|| base.child()))
     }

--- a/crates/almide-interp/src/lib.rs
+++ b/crates/almide-interp/src/lib.rs
@@ -160,6 +160,19 @@ pub struct Interpreter<'a> {
     /// before the fn-table lookup. First declaration wins on a shared case
     /// name, exactly like the scan it replaces.
     pub(crate) variant_ctors: HashMap<Sym, (Sym, dispatch::CtorKind)>,
+    /// The opaque NEWTYPE decls (`mod type SafeHtml = String`, `local type
+    /// JsonPath = Int`) under the identity their ctor call and ctor pattern
+    /// carry into the IR — bare for a bundled module's own or the entry
+    /// program's plain one, `self.Value` for the entry program's shadow of a
+    /// stdlib-owned name, `m.Token` for a module's (#1835). Both backends
+    /// ERASE the newtype: native renders the ctor call as the tuple-struct
+    /// construction and the pattern as its destructure, the wasm leg lowers
+    /// the value to its payload outright — so the interp's ctor arm is an
+    /// identity on the argument and its pattern arm a pass-through to the
+    /// payload sub-pattern. The same filter as codegen's
+    /// `collect_newtype_ctors` (pass_builtin_lowering.rs), minus the dotted
+    /// restriction it needs only because bare names never reach its flatten.
+    pub(crate) newtype_ctors: HashSet<Sym>,
     /// The global scope holding evaluated top-level lets. Every top-level fn
     /// call and `FnRef` closure parents off this so globals are visible from
     /// nested calls (not just from `main`'s body). Seeded once, lazily.
@@ -355,6 +368,22 @@ fn index_variant_ctors(program: &IrProgram) -> HashMap<Sym, (Sym, dispatch::Ctor
     out
 }
 
+/// The opaque-newtype decl names (program + modules) — a non-public `Alias`
+/// whose target is not a fn type, the decls native renders as `pub struct
+/// N(T)`. A PUBLIC alias is transparent (no ctor exists), and a fn-typed
+/// alias names a signature, not a wrapper.
+fn index_newtype_ctors(program: &IrProgram) -> HashSet<Sym> {
+    use almide_ir::{IrTypeDeclKind, IrVisibility};
+    program
+        .type_decls
+        .iter()
+        .chain(program.modules.iter().flat_map(|m| m.type_decls.iter()))
+        .filter(|td| matches!(td.visibility, IrVisibility::Mod | IrVisibility::Private))
+        .filter(|td| matches!(&td.kind, IrTypeDeclKind::Alias { target } if !matches!(target, Ty::Fn { .. })))
+        .map(|td| td.name)
+        .collect()
+}
+
 impl<'a> Interpreter<'a> {
     pub fn new(program: &'a IrProgram) -> Self {
         let mut fns = HashMap::new();
@@ -420,6 +449,7 @@ impl<'a> Interpreter<'a> {
         }
         let named_records = index_named_records(program);
         let variant_ctors = index_variant_ctors(program);
+        let newtype_ctors = index_newtype_ctors(program);
         let mut record_decls: HashMap<Sym, &'a [almide_ir::IrFieldDecl]> = HashMap::new();
         for td in program
             .type_decls
@@ -454,6 +484,7 @@ impl<'a> Interpreter<'a> {
             record_decls,
             named_records,
             variant_ctors,
+            newtype_ctors,
             globals: env::Scope::root(),
             module_globals: program.modules.iter().map(|_| env::Scope::root()).collect(),
             fn_space,

--- a/crates/almide-interp/src/stdlib_pool.rs
+++ b/crates/almide-interp/src/stdlib_pool.rs
@@ -89,7 +89,7 @@ fn build() -> StdlibPool {
                 impl_to_call.entry(sym(impl_name)).or_insert((sym(m), sym(f)));
             }
         }
-        if let Some(lowered) = lower_registry_source(source) {
+        if let Some(lowered) = lower_registry_source(source, owning_module(entries)) {
             for f in lowered {
                 // First writer wins: registry sources are name-disjoint (the wasm
                 // leg splices them into one namespace), so a collision would be a
@@ -101,12 +101,29 @@ fn build() -> StdlibPool {
     StdlibPool { fns, call_map, impl_to_call }
 }
 
+/// The bundled module a registry source belongs to: the ONE module every
+/// entry names (`SRC_BYTES_TYPED` → `bytes`). A source serving several
+/// modules (`SRC_CLOCK_NOW` → `datetime` + `env`) has no single owner and
+/// lowers as a plain entry program, as every source did before.
+fn owning_module(entries: &[(&str, &'static str)]) -> Option<&'static str> {
+    let mut modules = entries.iter().filter_map(|(_, call)| call.split_once('.').map(|(m, _)| m));
+    let first = modules.next()?;
+    modules.all(|m| m == first).then_some(first)
+}
+
 /// Parse + check + lower ONE registry source, `None` when any stage declines.
 /// The `catch_unwind` mirrors the harness's fixture lowering: a frontend
 /// `assert` on an out-of-scope construct must degrade to "this source is
 /// uncovered", never poison the whole pool.
-fn lower_registry_source(source: &str) -> Option<Vec<IrFunction>> {
+///
+/// The source is checked AS its owning module (`canonicalize_program_in`,
+/// the driver's bundled-entry recipe, #1837): an unprefixed type it declares
+/// (`type Endian` in the bytes source) keeps the stdlib's bare key instead of
+/// the `self.`-qualified shadow key an entry program's declaration takes —
+/// the same identity leak one level down that #1837 closed for the driver.
+fn lower_registry_source(source: &str, module: Option<&str>) -> Option<Vec<IrFunction>> {
     let src = source.to_string();
+    let module = module.map(str::to_string);
     std::panic::catch_unwind(move || {
         let tokens = Lexer::tokenize(&src);
         let mut parser = Parser::new(tokens);
@@ -114,7 +131,8 @@ fn lower_registry_source(source: &str) -> Option<Vec<IrFunction>> {
         if !parser.errors.is_empty() {
             return None;
         }
-        let canon = canonicalize::canonicalize_program(&prog, std::iter::empty());
+        let canon =
+            canonicalize::canonicalize_program_in(&prog, std::iter::empty(), module.as_deref());
         let mut checker = Checker::from_env(canon.env);
         let diags = checker.infer_program(&mut prog);
         if diags.iter().any(|d| d.level == almide_frontend::diagnostic::Level::Error) {

--- a/crates/almide-interp/tests/eval_test.rs
+++ b/crates/almide-interp/tests/eval_test.rs
@@ -1245,3 +1245,30 @@ fn opaque_newtype_ctor_is_identity_on_its_payload() {
     );
     assert_eq!((exit, out.as_str()), (0, "x true false 2 b\n3\n"), "stderr: {err}");
 }
+
+/// A Unit-returning in-place writer over a TEMPORARY receiver (#1849): the
+/// arguments evaluate in order, the temporary is mutated and dropped, and a
+/// temporary that aliases a live binding's `Rc` is mutated as a COW copy —
+/// the binding is untouched. A variable receiver keeps its write-back.
+#[test]
+fn inplace_writer_on_a_temporary_receiver_mutates_and_drops_it() {
+    let (exit, out, err) = run(
+        "fn same(b: Bytes) -> Bytes = b\n\
+         fn traced(v: Int) -> Int = {\n\
+         \x20 println(\"arg ${v}\")\n\
+         \x20 v\n\
+         }\n\
+         fn main() -> Unit = {\n\
+         \x20 bytes.append_u8(bytes.new(2), 511)\n\
+         \x20 bytes.append_i16_be(bytes.from_list([traced(1)]), traced(2))\n\
+         \x20 let x = bytes.from_list([1, 2])\n\
+         \x20 bytes.append_u8(same(x), 7)\n\
+         \x20 bytes.fill(same(x), 9)\n\
+         \x20 println(\"${bytes.to_list(x)}\")\n\
+         \x20 var v = bytes.new(0)\n\
+         \x20 bytes.append_u8(v, 511)\n\
+         \x20 println(\"${bytes.to_list(v)}\")\n\
+         }\n",
+    );
+    assert_eq!((exit, out.as_str()), (0, "arg 1\narg 2\n[1, 2]\n[255]\n"), "stderr: {err}");
+}

--- a/crates/almide-interp/tests/eval_test.rs
+++ b/crates/almide-interp/tests/eval_test.rs
@@ -1219,3 +1219,29 @@ fn every_consumption_site_still_sees_the_payload() {
         "stderr: {err}"
     );
 }
+
+/// An opaque newtype (`mod type` / `local type`) is erased by both backends:
+/// its ctor call is the payload and its ctor pattern destructures the
+/// payload. Pinned for the entry program's PLAIN newtype (bare identity,
+/// `Token`) and its shadow of a stdlib-owned name (`self.Value`, #1835), the
+/// two spellings the ctor call and pattern carry into the IR.
+#[test]
+fn opaque_newtype_ctor_is_identity_on_its_payload() {
+    let (exit, out, err) = run(
+        "mod type Value = String\n\
+         local type Token = Int\n\
+         fn un(v: Value) -> String = match v {\n\
+         \x20 Value(s) => s\n\
+         }\n\
+         fn depth(t: Token) -> Int = match t {\n\
+         \x20 Token(n) => n + 1\n\
+         }\n\
+         fn main() -> Unit = {\n\
+         \x20 let mine = Value(\"x\")\n\
+         \x20 let items: List[Value] = [Value(\"a\"), Value(\"b\")]\n\
+         \x20 println(\"${un(mine)} ${mine == Value(\"x\")} ${mine == Value(\"y\")} ${list.len(items)} ${un(items[1])}\")\n\
+         \x20 println(int.to_string(depth(Token(2))))\n\
+         }\n",
+    );
+    assert_eq!((exit, out.as_str()), (0, "x true false 2 b\n3\n"), "stderr: {err}");
+}

--- a/tests/wasm_runtime_test_parts/interp_leg.rs
+++ b/tests/wasm_runtime_test_parts/interp_leg.rs
@@ -54,7 +54,15 @@ fn lower_for_interp(source: &str) -> Result<almide_ir::IrProgram, String> {
         // MEASUREMENT (the abstain ledger names what each addition closes):
         // a module whose fns reach unfloored effect prims would lower fine
         // here and then abstain per call anyway, so listing it buys nothing.
-        const INTERP_BUNDLED_MODULES: &[&str] = &["args"];
+        //   args — #1217 (the argv floor).
+        //   html — #1844: closes availability_pure_batch (`html.escape`); its
+        //          `mod type SafeHtml = String` newtype is the interp's
+        //          identity ctor + pass-through pattern (#1835).
+        //   path — #1844: the next stop of availability_pure_batch after html
+        //          (`path.from_string`); a `mod type SafePath = String` twin.
+        //   url  — #1844: closes stdlib_type_shadow (`url.parse`); pure
+        //          string arithmetic over the bridge, no prim reached.
+        const INTERP_BUNDLED_MODULES: &[&str] = &["args", "html", "path", "url"];
         let mut bundled: Vec<(String, almide_lang::ast::Program)> = Vec::new();
         for imp in &prog.imports {
             let almide_lang::ast::Decl::Import { path, .. } = imp else { continue };


### PR DESCRIPTION
Refs #1844 (four of its five abstentions close here; the fifth is the interp-heap arc).

Widens the third oracle so the fixtures EVALUATE instead of abstaining — the ledger's preferred direction, never a relaxed vote:
- `stdlib_opaque_shadow` — an opaque newtype ctor (`self.Value(x)`) is identity on its payload; the ctor pattern passes through to the payload sub-pattern (`newtype_ctors` index in `lib.rs`, `dispatch.rs`, `eval_match.rs::try_match_ctor`).
- `bytes_temp_receiver` — an in-place writer over a call-result receiver evaluates the receiver, mutates it through the same `inplace::apply` (COW), and drops it; a field/index receiver still abstains, now by name.
- `availability_pure_batch` and `stdlib_type_shadow` — the interp leg loads bundled `html`, `path`, `url` (per-module allowlist `INTERP_BUNDLED_MODULES`), with an own-module-first sibling resolution (`cur_space`) so `html.concat`'s bare `to_string` binds in its own module; the stdlib pool checks each registry source as its owning module (`canonicalize_program_in(…, Some(module))`).

Remaining: `fs_glob_segments` (`prim.handle of a Result` plus `prim.read_dir` / `prim.path_filestat`, three new surfaces — HEAP_BOUNDARY; the other nine fs_* `Result`-handle rows share the blocker).

Voting line: `corpus 668, voting 636 → 640 (95.8%), abstaining 32 → 28`. Gates: interp abstain ledger (4 rows deleted, none added), 3-way oracle `668 fixtures | 639 interp==native==wasm | 28 skipped | 1 backend-split | 0 interp-dissent` (the split is the pre-existing `fan_race_mapper`), `cargo test -p almide-interp`, abstain classes, check-contracts, clippy (no new warnings). codopsy: `crates/almide-interp` B 87 before and after (pre-existing; #1856 lifts it to A).
