### PR TITLE
almide install of a branch resolves the remote head and builds that commit instead of reusing the cached clone

### DIFF
--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -3,8 +3,11 @@
 ///
 /// Mirrors the experience of `go install`: one command, source-to-binary,
 /// no manual cargo / build / cp dance. Uses the existing dependency
-/// fetcher (`fetch_dep`) for git clones with caching, then delegates the
-/// actual compile to `cli::cmd_build` after chdir'ing into the project.
+/// fetcher for git clones with caching — a tag is an immutable snapshot and
+/// keeps its cache entry, a branch (or the default HEAD) is resolved to the
+/// remote's current commit on every install (`go install pkg@latest`) —
+/// then delegates the actual compile to `cli::cmd_build` after chdir'ing
+/// into the project.
 ///
 /// Resolution order for the install directory:
 ///   1. `--bin-dir <path>`
@@ -151,7 +154,7 @@ fn resolve_source(
 
     // Otherwise resolve as a package spec or git URL.
     let (name, git_url, default_tag) =
-        if spec.starts_with("https://") || spec.starts_with("git@") || spec.starts_with("ssh://") {
+        if spec.starts_with("https://") || spec.starts_with("git@") || spec.starts_with("ssh://") || spec.starts_with("file://") {
             let name = spec
                 .rsplit('/')
                 .next()
@@ -171,6 +174,18 @@ fn resolve_source(
         version: None,
         path: None,
     };
+    // A tag names an immutable snapshot and keeps its cache entry. A branch
+    // (or the remote's default HEAD) MOVES: resolve the remote head now and
+    // build that commit — `go install pkg@latest` semantics — instead of
+    // reusing whatever clone the cache holds from an earlier install, which
+    // silently reinstalled a stale version (#1956). The commit is printed so
+    // what was built is visible.
+    if dep.tag.is_none() {
+        let ref_name = dep.branch.clone().unwrap_or_else(|| "HEAD".to_string());
+        let head = project_fetch::git_remote_head(&dep.git, &ref_name)?;
+        err(&format!("Resolved {} {} -> {}", dep.name, ref_name, &head[..12.min(head.len())]));
+        return project_fetch::fetch_dep_with_lock(&dep, Some(&head));
+    }
     project_fetch::fetch_dep(&dep)
 }
 

--- a/src/project_fetch.rs
+++ b/src/project_fetch.rs
@@ -479,7 +479,7 @@ pub fn update_locked_deps(project: &Project, only: Option<&str>) -> Result<Vec<(
 
 /// The remote's current commit for `ref_name` — read WITHOUT cloning
 /// (`git ls-remote`), so `update` costs one network round-trip per dep.
-fn git_remote_head(git_url: &str, ref_name: &str) -> Result<String, String> {
+pub fn git_remote_head(git_url: &str, ref_name: &str) -> Result<String, String> {
     let out = std::process::Command::new("git")
         .args(["ls-remote", git_url, ref_name])
         .output()

--- a/tests/install_remote_head_test.rs
+++ b/tests/install_remote_head_test.rs
@@ -1,0 +1,97 @@
+//! `almide install` of a branch (no tag) builds the remote's CURRENT head
+//! (#1956). Before, the clone cached under `~/.almide/cache/<name>/main` was
+//! reused as-is on every later install, so pushing new commits and running
+//! `almide install` again silently reinstalled the stale version; only
+//! `almide clean` fixed it. A branch install now resolves the remote head
+//! first and builds that commit (`go install pkg@latest` semantics); a tag
+//! keeps its immutable cache entry.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn tools_available() -> bool {
+    Command::new(almide_bin()).arg("--version").output().is_ok()
+        && Command::new("git").arg("--version").output().is_ok_and(|o| o.status.success())
+        && Command::new("rustc").arg("--version").output().is_ok_and(|o| o.status.success())
+}
+
+fn git(repo: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["-c", "user.email=test@example.com", "-c", "user.name=test"])
+        .args(args)
+        .output()
+        .expect("spawn git");
+    assert!(out.status.success(), "git {args:?} failed:\n{}", String::from_utf8_lossy(&out.stderr));
+}
+
+fn commit_version(repo: &Path, version: &str) {
+    std::fs::create_dir_all(repo.join("src")).expect("mkdir");
+    std::fs::write(repo.join("almide.toml"), "[package]\nname = \"hello\"\nversion = \"0.1.0\"\n").expect("write");
+    std::fs::write(
+        repo.join("src").join("main.almd"),
+        format!("effect fn main() -> Unit = println(\"{version}\")\n"),
+    )
+    .expect("write");
+    git(repo, &["add", "-A"]);
+    git(repo, &["commit", "-q", "-m", version]);
+}
+
+/// `almide install file://<repo>` with the dependency cache confined to
+/// `home`; answers the installed binary's stdout and the install's stderr.
+fn install_and_run(repo: &Path, home: &Path, bin_dir: &Path) -> (String, String) {
+    let out = Command::new(almide_bin())
+        .args(["install", &format!("file://{}", repo.display()), "--bin-dir", bin_dir.to_str().unwrap()])
+        .env("HOME", home)
+        .output()
+        .expect("spawn almide");
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+    assert!(out.status.success(), "install failed:\n{stderr}");
+    let run = Command::new(bin_dir.join("hello")).output().expect("run installed binary");
+    (String::from_utf8_lossy(&run.stdout).to_string(), stderr)
+}
+
+fn scratch() -> (PathBuf, PathBuf, PathBuf) {
+    let root = std::env::temp_dir().join(format!("almide-issue1956-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let repo = root.join("repo");
+    let home = root.join("home");
+    let bin_dir = root.join("bin");
+    std::fs::create_dir_all(&repo).expect("mkdir");
+    std::fs::create_dir_all(&home).expect("mkdir");
+    std::fs::create_dir_all(&bin_dir).expect("mkdir");
+    git(&repo, &["init", "-q", "-b", "main"]);
+    (repo, home, bin_dir)
+}
+
+#[test]
+fn reinstalling_a_branch_builds_the_new_remote_head() {
+    if !tools_available() {
+        eprintln!("skipping: almide, git, or rustc not available");
+        return;
+    }
+    let (repo, home, bin_dir) = scratch();
+    commit_version(&repo, "v1");
+    let (first, stderr) = install_and_run(&repo, &home, &bin_dir);
+    assert_eq!(first, "v1\n");
+    // The dependency name is the URL's last segment (`repo`), the binary
+    // name comes from the manifest (`hello`).
+    assert!(stderr.contains("Resolved repo HEAD -> "), "the built commit is not reported:\n{stderr}");
+
+    commit_version(&repo, "v2");
+    let (second, _) = install_and_run(&repo, &home, &bin_dir);
+    assert_eq!(second, "v2\n", "the second install reused the stale clone");
+    let _ = std::fs::remove_dir_all(repo.parent().unwrap());
+}


### PR DESCRIPTION
Closes #1956.

`almide install <repo>` reused the clone cached under `~/.almide/cache/<name>/main` on every later install, so after new commits were pushed a second install printed `✓ Installed` and left the stale binary in place; only `almide clean` fixed it.

- `src/cli/install.rs`: a branch install (no tag) resolves the remote head first (`git ls-remote`, the same helper `almide update` uses) and builds that commit through the commit-keyed cache, so it is `go install pkg@latest`: the current head every time. The resolved commit is printed (`Resolved <name> HEAD -> <sha12>`) so what was built is visible. A tag is an immutable snapshot and keeps its cache entry. `file://` URLs are accepted alongside `https://` / `git@` / `ssh://`, which also makes the behaviour testable against a local repository.
- `tests/install_remote_head_test.rs`: a local git repo at v1, install, commit v2, install again — the second binary must print `v2` and the install must report the resolved commit. HOME is confined to a temp dir so the test never touches the real cache. A/B: fails on the released 0.62.0, passes here.

https://claude.ai/code/session_01NvweJKc7fNXQn4BzB7GQQM
