### PR TITLE
Refresh the stamped ledger counts after the tail chain landed

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The guarantee is **continuous, with an explicit, ledger-managed scope**: "byte-i
 This claim is not prose. Every observable promise is a named contract in the [behavior-contract ledger](docs/contracts/), each traceable to executable evidence, and the numbers below are regenerated from the ledger (`scripts/gen-claims.sh`, enforced by `scripts/check-contracts.sh` in CI):
 
 <!-- claims:generated:start — derived from docs/contracts/contracts.toml by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
-> <!-- counts:generated:start (as of 2026-09-03) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
+> <!-- counts:generated:start (as of 2026-09-04) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
 > **Ledger: 339 contracts — 339 active, 0 flagged-for-revision.**
 > <!-- counts:generated:end -->
 >
@@ -230,7 +230,7 @@ The Perceus proof above proves one compiler pass, once. v1 generalizes that prin
 | Playground | [Live](https://almide.github.io/playground/) — the compiler runs as WASM in the browser |
 
 <!-- stats:generated:start — derived from docs/stdlib/*.md, spec/, and docs/contracts/contracts.toml by scripts/gen-readme-stats.sh; DO NOT EDIT between the markers -->
-<!-- counts:generated:start (as of 2026-09-03) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
+<!-- counts:generated:start (as of 2026-09-04) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
 | Derived count | Value |
 |---|---|
 | Stdlib | 983 functions across 43 modules — self-hosted `.almd`, signature indexes regenerated from the compiler by `tools/gen-stdlib-doc-index.py` |

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -30,7 +30,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-<!-- counts:generated:start (as of 2026-09-03) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
+<!-- counts:generated:start (as of 2026-09-04) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
 339 contracts
 <!-- counts:generated:end -->
 

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -14,8 +14,8 @@
 > block) and refreshed only by `bash scripts/gen-ledger-counts.sh` — a fixture
 > PR regenerates the rows and leaves it alone.
 
-<!-- counts:generated:start (as of 2026-09-03) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
-114 normative sections; 728 distinct executable fixtures.
+<!-- counts:generated:start (as of 2026-09-04) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
+114 normative sections; 730 distinct executable fixtures.
 <!-- counts:generated:end -->
 
 | Section | Contracts | Fixtures (how CI runs each) |

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -13,12 +13,12 @@ by `scripts/gen-ledger-counts.sh` (a release step, or the answer to the nightly
 re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 
 <!-- stages:generated:start — derived from the proofs/ ledgers by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
-<!-- counts:generated:start (as of 2026-09-03) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
+<!-- counts:generated:start (as of 2026-09-04) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
 > **Stage 1 (accept-and-wrong extinction): audits COMPLETE and gated** —
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 63 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 647/675 fixtures cast a real 3-way vote (95%)** —
+> **Stage 2 (translation validation): 649/677 fixtures cast a real 3-way vote (95%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
 > **Stage 3 (semantics freeze): 339/339 contracts spec-keyed; syntax-element coverage

--- a/proofs/ledger-counts.toml
+++ b/proofs/ledger-counts.toml
@@ -11,15 +11,15 @@
 #           whenever the nightly scripts/check-ledger-counts.sh reports drift).
 # A fixture or contract PR must NOT refresh it. Measurement recipes:
 # scripts/lib/ledger-counts.sh.
-date                       = "2026-09-03"
+date                       = "2026-09-04"
 contracts                  = 339
 contracts_active           = 339
 contracts_flagged          = 0
 contracts_spec_keyed       = 339
-wasm_cross_fixtures        = 675
+wasm_cross_fixtures        = 677
 interp_abstains            = 28
 conformance_sections       = 114
-conformance_fixtures       = 728
+conformance_fixtures       = 730
 stdlib_functions           = 983
 stdlib_modules             = 43
 spec_test_files            = 433


### PR DESCRIPTION
Counts-only refresh via scripts/gen-ledger-counts.sh: wasm_cross fixtures 675 → 677, conformance fixtures 728 → 730 (the #1879/#1881 fixtures). Contracts stay at 339. No fixture or code change.