### PR TITLE
The build validates every emitted exit against its checked ExitPlan and names a mismatch as compiler defect E083, never a wall

### DIFF
--- a/ci/mutations/043-exit-release-dropped.patch
+++ b/ci/mutations/043-exit-release-dropped.patch
@@ -1,0 +1,12 @@
+diff --git a/crates/almide-wasm/src/exit_plan.rs b/crates/almide-wasm/src/exit_plan.rs
+--- a/crates/almide-wasm/src/exit_plan.rs
++++ b/crates/almide-wasm/src/exit_plan.rs
+@@ -127,7 +127,7 @@ impl Emitter<'_> {
+             if omit_first && k == 0 {
+                 continue;
+             }
+-            self.f.instructions().local_get(idx).call(F_DEC_FLAT);
++            let _ = idx; // [MUTANT: exit releases dropped]
+         }
+         match plan.continuation {
+             Continuation::ReturnSuccess => {

--- a/crates/almide-wasm/src/display.rs
+++ b/crates/almide-wasm/src/display.rs
@@ -499,6 +499,7 @@ fn build_one_scan_helper(
             rc_owned: std::collections::BTreeSet::new(),
             owned_call_marks: Default::default(),
             borrowed_temps: Vec::new(),
+            exit_ledger: Vec::new(),
             borrow_base: 0, // helper bodies lower no arm argument
             table,
             types,
@@ -600,6 +601,7 @@ fn build_one_eq_helper(
             rc_owned: std::collections::BTreeSet::new(),
             owned_call_marks: Default::default(),
             borrowed_temps: Vec::new(),
+            exit_ledger: Vec::new(),
             borrow_base: 0, // helper bodies lower no arm argument
             table,
             types,
@@ -675,6 +677,7 @@ fn build_one_display_helper(
             rc_owned: std::collections::BTreeSet::new(),
             owned_call_marks: Default::default(),
             borrowed_temps: Vec::new(),
+            exit_ledger: Vec::new(),
             borrow_base: 0, // helper bodies lower no arm argument
             table,
             types,

--- a/crates/almide-wasm/src/emit.rs
+++ b/crates/almide-wasm/src/emit.rs
@@ -110,6 +110,12 @@ fn emit_program_pass(
     // Lower every callable function; a body that doesn't lower yet is
     // recorded (not fatal) — fatal only if `main` can reach it.
     let mut lowered: Vec<Result<(Function, HashSet<usize>), String>> = Vec::new();
+    // Source names for the E083 diagnostic, by (var space, VarId): space 0
+    // is the entry program, space i + 1 is modules[i] (collect_program_fns).
+    let var_name = |space: u32, id: VarId| -> Option<String> {
+        let vt = if space == 0 { &ir.var_table } else { &ir.modules.get(space as usize - 1)?.var_table };
+        vt.entries.get(id.0 as usize).map(|v| v.name.as_str().to_string())
+    };
     for (i, (f, qual, space)) in program_fns.iter().enumerate() {
         if let Some(r) = &table.infos[i].refuse {
             lowered.push(Err(r.clone()));
@@ -117,7 +123,7 @@ fn emit_program_pass(
         }
         let params: Vec<(VarId, SliceTy)> =
             f.params.iter().zip(&table.infos[i].params).map(|(p, &t)| (p.var, t)).collect();
-        let ctx = Ctx { table: &table, types: &types, work: &work, globals: &global_map };
+        let ctx = Ctx { table: &table, types: &types, work: &work, globals: &global_map, var_name: &var_name };
         let cur_module = qual.as_ref().and_then(|q| q.split('.').next());
         let effect_raw = if f.is_effect {
             match slice_ty_of(&f.ret_ty, &types) {
@@ -143,6 +149,7 @@ fn emit_program_pass(
             charge_entry: meter.user.contains(f.name.as_str())
                 && !meter.exempt.contains(f.name.as_str()),
             var_space: *space,
+            name: qual.clone().unwrap_or_else(|| f.name.as_str().to_string()),
             witness_name: Some(
                 qual.clone().unwrap_or_else(|| f.name.as_str().to_string()),
             ),
@@ -171,19 +178,26 @@ fn emit_program_pass(
                         lowered.push(Ok((body, fcalls)));
                     }
                     Err(EmitError::Unsupported(r)) => lowered.push(Err(r)),
+            // E083: a compiler defect is fatal for the whole program — a
+            // reachable-or-not leak is still a defect, never a wall.
+            Err(e @ EmitError::OwnershipLowering(_)) => return Err(e),
                 }
             }
             Err(EmitError::Unsupported(r)) => lowered.push(Err(r)),
+            // E083: a compiler defect is fatal for the whole program — a
+            // reachable-or-not leak is still a defect, never a wall.
+            Err(e @ EmitError::OwnershipLowering(_)) => return Err(e),
         }
     }
 
     // `main`: top-lets as the eager prelude, then the body. Failure here is
     // fatal — main is always reachable.
-    let ctx = Ctx { table: &table, types: &types, work: &work, globals: &global_map };
+    let ctx = Ctx { table: &table, types: &types, work: &work, globals: &global_map, var_name: &var_name };
     let main_plan = FnPlan {
         ret: None,
         cur_module: None,
         var_space: 0,
+        name: "main".to_string(),
         witness_name: Some("main".to_string()),
         effect_raw: None,
         in_main: true,
@@ -214,6 +228,7 @@ fn emit_program_pass(
                 ret: ll.ret,
                 cur_module: ll.cur_module.clone(),
                 var_space: ll.var_space,
+                name: "<lambda>".to_string(),
                 witness_name: None,
                 effect_raw: ll.effect_raw,
                 in_main: false,

--- a/crates/almide-wasm/src/emitter.rs
+++ b/crates/almide-wasm/src/emitter.rs
@@ -61,6 +61,9 @@ pub(crate) struct Emitter<'a> {
     pub(crate) borrowed_temps: Vec<u32>,
     /// First local of the borrow pool (`BORROW_POOL` i32 slots).
     pub(crate) borrow_base: u32,
+    /// Every exit `emit_exit` wrote, with the byte offset it started at —
+    /// the E083 validator (exit_plan.rs) reads the bytes back against it.
+    pub(crate) exit_ledger: Vec<crate::exit_plan::ExitRecord>,
     // NOTE: rc_owned and rc_frame_params are BOTH dec'd by the
     // epilogue — a local in the two sets at once is a double free. Use
     // rc_own(), never a raw insert (#1770: a mut-param writeback's

--- a/crates/almide-wasm/src/exit_plan.rs
+++ b/crates/almide-wasm/src/exit_plan.rs
@@ -119,7 +119,14 @@ impl Emitter<'_> {
     /// (`rc_share_guard` in lower_sum); a guard's borrowed value took its
     /// ret-inc before this; rc_owned holds only flat blocks.
     pub(crate) fn emit_exit(&mut self, plan: &ExitPlan) {
-        for &idx in &plan.released {
+        self.exit_ledger.push(ExitRecord { plan: plan.clone(), start: self.f.byte_len() });
+        // Negative-test hook (tests/exit_validation.rs): omit the first
+        // release so the validator has a defect to name. Off by default.
+        let omit_first = OMIT_FIRST_RELEASE.load(std::sync::atomic::Ordering::Relaxed);
+        for (k, &idx) in plan.released.iter().enumerate() {
+            if omit_first && k == 0 {
+                continue;
+            }
             self.f.instructions().local_get(idx).call(F_DEC_FLAT);
         }
         match plan.continuation {
@@ -147,4 +154,212 @@ impl Emitter<'_> {
             }
         }
     }
+}
+
+/// The negative-test switch: when set, `emit_exit` skips the first release
+/// of every plan. Process-wide; tests/exit_validation.rs is its one user.
+static OMIT_FIRST_RELEASE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Test hook (E083 negative half): make the emitter omit the first release
+/// of every exit plan, so the validator has a defect to name.
+#[doc(hidden)]
+pub fn test_omit_first_release(on: bool) {
+    OMIT_FIRST_RELEASE.store(on, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// One exit as `emit_exit` wrote it: the plan, and the function-body byte
+/// offset where its releases begin.
+#[derive(Clone, Debug)]
+pub(crate) struct ExitRecord {
+    pub(crate) plan: ExitPlan,
+    pub(crate) start: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Op {
+    LocalGet(u32),
+    Call(u32),
+    Return,
+    ReturnCall,
+    FnEnd,
+    Other,
+}
+
+/// E083 (#1996): read the function's bytes BACK and check that every exit
+/// window — from the plan's first release to the transfer instruction —
+/// implements the plan: each released credit is decremented exactly there,
+/// nothing carried is, nothing outside the plan is, the transfer is the
+/// instruction the continuation names, and a frame-replacing or returning
+/// edge leaves no credit outstanding. Independent of the writer: it parses
+/// wasm, not the emitter's intent. A mismatch is a compiler defect with its
+/// own diagnostic, never a wall.
+pub(crate) fn validate_exits(
+    f: &wasm_encoder::Function,
+    ledger: &[ExitRecord],
+    function: &str,
+    name_of: impl Fn(u32) -> String,
+) -> Result<(), EmitError> {
+    if ledger.is_empty() {
+        return Ok(());
+    }
+    use wasm_encoder::Encode;
+    let mut encoded = Vec::new();
+    f.encode(&mut encoded);
+    // Skip the LEB128 size prefix: what follows is the body `byte_len`
+    // measured (locals vector, then code).
+    let mut pos = 0;
+    while encoded[pos] & 0x80 != 0 {
+        pos += 1;
+    }
+    pos += 1;
+    let body = &encoded[pos..];
+    let defect = |headline: &str, value: String, expected: &str, emitted: &str| {
+        EmitError::OwnershipLowering(OwnDefect {
+            headline: headline.to_string(),
+            function: function.to_string(),
+            value,
+            expected: expected.to_string(),
+            emitted: emitted.to_string(),
+        })
+    };
+    let parse_fail = |what: String| {
+        defect("exit validator could not read the function back", what, "a parseable body", "wasmparser refused it")
+    };
+    let fb = wasmparser::FunctionBody::new(wasmparser::BinaryReader::new(body, 0));
+    let mut reader = fb.get_operators_reader().map_err(|e| parse_fail(e.to_string()))?;
+    let mut ops: Vec<(usize, Op)> = Vec::new();
+    let mut depth: u32 = 0;
+    while !reader.eof() {
+        let (op, off) = reader.read_with_offset().map_err(|e| parse_fail(e.to_string()))?;
+        use wasmparser::Operator as W;
+        let kind = match op {
+            W::LocalGet { local_index } => Op::LocalGet(local_index),
+            W::Call { function_index } => Op::Call(function_index),
+            W::Return => Op::Return,
+            W::ReturnCall { .. } | W::ReturnCallIndirect { .. } => Op::ReturnCall,
+            W::Block { .. } | W::Loop { .. } | W::If { .. } | W::TryTable { .. } => {
+                depth += 1;
+                Op::Other
+            }
+            W::End => {
+                if depth == 0 {
+                    Op::FnEnd
+                } else {
+                    depth -= 1;
+                    Op::Other
+                }
+            }
+            _ => Op::Other,
+        };
+        ops.push((off as usize, kind));
+    }
+    // Windows may nest (an early exit lowered inside a later-started
+    // exit's value): claim from the LATEST start backwards, and skip the
+    // ranges already claimed.
+    let mut order: Vec<usize> = (0..ledger.len()).collect();
+    order.sort_by_key(|&k| std::cmp::Reverse(ledger[k].start));
+    let mut claimed: Vec<(usize, usize)> = Vec::new();
+    for k in order {
+        let rec = &ledger[k];
+        let cont = rec.plan.continuation;
+        let cont_name = match cont {
+            Continuation::ReturnSuccess => "the epilogue return",
+            Continuation::ReturnError => "the error return",
+            Continuation::GuardReturn => "the guard return",
+            Continuation::TailTransfer { .. } => "the tail transfer",
+        };
+        let Some(first) = ops.iter().position(|&(off, _)| off >= rec.start) else {
+            return Err(defect(
+                "an exit plan has no instructions after it",
+                cont_name.to_string(),
+                "releases and a transfer",
+                "end of function",
+            ));
+        };
+        let mut decs: Vec<u32> = Vec::new();
+        let mut terminator: Option<(usize, Op)> = None;
+        let mut j = first;
+        while j < ops.len() {
+            let (off, kind) = ops[j];
+            if let Some(&(_, e)) = claimed.iter().find(|&&(s, e)| off >= s && off <= e) {
+                // Inside a nested exit's window: jump past it.
+                j = ops.iter().position(|&(o, _)| o > e).unwrap_or(ops.len());
+                continue;
+            }
+            match kind {
+                Op::Call(F_DEC_FLAT) => match (j > first).then(|| ops[j - 1].1) {
+                    Some(Op::LocalGet(i)) => decs.push(i),
+                    _ => {
+                        return Err(defect(
+                            "a release in an exit window names no local",
+                            cont_name.to_string(),
+                            "local.get <credit>; call $dec_flat",
+                            "call $dec_flat with another operand",
+                        ))
+                    }
+                },
+                Op::Return | Op::ReturnCall | Op::FnEnd => {
+                    terminator = Some((j, kind));
+                    break;
+                }
+                _ => {}
+            }
+            j += 1;
+        }
+        let Some((tj, tk)) = terminator else {
+            return Err(defect("an exit plan reaches no transfer", cont_name.to_string(), "return / return_call / end", "none"));
+        };
+        claimed.push((rec.start, ops[tj].0));
+        let want = match cont {
+            Continuation::ReturnSuccess => Op::FnEnd,
+            Continuation::ReturnError | Continuation::GuardReturn => Op::Return,
+            Continuation::TailTransfer { .. } => Op::ReturnCall,
+        };
+        if tk != want {
+            return Err(defect(
+                "an exit transfers by a different instruction than its plan",
+                cont_name.to_string(),
+                &format!("{want:?}"),
+                &format!("{tk:?}"),
+            ));
+        }
+        for &idx in &rec.plan.released {
+            if !decs.contains(&idx) {
+                return Err(defect(
+                    "an exit leaves a released credit undecremented",
+                    name_of(idx),
+                    &format!("release before {cont_name}"),
+                    "none",
+                ));
+            }
+        }
+        for &idx in &decs {
+            if rec.plan.carried.contains(&idx) {
+                return Err(defect(
+                    "an exit releases a credit its plan carries",
+                    name_of(idx),
+                    &format!("carried across {cont_name}"),
+                    "released",
+                ));
+            }
+            if !rec.plan.released.contains(&idx) {
+                return Err(defect(
+                    "an exit releases a value outside its plan",
+                    name_of(idx),
+                    "no release (not a frame credit at this edge)",
+                    "released",
+                ));
+            }
+        }
+        let replaces = !matches!(cont, Continuation::TailTransfer { replaces_frame: false });
+        if replaces && let Some(&idx) = rec.plan.carried.iter().next() {
+            return Err(defect(
+                "tail exit leaves an ownership credit outstanding",
+                name_of(idx),
+                "transfer or release before tail transfer",
+                "neither",
+            ));
+        }
+    }
+    Ok(())
 }

--- a/crates/almide-wasm/src/exit_plan.rs
+++ b/crates/almide-wasm/src/exit_plan.rs
@@ -185,52 +185,46 @@ enum Op {
     Other,
 }
 
-/// E083 (#1996): read the function's bytes BACK and check that every exit
-/// window — from the plan's first release to the transfer instruction —
-/// implements the plan: each released credit is decremented exactly there,
-/// nothing carried is, nothing outside the plan is, the transfer is the
-/// instruction the continuation names, and a frame-replacing or returning
-/// edge leaves no credit outstanding. Independent of the writer: it parses
-/// wasm, not the emitter's intent. A mismatch is a compiler defect with its
-/// own diagnostic, never a wall.
-pub(crate) fn validate_exits(
-    f: &wasm_encoder::Function,
-    ledger: &[ExitRecord],
-    function: &str,
-    name_of: impl Fn(u32) -> String,
-) -> Result<(), EmitError> {
-    if ledger.is_empty() {
-        return Ok(());
+/// The defect constructor every check shares: the function is fixed, the
+/// four lines vary.
+struct Defects<'a> {
+    function: &'a str,
+}
+
+impl Defects<'_> {
+    fn at(&self, headline: &str, value: String, expected: &str, emitted: &str) -> EmitError {
+        EmitError::OwnershipLowering(OwnDefect {
+            headline: headline.to_string(),
+            function: self.function.to_string(),
+            value,
+            expected: expected.to_string(),
+            emitted: emitted.to_string(),
+        })
     }
+}
+
+/// Re-encode the function and read its operators back with their body
+/// offsets (the offsets `byte_len` measured: locals vector, then code).
+fn read_ops(f: &wasm_encoder::Function, d: &Defects<'_>) -> Result<Vec<(usize, Op)>, EmitError> {
     use wasm_encoder::Encode;
     let mut encoded = Vec::new();
     f.encode(&mut encoded);
-    // Skip the LEB128 size prefix: what follows is the body `byte_len`
-    // measured (locals vector, then code).
+    // Skip the LEB128 size prefix.
     let mut pos = 0;
     while encoded[pos] & 0x80 != 0 {
         pos += 1;
     }
     pos += 1;
     let body = &encoded[pos..];
-    let defect = |headline: &str, value: String, expected: &str, emitted: &str| {
-        EmitError::OwnershipLowering(OwnDefect {
-            headline: headline.to_string(),
-            function: function.to_string(),
-            value,
-            expected: expected.to_string(),
-            emitted: emitted.to_string(),
-        })
-    };
-    let parse_fail = |what: String| {
-        defect("exit validator could not read the function back", what, "a parseable body", "wasmparser refused it")
+    let fail = |e: wasmparser::BinaryReaderError| {
+        d.at("exit validator could not read the function back", e.to_string(), "a parseable body", "wasmparser refused it")
     };
     let fb = wasmparser::FunctionBody::new(wasmparser::BinaryReader::new(body, 0));
-    let mut reader = fb.get_operators_reader().map_err(|e| parse_fail(e.to_string()))?;
+    let mut reader = fb.get_operators_reader().map_err(fail)?;
     let mut ops: Vec<(usize, Op)> = Vec::new();
     let mut depth: u32 = 0;
     while !reader.eof() {
-        let (op, off) = reader.read_with_offset().map_err(|e| parse_fail(e.to_string()))?;
+        let (op, off) = reader.read_with_offset().map_err(fail)?;
         use wasmparser::Operator as W;
         let kind = match op {
             W::LocalGet { local_index } => Op::LocalGet(local_index),
@@ -241,18 +235,111 @@ pub(crate) fn validate_exits(
                 depth += 1;
                 Op::Other
             }
+            W::End if depth == 0 => Op::FnEnd,
             W::End => {
-                if depth == 0 {
-                    Op::FnEnd
-                } else {
-                    depth -= 1;
-                    Op::Other
-                }
+                depth -= 1;
+                Op::Other
             }
             _ => Op::Other,
         };
         ops.push((off as usize, kind));
     }
+    Ok(ops)
+}
+
+/// One exit window: from `start` to the first transfer not inside an
+/// already-claimed (nested) window. Returns the locals decremented in it
+/// and the transfer's (op index, kind).
+fn scan_window(
+    ops: &[(usize, Op)],
+    start: usize,
+    claimed: &[(usize, usize)],
+    cont_name: &str,
+    d: &Defects<'_>,
+) -> Result<(Vec<u32>, usize, Op), EmitError> {
+    let Some(first) = ops.iter().position(|&(off, _)| off >= start) else {
+        return Err(d.at("an exit plan has no instructions after it", cont_name.to_string(), "releases and a transfer", "end of function"));
+    };
+    let mut decs: Vec<u32> = Vec::new();
+    let mut j = first;
+    while j < ops.len() {
+        let (off, kind) = ops[j];
+        if let Some(&(_, e)) = claimed.iter().find(|&&(s, e)| off >= s && off <= e) {
+            j = ops.iter().position(|&(o, _)| o > e).unwrap_or(ops.len());
+            continue;
+        }
+        match kind {
+            Op::Call(F_DEC_FLAT) => match (j > first).then(|| ops[j - 1].1) {
+                Some(Op::LocalGet(i)) => decs.push(i),
+                _ => {
+                    return Err(d.at(
+                        "a release in an exit window names no local",
+                        cont_name.to_string(),
+                        "local.get <credit>; call $dec_flat",
+                        "call $dec_flat with another operand",
+                    ))
+                }
+            },
+            Op::Return | Op::ReturnCall | Op::FnEnd => return Ok((decs, j, kind)),
+            _ => {}
+        }
+        j += 1;
+    }
+    Err(d.at("an exit plan reaches no transfer", cont_name.to_string(), "return / return_call / end", "none"))
+}
+
+/// The plan against the window: the transfer instruction, every released
+/// credit decremented, nothing carried or foreign decremented, nothing
+/// outstanding across a returning or frame-replacing edge.
+fn check_window(
+    rec: &ExitRecord,
+    decs: &[u32],
+    got: Op,
+    cont_name: &str,
+    name_of: &dyn Fn(u32) -> String,
+    d: &Defects<'_>,
+) -> Result<(), EmitError> {
+    let cont = rec.plan.continuation;
+    let want = match cont {
+        Continuation::ReturnSuccess => Op::FnEnd,
+        Continuation::ReturnError | Continuation::GuardReturn => Op::Return,
+        Continuation::TailTransfer { .. } => Op::ReturnCall,
+    };
+    if got != want {
+        return Err(d.at("an exit transfers by a different instruction than its plan", cont_name.to_string(), &format!("{want:?}"), &format!("{got:?}")));
+    }
+    if let Some(&idx) = rec.plan.released.iter().find(|i| !decs.contains(i)) {
+        return Err(d.at("an exit leaves a released credit undecremented", name_of(idx), &format!("release before {cont_name}"), "none"));
+    }
+    if let Some(&idx) = decs.iter().find(|i| rec.plan.carried.contains(i)) {
+        return Err(d.at("an exit releases a credit its plan carries", name_of(idx), &format!("carried across {cont_name}"), "released"));
+    }
+    if let Some(&idx) = decs.iter().find(|i| !rec.plan.released.contains(i)) {
+        return Err(d.at("an exit releases a value outside its plan", name_of(idx), "no release (not a frame credit at this edge)", "released"));
+    }
+    let replaces = !matches!(cont, Continuation::TailTransfer { replaces_frame: false });
+    if replaces && let Some(&idx) = rec.plan.carried.iter().next() {
+        return Err(d.at("tail exit leaves an ownership credit outstanding", name_of(idx), "transfer or release before tail transfer", "neither"));
+    }
+    Ok(())
+}
+
+/// E083 (#1996): read the function's bytes BACK and check that every exit
+/// window — from the plan's first release to the transfer instruction —
+/// implements the plan. Independent of the writer: it parses wasm, not the
+/// emitter's intent. A mismatch is a compiler defect with its own
+/// diagnostic, never a wall.
+pub(crate) fn validate_exits(
+    f: &wasm_encoder::Function,
+    ledger: &[ExitRecord],
+    function: &str,
+    name_of: impl Fn(u32) -> String,
+) -> Result<(), EmitError> {
+    if ledger.is_empty() {
+        return Ok(());
+    }
+    let d = Defects { function };
+    let ops = read_ops(f, &d)?;
     // Windows may nest (an early exit lowered inside a later-started
     // exit's value): claim from the LATEST start backwards, and skip the
     // ranges already claimed.
@@ -261,105 +348,15 @@ pub(crate) fn validate_exits(
     let mut claimed: Vec<(usize, usize)> = Vec::new();
     for k in order {
         let rec = &ledger[k];
-        let cont = rec.plan.continuation;
-        let cont_name = match cont {
+        let cont_name = match rec.plan.continuation {
             Continuation::ReturnSuccess => "the epilogue return",
             Continuation::ReturnError => "the error return",
             Continuation::GuardReturn => "the guard return",
             Continuation::TailTransfer { .. } => "the tail transfer",
         };
-        let Some(first) = ops.iter().position(|&(off, _)| off >= rec.start) else {
-            return Err(defect(
-                "an exit plan has no instructions after it",
-                cont_name.to_string(),
-                "releases and a transfer",
-                "end of function",
-            ));
-        };
-        let mut decs: Vec<u32> = Vec::new();
-        let mut terminator: Option<(usize, Op)> = None;
-        let mut j = first;
-        while j < ops.len() {
-            let (off, kind) = ops[j];
-            if let Some(&(_, e)) = claimed.iter().find(|&&(s, e)| off >= s && off <= e) {
-                // Inside a nested exit's window: jump past it.
-                j = ops.iter().position(|&(o, _)| o > e).unwrap_or(ops.len());
-                continue;
-            }
-            match kind {
-                Op::Call(F_DEC_FLAT) => match (j > first).then(|| ops[j - 1].1) {
-                    Some(Op::LocalGet(i)) => decs.push(i),
-                    _ => {
-                        return Err(defect(
-                            "a release in an exit window names no local",
-                            cont_name.to_string(),
-                            "local.get <credit>; call $dec_flat",
-                            "call $dec_flat with another operand",
-                        ))
-                    }
-                },
-                Op::Return | Op::ReturnCall | Op::FnEnd => {
-                    terminator = Some((j, kind));
-                    break;
-                }
-                _ => {}
-            }
-            j += 1;
-        }
-        let Some((tj, tk)) = terminator else {
-            return Err(defect("an exit plan reaches no transfer", cont_name.to_string(), "return / return_call / end", "none"));
-        };
+        let (decs, tj, tk) = scan_window(&ops, rec.start, &claimed, cont_name, &d)?;
         claimed.push((rec.start, ops[tj].0));
-        let want = match cont {
-            Continuation::ReturnSuccess => Op::FnEnd,
-            Continuation::ReturnError | Continuation::GuardReturn => Op::Return,
-            Continuation::TailTransfer { .. } => Op::ReturnCall,
-        };
-        if tk != want {
-            return Err(defect(
-                "an exit transfers by a different instruction than its plan",
-                cont_name.to_string(),
-                &format!("{want:?}"),
-                &format!("{tk:?}"),
-            ));
-        }
-        for &idx in &rec.plan.released {
-            if !decs.contains(&idx) {
-                return Err(defect(
-                    "an exit leaves a released credit undecremented",
-                    name_of(idx),
-                    &format!("release before {cont_name}"),
-                    "none",
-                ));
-            }
-        }
-        for &idx in &decs {
-            if rec.plan.carried.contains(&idx) {
-                return Err(defect(
-                    "an exit releases a credit its plan carries",
-                    name_of(idx),
-                    &format!("carried across {cont_name}"),
-                    "released",
-                ));
-            }
-            if !rec.plan.released.contains(&idx) {
-                return Err(defect(
-                    "an exit releases a value outside its plan",
-                    name_of(idx),
-                    "no release (not a frame credit at this edge)",
-                    "released",
-                ));
-            }
-        }
-        let replaces = !matches!(cont, Continuation::TailTransfer { replaces_frame: false });
-        if replaces && let Some(&idx) = rec.plan.carried.iter().next() {
-            return Err(defect(
-                "tail exit leaves an ownership credit outstanding",
-                name_of(idx),
-                "transfer or release before tail transfer",
-                "neither",
-            ));
-        }
+        check_window(rec, &decs, tk, cont_name, &name_of, &d)?;
     }
     Ok(())
 }

--- a/crates/almide-wasm/src/func.rs
+++ b/crates/almide-wasm/src/func.rs
@@ -104,6 +104,8 @@ fn emit_modinit_call(em: &mut crate::emitter::Emitter<'_>, il: &crate::InitLet, 
 /// How one function's body meets its wasm signature.
 #[derive(Clone)]
 pub(crate) struct FnPlan {
+    /// Qualified name, for the E083 diagnostic.
+    pub(crate) name: String,
     pub(crate) ret: Option<SliceTy>,
     /// The module this function belongs to (None = entry program).
     pub(crate) cur_module: Option<String>,
@@ -154,7 +156,13 @@ pub(crate) fn lower_fn(
         var_space,
         witness_name,
         self_index,
+        name: fn_name,
     } = plan;
+    // E083 (#1996): the exit ledger emit_exit records, and the names the
+    // diagnostic speaks — taken out of the emitter before its scope ends,
+    // validated against the bytes after the final `end`.
+    let exit_ledger: Vec<crate::exit_plan::ExitRecord>;
+    let mut local_names: HashMap<u32, String> = HashMap::new();
     let cur_module = cur_module.as_deref();
     let env_shift: u32 = u32::from(env_captures.is_some());
     let mut locals: HashMap<VarId, (u32, SliceTy)> = HashMap::new();
@@ -275,6 +283,7 @@ pub(crate) fn lower_fn(
             rc_owned: std::collections::BTreeSet::new(),
             owned_call_marks: Default::default(),
             borrowed_temps: Vec::new(),
+            exit_ledger: Vec::new(),
             borrow_base,
             table: ctx.table,
             types: ctx.types,
@@ -455,6 +464,12 @@ pub(crate) fn lower_fn(
         if let (Some(w), Some(name)) = (em.witness.take(), &witness_name) {
             crate::witness::push(name, w.certificate());
         }
+        exit_ledger = std::mem::take(&mut em.exit_ledger);
+        for (id, &(idx, _)) in em.locals.iter() {
+            if let Some(n) = (ctx.var_name)(var_space, *id) {
+                local_names.insert(idx, n);
+            }
+        }
         // Hold-balance invariant: every arm releases exactly what it
         // held. An over-release WRAPS the u32 depth and poisons every
         // later hold as a fake depth failure (string.get held 4, released
@@ -468,6 +483,9 @@ pub(crate) fn lower_fn(
         }
     }
     f.instructions().end();
+    crate::exit_plan::validate_exits(&f, &exit_ledger, &fn_name, |idx| {
+        local_names.get(&idx).map_or_else(|| format!("local #{idx}"), |n| format!("local `{n}`"))
+    })?;
     Ok((f, calls))
 }
 

--- a/crates/almide-wasm/src/lib.rs
+++ b/crates/almide-wasm/src/lib.rs
@@ -57,6 +57,32 @@ pub enum EmitError {
     /// This IR shape is outside the current slice. The reason string feeds
     /// the burn-up histogram — precise, greppable, shrink-only.
     Unsupported(String),
+    /// E083 (#1996): the emitted exit operations of a function do not
+    /// implement its checked ExitPlan. A COMPILER defect — never a wall
+    /// (the build must not reroute a valid program around an ownership
+    /// bug), never a source error (the text says so).
+    OwnershipLowering(OwnDefect),
+}
+
+/// One E-OWN-LOWERING finding (exit_plan.rs `validate_exits`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnDefect {
+    pub headline: String,
+    pub function: String,
+    pub value: String,
+    pub expected: String,
+    pub emitted: String,
+}
+
+impl std::fmt::Display for OwnDefect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "error[E083]: {}", self.headline)?;
+        writeln!(f, "  --> fn `{}`", self.function)?;
+        writeln!(f, "   = value: {}", self.value)?;
+        writeln!(f, "   = expected: {}", self.expected)?;
+        writeln!(f, "   = emitted: {}", self.emitted)?;
+        write!(f, "   = compiler contract failure; no artifact emitted (run `almide explain E083`)")
+    }
 }
 
 fn unsup<T>(what: &str) -> Result<T, EmitError> {
@@ -130,6 +156,7 @@ mod arg_temps;
 mod arm;
 pub(crate) use arm::{ArgMode, ArmResult, Lowered, Own};
 mod exit_plan;
+pub use exit_plan::test_omit_first_release;
 mod fuel;
 mod ranges;
 mod rc_ownership;
@@ -512,6 +539,9 @@ pub(crate) struct Ctx<'a> {
     /// (global index, slice type). Functions read them across function
     /// boundaries — the class main-local top-lets could never serve.
     pub(crate) globals: &'a HashMap<GVar, (u32, SliceTy)>,
+    /// Source name of a variable, by (var space, VarId) — for the E083
+    /// diagnostic (`value: local \`x\``). None for synthetic vars.
+    pub(crate) var_name: &'a dyn Fn(u32, VarId) -> Option<String>,
 }
 
 /// Function-VALUE work discovered during lowering: funcref-table entries

--- a/crates/almide-wasm/tests/backend_parity.rs
+++ b/crates/almide-wasm/tests/backend_parity.rs
@@ -77,6 +77,8 @@ fn corpus_burn_up() {
             Err(almide_wasm::EmitError::Unsupported(reason)) => {
                 *unsupported.entry(reason).or_default() += 1;
             }
+            // E083 is a compiler defect, not a wall: the burn-up fails on it.
+            Err(almide_wasm::EmitError::OwnershipLowering(d)) => panic!("{d}"),
         }
     }
 

--- a/crates/almide-wasm/tests/exit_validation.rs
+++ b/crates/almide-wasm/tests/exit_validation.rs
@@ -1,0 +1,43 @@
+//! E083 (#1996): the build validates each function's emitted exit
+//! operations against its checked ExitPlan, and a mismatch is a compiler
+//! defect with its own diagnostic — never a wall, never a source error.
+//!
+//! The negative half uses the emitter's test hook `test_omit_first_release`
+//! (exit_plan.rs `emit_exit` skips the first release of every plan): the
+//! validator must then name the local whose release is missing. Both halves
+//! run in ONE test so the process-wide switch cannot race a sibling.
+
+const SRC: &str = r#"fn helper(n: Int) -> Int = {
+  let xs = [n, n, n]
+  list.len(xs)
+}
+
+fn main() -> Unit = println("${helper(3)}")
+"#;
+
+fn emit() -> Result<Vec<u8>, almide_wasm::EmitError> {
+    let ir = almide_spine::s5::lower_to_ir("exit_validation.almd", SRC).expect("front");
+    almide_wasm::emit_program(&ir)
+}
+
+#[test]
+fn an_exit_that_skips_a_planned_release_is_a_compiler_defect_named_by_local() {
+    // Positive control: the honest emitter passes its own validator.
+    emit().expect("the unmutated emitter implements every plan");
+
+    almide_wasm::test_omit_first_release(true);
+    let res = emit();
+    almide_wasm::test_omit_first_release(false);
+    let Err(almide_wasm::EmitError::OwnershipLowering(d)) = res else {
+        panic!("a skipped release must be an E083 defect, got {res:?}");
+    };
+    let text = d.to_string();
+    assert!(text.starts_with("error[E083]: an exit leaves a released credit undecremented"), "{text}");
+    assert!(text.contains("--> fn `helper`"), "{text}");
+    assert!(text.contains("= value: local `xs`"), "{text}");
+    assert!(text.contains("= expected: release before the epilogue return"), "{text}");
+    assert!(text.contains("= emitted: none"), "{text}");
+    assert!(text.contains("compiler contract failure; no artifact emitted"), "{text}");
+    // Never a wall: the reason text must not read like an Unsupported shape.
+    assert!(!text.contains("wall"), "{text}");
+}

--- a/crates/almide-wasm/tests/fuzz_differential.rs
+++ b/crates/almide-wasm/tests/fuzz_differential.rs
@@ -663,6 +663,8 @@ fn run_seed(seed: u64, tally: &mut Tally) -> Result<(), String> {
     };
     let bytes = match almide_wasm::emit_program(&ir) {
         Ok(b) => b,
+        // E083 is a compiler defect, not a refusal: a finding, loudly.
+        Err(almide_wasm::EmitError::OwnershipLowering(d)) => panic!("{d}"),
         Err(almide_wasm::EmitError::Unsupported(_)) => {
             tally.emit_refused += 1;
             return Ok(());

--- a/crates/almide-wasm/tests/gauntlet.rs
+++ b/crates/almide-wasm/tests/gauntlet.rs
@@ -86,6 +86,8 @@ fn verdict(entry: &Path) -> String {
             format!("run\texit={} sha256={h}", run.exit)
         }
         Err(almide_wasm::EmitError::Unsupported(r)) => format!("wall\t{r}"),
+        // E083 is a compiler defect, not a wall: it must never enter the ledger.
+        Err(almide_wasm::EmitError::OwnershipLowering(d)) => panic!("{d}"),
     }
 }
 

--- a/docs/contracts/proven-vs-trusted.md
+++ b/docs/contracts/proven-vs-trusted.md
@@ -169,6 +169,7 @@ from its body on a bare-parameter tail) — the gate bites.
 | `proofs/output-parity.sh` | native and wasm agree, for the baseline set | anything outside that set |
 | `scripts/check-contracts.sh` | every observable cross-target promise has executable evidence | that the promise is the right one |
 | the cross-target fuzz | no divergence found in N programs | no divergence exists |
+| the E083 exit validator (`exit_plan.rs`, #1996) | every function's emitted exit windows implement its checked ExitPlan — each released credit decremented there, nothing carried or foreign decremented, the transfer instruction the plan names, no credit outstanding across a frame-replacing edge — read back from the wasm bytes, or the build stops with a compiler-defect diagnostic (never a wall, never a reroute) | that the plan's CONTENT is right (that is the credit harness and the witness); anything downstream of the bytes (wasmtime, the host) |
 | the kernel-conformance pin (C-280) | the compiled family's observables equal the kernel-checked λ_almd trace, on both targets; the generated corpus matches the compiled evaluator's traces | that every almide program refines the kernel — only the fragment's image is pinned; corpus `.expected` values are evaluator-pinned (compiled Lean), not kernel-checked |
 
 Reproduce all of it: `make verify-trust`.

--- a/docs/diagnostics/E083.md
+++ b/docs/diagnostics/E083.md
@@ -1,0 +1,37 @@
+# E083 — compiler ownership defect: an emitted exit does not implement its checked ExitPlan
+
+`--target wasm`'s structural leg decides every way a function frame ends in
+ONE place — the checked `ExitPlan` (#1995): which reference-count credits
+the edge releases and which it carries on. After a function is emitted the
+build reads its bytes back and checks each exit window against that plan
+(#1996). E083 means the bytes did not implement the plan:
+
+- a released credit has no decrement before the transfer,
+- a carried credit was decremented, or a value outside the plan was,
+- the transfer is a different instruction than the plan's continuation,
+- a frame-replacing tail transfer (or a return) leaves a credit outstanding.
+
+```text
+error[E083]: tail exit leaves an ownership credit outstanding
+  --> fn `helper`
+   = value: local `x`
+   = expected: transfer or release before tail transfer
+   = emitted: neither
+   = compiler contract failure; no artifact emitted (run `almide explain E083`)
+```
+
+**This is a defect in the compiler, not in your program.** A valid source
+that exposes it is valid. The build does NOT reroute around it (the
+incumbent leg would ship a program the checked plan says leaks), and it
+never asks you to rewrite the program into a shape the emitter happens to
+handle. Report it with the program: the function named is where the
+emitter's release bookkeeping and its bytes disagree.
+
+The same program always builds with `--target rust`.
+
+## Fix-it verdict
+
+**not-fixable** — there is no source rewrite to apply; the fix is in the
+compiler (`crates/almide-wasm/src/exit_plan.rs`). (`mechanical` = an
+unattended fixer may apply the rewrite; `conditional` = a suggested fix
+needs a human; `not-fixable` = no rewrite exists.)

--- a/scripts/check-diagnostic-code-coverage.sh
+++ b/scripts/check-diagnostic-code-coverage.sh
@@ -30,7 +30,11 @@ cd "$ROOT"
 # tests/wasm_availability_e081_test.rs (the E054 precedent).
 # E082 (#1922) is the both-legs wasm wall, same path and same precedent —
 # pinned by tests/wasm_both_legs_e082_test.rs.
-EXEMPT="E054 E081 E082"
+# E083 (#1996) is the wasm emitter's own contract failure (an exit that does
+# not implement its checked ExitPlan) — no source program triggers it; pinned
+# by crates/almide-wasm/tests/exit_validation.rs through the emit-time
+# negative hook `almide_wasm::test_omit_first_release`.
+EXEMPT="E054 E081 E082 E083"
 
 fail=0
 total=0

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -966,6 +966,13 @@ fn render_wasm_module_routed(
             Ok((bytes, true, host_ops.iter().copied().collect()))
         }
         Err(almide_wasm::EmitError::Unsupported(reason)) => reroute(&reason),
+        // E083 (#1996): a compiler ownership defect is NOT rerouted around —
+        // the incumbent would ship a program the checked plan says leaks,
+        // and the message must never tell the writer to change valid code.
+        Err(almide_wasm::EmitError::OwnershipLowering(d)) => {
+            err(&d.to_string());
+            Err(())
+        }
     }
 }
 


### PR DESCRIPTION
Closes #1996 (step 3 of the contract-relative survival arc #1998, ratified 2026-09-07).

Stacked on #2007 (base `fix-2004-arg-temporaries`); the stack is #1992 → #1993 → #2000 → #1999 → #2003 → #2006 → #2007 → this. Retarget to `develop` as the stack lands.

**The build reads every function's bytes back and checks each exit window against its checked ExitPlan; a mismatch is a compiler defect with its own diagnostic, never a wall.**

- `emit_exit` (the one writer of releases, #1995) now also RECORDS: the plan and the function-body byte offset its releases start at (`ExitRecord`, `exit_ledger`). After the function's final `end`, `validate_exits` (`crates/almide-wasm/src/exit_plan.rs`) re-encodes the body, parses it with wasmparser, and for every record — latest start first, so a nested early exit claims its own window — checks: each released credit is `local.get; call $dec_flat`'d in the window; nothing the plan carries is; nothing outside the plan is; the transfer is the instruction the continuation names (`end` / `return` / `return_call*`); and a returning or frame-replacing edge leaves no credit outstanding (the issue's own example: `tail exit leaves an ownership credit outstanding`). It validates wasm, not the emitter's intent.
- `EmitError::OwnershipLowering(OwnDefect)` is a new variant. The CLI (`--target wasm`) prints it as `error[E083]` and stops — it does NOT reroute to the incumbent leg (that would ship a program the checked plan says leaks) — and the text says "compiler contract failure" and never asks the writer to change a valid program. `lower_fn`'s callers treat it as fatal for the whole program (a leak in an unreachable function is still a defect); the gauntlet / burn-up / fuzz harnesses panic on it rather than counting it as a wall.
- `docs/diagnostics/E083.md` (`almide explain E083`, embedded like every code) with the fix-it verdict `not-fixable`; the diagnostic-coverage gate exempts it beside E081/E082 (no source program can trigger it) and names its pin.
- **Negative evidence.** `tests/exit_validation.rs`: the honest emitter passes; with the emitter's test switch `test_omit_first_release` the validator names `fn helper` / `local xs` / `expected: release before the epilogue return` / `emitted: none`. Mutant `ci/mutations/043-exit-release-dropped.patch` (every exit release dropped) is killed by the validator on the first function. `docs/contracts/proven-vs-trusted.md` carries the validator's claim and non-claim row.

**Evidence.** Full sweep green (whole `almide-wasm` crate with ledgers regenerated, `almide test spec/`, `almide-spine`, the explain-docs and E081 root tests, the diagnostic-coverage gate); the validator ran over every function of the corpus with zero findings — which is the standing evidence that #1995's plans and #2007's exits agree byte for byte.
