### PR TITLE
fuzz-nightly: re-run the shards the runner reclaimed

### DIFF
--- a/.github/workflows/fuzz-nightly-retry.yml
+++ b/.github/workflows/fuzz-nightly-retry.yml
@@ -1,0 +1,74 @@
+# fuzz-nightly RECLAIM RETRY (#924).
+#
+# The nightly's per-shard budget is 5 minutes, and the runner STILL gets a
+# shutdown signal mid-job on 2-4 of 8 shards most nights (exit 143, "The
+# runner has received a shutdown signal") — measured over 2026-08-23..09-05:
+# only 4 of 14 scheduled nights had every shard report. Job length is not
+# the cause, so no in-job mitigation can reach it; the campaign needs a
+# RE-RUN of exactly the reclaimed shards, from outside the run (a run can
+# only be re-run once it has completed, so the verdict job cannot do it).
+#
+# This workflow fires when a fuzz-nightly run completes. If any fuzz shard
+# job failed WITH the runner-shutdown annotation, and the run is still on
+# an early attempt, it re-runs the failed jobs: the reclaimed shards get a
+# fresh runner, the verdict job (their dependent) re-aggregates over the
+# run's artifacts — the surviving shards' uploads from attempt 1 are still
+# there, the retried shards add theirs — and the coverage line reports
+# shards=8/8 for a night whose only defect was infrastructure. A shard
+# that failed for any OTHER reason (a real crash of the harness) is never
+# retried: the annotation is the discriminator, not the exit code.
+#
+# Bounded: at most two retries (attempt 3 is the last that triggers one),
+# so a runner class that is reclaimed every time cannot loop.
+name: fuzz-nightly-retry
+
+on:
+  workflow_run:
+    workflows: ["Fuzz (nightly)"]
+    types: [completed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  retry-reclaimed-shards:
+    if: >-
+      github.event.workflow_run.conclusion != 'success' &&
+      github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Re-run the fuzz shards the runner reclaimed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Failed fuzz-shard jobs of THIS attempt.
+          failed=$(gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/attempts/$ATTEMPT/jobs" \
+            --jq '.jobs[] | select(.conclusion == "failure") | select(.name | test("Generative differential fuzz")) | .id')
+          if [ -z "$failed" ]; then
+            echo "no failed fuzz shard on attempt $ATTEMPT — nothing to retry (a verdict failure is findings, not infrastructure)"
+            exit 0
+          fi
+          reclaimed=0
+          for job in $failed; do
+            # The runner-shutdown message arrives as a job annotation; a
+            # shard that died any other way carries none and is left alone.
+            if gh api --paginate "repos/$REPO/check-runs/$job/annotations" \
+                 --jq '.[].message' | grep -q "runner has received a shutdown signal"; then
+              echo "job $job: reclaimed by the runner"
+              reclaimed=$((reclaimed + 1))
+            else
+              echo "job $job: failed on its own — not an infrastructure kill"
+            fi
+          done
+          if [ "$reclaimed" -eq 0 ]; then
+            echo "no reclaimed shard — nothing to retry"
+            exit 0
+          fi
+          echo "re-running $reclaimed reclaimed shard(s) of run $RUN_ID (attempt $ATTEMPT -> $((ATTEMPT + 1)))"
+          gh run rerun "$RUN_ID" --repo "$REPO" --failed

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -369,6 +369,9 @@ jobs:
         with:
           name: fuzz-findings-${{ github.run_id }}
           path: night-findings/
+          # A reclaim retry (fuzz-nightly-retry.yml) re-runs this job on
+          # attempt 2 of the same run; the aggregate is re-uploaded whole.
+          overwrite: true
           retention-days: 30
 
       - name: Open / update tracking issue


### PR DESCRIPTION
Toward #924. Measured over the last fourteen scheduled nights (2026-08-23..09-05), only 4 had every shard report; the rest lost 1–4 of 8 shards to the runner's shutdown signal (exit 143) — at a 5-minute per-shard budget, so job length is not the cause and no in-job mitigation can reach it. The `(5/6)^14` arithmetic the workflow header already names makes the issue's closure condition unreachable without a retry.

`fuzz-nightly-retry.yml` fires on the nightly's completion. If a fuzz shard job failed **with the runner-shutdown annotation** (the discriminator — a harness crash carries none and is never retried) and the run is on attempt < 3, it re-runs the failed jobs. The reclaimed shards get a fresh runner; the verdict job (their dependent) re-aggregates over the run's artifacts — the surviving shards' attempt-1 uploads are still there, a reclaimed shard uploaded nothing, so there is no name collision — and reports `shards=8/8` for a night whose only defect was infrastructure. The findings artifact upload gains `overwrite: true` for the re-run verdict. Bounded to two retries.

Not exercised until the next scheduled night (a `workflow_run` trigger cannot be dispatched by hand); the first retried night's attempt-2 verdict is the evidence.