### PR TITLE
The matrix byte loaders zero their cells explicitly instead of trusting fresh memory

### DIFF
--- a/crates/almide-wasm/src/matrix_load.rs
+++ b/crates/almide-wasm/src/matrix_load.rs
@@ -93,6 +93,14 @@ impl Emitter<'_> {
         i.i32_wrap_i64().call(F_ALLOC).local_set(ho);
         i.local_get(ho).local_get(hr).i32_wrap_i64().i32_store(slot_memarg(0));
         i.local_get(ho).local_get(hc).i32_wrap_i64().i32_store(slot_memarg(4));
+        // The cells start ZERO by contract (the OOB→zeros edge of the byte
+        // loaders fills nothing): `$alloc` hands back reused blocks
+        // unzeroed, so the constructor zeroes — the `bytes.new` lesson
+        // (#2004), met again the moment list spines were freed (#2010).
+        i.local_get(ho).i32_const(almide_layout::PAYLOAD as i32 + 8).i32_add();
+        i.i32_const(0);
+        i.local_get(hr).local_get(hc).i64_mul().i64_const(8).i64_mul().i32_wrap_i64();
+        i.memory_fill(0);
         let _ = i;
         Ok(ho)
     }


### PR DESCRIPTION
Refs #2010 (stage 2 audit, second finding) and #1909's OOB→zeros edge.

`matrix.from_bytes_f32_le` / `_f16_le` answer an out-of-range offset with the all-zero matrix by allocating the output and filling nothing — which was correct only while nothing was ever freed. `$alloc` hands back reused blocks unzeroed (the Coq-pinned reuse path), so once list spines are released the "zero" matrix printed subnormal garbage (the stage-2 experiment's last diverging fixture, `matrix_from_bytes_offset_domain`). The constructor now `memory.fill`s its cell region, exactly as `bytes.new` learned to in #2004. No observable change on the shipped set.