### PR TITLE
Host routing to the wasm legs is decided from the emitted op set instead of a module-level import scan

### DIFF
--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -837,7 +837,6 @@ fn render_wasm_module_routed(
     has_main: bool,
     dep_paths: &[(project::PkgId, std::path::PathBuf)],
     uses_incumbent_features: bool,
-    host_variant: bool,
 ) -> Result<(Vec<u8>, bool, Vec<i32>), ()> {
     //   - `ALMIDE_FUEL_PROBE` set         → incumbent (the charge-trace
     //     probe line is that leg's Σ-probe instrumentation — contract
@@ -855,8 +854,7 @@ fn render_wasm_module_routed(
         && (std::env::var_os("ALMIDE_WASM_INCUMBENT").is_some()
             || std::env::var_os("ALMIDE_FUEL_PROBE").is_some()
             || !has_main
-            || uses_incumbent_features
-            || (library_ok && host_variant));
+            || uses_incumbent_features);
     if incumbent {
         let r = render_wasm_module(source_text, v1_self_modules, library_ok).map(|(b, _)| (b, false, Vec::new()));
         // REVERSE handover (#1423 bucket A, the env.sleep_ms build shape):
@@ -947,7 +945,7 @@ fn render_wasm_module_routed(
                     .find(|op| !almide_wasm_run::wasi::P1_SERVED_OPS.contains(op))
             {
                 return reroute(&format!(
-                    "host op {op} has no stock-WASI service (the embedded host                      — `almide run --target wasm` — serves it)"
+                    "host op {op} has no stock-WASI service (the embedded host — `almide run --target wasm` — serves it)"
                 ));
             }
             // With the debug env, ALWAYS name the winning leg — the
@@ -1120,29 +1118,20 @@ pub(crate) fn compile_to_wasm_bytes(file: &str, allow_unverified: bool, verified
     // export mode yet (#1598's sibling surface), so those modules stay on
     // the incumbent leg.
     let has_exports = ir_program.functions.iter().any(|f| !f.export_attrs.is_empty());
-    let imports_module = |names: &[&str]| {
-        std::iter::once(&program)
-            .chain(resolved.modules.iter().map(|(_, p, _, _)| p))
-            .flat_map(|p| p.imports.iter())
-            .any(|d| {
-                matches!(d, almide::ast::Decl::Import { path, .. }
-                    if path.first().is_some_and(|r| names.contains(&r.as_str())))
-            })
-    };
-    // Build-time host routing: process rides the incumbent (no
-    // structural surface); fs rides the incumbent because the p1
-    // `to_wasi` transform carries no fs ops — EXCEPT when the build is
-    // headed for the direct p3 component (#1628 increment 2d), whose
-    // shim now carries the full fs read+write surface, so fs programs
-    // flip to the structural leg there by default (#1584's first
-    // default-route slice). `env` is NOT in the scan any more (#1921's
-    // first slice): the p1 shim serves get/set/os/cwd/temp_dir/args
-    // structurally, and an env fn it does not link walls at lowering and
-    // takes the verified-to-verified reroute like any other unlinked fn —
-    // the per-fn auto-flip #1598 established, not a module-level denial.
-    let p3_requested = std::env::var_os("ALMIDE_COMPONENT_P3").is_some();
-    let host_variant = imports_module(&["process"])
-        || (imports_module(&["fs"]) && !p3_requested);
+    // #1921 CLOSED: the module-level host-variant import scan is GONE. Host
+    // routing is decided from the EMITTED op set, not from import names:
+    // the structural leg lowers the program, and `render_wasm_module_routed`
+    // audits the host ops it emitted against the p1 shim's served set on the
+    // BUILD path (`library_ok`) — an fs op the `to_wasi` transform cannot
+    // serve reroutes the whole module to the incumbent's WASI rendering,
+    // while `almide run --target wasm` (the embedded host serves every op)
+    // and the direct p3 component (its shim carries the fs surface) keep the
+    // structural module. `process` fns have no structural surface and wall
+    // at lowering, taking the same verified-to-verified reroute. Before
+    // this, `import fs` / `import process` unconditionally denied the
+    // structural leg — including on the run path, where it served the
+    // program end to end — and an fs program whose only fs use was inside a
+    // `!`-consumed `fan.map` built on NEITHER leg.
     // #1598 CLOSED as per-fn auto-flip: the matrix/io module pre-scan is
     // GONE. The linked surfaces (io.read_all via the host's op-31 drain
     // joined io.print/write/write_bytes/read_n_bytes; the measured matrix
@@ -1166,7 +1155,6 @@ pub(crate) fn compile_to_wasm_bytes(file: &str, allow_unverified: bool, verified
         has_main,
         &dep_paths,
         has_exports,
-        host_variant,
     )
 }
 

--- a/tests/host_op_routing_test.rs
+++ b/tests/host_op_routing_test.rs
@@ -1,0 +1,86 @@
+//! #1921: host routing is decided from the EMITTED op set, not from a
+//! module-level import scan. `import fs` used to deny the structural leg
+//! unconditionally — on the run path too, where the embedded host serves
+//! every fs op — and an fs program whose only fs use sat inside a
+//! `!`-consumed `fan.map` built on neither leg. Now the structural leg
+//! lowers the program; on the BUILD path its emitted host ops are audited
+//! against the p1 shim's served set and an unserved op reroutes the module
+//! to the incumbent's WASI rendering.
+
+use std::process::Command;
+
+fn almide() -> &'static str {
+    env!("CARGO_BIN_EXE_almide")
+}
+
+const FS_PROGRAM: &str = r#"import fs
+effect fn main() -> Unit = {
+  let dir = fs.temp_dir()
+  let p = "${dir}/almide_1921_routing_probe.txt"
+  fs.write(p, "hello")!
+  let t = fs.read_text(p)!
+  println("read=${t} exists=${fs.exists(p)}")
+}
+"#;
+
+fn run_debug(args: &[&str]) -> (bool, String, String) {
+    let out = Command::new(almide())
+        .args(args)
+        .env("ALMIDE_VERIFIED_DEBUG", "1")
+        .output()
+        .expect("run almide");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// The run path: the embedded host serves the fs ops, so the structural
+/// leg keeps the module it emitted — no import-name denial.
+#[test]
+fn fs_program_runs_on_the_structural_leg() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("fs_probe.almd");
+    std::fs::write(&src, FS_PROGRAM).expect("write repro");
+    let (ok, stdout, stderr) = run_debug(&["run", src.to_str().unwrap(), "--target", "wasm"]);
+    assert!(ok, "run must succeed; stderr:\n{stderr}");
+    assert!(
+        stderr.contains("structural leg emitted the module"),
+        "the fs program must run on the structural leg (#1921); stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("incumbent renderer"),
+        "the run path must not reroute an fs program by import name; stderr:\n{stderr}"
+    );
+    assert_eq!(stdout.trim(), "read=hello exists=true");
+}
+
+/// The build path: the p1 `to_wasi` shim carries no fs ops, so the
+/// structural module is audited by its emitted op set and rerouted to the
+/// incumbent's WASI rendering — by OP, naming the op, not by import name.
+#[test]
+fn fs_program_build_reroutes_by_emitted_op() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("fs_probe.almd");
+    let wasm = dir.path().join("fs_probe.wasm");
+    std::fs::write(&src, FS_PROGRAM).expect("write repro");
+    let (ok, _, stderr) = run_debug(&[
+        "build",
+        src.to_str().unwrap(),
+        "--target",
+        "wasm",
+        "-o",
+        wasm.to_str().unwrap(),
+    ]);
+    assert!(ok, "build must succeed via the incumbent; stderr:\n{stderr}");
+    assert!(
+        stderr.contains("has no stock-WASI service"),
+        "the reroute must be decided by the emitted host op (#1921); stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("incumbent renderer"),
+        "the build must hand the fs module to the incumbent; stderr:\n{stderr}"
+    );
+    assert!(wasm.exists(), "the incumbent's WASI module must be written");
+}


### PR DESCRIPTION
Closes #1921

## What changed

`src/cli/build.rs` no longer scans import names (`process`, `fs`) to deny the structural leg up front. The structural leg lowers the program, and `render_wasm_module_routed` — which already audited emitted host ops against `P1_SERVED_OPS` on the build path since #1933 — decides:

| program | `almide run --target wasm` | `almide build --target wasm` (p1 `to_wasi`) |
|---|---|---|
| `import env` (`env.get`) | structural (unchanged, #1933) | structural |
| `import fs` (write / read_text / exists) | **structural** (was: incumbent by import name) — the embedded host serves every op | incumbent, rerouted **by op**: `host op 1 has no stock-WASI service` |
| `fan.map(paths, (p) => read_one(p)!)!` over fs | **structural, runs** (was: built on NEITHER leg) | structural declined by op audit → incumbent's honest `fan.map consumed by !` wall (the build-path residue is #1922's shape) |
| `import process` | E081 at check time (`process.exec` is not available on --target wasm) | same |

The direct p3 component path keeps its full fs surface (the audit is skipped under `ALMIDE_COMPONENT_P3`, as before). Nothing touches wall semantics; every handover stays verified-to-verified.

## Evidence

- `tests/host_op_routing_test.rs`: an fs program runs on the structural leg (debug line asserted, no import-name reroute, output pinned) and its build reroutes by the emitted op with the op named.
- `almide test spec/ --target wasm` 424 passed / 12 skipped (fs / env test files now take the structural leg where it lowers them); native 436/436; `proofs/check-wasm-fallback.sh` OK (12, all enumerated); `wasm_runtime_cross_target`; `both_walls_reported_test`; `wasi_gate`.

https://claude.ai/code/session_01NvweJKc7fNXQn4BzB7GQQM