### PR TITLE
Two release-path gates read true again: interface-diff sees through the legacy placeholder rendering, and the per-condition coverage job finds its test binaries

### DIFF
--- a/proofs/coverage.sh
+++ b/proofs/coverage.sh
@@ -101,8 +101,19 @@ echo "== 1/4 instrumented build (almide-mir + almide-codegen + almide-wasm tests
 # default `--target wasm` leg (and `almide test`'s wasm phase workload) runs
 # the structural emitter, so a spine-crate-only measurement halves the TOTAL
 # while the system's actual hot path goes unmeasured.
+# The test binaries are taken from cargo's own artifact messages, not from a
+# `find` over `<target-dir>/release/deps`: the dated nightly the CONDITION
+# mode pins lays its artifacts out under `build/<crate>/<hash>/out/` and the
+# `deps` directory does not exist there — from 2026-08-27 every nightly
+# per-condition measurement died at step 2/4 with "NO test binaries found"
+# (8 red nights) while the stable-toolchain run kept passing on the old
+# layout. The JSON `executable` field is the one location that does not
+# depend on the layout; the `find` below stays as the fallback.
 LLVM_PROFILE_FILE="$COVDIR/build/host-%m-%p.profraw" \
-  cargo test -p almide-mir -p almide-codegen -p almide-wasm --release --no-run --target-dir "$COVDIR/t" 2>&1 | tail -1
+  cargo test -p almide-mir -p almide-codegen -p almide-wasm --release --no-run --message-format=json --target-dir "$COVDIR/t" \
+  >"$COVDIR/build-tests.json" 2>"$COVDIR/build-tests.log" || { tail -20 "$COVDIR/build-tests.log"; exit 1; }
+tail -1 "$COVDIR/build-tests.log"
+grep -oE '"executable":"[^"]+"' "$COVDIR/build-tests.json" | sed -E 's/^"executable":"//; s/"$//' | LC_ALL=C sort -u >"$COVDIR/testbins.txt" || true
 LLVM_PROFILE_FILE="$COVDIR/build/host-%m-%p.profraw" \
   cargo build --release -p almide-mir --example render_program --target-dir "$COVDIR/t" 2>&1 | tail -1
 LLVM_PROFILE_FILE="$COVDIR/build/host-%m-%p.profraw" \
@@ -113,12 +124,15 @@ echo "== 2/4 run the test suites =="
 # (macOS) rejects it outright — the second call has no `|| true`, so under
 # `set -e` this whole gate died at step 2/4 with "illegal mode string" on every
 # non-GNU host, never reaching the ratchet it exists to enforce (#1244 round 5).
-TESTBINS="$(find "$COVDIR/t/release/deps" -maxdepth 1 -type f -perm -u+x ! -name '*.d' ! -name '*.dylib' | grep -E '/(almide_mir|almide_codegen|almide_wasm|backend_parity|section_dump|fuzz_differential|alias_semantics|tail_calls|integration|lower|render)[^/]*$' || true)"
-[ -n "$TESTBINS" ] || TESTBINS="$(find "$COVDIR/t/release/deps" -maxdepth 1 -type f -perm -u+x ! -name '*.d' ! -name '*.dylib')"
+TESTBIN_NAMES='/(almide_mir|almide_codegen|almide_wasm|backend_parity|section_dump|fuzz_differential|alias_semantics|tail_calls|integration|lower|render)[^/]*$'
+TESTBINS="$(grep -E "$TESTBIN_NAMES" "$COVDIR/testbins.txt" 2>/dev/null || true)"
+[ -n "$TESTBINS" ] || TESTBINS="$(cat "$COVDIR/testbins.txt" 2>/dev/null || true)"
+[ -n "$TESTBINS" ] || TESTBINS="$(find "$COVDIR/t/release/deps" -maxdepth 1 -type f -perm -u+x ! -name '*.d' ! -name '*.dylib' 2>/dev/null | grep -E "$TESTBIN_NAMES" || true)"
+[ -n "$TESTBINS" ] || TESTBINS="$(find "$COVDIR/t/release/deps" -maxdepth 1 -type f -perm -u+x ! -name '*.d' ! -name '*.dylib' 2>/dev/null || true)"
 # No vacuous measurement: zero test binaries would still produce profraw from
 # the step-3 workloads, so the run would report a NUMBER for a suite that never
 # ran. That is the #990 failure mode again — fail instead.
