### PR TITLE
The ALS pin gate refuses a contract id the judge has not seen at the pinned almide/als commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1123,6 +1123,9 @@ jobs:
       - name: Contract ledger traceability (every contract evidenced, every fixture contracted)
         run: scripts/check-contracts.sh
 
+      - name: ALS pin — every contract id is known to the judge at proofs/als-pin.txt (als #60)
+        run: bash scripts/check-als-pin.sh
+
       - name: WASI/Component-Model pin policy (#1628 stage 4)
         run: bash scripts/check-wasi-pins.sh
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,6 +336,10 @@ differential fuzz, an emit-time Σ-probe, or a Lean theorem. The index is
   names its contract(s), and the link is bidirectional. The evidence-class
   vocabulary is shared with the rt-oracle-registry via
   `scripts/lib/contract-classes.txt`.
+- **A new `C-NNN` lands in [almide/als](https://github.com/almide/als) FIRST.** The judge
+  holds the normative ledger; `scripts/check-als-pin.sh` (CI `checks`) refuses any contract
+  id absent from the judge's ledger at the commit pinned in `proofs/als-pin.txt`. Order: als
+  PR (contract + fixture) merges → advance the pin in its own commit → the implementation PR.
 - **Aggregate counts are stamped, not regenerated per PR.** Every "N contracts /
   N fixtures" total the generated docs quote renders from `proofs/ledger-counts.toml`
   inside a dated `counts:generated` block. A fixture/contract PR regenerates the

--- a/proofs/als-pin.txt
+++ b/proofs/als-pin.txt
@@ -1,0 +1,4 @@
+# The almide/als commit this tree's contract ledger is judged against
+# (scripts/check-als-pin.sh). Advance it AFTER the als PR that carries a
+# new contract id has merged — never in the same PR that mints the id.
+12099f37a7f86ce586175c6d2b1575df146f5a01

--- a/proofs/gate-verification.toml
+++ b/proofs/gate-verification.toml
@@ -30,6 +30,11 @@ class = "NEGATIVE_TESTED"
 evidence = "#576 slice-3 landing (2026-08-28): a hand-corrupted byte in StructuralDecode.v's inc_bytes list (65;1 -> 65;2) failed the gate naming the exact emitter-vs-proven diff, restored green (23/37/70/259 bytes matched; slice 4 added the $alloc row with LEB-aware wrapper stripping). The gate re-derives BOTH sides per run — the emitter's bytes through its own dump helper, the proven lists parsed out of the .v source — so neither can drift silently against the decode theorems."
 
 [[gate]]
+path = "scripts/check-als-pin.sh"
+class = "NEGATIVE_TESTED"
+evidence = "als #60 second-half landing (2026-09-07, almide #1982): a judge ledger with C-347 removed (ALS_LEDGER=<file>) went red naming the id and the remedy (land it in almide/als first, then advance proofs/als-pin.txt; ours 347, judge 346 at 12099f3), the live judge ledger at the pin green (347/347). A fetch failure is exit 2, red in CI — the gate cannot pass by not looking."
+
+[[gate]]
 path = "scripts/check-wasi-pins.sh"
 class = "NEGATIVE_TESTED"
 evidence = "#1628 stage-4 landing (2026-08-28): policy crate_major hand-flipped 47->48 went red naming the exact drifted pin (wasmtime Cargo pin is 47, policy says 48), restored green. The gate re-derives every fact the policy states from the tree per run — vendored WIT versions, the p3 shim's import versions, the wasmtime Cargo/CI pins, the p3 harness flag surface, the wasm-tools lockstep family — so the WASI-minor compat target is a checked ledger row, not an assumption."

--- a/scripts/check-als-pin.sh
+++ b/scripts/check-als-pin.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# ALS PIN GATE — the two-PR order, made mechanical (almide/als #60, second half).
+#
+# almide/als (the judge) holds the normative contract ledger; CONTRIBUTING
+# there promises that a contract enters the judge BEFORE the implementation
+# claims it. Between 2026-08-25 and 2026-09-06 that order lapsed 26 times
+# (C-322..C-347 were minted here first) and the judge's verdict went stale.
+# This gate is the reverse of the judge's `check-contracts.sh --impl-root`:
+#
+#   every `id = "C-NNN"` in docs/contracts/contracts.toml must exist in the
+#   judge's docs/contracts/contracts.toml AT THE PINNED COMMIT
+#   (proofs/als-pin.txt) — an id the judge has not seen is refused.
+#
+# Advancing the pin is its own change, after the als PR carrying the new id
+# has merged; the pin never moves in the PR that mints the id.
+#
+#   bash scripts/check-als-pin.sh            # gate (CI `checks` job)
+#   ALS_LEDGER=<path> bash scripts/check-als-pin.sh   # offline: judge ledger from a file
+#
+# Exit 0 = every id is judge-known; 1 = a violation; 2 = environment (the
+# judge ledger could not be fetched — CI treats that as red too, since a
+# gate that cannot look is not a gate).
+set -uo pipefail
+export LC_ALL=C
+cd "$(dirname "$0")/.." || exit 2
+
+PIN_FILE="proofs/als-pin.txt"
+LEDGER="docs/contracts/contracts.toml"
+
+pin="$(grep -vE '^\s*(#|$)' "$PIN_FILE" | head -1 | tr -d '[:space:]')"
+if ! [[ "$pin" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "::error::$PIN_FILE does not name a full 40-hex als commit (got '$pin')"
+  exit 2
+fi
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+if [ -n "${ALS_LEDGER:-}" ]; then
+  cp "$ALS_LEDGER" "$tmp" || exit 2
+else
+  url="https://raw.githubusercontent.com/almide/als/$pin/docs/contracts/contracts.toml"
+  if ! curl -fsSL --retry 3 --retry-delay 2 -o "$tmp" "$url"; then
+    echo "::error::could not fetch the judge ledger at the pin ($url)"
+    exit 2
+  fi
+fi
+
+ids() { grep -oE '^\s*id\s*=\s*"C-[0-9]+"' "$1" | grep -oE 'C-[0-9]+' | sort -u; }
+ours="$(ids "$LEDGER")"
+judge="$(ids "$tmp")"
+missing="$(comm -23 <(echo "$ours") <(echo "$judge"))"
+n_ours="$(echo "$ours" | grep -c .)"
+n_judge="$(echo "$judge" | grep -c .)"
+
+if [ -n "$missing" ]; then
+  for id in $missing; do
+    echo "::error::$id is in $LEDGER but not in the judge ledger at pin ${pin:0:7} — land it in almide/als first, then advance $PIN_FILE"
+  done
+  echo "als-pin FAILED: $(echo "$missing" | grep -c .) id(s) unknown to the judge (ours $n_ours, judge $n_judge at ${pin:0:7})"
+  exit 1
+fi
+echo "als-pin OK: $n_ours contract id(s) all present in the judge ledger at ${pin:0:7} (judge holds $n_judge)"


### PR DESCRIPTION
The second half of almide/als#60 (the first half, the pin advance, merged as als#61). Closes the process gap that let C-322..C-347 enter this ledger before the judge's.

- `scripts/check-als-pin.sh`: fetches the judge's `docs/contracts/contracts.toml` at the commit in `proofs/als-pin.txt` and refuses any `C-NNN` present here and absent there. Offline: `ALS_LEDGER=<file>`. A fetch failure is red (exit 2), since a gate that cannot look is not a gate. Verified live (347/347 at als 12099f3) and with a negative control (a judge ledger missing C-347 → `C-347 … land it in almide/als first`).
- `proofs/als-pin.txt`: the pin, als main after #61. Advancing it is its own commit after the als PR merges — never in the PR that mints the id.
- CI `checks` step right after the contract-ledger gate; CLAUDE.md states the order.

https://claude.ai/code/session_01NvweJKc7fNXQn4BzB7GQQM