### PR TITLE
value.object retains the pairs spine the Value keeps, instead of borrowing it

### DIFF
--- a/crates/almide-wasm/src/value.rs
+++ b/crates/almide-wasm/src/value.rs
@@ -84,7 +84,12 @@ impl Emitter<'_> {
             // insertion order IS the block, exactly the interp's ordered
             // object model.
             ("object", [pairs]) => {
-                let got = self.lower_arg(pairs, None, ArgMode::Borrow)?;
+                // The Value KEEPS the pairs spine (its entries are read
+                // through it forever): retained, like `array`'s elements.
+                // Declared Borrow, a born-here literal was released under
+                // the object the moment list spines became droppable
+                // (`{"":null}` across the codec family, #2010 stage 2).
+                let got = self.lower_arg(pairs, None, ArgMode::Retain)?;
                 let SliceTy::List(h) = got else {
                     return Err(EmitError::Unsupported(format!("value.object-of:{got:?}")));
                 };


### PR DESCRIPTION
Refs #2010 (stage 2, the first finding of the spine-sharing audit).

`value.object(pairs)` declared its argument `Borrow` while the Value keeps that list spine and reads its entries through it forever. Today nothing frees a list of tuples, so the borrow was invisible; the moment list spines become droppable (the stage-2 experiment), a born-here pairs literal was released under the object and every codec fixture printed `{"":null}`. With `Retain` — the same declaration `value.array` already carries — all 20 codec fixtures of the experiment are identical again. No observable change on the shipped set; the declaration is now honest, which is what the arm-args discipline is for.