### PR TITLE
Fuzz follow-ups on the ownership stack: sum-combinator callback results take their share

### DIFF
--- a/ci/mutations/019-captures-not-stored.patch
+++ b/ci/mutations/019-captures-not-stored.patch
@@ -1,8 +1,8 @@
 diff --git a/crates/almide-wasm/src/emitter_values.rs b/crates/almide-wasm/src/emitter_values.rs
-index 17dedf42b..48c97d417 100644
+index 730bdb293..7c4bc6a71 100644
 --- a/crates/almide-wasm/src/emitter_values.rs
 +++ b/crates/almide-wasm/src/emitter_values.rs
-@@ -122,13 +122,7 @@ impl Emitter<'_> {
+@@ -122,18 +122,7 @@ impl Emitter<'_> {
                          .i32_store(slot_memarg(0));
                      for (v, t, off, is_cell) in &captures {
                          let (idx, _) = self.locals[v];
@@ -11,6 +11,11 @@ index 17dedf42b..48c97d417 100644
 -                            // the local already holds the cell address
 -                            self.f.instructions().i32_store(slot_memarg(*off));
 -                        } else {
+-                            // The env is a holder: a captured handle takes +1
+-                            // (leak-not-dangle until closures drop, #2010) —
+-                            // a tail-called closure returning its capture read
+-                            // the frame's released local (fuzz 20260909).
+-                            self.share_handle_top(*t);
 -                            self.store_ty_slot(*t, *off);
 -                        }
 +                        let _ = (idx, t, off, is_cell); // [MUTANT: captures not stored]

--- a/ci/mutations/020-index-assign-header-write.patch
+++ b/ci/mutations/020-index-assign-header-write.patch
@@ -1,15 +1,15 @@
-diff --git a/crates/almide-wasm/src/stmts.rs b/crates/almide-wasm/src/stmts.rs
-index 4c1adcfae..ad13398cc 100644
---- a/crates/almide-wasm/src/stmts.rs
-+++ b/crates/almide-wasm/src/stmts.rs
-@@ -330,9 +330,7 @@ impl Emitter<'_> {
-                         .i64_const(stride)
-                         .i64_mul()
-                         .i64_add()
--                        .i32_wrap_i64()
--                        .i32_const(almide_layout::PAYLOAD as i32)
--                        .i32_add();
-+                        .i32_wrap_i64();
-                     i.local_get(hv);
-                 }
-                 self.store_ty_slot_raw(el);
+diff --git a/crates/almide-wasm/src/stmts_index.rs b/crates/almide-wasm/src/stmts_index.rs
+index 02ed8c7b4..501570900 100644
+--- a/crates/almide-wasm/src/stmts_index.rs
++++ b/crates/almide-wasm/src/stmts_index.rs
+@@ -25,9 +25,7 @@ impl Emitter<'_> {
+             .i64_const(stride)
+             .i64_mul()
+             .i64_add()
+-            .i32_wrap_i64()
+-            .i32_const(almide_layout::PAYLOAD as i32)
+-            .i32_add();
++            .i32_wrap_i64(); // [MUTANT: header write]
+     }
+ 
+     /// `xs[i] = v` — copy-on-write (split from lower_stmt for the complexity budget).

--- a/ci/mutations/033-field-assign-copy-dropped.patch
+++ b/ci/mutations/033-field-assign-copy-dropped.patch
@@ -1,13 +1,15 @@
 diff --git a/crates/almide-wasm/src/stmts.rs b/crates/almide-wasm/src/stmts.rs
-index 865fb01ec..985238e2b 100644
+index abe6f3302..e99d25854 100644
 --- a/crates/almide-wasm/src/stmts.rs
 +++ b/crates/almide-wasm/src/stmts.rs
-@@ -254,7 +254,7 @@ impl Emitter<'_> {
+@@ -682,8 +682,8 @@ impl Emitter<'_> {
                      Ok(idx) => self.f.instructions().local_get(idx),
                      Err(gidx) => self.f.instructions().global_get(gidx),
                  };
--                self.f.instructions().call(F_BLOCK_COPY).local_tee(hb);
+-                let copy = self.copy_fn_of(SliceTy::Named(ti));
+-                self.f.instructions().call(copy).local_tee(hb);
++                let _ = self.copy_fn_of(SliceTy::Named(ti));
 +                self.f.instructions().local_tee(hb); // [MUTANT: copy dropped]
