### PR TITLE
Mutant 025 is refreshed against the strict unwrap_or lowering

### DIFF
--- a/ci/mutations/025-unwrap-or-inverted.patch
+++ b/ci/mutations/025-unwrap-or-inverted.patch
@@ -1,12 +1,13 @@
 diff --git a/crates/almide-wasm/src/calls_modules.rs b/crates/almide-wasm/src/calls_modules.rs
-index ccf06d9ba..b54228042 100644
+index bd5aafdce..1ac2b792b 100644
 --- a/crates/almide-wasm/src/calls_modules.rs
 +++ b/crates/almide-wasm/src/calls_modules.rs
-@@ -188,6 +188,7 @@ impl Emitter<'_> {
-                             .instructions()
-                             .local_tee(self.scr_i32_local)
-                             .i32_eqz()
-+                            .i32_eqz()
-                             .if_(BlockType::Result(et.val_type()));
-                         self.lower(&args[1], Some(et))?;
-                         self.f.instructions().else_().local_get(self.scr_i32_local);
+@@ -208,7 +208,7 @@ impl Emitter<'_> {
+                     i.local_set(hdef);
+                     i.local_get(hrecv);
+                     if is_option {
+-                        i.i32_eqz();
++                        i.i32_eqz().i32_eqz();
+                     } else {
+                         i.i32_load(slot_memarg(almide_layout::SUM_TAG)).i32_const(0).i32_ne();
+                     }


### PR DESCRIPTION
#1913 rewrote the structural leg's `unwrap_or` lowering (the default is evaluated before the select), and `ci/mutations/025-unwrap-or-inverted.patch` no longer applied — the commissioned mutation gate went red on develop. Same mutation, regenerated against the current tree: the option arm's `i32.eqz` is doubled (the select inverts), and `backend_parity` still kills it. Verified locally with `git apply` + `cargo test -p almide-wasm --test backend_parity` (red under the mutant, green without).