### PR TITLE
The embedded host reports a named die as its one Error line

### DIFF
--- a/crates/almide-wasm-run/src/host.rs
+++ b/crates/almide-wasm-run/src/host.rs
@@ -736,7 +736,18 @@ fn run_wasm_src(
             // `Error: <msg>` from a defined guard), so the `wasm trap:`
             // prefix is this leg's own spelling — a fuzz finding or a
             // user is never left with an empty stderr and a bare 1.
-            err.lock().expect("test harness invariant").push_str(&trap_line(e));
+            // EXCEPT the die convention (#1912): a defined guard's
+            // `prim.die` prints its `Error: <msg>` line and then executes
+            // `unreachable` — the trap IS the exit, already named. The stock
+            // wasmtime lane and native show that one line; adding
+            // `Error: wasm trap: unreachable…` after it made the embedded
+            // lane the odd one out.
+            let mut buf = err.lock().expect("test harness invariant");
+            let named_die = is_unreachable_trap(e)
+                && buf.lines().last().is_some_and(|l| l.starts_with("Error: "));
+            if !named_die {
+                buf.push_str(&trap_line(e));
+            }
             1
         }
         (Ok(()), Some(_)) => {
@@ -763,6 +774,11 @@ fn run_wasm_src(
 /// `unreachable` instruction executed", "call stack exhausted", …) —
 /// when the error is a trap, else the chain's root cause under the same
 /// prefix. Never the multi-line backtrace.
+/// The `unreachable` trap — the instruction the die lowering ends on.
+fn is_unreachable_trap(e: &wasmtime::Error) -> bool {
+    matches!(e.downcast_ref::<wasmtime::Trap>(), Some(wasmtime::Trap::UnreachableCodeReached))
+}
+
 fn trap_line(e: &wasmtime::Error) -> String {
     match e.downcast_ref::<wasmtime::Trap>() {
         Some(t) => format!("Error: {t}\n"),

--- a/tests/embedded_host_die_line_test.rs
+++ b/tests/embedded_host_die_line_test.rs
@@ -1,0 +1,58 @@
+//! #1912: a self-hosted guard's `prim.die` prints its one `Error: <msg>`
+//! line and ends on `unreachable`; the embedded host (`almide run --target
+//! wasm`) must not add `Error: wasm trap: …` after it — stock wasmtime and
+//! native show the one line. A GENUINE trap (an unnamed one) still names
+//! itself, and a named non-unreachable abort keeps its own line.
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn run_wasm(src: &str, name: &str) -> (i32, String, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join(name);
+    std::fs::write(&path, src).unwrap();
+    let out = Command::new(almide_bin())
+        .args(["run"])
+        .arg(&path)
+        .args(["--target", "wasm"])
+        .output()
+        .expect("spawn almide run --target wasm");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+#[test]
+fn a_named_die_is_one_stderr_line_on_the_embedded_host() {
+    let (code, out, err) = run_wasm(
+        "fn main() -> Unit = {\n  println(\"before\")\n  println(\"${int.clamp(3, 3, 1)}\")\n  println(\"after\")\n}\n",
+        "die.almd",
+    );
+    assert_eq!(code, 1);
+    assert_eq!(out.trim(), "before");
+    assert_eq!(err.trim(), "Error: clamp requires min <= max", "no trap line after a named die");
+}
+
+#[test]
+fn an_unnamed_trap_still_names_itself() {
+    let (code, _out, err) = run_wasm(
+        "fn main() -> Unit = {\n  let xs = [1, 2]\n  println(\"${xs[5]}\")\n}\n",
+        "oob.almd",
+    );
+    assert_eq!(code, 1);
+    assert!(err.trim().starts_with("Error: "), "{err}");
+    assert_eq!(err.trim().lines().count(), 1, "one line: {err}");
+}


### PR DESCRIPTION
Closes #1912. A self-hosted guard's `prim.die` prints its `Error: <msg>` line and ends on `unreachable`; the embedded host treated that trap as an unnamed abort and appended `Error: wasm trap: wasm \`unreachable\` instruction executed`, so `almide run --target wasm` showed two lines where stock wasmtime and native show one. The host now skips the trap line when the trap is `unreachable` and stderr already ends in an `Error: ` line; an unnamed trap (an out-of-bounds index) still names itself. `tests/embedded_host_die_line_test.rs` pins both.