### PR TITLE
A module top-let seeded as a partially unknown type is upgraded to its inferred concrete type

### DIFF
--- a/crates/almide-frontend/src/check/module_inference.rs
+++ b/crates/almide-frontend/src/check/module_inference.rs
@@ -486,13 +486,23 @@ impl Checker {
             "refresh: name={} prefix={:?} resolved={:?} existing_prefixed={:?}",
             name, self.current_module_prefix, resolved,
             prefixed_key.as_ref().map(|k| self.env.top_lets.get(k))));
+        // A seeded entry that is PARTIALLY unknown (`List[Unknown]` — the
+        // pre-registration of `let RULES = [Rule {..}]` before `Rule` was
+        // in scope) must be upgraded too, not only a bare `Unknown`: the
+        // old exact-`Unknown` test left `redact.RULES` at `List[Unknown]`,
+        // and the module's own `for r in RULES` lowered `r` as Unknown —
+        // the ConcretizeTypes refusal behind a green check (#1931). A
+        // fully concrete resolution replaces any partial entry; a still-
+        // partial one is left to the post-solve flush.
+        let partial = |t: Option<&Ty>| t.is_none_or(|t| t.contains_unknown() || t.contains_typevar());
+        let concrete = !resolved.contains_unknown() && !resolved.contains_typevar();
         if let Some(k) = prefixed_key {
-            if matches!(self.env.top_lets.get(&k), Some(Ty::Unknown) | None) {
+            if partial(self.env.top_lets.get(&k)) && (concrete || self.env.top_lets.get(&k).is_none_or(|t| matches!(t, Ty::Unknown))) {
                 self.env.top_lets.insert(k, resolved.clone());
             }
             self.pending_toplet_tys.push((k, ity.clone()));
         }
-        if matches!(self.env.top_lets.get(&sym(name)), Some(Ty::Unknown) | None) {
+        if partial(self.env.top_lets.get(&sym(name))) && (concrete || self.env.top_lets.get(&sym(name)).is_none_or(|t| matches!(t, Ty::Unknown))) {
             self.env.top_lets.insert(sym(name), resolved);
         }
         self.pending_toplet_tys.push((sym(name), ity));

--- a/tests/crossmod_matrix_test.rs
+++ b/tests/crossmod_matrix_test.rs
@@ -51,6 +51,12 @@ let MAYBE = some(Cfg { name: "opt" })
 let N = 7
 
 fn mk() -> Cfg = Cfg { name: "via-fn" }
+// #1931: the module's OWN fn iterating its unannotated record-list top-let.
+fn cfg_name_len() -> Int = {
+  var n = 0
+  for c in CFGS { n = n + string.len(c.name) }
+  n
+}
 
 effect fn estep(n: Int) -> Int = n + 1
 
@@ -277,6 +283,19 @@ effect fn main() -> Unit =
 effect fn main() -> Unit = println(int.to_string(m.N + 1))
 "#,
             expected: "8",
+            status: Status::Works,
+        },
+        Cell {
+            // #1931: `for r in RULES` over the module's own unannotated
+            // `let RULES = [Rule {..}]` lowered `r` as Unknown — the seeded
+            // `List[Unknown]` entry was never upgraded (the refresh replaced
+            // only a bare `Unknown`), a ConcretizeTypes refusal behind a
+            // green check. Single-file and annotated forms were fine.
+            name: "list_record_toplet_for_in_within_module",
+            main: r#"import self as m
+effect fn main() -> Unit = println(int.to_string(m.cfg_name_len()))
+"#,
+            expected: "2",
             status: Status::Works,
         },
         Cell {


### PR DESCRIPTION
Closes #1931. `register_decls` seeds a module's unannotated top-let (`let RULES = [Rule {..}]`) as `List[Unknown]` (the record is not yet in scope when the seed is computed); the inference refresh then replaced the entry only when it was a BARE `Unknown`, so the partial seed stayed, and the module's own `for r in RULES` lowered `r` as Unknown — the ConcretizeTypes refusal behind a green check. Single-file and annotated forms never hit it (traced with `ALMIDE_TOPLET_DEBUG`: `resolved=List[redact.Rule] existing=List[Unknown]`). The refresh now replaces any partially unknown entry with a fully concrete resolution; a still-partial resolution stays with the post-solve flush. New cross-module matrix cell `list_record_toplet_for_in_within_module` (A/B: every cell of the shared module refuses on develop's binary, passes here).