### PR TITLE
string.split_once and datetime.parse_iso are served by the structural leg, closing two pending-self-host rows

### DIFF
--- a/crates/almide-wasm/src/calls.rs
+++ b/crates/almide-wasm/src/calls.rs
@@ -394,6 +394,14 @@ impl Emitter<'_> {
                 // value.* surface, which THIS emitter lowers natively —
                 // the whole body is layout-consistent by construction.
                 "json_parse",
+                // (String, String) -> (String, String)?: byte-level find
+                // over the source payload, LEN read on STRING blocks only
+                // (digest-shared), two fresh alloc_str buffers, the pair
+                // and the option built by constructors (#1423 stage 4).
+                "string_split_once",
+                // (String) -> DateTime!: no prim access at all — language-
+                // level slicing and int parsing, Result via ok()/err().
+                "datetime_parse_iso",
             ];
             if !VERIFIED.contains(&impl_fn)
                 && !VERIFIED_SUM_BUILDERS.contains(&impl_fn)

--- a/proofs/target-availability.toml
+++ b/proofs/target-availability.toml
@@ -58,7 +58,7 @@ schema = 2
 # linked-impl whitelist, split and lines get native arms (their self-host
 # twins write the incumbent's 8-byte List slot stride raw), and the
 # i2f32 prim converts i64 -> f32 directly (single rounding).
-pending_self_host_ceiling = 36
+pending_self_host_ceiling = 34
 
 # The unprobed class (#1827), per leg. Today: the five HttpRequest
 # accessors (http.query_params / req_body / req_header / req_method /
@@ -88,11 +88,6 @@ legs = ["structural"]
 reason = "host-surface"
 issue = "#1827"
 
-[[unavailable]]
-fn = "datetime.parse_iso"
-legs = ["structural"]
-reason = "pending-self-host"
-issue = "#1423"
 
 [[unavailable]]
 fn = "env.millis"
@@ -828,11 +823,6 @@ legs = ["structural"]
 reason = "structural-leg-gap: the structural leg declines the self-host body's hole expression (expr:Hole); the incumbent serves it"
 issue = "#1827"
 
-[[unavailable]]
-fn = "string.split_once"
-legs = ["structural"]
-reason = "pending-self-host"
-issue = "#1827"
 
 [[unavailable]]
 fn = "testing.assert_approx"


### PR DESCRIPTION
Refs #1423 (stage 4: pending-self-host rows close one at a time, each with its own parity evidence).

Stacked on #2011; retarget to `develop` as the stack lands.

Two self-host impls join the structural leg's resolvable set (`resolve_qualified`, `VERIFIED_SUM_BUILDERS`), audited against the admission rule the list documents — no raw LIST header read, since LEN is bytes here and an element count on the incumbent:

- `string_split_once` — byte-level find over the source payload, LEN read on STRING blocks only (digest-shared), two fresh `alloc_str` buffers, the pair and the option built by constructors.
- `datetime_parse_iso` — no prim access at all: language-level slicing and int parsing, `Result` via `ok()` / `err()`.

Evidence: a 12-case probe (found / absent / empty separator / empty source / multibyte separator / overlapping / longer-than-source; ISO with and without time, garbage, out-of-range fields) prints byte-identical on native and the forced structural leg (`ALMIDE_WASM_STRUCTURAL=1`); `spec/stdlib/string_split_once_test.almd` and `spec/stdlib/datetime_test.almd` now run through the wasm leg. `proofs/target-availability.toml`: the two `[[unavailable]]` rows retired, `pending_self_host_ceiling` 36 → 34 (the ratchet only shrinks); `scripts/check-target-availability.sh` re-measured green.

Not admitted, on purpose: `list_partition` (reads the list LEN as a count and writes packed counts back) and the `matrix_core` family (LEN as a row count, and `prim.alloc_list_str`, which the structural prim has no arm for). Closing stage 4 needs a layout-independent element-count prim lowered per leg; that is the next step on the issue, not a per-row admission.
