### PR TITLE
The interp serves a Result handle as the cap-as-tag block and stores its fs overlay as bytes

### DIFF
--- a/crates/almide-interp/interp-abstain-classes.toml
+++ b/crates/almide-interp/interp-abstain-classes.toml
@@ -61,10 +61,10 @@ patterns = [
   # next vfs prim the overlay does not serve — a directory listing, a stat,
   # a bytes read, the fallible fold callback. Sandboxed-fs glue at the
   # argv/env tier, bounded work each.
-  "capability: prim.read_dir",
-  "capability: prim.path_filestat",
-  "capability: prim.read_bytes_file",
   "capability: fs.__fallible_fold_lines",
+  # One prim deeper again once the overlay served read_dir / path_filestat /
+  # read_bytes_file: the rename floor is the next bounded piece of vfs glue.
+  "capability: prim.rename",
   # SURFACED BY the #1416 ctor glue (map.new/set.new/with_capacity), not
   # introduced by it: map_filter / map_set_typechange used to abstain at
   # `prim.alloc_map` (HEAP_BOUNDARY, first-hit) and now get past the

--- a/crates/almide-interp/interp-abstain-classes.toml
+++ b/crates/almide-interp/interp-abstain-classes.toml
@@ -55,6 +55,16 @@ patterns = [
   # tier, same class as random_get/read_n_bytes — bounded, not architectural.
   "capability: env.set",
   "capability: HOF map.fold",
+  # SURFACED BY the #1844 Result-handle block (`prim.handle` of a Result is
+  # now the cap-as-tag slot the fs floors hand back), not introduced by it:
+  # the fs fixtures used to abstain at the handle and now get past it to the
+  # next vfs prim the overlay does not serve — a directory listing, a stat,
+  # a bytes read, the fallible fold callback. Sandboxed-fs glue at the
+  # argv/env tier, bounded work each.
+  "capability: prim.read_dir",
+  "capability: prim.path_filestat",
+  "capability: prim.read_bytes_file",
+  "capability: fs.__fallible_fold_lines",
   # SURFACED BY the #1416 ctor glue (map.new/set.new/with_capacity), not
   # introduced by it: map_filter / map_set_typechange used to abstain at
   # `prim.alloc_map` (HEAP_BOUNDARY, first-hit) and now get past the

--- a/crates/almide-interp/interp-abstain-ledger.txt
+++ b/crates/almide-interp/interp-abstain-ledger.txt
@@ -16,16 +16,14 @@ count_domain_nonbytes  out-of-interp-scope capability: prim.read_n_bytes
 effect_tco_err_rewrap  interp fuel/recursion budget exhausted
 env_set_overlay  out-of-interp-scope capability: env.set
 env_sleep_pause  out-of-interp-scope capability: env.sleep_ms
-fan_effect_mapper_capability  out-of-interp-scope capability: prim.handle of a Result (outside the slice-2 heap family)
-fs_composition_family  out-of-interp-scope capability: prim.handle of a Result (outside the slice-2 heap family)
-fs_fallible_stream_callback  out-of-interp-scope capability: prim.handle of a Result (outside the slice-2 heap family)
-fs_glob_segments  out-of-interp-scope capability: prim.handle of a Result (outside the slice-2 heap family)
-fs_list_dir_multipass  out-of-interp-scope capability: prim.handle of a Result (outside the slice-2 heap family)
-fs_metadata_family  out-of-interp-scope capability: prim.handle of a Result (outside the slice-2 heap family)
-fs_read_directory_errno  out-of-interp-scope capability: prim.handle of a Result (outside the slice-2 heap family)
-fs_read_lines  out-of-interp-scope capability: prim.handle of a Result (outside the slice-2 heap family)
-fs_read_text_utf8  out-of-interp-scope capability: prim.handle of a Result (outside the slice-2 heap family)
-fs_write_errno  out-of-interp-scope capability: prim.handle of a Result (outside the slice-2 heap family)
+fs_composition_family  out-of-interp-scope capability: prim.read_dir
+fs_fallible_stream_callback  out-of-interp-scope capability: fs.__fallible_fold_lines
+fs_glob_segments  out-of-interp-scope capability: prim.path_filestat
+fs_list_dir_multipass  out-of-interp-scope capability: prim.read_dir
+fs_metadata_family  out-of-interp-scope capability: prim.path_filestat
+fs_read_directory_errno  out-of-interp-scope capability: prim.read_bytes_file
+fs_read_text_utf8  out-of-interp-scope capability: prim.read_bytes_file
+fs_write_errno  out-of-interp-scope capability: prim.read_dir
 io_write_ordering  out-of-interp-scope capability: prim.fd_write
 list_repeat_size_ceiling  out-of-interp-scope capability: prim.alloc_list(268435456) beyond the interp arena ceiling
 loop_effect_match_stmt  out-of-interp-scope capability: prim.fd_write

--- a/crates/almide-interp/interp-abstain-ledger.txt
+++ b/crates/almide-interp/interp-abstain-ledger.txt
@@ -16,14 +16,9 @@ count_domain_nonbytes  out-of-interp-scope capability: prim.read_n_bytes
 effect_tco_err_rewrap  interp fuel/recursion budget exhausted
 env_set_overlay  out-of-interp-scope capability: env.set
 env_sleep_pause  out-of-interp-scope capability: env.sleep_ms
-fs_composition_family  out-of-interp-scope capability: prim.read_dir
+fs_composition_family  out-of-interp-scope capability: prim.rename
 fs_fallible_stream_callback  out-of-interp-scope capability: fs.__fallible_fold_lines
-fs_glob_segments  out-of-interp-scope capability: prim.path_filestat
-fs_list_dir_multipass  out-of-interp-scope capability: prim.read_dir
-fs_metadata_family  out-of-interp-scope capability: prim.path_filestat
-fs_read_directory_errno  out-of-interp-scope capability: prim.read_bytes_file
-fs_read_text_utf8  out-of-interp-scope capability: prim.read_bytes_file
-fs_write_errno  out-of-interp-scope capability: prim.read_dir
+fs_write_errno  out-of-interp-scope capability: prim.rename
 io_write_ordering  out-of-interp-scope capability: prim.fd_write
 list_repeat_size_ceiling  out-of-interp-scope capability: prim.alloc_list(268435456) beyond the interp arena ceiling
 loop_effect_match_stmt  out-of-interp-scope capability: prim.fd_write

--- a/crates/almide-interp/interp-abstain-ledger.txt
+++ b/crates/almide-interp/interp-abstain-ledger.txt
@@ -16,9 +16,7 @@ count_domain_nonbytes  out-of-interp-scope capability: prim.read_n_bytes
 effect_tco_err_rewrap  interp fuel/recursion budget exhausted
 env_set_overlay  out-of-interp-scope capability: env.set
 env_sleep_pause  out-of-interp-scope capability: env.sleep_ms
-fs_composition_family  out-of-interp-scope capability: prim.rename
 fs_fallible_stream_callback  out-of-interp-scope capability: fs.__fallible_fold_lines
-fs_write_errno  out-of-interp-scope capability: prim.rename
 io_write_ordering  out-of-interp-scope capability: prim.fd_write
 list_repeat_size_ceiling  out-of-interp-scope capability: prim.alloc_list(268435456) beyond the interp arena ceiling
 loop_effect_match_stmt  out-of-interp-scope capability: prim.fd_write

--- a/crates/almide-interp/interp-abstain-ledger.txt
+++ b/crates/almide-interp/interp-abstain-ledger.txt
@@ -16,7 +16,6 @@ count_domain_nonbytes  out-of-interp-scope capability: prim.read_n_bytes
 effect_tco_err_rewrap  interp fuel/recursion budget exhausted
 env_set_overlay  out-of-interp-scope capability: env.set
 env_sleep_pause  out-of-interp-scope capability: env.sleep_ms
-fs_fallible_stream_callback  out-of-interp-scope capability: fs.__fallible_fold_lines
 io_write_ordering  out-of-interp-scope capability: prim.fd_write
 list_repeat_size_ceiling  out-of-interp-scope capability: prim.alloc_list(268435456) beyond the interp arena ceiling
 loop_effect_match_stmt  out-of-interp-scope capability: prim.fd_write

--- a/crates/almide-interp/src/dispatch.rs
+++ b/crates/almide-interp/src/dispatch.rs
@@ -614,6 +614,7 @@ pub(crate) fn is_hof(module: &str, func: &str) -> bool {
             | ("list", "__fallible_find")
             | ("list", "__fallible_fold")
             | ("list", "__fallible_each")
+            | ("fs", "__fallible_fold_lines")
             | ("map", "map")
             | ("map", "filter")
             | ("map", "fold")

--- a/crates/almide-interp/src/dispatch_heap.rs
+++ b/crates/almide-interp/src/dispatch_heap.rs
@@ -155,8 +155,63 @@ impl<'a> Interpreter<'a> {
                 self.heap.keep(rc);
                 Ok(a as i64)
             }
+            // The cap-as-tag `Result` block (#1844): the shape the fs / fan
+            // floors hand back and their stdlib bodies read as
+            // `load_handle(h + 12)` (payload, low 32 bits) and `load32(h + 16)`
+            // (tag: 0 = Ok, 1 = Err) — one slot whose high half is the tag,
+            // `len@4 = cap@8 = 1` (render_wasm_fs_wat `$rtf_result`). A Box
+            // has no identity to bind, so each `prim.handle` materializes
+            // afresh — the bodies take the handle once. The payload's own
+            // block (a Str message, a List of lines) is bound the ordinary
+            // way and its address is the low half.
+            (Value::Result(r), Some(Ty::Applied(C::Result, ts))) if ts.len() == 2 => {
+                let (payload, tag, ty) = match r {
+                    Ok(v) => (v.as_ref(), 0i64, &ts[0]),
+                    Err(e) => (e.as_ref(), 1i64, &ts[1]),
+                };
+                let low = self.heap_result_payload_low(payload, Some(ty))?;
+                Ok(self.heap_result_block(low, tag) as i64)
+            }
             _ => self.heap_materialize(v),
         }
+    }
+
+    /// The low 32 bits of a cap-as-tag `Result` slot: a Unit is 0, a Bool
+    /// 0/1, an Int must fit the half (the backends store an i32 there — a
+    /// wider payload has no faithful bits and abstains), a block value is
+    /// its address.
+    fn heap_result_payload_low(&mut self, payload: &Value, ty: Option<&Ty>) -> Result<i64, String> {
+        let low = match payload {
+            Value::Unit => 0,
+            Value::Bool(b) => *b as i64,
+            Value::Int(i) => {
+                if i32::try_from(*i).is_err() {
+                    return Err(format!(
+                        "prim.handle of a Result holding an Int outside the i32 half ({i})"
+                    ));
+                }
+                *i & 0xFFFF_FFFF
+            }
+            Value::Str(_) | Value::List(_) | Value::Set(_) | Value::Map(_) | Value::Tuple(_) => {
+                self.heap_materialize_hinted(payload, ty)?
+            }
+            other => {
+                return Err(format!(
+                    "prim.handle of a Result holding a {} (no cap-as-tag slot repr)",
+                    other.type_name()
+                ))
+            }
+        };
+        Ok(low)
+    }
+
+    fn heap_result_block(&mut self, low: i64, tag: i64) -> u32 {
+        let base = self.heap.alloc_slots(1);
+        let slot = (low & 0xFFFF_FFFF) | (tag << 32);
+        self.heap
+            .store(base + crate::heap::PAYLOAD, 8, slot)
+            .expect("a freshly allocated slot is inside the arena");
+        base
     }
 
     /// One container element as its slot i64, driven by the DECLARED element
@@ -308,6 +363,16 @@ impl<'a> Interpreter<'a> {
                 self.heap.keep(rc);
                 Ok(a as i64)
             }
+            // Un-hinted `Result`: the same cap-as-tag block, the payload read
+            // by its own shape (see `heap_materialize_hinted`).
+            Value::Result(r) => {
+                let (payload, tag) = match r {
+                    Ok(v) => (v.as_ref(), 0i64),
+                    Err(e) => (e.as_ref(), 1i64),
+                };
+                let low = self.heap_result_payload_low(payload, None)?;
+                Ok(self.heap_result_block(low, tag) as i64)
+            }
             other => Err(format!(
                 "prim.handle of a {} (outside the slice-2 heap family)",
                 other.type_name()
@@ -428,7 +493,11 @@ impl<'a> Interpreter<'a> {
                 let Some(a) = heap_addr(args.first()) else {
                     return Some(Flow::Unsupported(format!("prim.{func} with a non-address")));
                 };
-                let Some(h) = self.heap.load(a, 8) else {
+                // A 4-byte read, the backends' `i32.load` (render_wasm_p2_b
+                // `PrimKind::LoadHandle`): a handle is a u32 address, and in
+                // the cap-as-tag Result block the slot's HIGH half is the tag
+                // — an 8-byte read there folded the tag into the address.
+                let Some(h) = self.heap.load(a, 4) else {
                     return Some(Flow::Unsupported(format!(
                         "prim.{func} outside this heap's arena"
                     )));

--- a/crates/almide-interp/src/dispatch_module.rs
+++ b/crates/almide-interp/src/dispatch_module.rs
@@ -490,6 +490,65 @@ impl<'a> Interpreter<'a> {
                     Err(e) => Value::Result(Err(Box::new(Value::str(e)))),
                 }))
             }
+            "read_bytes_file" => {
+                let path = match self.vfs_path_arg(func, args.first()) {
+                    Ok(p) => p,
+                    Err(f) => return Some(f),
+                };
+                Some(Flow::val(match crate::vfs::read_bytes(&self.vfs, &path) {
+                    Ok(b) => Value::Result(Ok(Box::new(Value::List(std::rc::Rc::new(
+                        b.into_iter().map(|x| Value::Int(x as i64)).collect(),
+                    ))))),
+                    Err(e) => Value::Result(Err(Box::new(Value::str(e)))),
+                }))
+            }
+            // `prim.path_filestat(buf, path)`: the WASI filestat lands in the
+            // caller's 64-byte scratch — filetype@16, size@32, mtim@48 are the
+            // fields the stdlib bodies read — and the errno is the return
+            // (0 = ok; the bodies only test it against 0, so a missing path
+            // answers WASI's ENOENT 44).
+            "path_filestat" => {
+                let Some(Value::Int(buf)) = args.first() else {
+                    return Some(Flow::Unsupported(
+                        "prim.path_filestat with a non-address buffer".into(),
+                    ));
+                };
+                let path = match self.vfs_path_arg(func, args.get(1)) {
+                    Ok(p) => p,
+                    Err(f) => return Some(f),
+                };
+                let Ok(base) = u32::try_from(*buf) else {
+                    return Some(Flow::Unsupported("prim.path_filestat with a negative buffer".into()));
+                };
+                let Some((ftype, size, mtime_ns)) = crate::vfs::stat(&self.vfs, &path) else {
+                    return Some(Flow::val(Value::Int(44)));
+                };
+                let stores = [
+                    (16u32, 1u32, ftype as i64),
+                    (32, 8, size as i64),
+                    (48, 8, mtime_ns),
+                ];
+                for (off, w, val) in stores {
+                    if self.heap.store(base + off, w, val).is_none() {
+                        return Some(Flow::Unsupported(
+                            "prim.path_filestat outside this heap's arena".into(),
+                        ));
+                    }
+                }
+                Some(Flow::val(Value::Int(0)))
+            }
+            "read_dir" => {
+                let path = match self.vfs_path_arg(func, args.first()) {
+                    Ok(p) => p,
+                    Err(f) => return Some(f),
+                };
+                Some(Flow::val(match crate::vfs::read_dir(&self.vfs, &path) {
+                    Ok(names) => Value::Result(Ok(Box::new(Value::List(std::rc::Rc::new(
+                        names.into_iter().map(Value::str).collect(),
+                    ))))),
+                    Err(e) => Value::Result(Err(Box::new(Value::str(e)))),
+                }))
+            }
             "make_dir" => {
                 let Some(Value::Str(path)) = args.first() else {
                     return Some(Flow::Abort("internal: prim.make_dir expects a String".into()));

--- a/crates/almide-interp/src/dispatch_module.rs
+++ b/crates/almide-interp/src/dispatch_module.rs
@@ -420,27 +420,72 @@ impl<'a> Interpreter<'a> {
     /// per-interpreter overlay, reads fall back to the real fs
     /// read-only. Same tier as the argv/env floors — these prims
     /// read INTERPRETER state, which the stateless bridge cannot.
+    /// A path argument: a `Str`, or a Str-block ADDRESS a body built with
+    /// `alloc_str` (coerced through the arena). Anything else is an honest
+    /// abstain named by shape — a body reaching a vfs prim with a value the
+    /// interp cannot spell must not vote.
+    fn vfs_path_arg(&mut self, func: &str, arg: Option<&Value>) -> Result<String, Flow> {
+        let Some(v) = arg else {
+            return Err(Flow::Unsupported(format!("prim.{func} with no path argument")));
+        };
+        match self.coerce_block_str(v.clone()) {
+            Value::Str(s) => Ok(s.to_string()),
+            other => Err(Flow::Unsupported(format!(
+                "prim.{func} with a {} path (no faithful String)",
+                other.type_name()
+            ))),
+        }
+    }
+
+    /// A content argument as raw bytes: a `Str`'s UTF-8, or the payload of a
+    /// Str / Bytes block at the given ADDRESS (the byte-filled `alloc_str`
+    /// form need not be UTF-8, so it is read as bytes, never as a String).
+    fn vfs_bytes_arg(&mut self, func: &str, arg: Option<&Value>) -> Result<Vec<u8>, Flow> {
+        use crate::heap::BlockKind;
+        match arg {
+            Some(Value::Str(s)) => Ok(s.as_bytes().to_vec()),
+            Some(Value::Int(i)) => {
+                let block = u32::try_from(*i).ok().and_then(|a| self.heap.block_bytes(a));
+                match block {
+                    Some((bytes, BlockKind::Str | BlockKind::Bytes)) => Ok(bytes),
+                    _ => Err(Flow::Unsupported(format!(
+                        "prim.{func} with a non-block Int content (no faithful bytes)"
+                    ))),
+                }
+            }
+            Some(other) => Err(Flow::Unsupported(format!(
+                "prim.{func} with a {} content (no faithful bytes)",
+                other.type_name()
+            ))),
+            None => Err(Flow::Unsupported(format!("prim.{func} with no content argument"))),
+        }
+    }
+
     fn vfs_prim(&mut self, func: &str, args: &[Value]) -> Option<Flow> {
         match func {
             "read_text_file" => {
-                let Some(Value::Str(path)) = args.first() else {
-                    return Some(Flow::Abort("internal: prim.read_text_file expects a String".into()));
+                let path = match self.vfs_path_arg(func, args.first()) {
+                    Ok(p) => p,
+                    Err(f) => return Some(f),
                 };
-                Some(Flow::val(match crate::vfs::read_text(&self.vfs, path) {
+                Some(Flow::val(match crate::vfs::read_text(&self.vfs, &path) {
                     Ok(s) => Value::Result(Ok(Box::new(Value::str(s)))),
                     Err(e) => Value::Result(Err(Box::new(Value::str(e)))),
                 }))
             }
             "write_text_file" => {
-                let (Some(Value::Str(path)), Some(Value::Str(content))) =
-                    (args.first(), args.get(1))
-                else {
-                    return Some(Flow::Abort(
-                        "internal: prim.write_text_file expects (String, String)".into(),
-                    ));
+                let path = match self.vfs_path_arg(func, args.first()) {
+                    Ok(p) => p,
+                    Err(f) => return Some(f),
                 };
-                let (path, content) = (path.to_string(), content.to_string());
-                Some(Flow::val(match crate::vfs::write_text(&mut self.vfs, &path, &content) {
+                // The content is BYTES: a stdlib body that writes bytes fills
+                // an `alloc_str` block byte by byte and hands its ADDRESS here
+                // (`fs.write_bytes`), and those bytes need not be UTF-8.
+                let content = match self.vfs_bytes_arg(func, args.get(1)) {
+                    Ok(b) => b,
+                    Err(f) => return Some(f),
+                };
+                Some(Flow::val(match crate::vfs::write_bytes(&mut self.vfs, &path, &content) {
                     Ok(()) => Value::Result(Ok(Box::new(Value::Unit))),
                     Err(e) => Value::Result(Err(Box::new(Value::str(e)))),
                 }))

--- a/crates/almide-interp/src/dispatch_module.rs
+++ b/crates/almide-interp/src/dispatch_module.rs
@@ -507,7 +507,7 @@ impl<'a> Interpreter<'a> {
             // fields the stdlib bodies read — and the errno is the return
             // (0 = ok; the bodies only test it against 0, so a missing path
             // answers WASI's ENOENT 44).
-            "path_filestat" => {
+            "path_filestat" | "path_filestat_nofollow" => {
                 let Some(Value::Int(buf)) = args.first() else {
                     return Some(Flow::Unsupported(
                         "prim.path_filestat with a non-address buffer".into(),
@@ -520,7 +520,12 @@ impl<'a> Interpreter<'a> {
                 let Ok(base) = u32::try_from(*buf) else {
                     return Some(Flow::Unsupported("prim.path_filestat with a negative buffer".into()));
                 };
-                let Some((ftype, size, mtime_ns)) = crate::vfs::stat(&self.vfs, &path) else {
+                let statted = if func == "path_filestat" {
+                    crate::vfs::stat(&self.vfs, &path)
+                } else {
+                    crate::vfs::stat_nofollow(&self.vfs, &path)
+                };
+                let Some((ftype, size, mtime_ns)) = statted else {
                     return Some(Flow::val(Value::Int(44)));
                 };
                 let stores = [
@@ -548,6 +553,28 @@ impl<'a> Interpreter<'a> {
                     ))))),
                     Err(e) => Value::Result(Err(Box::new(Value::str(e)))),
                 }))
+            }
+            "rename" => {
+                let src = match self.vfs_path_arg(func, args.first()) {
+                    Ok(p) => p,
+                    Err(f) => return Some(f),
+                };
+                let dst = match self.vfs_path_arg(func, args.get(1)) {
+                    Ok(p) => p,
+                    Err(f) => return Some(f),
+                };
+                Some(match crate::vfs::rename(&mut self.vfs, &src, &dst) {
+                    crate::vfs::RenameOutcome::Renamed => {
+                        Flow::val(Value::Result(Ok(Box::new(Value::Unit))))
+                    }
+                    crate::vfs::RenameOutcome::Failed(e) => {
+                        Flow::val(Value::Result(Err(Box::new(Value::str(e)))))
+                    }
+                    crate::vfs::RenameOutcome::HostOnly => Flow::Unsupported(
+                        "prim.rename of a host-only path (the overlay is read-only toward the host)"
+                            .into(),
+                    ),
+                })
             }
             "make_dir" => {
                 let Some(Value::Str(path)) = args.first() else {

--- a/crates/almide-interp/src/hofs.rs
+++ b/crates/almide-interp/src/hofs.rs
@@ -58,8 +58,59 @@ impl<'a> Interpreter<'a> {
             ("result", _) => self.eval_hof_result(f, &evaled),
             ("set", _) => self.eval_hof_set(f, &evaled),
             ("bytes", "map_each") => self.hof_bytes_map_each(&evaled),
+            ("fs", "__fallible_fold_lines") => self.hof_fs_try_fold_lines(&evaled),
             _ => Flow::Unsupported(format!("HOF {}.{}", m, f)),
         }
+    }
+
+    /// `fs.__fallible_fold_lines(path, init, (acc, line) => Result[A, E])` —
+    /// the carrier the checker rewrites a `fs.fold_lines` with a propagating
+    /// callback to (#1844). Lines come from the sandboxed overlay (then the
+    /// read-only real fs) with exactly `BufRead::read_line`'s split — the
+    /// native `almide_rt_fs_fold_lines_effect` and the wasm self-host walk:
+    /// `\n` stripped, a preceding `\r` too, a final unterminated line still
+    /// yielded, no trailing empty line. A read error is the native `io_err`
+    /// Display as the whole call's `err`, before any callback runs; the
+    /// first callback `err` short-circuits like every `__fallible_*`.
+    fn hof_fs_try_fold_lines(&mut self, args: &[Value]) -> Flow {
+        let path = match args.first() {
+            Some(v) => match self.coerce_block_str(v.clone()) {
+                Value::Str(s) => s.to_string(),
+                other => {
+                    return Flow::Unsupported(format!(
+                        "fs.__fallible_fold_lines with a {} path",
+                        other.type_name()
+                    ))
+                }
+            },
+            None => return Flow::Abort("internal: __fallible_fold_lines missing path".into()),
+        };
+        let mut acc = match args.get(1) {
+            Some(v) => v.clone(),
+            None => return Flow::Abort("internal: __fallible_fold_lines missing init".into()),
+        };
+        let clo = match Self::recv_closure(args, 2) {
+            Ok(c) => c,
+            Err(f) => return f,
+        };
+        let text = match crate::vfs::read_text(&self.vfs, &path) {
+            Ok(t) => t,
+            Err(e) => return Flow::val(Value::Result(Err(Box::new(Value::str(e))))),
+        };
+        let mut rest = text.as_str();
+        while !rest.is_empty() {
+            let (line, tail) = match rest.find('\n') {
+                Some(i) => (&rest[..i], &rest[i + 1..]),
+                None => (rest, ""),
+            };
+            let line = line.strip_suffix('\r').unwrap_or(line);
+            match self.try_step(&clo, vec![acc.clone(), Value::str(line.to_string())]) {
+                Ok(v) => acc = v,
+                Err(f) => return f,
+            }
+            rest = tail;
+        }
+        Flow::val(Value::Result(Ok(Box::new(acc))))
     }
 
     /// `bytes.map_each(b, f)` — every octet through `f` once, in order, the

--- a/crates/almide-interp/src/vfs.rs
+++ b/crates/almide-interp/src/vfs.rs
@@ -19,7 +19,10 @@
 use std::collections::HashMap;
 
 pub(crate) enum VfsEntry {
-    File(String),
+    /// The file's BYTES — not a String: `fs.write_bytes` lands raw bytes
+    /// (a latin1 line, a truncated sequence) and the text read must then
+    /// answer the backends' InvalidData error, not silently re-encode.
+    File(Vec<u8>),
     Dir,
 }
 
@@ -58,7 +61,10 @@ const ENOENT: &str = "No such file or directory (os error 2)";
 pub(crate) fn read_text(vfs: &Vfs, path: &str) -> Result<String, String> {
     let path = &normalize(path);
     match vfs.get(path.as_str()) {
-        Some(VfsEntry::File(content)) => Ok(content.clone()),
+        // The exact `std::fs::read_to_string` InvalidData Display the native
+        // runtime's `io_err` forwards (and the wasm text floor spells, #1506).
+        Some(VfsEntry::File(content)) => String::from_utf8(content.clone())
+            .map_err(|_| "stream did not contain valid UTF-8".to_string()),
         Some(VfsEntry::Dir) => Err("Is a directory (os error 21)".to_string()),
         None => std::fs::read_to_string(path).map_err(|e| format!("{e}")),
     }
@@ -67,7 +73,10 @@ pub(crate) fn read_text(vfs: &Vfs, path: &str) -> Result<String, String> {
 /// `prim.write_text_file` — into the overlay only. The parent must exist
 /// (overlay dir, or a real directory), the same precondition `std::fs::write`
 /// enforces natively.
-pub(crate) fn write_text(vfs: &mut Vfs, path: &str, content: &str) -> Result<(), String> {
+/// The content is BYTES: what `prim.write_text_file` really carries once a
+/// stdlib body has filled an `alloc_str` block byte by byte
+/// (`fs.write_bytes` / `fs.write_bytes_raw`) — a String arrives as its UTF-8.
+pub(crate) fn write_bytes(vfs: &mut Vfs, path: &str, content: &[u8]) -> Result<(), String> {
     let path = &normalize(path);
     if matches!(vfs.get(path.as_str()), Some(VfsEntry::Dir)) {
         return Err("Is a directory (os error 21)".to_string());
@@ -78,7 +87,7 @@ pub(crate) fn write_text(vfs: &mut Vfs, path: &str, content: &str) -> Result<(),
             return Err(ENOENT.to_string());
         }
     }
-    vfs.insert(path.to_string(), VfsEntry::File(content.to_string()));
+    vfs.insert(path.to_string(), VfsEntry::File(content.to_vec()));
     Ok(())
 }
 

--- a/crates/almide-interp/src/vfs.rs
+++ b/crates/almide-interp/src/vfs.rs
@@ -145,3 +145,83 @@ pub(crate) fn remove_all(vfs: &mut Vfs, path: &str) -> RemoveOutcome {
     }
     RemoveOutcome::Removed
 }
+
+const ENOTDIR: &str = "Not a directory (os error 20)";
+const EISDIR: &str = "Is a directory (os error 21)";
+
+/// `prim.read_bytes_file` — the bytes floor: the overlay's bytes as they
+/// were written, else a read-only real-fs `std::fs::read`.
+pub(crate) fn read_bytes(vfs: &Vfs, path: &str) -> Result<Vec<u8>, String> {
+    let path = &normalize(path);
+    match vfs.get(path.as_str()) {
+        Some(VfsEntry::File(content)) => Ok(content.clone()),
+        Some(VfsEntry::Dir) => Err(EISDIR.to_string()),
+        None => std::fs::read(path).map_err(|e| format!("{e}")),
+    }
+}
+
+/// `prim.path_filestat` — the three WASI filestat fields the stdlib bodies
+/// read back (`filetype@16`: 3 = directory, 4 = regular file; `size@32`;
+/// `mtim@48` in nanoseconds), or `None` for a path that exists nowhere. An
+/// overlay entry stamps the CURRENT time: the backend legs write real files
+/// and stat them in the same run, so "now" is the faithful reading of the
+/// field they see (a fixture can only assert its shape, never its value).
+pub(crate) fn stat(vfs: &Vfs, path: &str) -> Option<(u8, u64, i64)> {
+    let norm = normalize(path);
+    let now_ns = || {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as i64)
+            .unwrap_or(0)
+    };
+    match vfs.get(norm.as_str()) {
+        Some(VfsEntry::File(content)) => Some((4, content.len() as u64, now_ns())),
+        Some(VfsEntry::Dir) => Some((3, 0, now_ns())),
+        None => {
+            let md = std::fs::metadata(path).ok()?;
+            let ftype = if md.is_dir() { 3 } else if md.is_file() { 4 } else { 0 };
+            let mtime = md
+                .modified()
+                .ok()
+                .and_then(|m| m.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_nanos() as i64)
+                .unwrap_or(0);
+            Some((ftype, md.len(), mtime))
+        }
+    }
+}
+
+/// `prim.read_dir` — the sorted names under `path`: the overlay's direct
+/// children (a file or a dir written under it) merged with the real
+/// directory's entries when one exists there, `names.sort()`ed like native
+/// `almide_rt_fs_list_dir` (the wasm leg sorts the same way). A missing path
+/// is the native ENOENT, a file the native ENOTDIR.
+pub(crate) fn read_dir(vfs: &Vfs, path: &str) -> Result<Vec<String>, String> {
+    let norm = normalize(path);
+    let overlay_dir = matches!(vfs.get(norm.as_str()), Some(VfsEntry::Dir));
+    if matches!(vfs.get(norm.as_str()), Some(VfsEntry::File(_))) {
+        return Err(ENOTDIR.to_string());
+    }
+    let real = std::path::Path::new(path);
+    let mut names: Vec<String> = Vec::new();
+    if real.is_dir() {
+        let entries = std::fs::read_dir(path).map_err(|e| format!("{e}"))?;
+        for entry in entries {
+            let e = entry.map_err(|e| format!("{e}"))?;
+            names.push(e.file_name().to_string_lossy().to_string());
+        }
+    } else if !overlay_dir {
+        return Err(if real.exists() { ENOTDIR.to_string() } else { ENOENT.to_string() });
+    }
+    let prefix = format!("{norm}/");
+    for k in vfs.keys() {
+        if let Some(rest) = k.strip_prefix(&prefix) {
+            let child = rest.split('/').next().unwrap_or(rest).to_string();
+            if !child.is_empty() && !names.contains(&child) {
+                names.push(child);
+            }
+        }
+    }
+    names.sort();
+    Ok(names)
+}

--- a/crates/almide-interp/src/vfs.rs
+++ b/crates/almide-interp/src/vfs.rs
@@ -79,7 +79,10 @@ pub(crate) fn read_text(vfs: &Vfs, path: &str) -> Result<String, String> {
 pub(crate) fn write_bytes(vfs: &mut Vfs, path: &str, content: &[u8]) -> Result<(), String> {
     let path = &normalize(path);
     if matches!(vfs.get(path.as_str()), Some(VfsEntry::Dir)) {
-        return Err("Is a directory (os error 21)".to_string());
+        return Err(EISDIR.to_string());
+    }
+    if ancestor_is_file(vfs, path) {
+        return Err(ENOTDIR.to_string());
     }
     if let Some(parent) = parent_of(path) {
         let in_overlay = matches!(vfs.get(parent), Some(VfsEntry::Dir));
@@ -91,12 +94,32 @@ pub(crate) fn write_bytes(vfs: &mut Vfs, path: &str, content: &[u8]) -> Result<(
     Ok(())
 }
 
+/// A path component ABOVE `path` that is a file — in the overlay or on the
+/// real filesystem: every write-side floor answers the native ENOTDIR for
+/// it (`std::fs::write` / `create_dir_all` through a plain file), before any
+/// "parent missing" verdict.
+fn ancestor_is_file(vfs: &Vfs, path: &str) -> bool {
+    let mut p = path;
+    while let Some(parent) = parent_of(p) {
+        if matches!(vfs.get(parent), Some(VfsEntry::File(_)))
+            || std::path::Path::new(parent).is_file()
+        {
+            return true;
+        }
+        p = parent;
+    }
+    false
+}
+
 /// `prim.make_dir` — `create_dir_all` semantics: every ancestor becomes a dir,
 /// an existing dir is Ok, an existing FILE at the path is the EEXIST error.
 pub(crate) fn make_dir(vfs: &mut Vfs, path: &str) -> Result<(), String> {
     let path = &normalize(path);
     if matches!(vfs.get(path.as_str()), Some(VfsEntry::File(_))) {
         return Err("File exists (os error 17)".to_string());
+    }
+    if ancestor_is_file(vfs, path) {
+        return Err(ENOTDIR.to_string());
     }
     let mut p = path.as_str();
     loop {
@@ -167,6 +190,17 @@ pub(crate) fn read_bytes(vfs: &Vfs, path: &str) -> Result<Vec<u8>, String> {
 /// and stat them in the same run, so "now" is the faithful reading of the
 /// field they see (a fixture can only assert its shape, never its value).
 pub(crate) fn stat(vfs: &Vfs, path: &str) -> Option<(u8, u64, i64)> {
+    stat_with(vfs, path, true)
+}
+
+/// `prim.path_filestat_nofollow` — the same query without following a
+/// symlink at the leaf (filetype 7 = symbolic link on the real fs; the
+/// overlay holds no symlinks, so its answer is `stat`'s).
+pub(crate) fn stat_nofollow(vfs: &Vfs, path: &str) -> Option<(u8, u64, i64)> {
+    stat_with(vfs, path, false)
+}
+
+fn stat_with(vfs: &Vfs, path: &str, follow: bool) -> Option<(u8, u64, i64)> {
     let norm = normalize(path);
     let now_ns = || {
         std::time::SystemTime::now()
@@ -178,8 +212,20 @@ pub(crate) fn stat(vfs: &Vfs, path: &str) -> Option<(u8, u64, i64)> {
         Some(VfsEntry::File(content)) => Some((4, content.len() as u64, now_ns())),
         Some(VfsEntry::Dir) => Some((3, 0, now_ns())),
         None => {
-            let md = std::fs::metadata(path).ok()?;
-            let ftype = if md.is_dir() { 3 } else if md.is_file() { 4 } else { 0 };
+            let md = if follow {
+                std::fs::metadata(path).ok()?
+            } else {
+                std::fs::symlink_metadata(path).ok()?
+            };
+            let ftype = if md.file_type().is_symlink() {
+                7
+            } else if md.is_dir() {
+                3
+            } else if md.is_file() {
+                4
+            } else {
+                0
+            };
             let mtime = md
                 .modified()
                 .ok()
@@ -224,4 +270,53 @@ pub(crate) fn read_dir(vfs: &Vfs, path: &str) -> Result<Vec<String>, String> {
     }
     names.sort();
     Ok(names)
+}
+
+/// `prim.rename` over the overlay. `HostOnly` is the source that exists only
+/// on the real filesystem — the overlay is read-only toward the host, and a
+/// rename that "succeeded" without moving anything would be a wrong vote,
+/// so the caller abstains. A missing source is the native ENOENT; a
+/// destination whose parent exists nowhere is ENOENT too (`std::fs::rename`
+/// does not create directories); an existing destination file is replaced,
+/// as on both legs.
+pub(crate) enum RenameOutcome {
+    Renamed,
+    HostOnly,
+    Failed(String),
+}
+
+pub(crate) fn rename(vfs: &mut Vfs, src: &str, dst: &str) -> RenameOutcome {
+    let src = normalize(src);
+    let dst = normalize(dst);
+    let sub_prefix = format!("{src}/");
+    let keys: Vec<String> = vfs
+        .keys()
+        .filter(|k| **k == src || k.starts_with(&sub_prefix))
+        .cloned()
+        .collect();
+    if keys.is_empty() {
+        return if std::path::Path::new(&src).exists() {
+            RenameOutcome::HostOnly
+        } else {
+            RenameOutcome::Failed(ENOENT.to_string())
+        };
+    }
+    if let Some(parent) = parent_of(&dst) {
+        let in_overlay = matches!(vfs.get(parent), Some(VfsEntry::Dir));
+        if !in_overlay && !std::path::Path::new(parent).is_dir() {
+            return RenameOutcome::Failed(ENOENT.to_string());
+        }
+    }
+    let moved: Vec<(String, VfsEntry)> = keys
+        .into_iter()
+        .filter_map(|k| {
+            let entry = vfs.remove(&k)?;
+            let tail = &k[src.len()..];
+            Some((format!("{dst}{tail}"), entry))
+        })
+        .collect();
+    for (k, e) in moved {
+        vfs.insert(k, e);
+    }
+    RenameOutcome::Renamed
 }

--- a/tests/wasm_runtime_test_parts/corpus.rs
+++ b/tests/wasm_runtime_test_parts/corpus.rs
@@ -71,6 +71,18 @@ fn build_corpus() -> Option<Vec<FixtureLegs>> {
         .filter(|e| e.path().extension().map(|x| x == "almd").unwrap_or(false))
         .collect();
     entries.sort_by_key(|e| e.path());
+    // ALMIDE_CORPUS_FILTER=<substring>: a developer's single-fixture loop for
+    // the 3-way harnesses (seconds instead of the ~6 min full corpus). Never
+    // set in CI — the ledger gate over a filtered corpus would read every
+    // filtered-out row as stale.
+    if let Ok(filter) = std::env::var("ALMIDE_CORPUS_FILTER") {
+        entries.retain(|e| {
+            e.path()
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .is_some_and(|s| s.contains(filter.as_str()))
+        });
+    }
     if entries.is_empty() {
         return None;
     }


### PR DESCRIPTION
Closes #1844 — started as the `prim.handle of a Result` cell (ten of the ledger's rows) and, one prim deeper each pass, ends with every one of them evaluating.

The fs and fan floors hand their stdlib bodies a `Result` and the bodies read it through the arena: `load_handle(h + 12)` for the payload and `load32(h + 16)` for the tag. That block is the cap-as-tag family (`render_wasm_fs_wat` `$rtf_result`): one slot, `len@4 = cap@8 = 1`, the payload's u32 in the low half, the 0/1 tag in the high half. The interp had no shape for it and abstained at the handle. It now materializes a `Value::Result` exactly so — Unit as 0, Bool as 0/1, an Int only when it fits the half (a wider one abstains by name), a Str / List / Map / Tuple payload as its own bound block's address — and `load_handle` / `load_str` read 4 bytes, the `i32.load` both backends emit (`PrimKind::LoadHandle`); the old 8-byte read folded the tag into the address on exactly this block.

Getting past the handle exposed a second gap: `fs.write_bytes` fills an `alloc_str` block byte by byte and passes its ADDRESS to `prim.write_text_file`, and the overlay stored `String`s — the arm aborted ("expects (String, String)"), which the 3-way gate rightly reported as an interp dissent on two fixtures. The overlay now stores bytes; `read_text` answers the backends' `stream did not contain valid UTF-8` on non-UTF-8 content (the `fs_read_text_utf8` contract); the vfs prims take a `Str` or a Str-block address for the path and a `Str` or a Str/Bytes-block address for the content, and anything else is an honest abstain named by shape, never an abort.

Ledger: 10 rows → 8. `fan_effect_mapper_capability` and `fs_read_lines` evaluate and agree (650 of 677 fixtures `interp == native == wasm`, 0 dissent, 1 pre-existing backend split); the other eight now abstain one prim deeper, each named — `prim.read_dir` (×3), `prim.path_filestat` (×2), `prim.read_bytes_file` (×2), `fs.__fallible_fold_lines` — classified BRIDGEABLE (sandboxed-fs glue). The issue's html / url cells are no longer in the ledger (their fixtures evaluate on develop); `fs_glob_segments` now stops at `path_filestat`, so the issue stays open for the vfs listing/stat/bytes-read glue.
