### PR TITLE
Native main restores the default SIGPIPE disposition so a closed reader ends the program quietly

### DIFF
--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -463,6 +463,15 @@ fn collect_ref_params(func: &IrFunction) -> (std::collections::HashSet<VarId>, s
 /// declaration order, so an aborting initializer (integer `/`/`%`) fires at
 /// startup — byte-identical to wasm's eager top-let evaluation in
 /// `_start`. Extracted from `render_function` (cog>25 decomposition).
+/// The first statements of every native `main` (#1950): put SIGPIPE back to
+/// its default disposition. Rust's std ignores SIGPIPE at startup, so a
+/// reader closing early (`prog | head`) would turn the next `println` into
+/// "failed printing to stdout: Broken pipe" and exit 101; with the default
+/// disposition the process stops quietly the way `yes | head` does.
+/// Self-contained (no runtime symbol) so it renders the same in the
+/// single-file and module layouts. A no-op off unix.
+const MAIN_SIGPIPE_PRELUDE: &str = "    #[cfg(unix)]\n    {\n        extern \"C\" {\n            fn signal(sig: i32, handler: usize) -> usize;\n        }\n        // SIGPIPE = 13, SIG_DFL = 0\n        unsafe {\n            signal(13, 0);\n        }\n    }\n";
+
 fn wrap_main_fn_code(fn_code: String, ctx: &RenderContext, is_rust_effect_main: bool, is_rust_plain_main_with_forces: bool) -> String {
     let force_lines: String = ctx.ann.global_init_order.iter()
         .filter_map(|v| ctx.ann.globals.get(v))
@@ -470,9 +479,9 @@ fn wrap_main_fn_code(fn_code: String, ctx: &RenderContext, is_rust_effect_main: 
         .map(|i| format!("    std::sync::LazyLock::force(&{});\n", i.static_name))
         .collect();
     if is_rust_effect_main {
-        format!("{}\n\nfn main() {{\n{}    if let Err(__almide_err) = __almide_main() {{\n        eprintln!(\"Error: {{}}\", __almide_err);\n        std::process::exit(1);\n    }}\n}}", fn_code, force_lines)
+        format!("{}\n\nfn main() {{\n{}{}    if let Err(__almide_err) = __almide_main() {{\n        eprintln!(\"Error: {{}}\", __almide_err);\n        std::process::exit(1);\n    }}\n}}", fn_code, MAIN_SIGPIPE_PRELUDE, force_lines)
     } else if is_rust_plain_main_with_forces {
-        format!("{}\n\nfn main() {{\n{}    __almide_main();\n}}", fn_code, force_lines)
+        format!("{}\n\nfn main() {{\n{}{}    __almide_main();\n}}", fn_code, MAIN_SIGPIPE_PRELUDE, force_lines)
     } else {
         fn_code
     }
@@ -619,17 +628,12 @@ fn main_wrapper_kinds(ctx: &RenderContext, func: &IrFunction) -> (bool, bool) {
     let is_rust_main = matches!(ctx.target, Target::Rust)
         && func.name.as_str() == "main"
         && !func.is_test;
-    let plain_main_forces = || {
-        ctx.ann.global_init_order.iter().any(|v| {
-            matches!(
-                ctx.ann.globals.get(v).map(|i| i.storage),
-                Some(almide_ir::top_let_storage::TopLetStorage::Lazy { eager_force: true })
-            )
-        })
-    };
+    // A plain `main` is wrapped as well since #1950: the wrapper is where
+    // the process-level setup (SIGPIPE back to its default disposition, the
+    // eager top-let forces) runs before the user's body.
     (
         is_rust_main && func.is_effect,
-        is_rust_main && !func.is_effect && plain_main_forces(),
+        is_rust_main && !func.is_effect,
     )
 }
 

--- a/tests/for_in_clone_elision_test.rs
+++ b/tests/for_in_clone_elision_test.rs
@@ -46,7 +46,12 @@ fn emitted_main(source: &str, tag: &str) -> String {
     let rust = String::from_utf8_lossy(&output.stdout).to_string();
     std::fs::remove_dir_all(&dir).ok();
     assert!(output.status.success(), "--target rust emit failed:\n{}", String::from_utf8_lossy(&output.stderr));
-    let start = rust.find("pub fn main(").unwrap_or_else(|| panic!("emitted Rust has no `pub fn main(`:\n{rust}"));
+    // Since #1950 every native main is wrapped: the user's body renders as
+    // `pub fn __almide_main(` and `fn main()` is the process-setup shell.
+    let start = rust
+        .find("pub fn __almide_main(")
+        .or_else(|| rust.find("pub fn main("))
+        .unwrap_or_else(|| panic!("emitted Rust has no `pub fn __almide_main(` / `pub fn main(`:\n{rust}"));
     let rest = &rust[start..];
     let end = rest.find("\n}").map(|i| i + 2).unwrap_or(rest.len());
     rest[..end].to_string()

--- a/tests/sigpipe_default_test.rs
+++ b/tests/sigpipe_default_test.rs
@@ -1,0 +1,87 @@
+//! #1950: a native binary whose reader closes early (`prog | head`) must end
+//! quietly under SIGPIPE, not panic with "failed printing to stdout: Broken
+//! pipe" (exit 101). Rust's std ignores SIGPIPE at startup; the native `main`
+//! wrapper restores the default disposition before the user's body runs, for
+//! an effect main and a plain main alike.
+
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn rustc_available() -> bool {
+    Command::new("rustc").arg("--version").output().is_ok_and(|o| o.status.success())
+}
+
+/// Build `src`, run it with stdout piped, read two lines, close the pipe and
+/// wait: the process must stop through SIGPIPE (never a panic exit).
+fn assert_quiet_under_closed_pipe(name: &str, src: &str) {
+    let dir = std::env::temp_dir().join(format!("almide-sigpipe-{}-{}", name, std::process::id()));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let almd = dir.join(format!("{name}.almd"));
+    std::fs::write(&almd, src).expect("write");
+    let bin = dir.join(name);
+    let build = Command::new(almide_bin())
+        .args(["build", almd.to_str().unwrap(), "-o", bin.to_str().unwrap()])
+        .output()
+        .expect("spawn almide");
+    assert!(build.status.success(), "build failed:\n{}", String::from_utf8_lossy(&build.stderr));
+
+    let mut child = Command::new(&bin)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn program");
+    {
+        let stdout = child.stdout.take().expect("stdout");
+        let mut lines = BufReader::new(stdout).lines();
+        assert_eq!(lines.next().unwrap().unwrap(), "1");
+        assert_eq!(lines.next().unwrap().unwrap(), "2");
+        // The reader goes away here, like `head` exiting.
+    }
+    let out = child.wait_with_output().expect("wait");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("Broken pipe"),
+        "{name}: the program panicked on the closed pipe:\n{stderr}"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        assert_eq!(out.status.signal(), Some(13), "{name}: expected SIGPIPE, got {:?}", out.status);
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+const EFFECT_MAIN: &str =
+    "effect fn main() -> Unit = { for i in list.range(1, 200001) { println(int.to_string(i)) } }\n";
+const PLAIN_MAIN: &str =
+    "fn main() -> Unit = { for i in list.range(1, 200001) { println(int.to_string(i)) } }\n";
+
+#[test]
+fn effect_main_stops_quietly_when_the_reader_closes() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not available");
+        return;
+    }
+    assert_quiet_under_closed_pipe("pipe_effect", EFFECT_MAIN);
+}
+
+#[test]
+fn plain_main_stops_quietly_when_the_reader_closes() {
+    if !rustc_available() {
+        eprintln!("skipping: rustc not available");
+        return;
+    }
+    assert_quiet_under_closed_pipe("pipe_plain", PLAIN_MAIN);
+}

--- a/tests/snapshots/codegen_snapshot_test__lambda.snap
+++ b/tests/snapshots/codegen_snapshot_test__lambda.snap
@@ -6,6 +6,20 @@ pub fn apply(f: std::rc::Rc<dyn Fn(i64) -> i64>, x: i64) -> i64 {
     (f.clone())(x)
 }
 
-pub fn main() -> () {
+pub fn __almide_main() -> () {
     println!("{}", format!("{}", apply((std::rc::Rc::new(move |x: i64| (x).wrapping_add(1i64)) as std::rc::Rc<dyn Fn(i64) -> i64>), 41i64)))
+}
+
+fn main() {
+    #[cfg(unix)]
+    {
+        extern "C" {
+            fn signal(sig: i32, handler: usize) -> usize;
+        }
+        // SIGPIPE = 13, SIG_DFL = 0
+        unsafe {
+            signal(13, 0);
+        }
+    }
+    __almide_main();
 }


### PR DESCRIPTION
Closes #1950.

Rust's std ignores SIGPIPE at startup, so once a reader closes early (`prog | head`) the next `println` fails with EPIPE and std panics: "failed printing to stdout: Broken pipe", exit 101. Every Almide CLI hit this the moment it was piped into `head`, `less -F`, or a closed pager.

- The native `main` wrapper now begins with a self-contained prelude that puts SIGPIPE back to `SIG_DFL` (an `extern "C" signal(13, 0)` under `#[cfg(unix)]`, no runtime symbol, so it renders identically in the single-file and module layouts). The process then stops the way `yes | head` does: killed by SIGPIPE, exit 141, nothing on stderr.
- A plain (non-effect) `main` is wrapped as well now, not only when an eager top-let force needs the wrapper; the wrapper is where process-level setup belongs.
- `tests/sigpipe_default_test.rs` builds an effect main and a plain main, reads two lines, closes the pipe, and asserts no panic text and termination by signal 13. A/B: the test fails against the released 0.62.0 binary (exit 101 with the panic) and passes on this branch.

Verified locally: spec/lang 211/211, crossmod matrix and checker suites green, generated Rust warning-free; the full cross-target corpus is running as a second check.

This is a native host disposition, not a cross-target promise, so no contract entry: the wasm leg's stdout is owned by the embedding host.

https://claude.ai/code/session_01NvweJKc7fNXQn4BzB7GQQM
