### PR TITLE
The wasm compile path prints checker warnings like the native driver

### DIFF
--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -584,6 +584,15 @@ fn typecheck_wasm_program(file: &str, source_text: &str, program: &mut almide::a
         }
         return Err(());
     }
+    // Warnings reach this leg too (#1911): the native driver prints every
+    // checker warning before the program runs (compile_driver), and
+    // `run --target wasm` printed none — an E052 deprecation a program
+    // carried was visible on one target and silent on the other.
+    if !crate::warnings_suppressed() {
+        for d in diagnostics.iter().filter(|d| d.level == diagnostic::Level::Warning) {
+            err(&format!("{}", crate::diagnostic_render::display_with_source(d, source_text)));
+        }
+    }
     Ok(checker)
 }
 

--- a/tests/wasm_run_warnings_test.rs
+++ b/tests/wasm_run_warnings_test.rs
@@ -1,0 +1,34 @@
+//! #1911: checker warnings reach `almide run --target wasm` (and `build
+//! --target wasm`) exactly as they reach the native run — a deprecation a
+//! program carries must not be visible on one target and silent on the other.
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+#[test]
+fn the_wasm_run_prints_the_same_checker_warning_as_native() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("warn.almd");
+    std::fs::write(&path, "fn main() -> Unit = {\n  let o: Int? = some(7)\n  println(\"${option.unwrap_or(o, 1)}\")\n}\n").unwrap();
+    let native = Command::new(almide_bin()).args(["run"]).arg(&path).output().unwrap();
+    let wasm = Command::new(almide_bin()).args(["run"]).arg(&path).args(["--target", "wasm"]).output().unwrap();
+    let warn_lines = |b: &[u8]| -> Vec<String> {
+        String::from_utf8_lossy(b).lines().filter(|l| l.starts_with("warning[")).map(str::to_string).collect()
+    };
+    let n = warn_lines(&native.stderr);
+    let w = warn_lines(&wasm.stderr);
+    assert!(!n.is_empty(), "native must warn (E052): {}", String::from_utf8_lossy(&native.stderr));
+    assert_eq!(n, w, "the wasm run must carry the same warning lines");
+    assert_eq!(String::from_utf8_lossy(&native.stdout), String::from_utf8_lossy(&wasm.stdout));
+}


### PR DESCRIPTION
Closes #1911. `typecheck_wasm_program` (the `run` / `build --target wasm` path) reported only errors; the native driver prints every checker warning before the program runs (compile_driver.rs). Warnings now print on the wasm path under the same `warnings_suppressed()` switch (the REPL's), so an E052 deprecation a program carries is visible on both targets. `tests/wasm_run_warnings_test.rs` pins the two runs' warning lines equal. The cross-target harness builds with `-o` and compares the program's own stderr, so fixture verdicts are unaffected (spec/lang 208/208).