-                 self.lower(value, Some(fty))?;
-                 self.rc_share_guard(value, fty);
-                 self.store_ty_slot(fty, off);
+                 // The replaced field's credit goes with it (stage 2c-ii).
+                 if let Some(dec) = self.elem_is_handle(fty).then(|| self.dec_fn_of(fty)) {
+                     self.f.instructions().local_get(hb).i32_load(slot_memarg(off)).call(dec);

--- a/ci/mutations/041-cell-bind-alloc-dropped.patch
+++ b/ci/mutations/041-cell-bind-alloc-dropped.patch
@@ -1,9 +1,9 @@
 diff --git a/crates/almide-wasm/src/stmts.rs b/crates/almide-wasm/src/stmts.rs
-index ce2696629..60af7656c 100644
+index abe6f3302..c0213f23e 100644
 --- a/crates/almide-wasm/src/stmts.rs
 +++ b/crates/almide-wasm/src/stmts.rs
-@@ -193,7 +193,7 @@ impl Emitter<'_> {
-         {
+@@ -250,7 +250,7 @@ impl Emitter<'_> {
+         } else if self.rc_droppable(declared) && !self.rc_owned_result(value) {
              self.rc_inc_top();
          }
 -        if self.cells.contains(var) {

--- a/ci/mutations/043-exit-release-dropped.patch
+++ b/ci/mutations/043-exit-release-dropped.patch
@@ -1,11 +1,13 @@
 diff --git a/crates/almide-wasm/src/exit_plan.rs b/crates/almide-wasm/src/exit_plan.rs
+index c60de10cc..28ad8c600 100644
 --- a/crates/almide-wasm/src/exit_plan.rs
 +++ b/crates/almide-wasm/src/exit_plan.rs
-@@ -127,7 +127,7 @@ impl Emitter<'_> {
+@@ -127,8 +127,7 @@ impl Emitter<'_> {
              if omit_first && k == 0 {
                  continue;
              }
--            self.f.instructions().local_get(idx).call(F_DEC_FLAT);
+-            let dec = self.dec_fn_of_local(idx);
+-            self.f.instructions().local_get(idx).call(dec);
 +            let _ = idx; // [MUTANT: exit releases dropped]
          }
          match plan.continuation {

--- a/crates/almide-wasm/src/sums.rs
+++ b/crates/almide-wasm/src/sums.rs
@@ -79,6 +79,9 @@ impl Emitter<'_> {
                 self.load_ty_slot(a, almide_layout::SUM_FIELD);
                 self.f.instructions().local_set(params[0]);
                 self.lower(body, Some(rb))?;
+                // A callback result RETURNED as the arm's value: a view (a captured var,
+                // the input) takes its share so the value is owned on every path.
+                self.rc_share_guard(body, rb);
                 self.f.instructions().end();
                 self.release_i32();
                 Some(Lowered::owned(rb))
@@ -103,6 +106,9 @@ impl Emitter<'_> {
                 self.load_ty_slot(e, almide_layout::SUM_FIELD);
                 self.f.instructions().local_set(params[0]);
                 self.lower(body, Some(a))?;
+                // A callback result RETURNED as the arm's value: a view (a captured var,
+                // the input) takes its share so the value is owned on every path.
+                self.rc_share_guard(body, a);
                 self.f.instructions().else_().local_get(hs);
                 self.load_ty_slot(a, almide_layout::SUM_FIELD);
                 // The payload handed out is a SHARE of the Option's (the
@@ -342,6 +348,9 @@ impl Emitter<'_> {
                 self.f.instructions().local_set(params[0]);
                 let out_ty = if flat {
                     self.lower(body, Some(b))?;
+                    // A callback result RETURNED as the arm's value: a view (a captured var,
+                    // the input) takes its share so the value is owned on every path.
+                    self.rc_share_guard(body, b);
                     b
                 } else {
                     self.f
@@ -401,6 +410,9 @@ impl Emitter<'_> {
                     i.if_(BlockType::Result(a.val_type()));
                 }
                 self.lower(body, Some(a))?;
+                // A callback result RETURNED as the arm's value: a view (a captured var,
+                // the input) takes its share so the value is owned on every path.
+                self.rc_share_guard(body, a);
                 self.f.instructions().else_().local_get(hs);
                 self.load_ty_slot(a, almide_layout::OPTION_FIELD);
                 // The payload handed out is a SHARE of the Option's (the
@@ -424,6 +436,9 @@ impl Emitter<'_> {
                     i.if_(BlockType::Result(ValType::I32));
                 }
                 self.lower(body, Some(got))?;
+                // A callback result RETURNED as the arm's value: a view (a captured var,
+                // the input) takes its share so the value is owned on every path.
+                self.rc_share_guard(body, got);
                 self.f.instructions().else_().local_get(hs).end();
                 self.release_i32();
                 // `some` hands the INPUT back: retained in, owned out (see result.map).


### PR DESCRIPTION
Stacked on #2022. Fuzz (seed 20260914, trap armed) found `result.flat_map(r, (x) => captured)`: the callback's result is RETURNED as the arm's owned value, and a view (a captured var, the input) was handed out without a share — the five sum-combinator sites (result.flat_map, result/option.unwrap_or_else fallbacks, option.map, option.or_else) now share it. Corpus + gauntlet green under the trap.