-[ -n "$TESTBINS" ] || { echo "coverage: NO test binaries found under $COVDIR/t/release/deps — the discovery went blind"; exit 1; }
+[ -n "$TESTBINS" ] || { echo "coverage: NO test binaries found (cargo artifact messages empty, $COVDIR/t/release/deps absent) — the discovery went blind"; exit 1; }
 i=0
 for tb in $TESTBINS; do
     i=$((i+1))

--- a/scripts/check-interface-diff-negative.sh
+++ b/scripts/check-interface-diff-negative.sh
@@ -76,8 +76,19 @@ pure_file=${pure_pick%%	*};     pure_line=${pure_pick#*	}
 forged_effect='effect negative_control.forged(x: Int) -> Result[Int, String]'
 forged_pure='negative_control.forged_pure(x: Int) -> Int'
 
+# The legacy-placeholder control (394c64294): the SAME tuple-returning fn
+# rendered `-> List[()]` in the base index must read as identical against
+# its named-tuple rendering, while a placeholder line with no current twin
+# (or a twin whose parameter list changed) is still a removal.
+tuple_pick=$(pick '^[a-z_0-9]+\.[a-z_0-9]+\(.*-> List\[\(') \
+  || { echo "FAIL: no tuple-returning fn line in the committed index — the placeholder control has no subject" >&2; exit 1; }
+tuple_file=${tuple_pick%%	*}; tuple_line=${tuple_pick#*	}
+legacy_line="${tuple_line%% -> *} -> List[()]"
+legacy_orphan="${tuple_line%%(*}_orphan(${tuple_line#*(}"; legacy_orphan="${legacy_orphan%% -> *} -> List[()]"
 g init -q
 snapshot base
+drop_line "$tuple_file" "$tuple_line"; add_line "$tuple_file" "$legacy_line"; snapshot legacy-tuple
+drop_line "$tuple_file" "$tuple_line"; add_line "$tuple_file" "$legacy_orphan"; snapshot legacy-orphan
 
 drop_line "$effect_file" "$effect_line"; snapshot rm-effect
 drop_line "$pure_file"   "$pure_line";   snapshot rm-pure
@@ -141,8 +152,12 @@ run rm-effect base
 expect "reversed effect removal" 0 "= additive (added=1 removed=0)" "  + $effect_line"
 
 # Blind-gate guard: an index with no signatures is an error, never a verdict.
+run legacy-tuple base
+expect "legacy placeholder re-rendered as a named tuple" 0 "= identical (added=0 removed=0)" "re-rendered (legacy placeholder -> named type, same name and arity): 1"
+run legacy-orphan base
+expect "legacy placeholder with no current twin is a removal" 1 "= breaking (added=1 removed=1)" "  - $legacy_orphan"
 run base blank
 expect "blank index goes loud" 2 "no generated signature index"
 
-echo "interface-diff negative controls: 1 positive + 8 forged inputs all behaved" \
+echo "interface-diff negative controls: 1 positive + 10 forged inputs all behaved" \
   "(effect: $effect_line | pure: $pure_line)"

--- a/scripts/check-interface-diff.sh
+++ b/scripts/check-interface-diff.sh
@@ -85,6 +85,57 @@ cur_s=$(surface "$CUR" || true)
 removed=$(comm -23 <(printf '%s\n' "$prev_s") <(printf '%s\n' "$cur_s"))
 added=$(comm -13 <(printf '%s\n' "$prev_s") <(printf '%s\n' "$cur_s"))
 
+# Legacy placeholder rendering. Indexes written before the interface JSON
+# named RawPtr / Never / Matrix[Float32] and spelled tuple types
+# (394c64294) rendered every tuple as a bare `()` and every unnamed type as
+# `?` — `list.zip(...) -> List[()]`, `bytes.as_ptr(b: Bytes) -> ?`. Read
+# textually against a current index those lines are 51 "removals" that are
+# the SAME functions re-rendered, and a release would have to declare
+# `--allow-breaking` for a diff that breaks nothing. A prev-only line that
+# carries a placeholder is matched against the cur-only lines by turning
+# each placeholder into a wildcard (`()` -> any parenthesised tuple, `?` ->
+# any type); exactly one match reclassifies the pair as a re-rendering and
+# drops it from both sides. A genuine function type `() -> A` is not a
+# placeholder (the `()` is followed by `->`) and never wildcards. A
+# placeholder line with NO current twin is still a removal, and a twin
+# whose parameter list changed still fails to match — the wildcard covers
+# the type slot only, never the name or the arity. Reported on its own line
+# so the count stays auditable.
+rerendered=0
+if [ -n "$removed" ] && [ -n "$added" ]; then
+  norm=$(python3 - "$removed" "$added" <<'PY'
+import re, sys
+removed = [l for l in sys.argv[1].split("\n") if l]
+added = [l for l in sys.argv[2].split("\n") if l]
+PLACEHOLDER = re.compile(r"\(\)(?!\s*->)|\?")
+def wildcard(line):
+    out, pos = "", 0
+    for m in PLACEHOLDER.finditer(line):
+        out += re.escape(line[pos:m.start()])
+        out += r"\((?:[^()]|\([^()]*\))*\)" if m.group() == "()" else r"[A-Za-z0-9_\[\], ]+"
+        pos = m.end()
+    return re.compile("^" + out + re.escape(line[pos:]) + "$")
+keep_removed, matched_added, n = [], set(), 0
+for r in removed:
+    if not PLACEHOLDER.search(r):
+        keep_removed.append(r); continue
+    rx = wildcard(r)
+    hits = [a for a in added if a not in matched_added and rx.match(a)]
+    if len(hits) == 1:
+        matched_added.add(hits[0]); n += 1
+    else:
+        keep_removed.append(r)
+print(n)
+print("\n".join(keep_removed))
+print("--")
+print("\n".join(a for a in added if a not in matched_added))
+PY
+)
+  rerendered=$(printf '%s\n' "$norm" | sed -n 1p)
+  removed=$(printf '%s\n' "$norm" | sed -n '2,/^--$/p' | sed '$d' | grep . || true)
+  added=$(printf '%s\n' "$norm" | sed '1,/^--$/d' | grep . || true)
+fi
+
 if [ -z "$removed" ] && [ -z "$added" ]; then
   verdict="identical"
 elif [ -z "$removed" ]; then
@@ -94,6 +145,9 @@ else
 fi
 
 echo "interface-diff: $PREV -> $CUR = $verdict (added=$(printf '%s' "$added" | grep -c . || true) removed=$(printf '%s' "$removed" | grep -c . || true))"
+if [ "$rerendered" != "0" ]; then
+  echo "re-rendered (legacy placeholder -> named type, same name and arity): $rerendered — not counted"
+fi
 if [ -n "$removed" ]; then
   echo "removed/changed signatures:"
   printf '%s\n' "$removed" | sed 's/^/  - /'

--- a/src/cli/test_report.rs
+++ b/src/cli/test_report.rs
@@ -341,6 +341,7 @@ fn parse_t18(file: &str, output: &str) -> Vec<TestFailure> {
     let mut out = Vec::new();
     let lines: Vec<&str> = output.lines().collect();
     for (i, l) in lines.iter().enumerate() {
+        let l = strip_libtest_progress(l);
         // The snapshot block (#1314) is the same record under its own header,
         // so the report can carry the accept hint for it alone.
         let op = if let Some(head) = l.strip_prefix("Error: assertion failed") {
@@ -363,6 +364,25 @@ fn parse_t18(file: &str, output: &str) -> Vec<TestFailure> {
         out.push(f);
     }
     out
+}
+
+/// libtest prints `test <name> ... ` WITHOUT a newline before it runs the
+/// test, and the abort's `process.exit(1)` leaves that fragment on stdout.
+/// The captured text is stdout followed by stderr, so whether the T18 header
+/// starts its own line depends on whether libtest's partial line was flushed
+/// before the abort — usually it was not, and the header parsed; when it
+/// was, the line read `test tests::x ... Error: snapshot mismatch`, the
+/// block went unrecognised, and the report fell back to the raw output
+/// without the accept hint (one queue run in three, PR #1892). The fragment
+/// is libtest's, not the program's: strip it and read the header behind it.
+fn strip_libtest_progress(l: &str) -> &str {
+    if !l.starts_with("test ") {
+        return l;
+    }
+    match l.find(" ... Error: ") {
+        Some(pos) => &l[pos + " ... ".len()..],
+        None => l,
+    }
 }
 
 /// The `  key: value` tail of a T18 block. `expected` ends where `  found: `
@@ -662,6 +682,23 @@ mod tests {
         let r = fs[0].render();
         assert!(r.contains("new snapshot"), "{r}");
         assert!(r.contains("almide test --update-snapshots m.almd"), "{r}");
+    }
+
+    #[test]
+    fn t18_header_glued_to_libtest_progress_still_parses() {
+        // stdout ended mid-line (`test x ... ` flushed, no newline) and stderr's
+        // block followed it in the captured text.
+        let out = "running 3 tests\ntest tests::__test_a ... Error: snapshot mismatch\n  at: line 10\n  expected: item 1\nitem 2\n  found: item 1\nitem 2\nitem 3\n";
+        let fs = parse("plain_test.almd", "", out);
+        assert_eq!(fs.len(), 1, "{fs:?}");
+        assert_eq!(fs[0].op, "assert_snapshot");
+        assert_eq!(fs[0].line, Some(10));
+        assert_eq!(fs[0].expected.as_deref(), Some("item 1\nitem 2"));
+        assert_eq!(fs[0].found.as_deref(), Some("item 1\nitem 2\nitem 3"));
+        let r = fs[0].render();
+        assert!(r.contains("accept: snapshot drift — run `almide test --update-snapshots plain_test.almd`"), "{r}");
+        // A program line that merely mentions the words is not a header.
+        assert!(parse("f.almd", "", "note: Error: snapshot mismatch is what it prints\n").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Two release-path gates that had quietly stopped meaning what they say.

**interface-diff (#1488)** — `check-interface-diff.sh v0.61.1 develop` reported `breaking (added=63 removed=51)`. Every "removed" line is the same function re-rendered: indexes written before 394c64294 spelled every tuple as a bare `()` and every unnamed type as `?` (`list.zip(...) -> List[()]`, `bytes.as_ptr(b: Bytes) -> ?`), and the textual diff cannot see through that. Left alone, the 0.62.0 tag would have to declare `--allow-breaking` for a diff that breaks nothing. A prev-only line carrying a placeholder is now matched against the cur-only lines with the placeholder as a wildcard (`()` → any parenthesised tuple, `?` → any type; name and arity fixed); exactly one match reclassifies the pair as a re-rendering, reported on its own `re-rendered … — not counted` line. A genuine function type `() -> A` is not a placeholder (the `()` is followed by `->`), a placeholder line with no current twin stays a removal, and a twin whose parameter list changed still does not match. The real verdict is now `additive (added=12 removed=0)` with 51 re-rendered. Two controls join the negative script (legacy tuple → identical; legacy orphan → breaking).

**MC/DC per-condition measurement (#566)** — the fuzz-nightly job "Condition-level coverage" has failed every night since 2026-08-27 at step 2/4: `find <target-dir>/release/deps` finds nothing under the dated nightly's build-dir layout (`build/<crate>/<hash>/out/`), so the gate exits with "NO test binaries found" while the stable-toolchain run passes on the old layout. The test binaries are now taken from `cargo test --no-run --message-format=json`'s `executable` field (layout-independent); the `find` stays as the fallback and the no-binaries guard keeps its teeth.
