### PR TITLE
Refresh the cow-skipped mutant for the typed cow helper site

### DIFF
--- a/ci/mutations/004-list-bind-copy-skipped.patch
+++ b/ci/mutations/004-list-bind-copy-skipped.patch
@@ -1,12 +1,14 @@
 diff --git a/crates/almide-wasm/src/emitter_vars.rs b/crates/almide-wasm/src/emitter_vars.rs
-index f87957dc7..b7b0d4c86 100644
+index d95d31b18..1e7f1fa6f 100644
 --- a/crates/almide-wasm/src/emitter_vars.rs
 +++ b/crates/almide-wasm/src/emitter_vars.rs
-@@ -68,7 +68,7 @@ impl Emitter<'_> {
+@@ -68,8 +68,8 @@ impl Emitter<'_> {
              && (global || idx >= self.rc_param_ceiling)
          {
              let scr = self.scr_i32_local;
--            self.f.instructions().call(F_COW).local_set(scr);
+-            let cow = self.cow_fn_of(ty);
+-            self.f.instructions().call(cow).local_set(scr);
++            let _ = self.cow_fn_of(ty);
 +            self.f.instructions().local_set(scr); // [MUTANT: cow skipped]
              self.f.instructions().local_get(scr);
              self.emit_store_mut_var(*id, idx, ty, global)?;


### PR DESCRIPTION
The full mutation sweep on develop (shard 3/4) reported `004-list-bind-copy-skipped.patch no longer applies`: the site moved from `call(F_COW)` to the typed `cow_fn_of(ty)` helper under #2022. Refreshed against the current emitter_vars.rs; `ALMIDE_MUTATION_SCOPE=incremental ALMIDE_MUTATION_BASE=HEAD~1 bash scripts/check-mutation-gate.sh` → `ok: 004-list-bind-copy-skipped.patch caught (by backend_parity)`.