### PR TITLE
The structural leg's bind collector walks the Result-to-Option and optional-chain wrappers

### DIFF
--- a/crates/almide-wasm/src/collect.rs
+++ b/crates/almide-wasm/src/collect.rs
@@ -317,11 +317,18 @@ fn collect_binds_data_b(
         // carries its `__mp_res`/`__mp_buf` binds beneath a Try (#1576's
         // DDD tree: `" ${cancel_order(mem, id)!} …"`) — missing it here
         // surfaced as `bind:unmapped`.
+        // `r?` (ToOption) and `o?.field` (OptionalChain) are wrappers like
+        // `Try`/`Unwrap`: a `match` with a pattern bind beneath them
+        // (`w(match o { some(v) => v, none => d })? ?? d2`, the composition
+        // family's seed-7 draws 11/21/30/57/88/98/103) surfaced as
+        // `bind:unmapped` on BOTH legs because this walk never reached `v`.
         IrExprKind::OptionSome { expr }
         | IrExprKind::ResultOk { expr }
         | IrExprKind::ResultErr { expr }
         | IrExprKind::Try { expr }
-        | IrExprKind::Unwrap { expr } => collect_binds(expr, out, seen, types),
+        | IrExprKind::Unwrap { expr }
+        | IrExprKind::ToOption { expr }
+        | IrExprKind::OptionalChain { expr, .. } => collect_binds(expr, out, seen, types),
         IrExprKind::UnwrapOr { expr, fallback } => {
             collect_binds(expr, out, seen, types)?;
             collect_binds(fallback, out, seen, types)

--- a/crates/almide-wasm/tests/bind_collect_wrappers.rs
+++ b/crates/almide-wasm/tests/bind_collect_wrappers.rs
@@ -1,0 +1,56 @@
+//! The local-bind collector must walk EVERY expression wrapper: a `match`
+//! with a pattern bind beneath `r?` (ToOption) or `o?.field`
+//! (OptionalChain) surfaced as `bind:unmapped` on the structural leg — and,
+//! the incumbent walling the same draws for its own reasons, on BOTH legs
+//! (composition fuzz family, seed 7 draws 11 / 21 / 30 / 57 / 88 / 98 / 103).
+
+mod harness;
+use harness::run_wasm;
+
+const TO_OPTION_OVER_MATCH: &str = r#"fn w_some_tup(x: (Int, String)) -> (Int, String)? = some(x)
+
+fn w_ok_tup(x: (Int, String)) -> Result[(Int, String), String] = ok(x)
+
+fn probe_c() -> (Int, String) = w_ok_tup(match w_some_tup((7, "t")) {
+  some(v) => v,
+  none => (8, "t"),
+})? ?? (9, "t")
+
+fn probe_d() -> Int = w_ok_tup(match w_some_tup((5, "u")) {
+  some(v) => (v.0 + 1, v.1),
+  none => (0, "u"),
+})? ?? (9, "t") |> ((t) => t.0)
+
+effect fn main() -> Unit = println("c=${probe_c().0} d=${probe_d()}")
+"#;
+
+const OPTIONAL_CHAIN_OVER_MATCH: &str = r#"type P = { n: Int, s: String }
+
+fn w_some_rec(p: P) -> P? = some(p)
+
+fn probe_e() -> Int = (match w_some_rec(P { n: 3, s: "r" }) {
+  some(v) => some(v),
+  none => none,
+})?.n ?? 9
+
+effect fn main() -> Unit = println("e=${probe_e()}")
+"#;
+
+fn run(name: &str, src: &str) -> String {
+    let ir = almide_spine::s5::lower_to_ir(name, src).expect("front end");
+    let bytes = almide_wasm::emit_program(&ir)
+        .unwrap_or_else(|e| panic!("the structural leg must lower {name}: {e:?}"));
+    let out = run_wasm(&bytes).expect("wasmtime run");
+    assert_eq!(out.exit, 0, "{name} stderr: {}", out.stderr);
+    out.stdout
+}
+
+#[test]
+fn a_pattern_bind_beneath_to_option_is_mapped() {
+    assert_eq!(run("to_option.almd", TO_OPTION_OVER_MATCH), "c=7 d=6\n");
+}
+
+#[test]
+fn a_pattern_bind_beneath_optional_chain_is_mapped() {
+    assert_eq!(run("optional_chain.almd", OPTIONAL_CHAIN_OVER_MATCH), "e=3\n");
+}


### PR DESCRIPTION
Closes #1976

`crates/almide-wasm/src/collect.rs`: `ToOption` (`r?`) and `OptionalChain` (`o?.field`) join the wrapper walk, so a `match` with a pattern bind beneath them gets its local slot. Before, the structural leg walled `bind:unmapped` and — the incumbent walling the same draws for its own reasons — the program built on neither wasm leg. Every both-legs wall in the composition family's seed-7 scan (draws 11 / 21 / 30 / 57 / 88 / 98 / 103) was this one shape; all seven now lower structurally with the by-construction output.

Evidence: `crates/almide-wasm/tests/bind_collect_wrappers.rs` (both wrappers, run through the embedded host); `almide test spec/ --target wasm` structural and default 424 / 12 skipped; `wasm_runtime_cross_target`.

https://claude.ai/code/session_01NvweJKc7fNXQn4BzB7GQQM