### PR TITLE
list.range and list.len join the native v1 runtime floor

### DIFF
--- a/crates/almide-mir/src/render_native_b.rs
+++ b/crates/almide-mir/src/render_native_b.rs
@@ -372,7 +372,11 @@ fn render_closed_shim_call(
     match (dst, ret_ty) {
         (Some(d), Some(t)) => {
             tys.insert(*d, t);
-            let ty_name = if t == NTy::Str { "String" } else { "i64" };
+            let ty_name = match t {
+                NTy::Str => "String",
+                NTy::Vec => "Vec<i64>",
+                _ => "i64",
+            };
             line!("let mut {}: {} = {};", var(*d), ty_name, call);
         }
         (None, _) => line!("{call};"),
@@ -401,6 +405,13 @@ fn shim_arg_in_declared_mode(
             }
             Ok(code)
         }
+        // A scalar-list param (#1869): borrowed at the MIR call boundary —
+        // an owned `Vec<i64>` local by reference, a `&[i64]` param as is.
+        NTy::VecRef | NTy::Vec => match got {
+            NTy::Vec => Ok(format!("&{code}")),
+            NTy::VecRef => Ok(code),
+            _ => Err(wall(format!("native: shim `{name}` arg type mismatch"))),
+        },
         _ => {
             if !got.is_stringy() {
                 return Err(wall(format!("native: shim `{name}` arg type mismatch")));

--- a/crates/almide-mir/src/render_native_shims.rs
+++ b/crates/almide-mir/src/render_native_shims.rs
@@ -54,8 +54,13 @@ const SHIMS: &[(&str, &[NTy], Option<NTy>, &str)] = &[
     // materializes a `let`-bound range that is indexed or measured as
     // `CallFn list.range(s, e)`; without a floor entry the whole program
     // left the trust-spine for the v3 codegen — silently — on every such
-    // read. Same contract as the wasm self-host body (stdlib list_range):
-    // empty when e <= s, i64 values, rung-4 owned `Vec<i64>`.
+    // read. The body is the v3 runtime's `almide_rt_list_range` verbatim
+    // (runtime/rs/src/list.rs): empty when e <= s, the span through
+    // `saturating_sub` so `end - start` cannot wrap, and a span the machine
+    // cannot satisfy is the C-197 `Error: out of memory` abort via
+    // `try_reserve_exact` — never `(s..e).collect()`'s raw `capacity
+    // overflow` panic (range_materialize_oom reads exit 1 + that line on
+    // both legs). Rung-4 owned `Vec<i64>`.
     // #1869: `list.len` over a rung-4 scalar list — the read that, with an
     // index, forces the `list.range` materialization above; borrowed, like
     // every heap arg at the MIR call boundary.
@@ -64,7 +69,7 @@ const SHIMS: &[(&str, &[NTy], Option<NTy>, &str)] = &[
             "fn rt_list_len(xs: &[i64]) -> i64 {\n    xs.len() as i64\n}"),
     ("list.range", &[NTy::I64, NTy::I64],
             Some(NTy::Vec),
-            "fn rt_list_range(s: i64, e: i64) -> Vec<i64> {\n    if e <= s { Vec::new() } else { (s..e).collect() }\n}"),
+            "fn rt_list_range(s: i64, e: i64) -> Vec<i64> {\n    let count = e.saturating_sub(s).max(0) as usize;\n    let mut v: Vec<i64> = Vec::new();\n    if v.try_reserve_exact(count).is_err() {\n        eprintln!(\"Error: out of memory\");\n        std::process::exit(1);\n    }\n    v.extend(s..e);\n    v\n}"),
     ("string.repeat", &[NTy::Str, NTy::I64],
             Some(NTy::Str),
             // The SAME clamp + ceiling as the v0 runtime and the wasm self-host

--- a/crates/almide-mir/src/render_native_shims.rs
+++ b/crates/almide-mir/src/render_native_shims.rs
@@ -50,6 +50,21 @@ const SHIMS: &[(&str, &[NTy], Option<NTy>, &str)] = &[
     ("string.trim", &[NTy::Str],
             Some(NTy::Str),
             "fn rt_string_trim(s: &str) -> String { s.trim().to_string() }"),
+    // #1869: `list.range` joins the floor as a closed shim. The lowering
+    // materializes a `let`-bound range that is indexed or measured as
+    // `CallFn list.range(s, e)`; without a floor entry the whole program
+    // left the trust-spine for the v3 codegen — silently — on every such
+    // read. Same contract as the wasm self-host body (stdlib list_range):
+    // empty when e <= s, i64 values, rung-4 owned `Vec<i64>`.
+    // #1869: `list.len` over a rung-4 scalar list — the read that, with an
+    // index, forces the `list.range` materialization above; borrowed, like
+    // every heap arg at the MIR call boundary.
+    ("list.len", &[NTy::VecRef],
+            Some(NTy::I64),
+            "fn rt_list_len(xs: &[i64]) -> i64 {\n    xs.len() as i64\n}"),
+    ("list.range", &[NTy::I64, NTy::I64],
+            Some(NTy::Vec),
+            "fn rt_list_range(s: i64, e: i64) -> Vec<i64> {\n    if e <= s { Vec::new() } else { (s..e).collect() }\n}"),
     ("string.repeat", &[NTy::Str, NTy::I64],
             Some(NTy::Str),
             // The SAME clamp + ceiling as the v0 runtime and the wasm self-host

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -285,10 +285,16 @@ static __ALMIDE_CAP_ALLOC: __AlmideCapAlloc = __AlmideCapAlloc;
 "#
     );
     // Inner attributes must precede all items: split after the leading run of
-    // `#![...]` / blank lines, then place the runtime between the two halves.
+    // `#![...]` / blank / `//` comment lines, then place the runtime between
+    // the two halves. The v1 trust-spine render opens with a `// Generated
+    // by …` line BEFORE its `#![allow(..)]`; a leading run that stopped at
+    // the comment put the runtime ahead of the inner attribute — "an inner
+    // attribute is not permitted in this context" — which stayed invisible
+    // while every cap-test program still walled v1 (#1869 widened the floor).
     let mut split = 0;
     for line in rs_code.split_inclusive('\n') {
-        if line.trim().is_empty() || line.trim_start().starts_with("#![") {
+        let l = line.trim_start();
+        if l.trim().is_empty() || l.starts_with("#![") || l.starts_with("//") {
             split += line.len();
         } else {
             break;

--- a/tests/heap_cap_test.rs
+++ b/tests/heap_cap_test.rs
@@ -219,20 +219,24 @@ fn map_literal_intermediates_do_not_leak_under_the_cap() {
 
 /// #1857: a `let`-bound range read ONLY as a `for-in` head allocates nothing
 /// on native even when the program falls off the v1 trust-spine onto the v3
-/// codegen. The `list.len` / index reads of `idx` force a `list.range`
-/// materialization v1 cannot link, so `main` renders through v3 — where,
+/// codegen. The top-level `let` keeps the program off the v1 render (rung 1
+/// has no top-level lets) — it used to be the `list.len` / index reads of
+/// `idx`, until `list.range` and `list.len` joined the native floor (#1869)
+/// — so `main` renders through v3 — where,
 /// before the fix, `big` was materialized as a 1 GiB `Vec<i64>` (the nightly
 /// fuzzer's seed 539646620663 index 1415 carried 16 GiB: 33.6 s native vs
 /// 0.7 s wasm, byte-identical). Under a 4 MiB ceiling that materialization is
 /// the deterministic OOM; the head-only deferral (`RangeCountingVarsPass`)
 /// is what makes this a green run.
-const WALLED_RANGE_PROBE: &str = r#"effect fn main() -> Unit = {
+const WALLED_RANGE_PROBE: &str = r#"let bump = 0
+
+effect fn main() -> Unit = {
   let idx = 0..<5
   println("len=" + int.to_string(list.len(idx)) + " at2=" + int.to_string(idx[2]))
   let big = 0..<134217728
   var e = 0
   for _i in big {
-    e = e + 1
+    e = e + 1 + bump
   }
   println("e=" + int.to_string(e))
 }
@@ -262,9 +266,10 @@ fn walled_head_only_range_allocates_nothing_natively() {
         String::from_utf8_lossy(&build.stderr)
     );
     let build_note = String::from_utf8_lossy(&build.stderr);
-    // The probe is only a witness while it actually walls v1: if the native
-    // floor ever grows `list.range`, this program stops exercising the v3
-    // fallback and the gate must move to a shape that still does.
+    // The probe is only a witness while it actually walls v1: if rung 1 ever
+    // admits top-level lets, this program stops exercising the v3 fallback
+    // and the gate must move to a shape that still does (it moved once
+    // already, when `list.range` / `list.len` joined the floor — #1869).
     assert!(
         build_note.contains("verified native render walled"),
         "the walled-range probe no longer walls the v1 native render — pick a shape that does: {build_note}"

--- a/tests/native_floor_list_range_test.rs
+++ b/tests/native_floor_list_range_test.rs
@@ -1,0 +1,69 @@
+//! #1869: `list.range` and `list.len` are in the native v1 runtime floor.
+//! A `let`-bound range that is indexed or measured materializes through
+//! `CallFn list.range`; before the floor carried it, EVERY such program
+//! left the certified trust-spine render for the v3 codegen — silently
+//! (`ALMIDE_VERIFIED_DEBUG` was the only witness). The probe pins the
+//! route (the debug note names the v1 render) and the output on both
+//! native and wasm, with the heap-cap splice on top: the cap runtime lands
+//! AFTER the v1 render's inner attribute (it did not, while no capped
+//! program reached v1).
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+const PROBE: &str = r#"effect fn main() -> Unit = {
+  let idx = 0..<5
+  println("len=" + int.to_string(list.len(idx)) + " at2=" + int.to_string(idx[2]))
+  let r = list.range(3, 7)
+  println(int.to_string(list.len(r)) + " " + int.to_string(r[0]) + " " + int.to_string(r[3]))
+  let e = list.range(5, 5)
+  let neg = list.range(4, 1)
+  println(int.to_string(list.len(e)) + " " + int.to_string(list.len(neg)))
+}
+"#;
+const EXPECTED: &str = "len=5 at2=2\n4 3 6\n0 0";
+
+#[test]
+fn a_measured_range_stays_on_the_v1_native_render() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("range_floor.almd");
+    std::fs::write(&src, PROBE).expect("write probe");
+    let bin = dir.path().join("range_floor");
+    let build = Command::new(almide_bin())
+        .env("ALMIDE_VERIFIED_DEBUG", "1")
+        .args(["build", "--heap-cap", "1048576"])
+        .arg(&src)
+        .arg("-o")
+        .arg(&bin)
+        .output()
+        .expect("spawn almide build");
+    let note = String::from_utf8_lossy(&build.stderr);
+    assert!(build.status.success(), "build failed: {note}");
+    assert!(
+        note.contains("native: v1 trust-spine render"),
+        "the measured range left the v1 render for the fallback — `list.range` / `list.len` fell out of the floor: {note}"
+    );
+    let run = Command::new(&bin).output().expect("spawn probe");
+    assert_eq!(run.status.code(), Some(0), "{}", String::from_utf8_lossy(&run.stderr));
+    assert_eq!(String::from_utf8_lossy(&run.stdout).trim(), EXPECTED, "native output");
+
+    let wasm = Command::new(almide_bin())
+        .args(["run"])
+        .arg(&src)
+        .args(["--target", "wasm"])
+        .output()
+        .expect("spawn almide run --target wasm");
+    assert!(wasm.status.success(), "{}", String::from_utf8_lossy(&wasm.stderr));
+    assert_eq!(String::from_utf8_lossy(&wasm.stdout).trim(), EXPECTED, "wasm output must match native");
+}

--- a/tests/native_v1_differential_test.rs
+++ b/tests/native_v1_differential_test.rs
@@ -200,7 +200,9 @@ fn v0_mutual_tail_recursion_survives_opt_level_0() {
 #[test]
 fn out_of_subset_walls_honestly() {
     let walls = [
-        ("list", "fn main() -> Unit = {\n  let xs = [1, 2, 3]\n  println(int.to_string(list.len(xs)))\n}\n"),
+        // `list.len` over a scalar list joined the floor with `list.range`
+        // (#1869); a combinator over the list is still outside it.
+        ("list", "fn main() -> Unit = {\n  let xs = [1, 2, 3]\n  let ys = list.reverse(xs)\n  println(int.to_string(list.len(ys)))\n}\n"),
         ("str_split", "fn main() -> Unit = {\n  let parts = string.split(\"a,b\", \",\")\n  println(parts[0])\n}\n"),
         // list_param moved to the POSITIVE corpus — rung 4 renders scalar-list
         // params/literals/indexing natively (`vec![…]` + the bounds shims).


### PR DESCRIPTION
Closes #1869.

A `let`-bound range that is indexed or measured (`idx[2]`, `list.len(idx)`) lowers to `CallFn list.range`; the native v1 trust-spine render had no floor entry for it — nor for `list.len` over a scalar list — so the whole program left the certified leg for the v3 codegen, silently (`ALMIDE_VERIFIED_DEBUG` was the only witness). Both join `render_native_shims` as closed shims: `rt_list_range(s, e) -> Vec<i64>` (empty when `e <= s`, the self-host body's contract) and `rt_list_len(&[i64]) -> i64`. The closed-shim call binds a `Vec` result as `Vec<i64>` (it knew only `String` / `i64`), and the declared-mode arg check gains the borrowed-list mode (an owned `Vec` local by reference, a `&[i64]` param as is). The probe now reports `native: v1 trust-spine render` and prints the same bytes on both targets; `tests/native_floor_list_range_test.rs` pins the route and the output.

Two things that fell out once a capped program reached v1 for the first time:

- `inject_heap_cap` splits the generated source after the leading run of `#![...]` / blank lines to keep inner attributes first — but the v1 render opens with a `// Generated by …` comment BEFORE its `#![allow(..)]`, so the runtime landed ahead of the attribute ("an inner attribute is not permitted in this context"). The leading run now includes `//` lines. `heap_cap_test::native_cap_enforcement_is_live` is the witness (its churn probe uses `list.len`, and walled v1 until now).
- `heap_cap_test`'s walled-range probe (#1857) is only a witness while it walls v1; it moves onto a top-level `let` (rung 1 has none), same output, and its comment says so.

Re-measured: `proofs/corpus-wall.sh` is unchanged at 40 walled-real rows — that gate classifies the MIR lowering, and `list.range` never walled there; the drop the issue expected shows up on the native route, not in that ledger. `almide test spec/lang/` 208/208, almide-mir unit tests 631/631, the native test files green.
