### PR TITLE
A callback lambda inside a map literal lowers on the structural leg: the local-collection walk gains its MapLiteral arm

### DIFF
--- a/crates/almide-wasm/src/collect.rs
+++ b/crates/almide-wasm/src/collect.rs
@@ -103,6 +103,17 @@ pub(crate) fn collect_binds_data(
             }
             Ok(())
         }
+        // A map literal's keys and values are expressions like a list's
+        // elements: a callback lambda inside one (`["k": (if list.all(xs,
+        // (x) => …) then …)]`) needs its params as locals too — the
+        // `bind:unmapped` wall the 2026-09-08 campaign dumped (#1423).
+        IrExprKind::MapLiteral { entries } => {
+            for (k, v) in entries {
+                collect_binds(k, out, seen, types)?;
+                collect_binds(v, out, seen, types)?;
+            }
+            Ok(())
+        }
         IrExprKind::TupleIndex { object, .. } => collect_binds(object, out, seen, types),
         // Lambda params become locals (used when the lambda is inlined as
         // a direct HOF callback; harmless extras otherwise).

--- a/crates/almide-wasm/tests/map_literal_callback.rs
+++ b/crates/almide-wasm/tests/map_literal_callback.rs
@@ -1,0 +1,26 @@
+//! #1423 stage 5 (the 2026-09-08 campaign's `bind:unmapped` walls): a
+//! callback lambda inside a MAP LITERAL's key or value — `["k": (if
+//! list.all(xs, (x) => …) then … else …)]` — is inlined by the HOF arm
+//! like any other, so its params must be collected as locals. The
+//! collection walk had no `MapLiteral` arm; every such program walled the
+//! structural leg and then hit the incumbent's unlinked typed twins.
+
+mod harness;
+use harness::run_wasm;
+
+const SRC: &str = r#"fn main() -> Unit = {
+  let xs: List[Bool] = [true, false]
+  let m: Map[String, Int] = ["k0": (if list.all(xs, (x) => x) then 10 else 1), "k1": list.count([1, 2, 3], (n) => n > 1)]
+  let keyed: Map[String, Int] = [(if list.any(xs, (x) => x) then "yes" else "no"): 7]
+  println("${map.get_or(m, "k0", -1)} ${map.get_or(m, "k1", -1)} ${map.get_or(keyed, "yes", -1)}")
+}
+"#;
+
+#[test]
+fn a_callback_inside_a_map_literal_lowers_on_the_structural_leg() {
+    let ir = almide_spine::s5::lower_to_ir("map_literal_callback.almd", SRC).expect("front");
+    let bytes = almide_wasm::emit_program(&ir).expect("the structural leg lowers a map literal's callbacks");
+    let out = run_wasm(&bytes).expect("run");
+    assert_eq!(out.exit, 0, "{}", out.stderr);
+    assert_eq!(out.stdout.trim(), "1 2 7");
+}


### PR DESCRIPTION
Refs #1423 (stage 5: the campaign's "walled but declared available" class).

The 2026-09-08 local campaign dumped four walled programs; every one reduced to the same shape: a callback lambda inside a MAP LITERAL's key or value (`["k0": (if list.all(xs, (x) => …) then … else …)]`). The HOF arm inlines the callback, so its params must be locals — but `collect_binds_data` had no `MapLiteral` arm, the params were never collected, and the bind walled as `bind:unmapped`; the program then fell to the incumbent, whose typed twins (`list.zip_with_x`, `list.drop_while_heapelem`, `list.scan_x`, `result.flatten_x`) are unlinked — the four "unlinked stdlib/runtime call" wall reasons of the campaign, all one defect.

Evidence: the four dumped programs print identically on native and the forced structural leg; `tests/map_literal_callback.rs` pins key- and value-position callbacks; corpus burn-up green; `almide test spec/wasm_cross/` green.