### PR TITLE
fuzz-nightly-retry: recognize a reclaim by the log's shutdown line or the exit-143 annotation

### DIFF
--- a/.github/workflows/fuzz-nightly-retry.yml
+++ b/.github/workflows/fuzz-nightly-retry.yml
@@ -56,10 +56,17 @@ jobs:
           fi
           reclaimed=0
           for job in $failed; do
-            # The runner-shutdown message arrives as a job annotation; a
-            # shard that died any other way carries none and is left alone.
-            if gh api --paginate "repos/$REPO/check-runs/$job/annotations" \
-                 --jq '.[].message' | grep -q "runner has received a shutdown signal"; then
+            # A reclaim leaves TWO marks and only the second is in the
+            # annotations: the step's `Process completed with exit code 143`
+            # (SIGTERM) annotation, and the runner's own `The runner has
+            # received a shutdown signal` line in the job LOG (measured on
+            # run 34012629910 shard 4: the first retry judged it "failed on
+            # its own" because it read the annotations alone). Either mark
+            # names the reclaim; a harness crash carries neither.
+            if gh api "repos/$REPO/actions/jobs/$job/logs" 2>/dev/null \
+                 | grep -q "runner has received a shutdown signal" \
+               || gh api --paginate "repos/$REPO/check-runs/$job/annotations" \
+                 --jq '.[].message' | grep -q "exit code 143"; then
               echo "job $job: reclaimed by the runner"
               reclaimed=$((reclaimed + 1))
             else


### PR DESCRIPTION
Follow-up to #1940 (toward #924). Its first live firing (run 34013699293 on nightly 34012629910) judged the reclaimed shard 4 "failed on its own": the runner's `The runner has received a shutdown signal` line is in the job LOG only — the annotations carry just `Process completed with exit code 143`. The discriminator now accepts either mark (log line, or the exit-143 annotation); a harness crash carries neither. Both marks verified against that shard by hand.

https://claude.ai/code/session_01NvweJKc7fNXQn4BzB7GQQM