### PR TITLE
A type declaration's body resolves in the declaring module's scope

### DIFF
--- a/crates/almide-frontend/src/canonicalize/registration.rs
+++ b/crates/almide-frontend/src/canonicalize/registration.rs
@@ -644,7 +644,15 @@ pub fn register_type_decl(env: &mut TypeEnv, diagnostics: &mut Vec<Diagnostic>, 
     // destroy same-named type bindings that already exist.
     let shadowed: Vec<(Sym, Option<Ty>)> =
         gnames.iter().map(|gn| (*gn, env.types.insert(*gn, Ty::TypeVar(*gn)))).collect();
-    let mut resolved = resolve(env, ty);
+    // The declaration's BODY resolves in the declaring module's scope, like
+    // every fn signature does: a module record's field `List[Entry]` must pin
+    // to that module's own `Entry`. Resolved bare, it fell to the
+    // unique-owner rule, which is ambiguous the moment a second module also
+    // declares `Entry` — the field stayed a bare `Entry`, the entry program
+    // saw it through `mod.Toc.symbols`, and the flat leg refused the build
+    // (#433 gate) while the wasm leg read the other `Entry`'s layout
+    // (#1957).
+    let mut resolved = resolve_in(env, ty, type_cur_mod(env, prefix));
     for (gn, prev) in shadowed.into_iter().rev() {
         match prev {
             Some(t) => { env.types.insert(gn, t); }

--- a/tests/module_same_type_name_field_test.rs
+++ b/tests/module_same_type_name_field_test.rs
@@ -1,0 +1,94 @@
+//! Two modules of one package each declare `type Entry`, and the entry
+//! program reads a record FIELD typed with one of them (#1957, case 2).
+//!
+//! A type declaration's body was resolved without the declaring module's
+//! scope, so `symbols.Toc`'s field `symbols: List[Entry]` fell to the
+//! unique-owner rule — ambiguous once `vault.Entry` existed too — and stayed
+//! a bare `Entry`. The entry program saw that bare name through
+//! `symbols.toc().symbols`: the flat native leg refused the build with the
+//! #433 "unresolvable bare type name" gate, and the wasm leg read the OTHER
+//! `Entry`'s layout and printed a blank. `almide check` was green. The body
+//! now resolves in the declaring module's scope, like a fn signature.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn tools_available() -> bool {
+    Command::new(almide_bin()).arg("--version").output().is_ok()
+}
+
+fn wasmtime_available() -> bool {
+    Command::new("wasmtime").arg("--version").output().is_ok_and(|o| o.status.success())
+}
+
+fn write(path: &Path, content: &str) {
+    std::fs::create_dir_all(path.parent().unwrap()).expect("mkdir");
+    std::fs::write(path, content).expect("write");
+}
+
+fn scratch() -> PathBuf {
+    let root = std::env::temp_dir().join(format!("almide-issue1957-entry-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    write(&root.join("almide.toml"), "[package]\nname = \"app\"\nversion = \"0.1.0\"\n");
+    write(
+        &root.join("src").join("vault.almd"),
+        "type Entry = { id: Int, body: String }\nfn make(id: Int) -> Entry = Entry { id: id, body: \"b${int.to_string(id)}\" }\n",
+    );
+    write(
+        &root.join("src").join("symbols.almd"),
+        "type Entry = { kind: String, name: String, start: Int, end: Int }\n\
+         type Toc = { lang: String, symbols: List[Entry] }\n\
+         fn toc() -> Toc = Toc { lang: \"rs\", symbols: [Entry { kind: \"fn\", name: \"a\", start: 1, end: 2 }] }\n",
+    );
+    write(
+        &root.join("src").join("main.almd"),
+        "import self.vault\nimport self.symbols\n\n\
+         fn read_as_outline() -> List[String] = list.map(symbols.toc().symbols, (s) => \"${s.kind} ${s.name}\")\n\n\
+         effect fn main() -> Unit = {\n  println(vault.make(1).body)\n  println(list.join(read_as_outline(), \",\"))\n}\n",
+    );
+    root
+}
+
+fn run(root: &Path, target: Option<&str>) -> (bool, String, String) {
+    let mut cmd = Command::new(almide_bin());
+    cmd.args(["run", "src/main.almd"]).current_dir(root);
+    if let Some(t) = target {
+        cmd.args(["--target", t]);
+    }
+    let out = cmd.output().expect("spawn almide");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+#[test]
+fn a_module_record_field_pins_to_its_own_same_named_type_on_both_legs() {
+    if !tools_available() {
+        return;
+    }
+    let root = scratch();
+    let (ok, stdout, stderr) = run(&root, None);
+    assert!(!stderr.contains("COMPILER BUG"), "the #433 gate fired:\n{stderr}");
+    assert!(ok, "native run failed:\nstdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "b1\nfn a\n", "wrong native output: {stdout}");
+
+    if wasmtime_available() {
+        let (ok, stdout, stderr) = run(&root, Some("wasm"));
+        assert!(ok, "wasm run failed:\nstdout: {stdout}\nstderr: {stderr}");
+        assert_eq!(stdout, "b1\nfn a\n", "wrong wasm output (the other Entry's layout?): {stdout}");
+    }
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
Closes #1957 (case 2; case 1 is #1964).

Two modules of one package each declared `type Entry`, and the entry program read `symbols.toc().symbols` (a `List[Entry]` field of `symbols.Toc`). `almide check` was green; the native build refused with the #433 "unresolvable bare type name" gate (`Entry` — candidates `vault.Entry`, `symbols.Entry`), and the wasm leg printed a blank line where `fn a` belongs: it had read the OTHER `Entry`'s layout. Reproduced on the reporter's repository (with the `TocEntry` workaround reverted) and with two local modules, no dependency needed.

The cause: `register_type_decl` resolved the declaration's BODY with the bare `resolve(env, ty)`, without the declaring module's scope, while every fn signature goes through `resolve_in` with it. A module record's field `List[Entry]` therefore fell to the unique-owner rule, which is ambiguous the moment a second module declares `Entry`, and stayed bare. The body now resolves with `type_cur_mod(env, prefix)`, the same scope the signatures use.

- `tests/module_same_type_name_field_test.rs`: the two-module shape, run natively (no #433 gate, `b1` / `fn a`) and on wasm (same bytes). A/B: fails on the released 0.62.0, passes here.

Verified locally: `almide test spec/` 436/436 native, 424 + 12 skipped wasm; frontend crate, crossmod matrix, checker, `dep_*`, module repr, IDE outline and codegen snapshot suites green.

https://claude.ai/code/session_01NvweJKc7fNXQn4BzB7GQQM
