### PR TITLE
The embedded wasm host is an optional feature of the almide crate, on by default, so a library consumer that compiles to wasm32 can leave wasmtime out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -733,6 +733,14 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: wasm32-wasip1, wasm32-unknown-unknown
 
+      # The library must build for the BROWSER without the embedded host: this is
+      # the exact dependency shape almide/playground consumes (`default-features =
+      # false`). The playground's deploy went red (2026-08-30 onwards) when
+      # almide-wasm-run — wasmtime, hence ring/getrandom — became an unconditional
+      # dependency of the root crate; this step is the tripwire.
+      - name: Library builds for wasm32-unknown-unknown without the embedded host
+        run: cargo check --lib --no-default-features --target wasm32-unknown-unknown --locked
+
       - uses: actions/setup-node@v7
         with:
           node-version: 20

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,12 @@ almide-mir = { path = "crates/almide-mir" }
 # the embedded almide.* host + the WASI transform for stock-runtime artifacts.
 almide-types = { path = "crates/almide-types" }
 almide-wasm = { path = "crates/almide-wasm" }
-almide-wasm-run = { path = "crates/almide-wasm-run" }
+# OPTIONAL: the embedded host carries wasmtime, which cannot be built for
+# wasm32-unknown-unknown. The CLI always has it (`default`); a LIBRARY consumer
+# that itself compiles to the browser (almide/playground) turns it off with
+# `default-features = false`. Only `src/cli/` references the crate, so the lib
+# surface is identical either way; `src/main.rs` refuses to build without it.
+almide-wasm-run = { path = "crates/almide-wasm-run", optional = true }
 # WAT (text) → wasm bytes: the v1 renderer emits WAT; the CLI assembles it to a module.
 wat = "1"
 # Structural validation of the assembled v1 module: `wat` assembles without full stack-shape
@@ -64,6 +69,11 @@ crossbeam-channel = "0.5"
 lsp-types = "0.97"
 wit-component = "0.258"
 wasi-preview1-component-adapter-provider = "48.0.1"
+
+[features]
+default = ["embedded-host"]
+# The embedded `almide.*` host (wasmtime) behind `almide run/bench/build --target wasm`.
+embedded-host = ["dep:almide-wasm-run"]
 
 # Cross-platform advisory file lock (flock / LockFileEx) for the shared build
 # scratch dir (see BuildDirLock) — lets CI run the suite in parallel on every

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,10 @@
+// The CLI is never built without the embedded wasm host: `run`, `bench` and
+// `build --target wasm` are its callers. The feature exists for LIBRARY
+// consumers that compile to wasm32 themselves (almide/playground), where
+// wasmtime cannot be built — see the `almide-wasm-run` note in Cargo.toml.
+#[cfg(not(feature = "embedded-host"))]
+compile_error!("the `almide` binary requires the `embedded-host` feature (default); only the library builds without it");
+
 mod cli;
 mod compile_driver;
 


### PR DESCRIPTION
almide/playground's deploy has been red since 2026-08-30. Its build for wasm32-unknown-unknown fails in `getrandom` 0.2, pulled by ring ← rustls ← wasmtime ← `almide-wasm-run`, which became an unconditional dependency of the root `almide` crate. wasmtime cannot be built for the browser target at all, so no getrandom feature flag rescues it; the host has to be optional.

- `almide-wasm-run` is `optional = true` behind a new `embedded-host` feature, in `default`. The CLI is unchanged: `src/main.rs` carries a `compile_error!` for a build without it, since `run`, `bench` and `build --target wasm` are its callers and live in `src/cli/` (bin-only). The library surface is identical either way.
- CI (the WASM host-arch determinism job, which already has the wasm32-unknown-unknown target): `cargo check --lib --no-default-features --target wasm32-unknown-unknown --locked` — the exact shape the playground consumes, so the next unconditional wasmtime edge trips here instead of on the playground's deploy.

Verified locally: `cargo check --lib --no-default-features` and `cargo check --bins` green; `cargo tree --no-default-features -i wasmtime` finds no package; host-target `cargo check` of the playground crate against current main is clean (no API drift, this is the only breakage). The playground side is a one-line `default-features = false` and takes effect once this reaches `main`, i.e. with the next release.

https://claude.ai/code/session_018P7iXCiULezW9PnHf1JpGe
