### PR TITLE
Seal the v0.62.0 release evidence, refresh the ledger counts, and retitle C-023

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ The guarantee is **continuous, with an explicit, ledger-managed scope**: "byte-i
 This claim is not prose. Every observable promise is a named contract in the [behavior-contract ledger](docs/contracts/), each traceable to executable evidence, and the numbers below are regenerated from the ledger (`scripts/gen-claims.sh`, enforced by `scripts/check-contracts.sh` in CI):
 
 <!-- claims:generated:start — derived from docs/contracts/contracts.toml by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
-> <!-- counts:generated:start (as of 2026-09-06) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
-> **Ledger: 342 contracts — 342 active, 0 flagged-for-revision.**
+> <!-- counts:generated:start (as of 2026-09-08) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
+> **Ledger: 347 contracts — 347 active, 0 flagged-for-revision.**
 > <!-- counts:generated:end -->
 >
 > **Divergences awaiting a fix: none.** Every contract in the ledger is
@@ -232,11 +232,11 @@ The Perceus proof above proves one compiler pass, once. v1 generalizes that prin
 | Playground | [Live](https://almide.github.io/playground/) — the compiler runs as WASM in the browser |
 
 <!-- stats:generated:start — derived from docs/stdlib/*.md, spec/, and docs/contracts/contracts.toml by scripts/gen-readme-stats.sh; DO NOT EDIT between the markers -->
-<!-- counts:generated:start (as of 2026-09-06) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
+<!-- counts:generated:start (as of 2026-09-08) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
 | Derived count | Value |
 |---|---|
 | Stdlib | 985 functions across 43 modules — self-hosted `.almd`, signature indexes regenerated from the compiler by `tools/gen-stdlib-doc-index.py` |
-| Tests | 433 `.almd` test files under `spec/` (`almide test spec/`) + the 342-contract cross-target ledger |
+| Tests | 436 `.almd` test files under `spec/` (`almide test spec/`) + the 347-contract cross-target ledger |
 <!-- counts:generated:end -->
 <!-- stats:generated:end -->
 

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -30,8 +30,8 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 `fixture` < `fuzz` < `exhaustive` < `lean`. An **active** contract must carry
 ≥1 evidence of class ≥ `fixture`.
 
-<!-- counts:generated:start (as of 2026-09-06) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
-342 contracts
+<!-- counts:generated:start (as of 2026-09-08) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
+347 contracts
 <!-- counts:generated:end -->
 
 | ID | Contract | Since | Status | Strongest Evidence | # Fixtures |

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -58,7 +58,7 @@ Evidence classes (weakest → strongest): `doc-only` < `by-construction` <
 | C-020 | Unicode case transforms (to_upper/to_lower/capitalize) are full-Unicode | 0.24.0 | active | fixture | 1 |
 | C-021 | Whitespace trim / is_whitespace use the full Unicode White_Space property | 0.24.0 | active | fixture | 1 |
 | C-022 | string.from_bytes is UTF-8-lossy decode (inverse of to_bytes) | 0.24.0 | active | fixture | 1 |
-| C-023 | float.to_string is shortest round-tripping decimal (Dragon4) | 0.24.0 | active | fixture | 2 |
+| C-023 | float.to_string is shortest round-tripping decimal, byte-equal to Rust Display | 0.24.0 | active | fixture | 2 |
 | C-024 | float.parse is correctly-rounded round-to-nearest-even (Clinger AlgorithmM) | 0.24.0 | active | fixture | 1 |
 | C-025 | float.to_fixed is round-half-to-even on the exact binary value | 0.24.0 | active | fuzz(1000) | 1 |
 | C-026 | Vendored-libm trig / exp / log / pow are byte-identical cross-target | 0.24.0 | active | fuzz(4000) | 3 |

--- a/docs/contracts/conformance.md
+++ b/docs/contracts/conformance.md
@@ -14,8 +14,8 @@
 > block) and refreshed only by `bash scripts/gen-ledger-counts.sh` — a fixture
 > PR regenerates the rows and leaves it alone.
 
-<!-- counts:generated:start (as of 2026-09-06) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
-114 normative sections; 735 distinct executable fixtures.
+<!-- counts:generated:start (as of 2026-09-08) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
+128 normative sections; 751 distinct executable fixtures.
 <!-- counts:generated:end -->
 
 | Section | Contracts | Fixtures (how CI runs each) |

--- a/docs/contracts/contracts.toml
+++ b/docs/contracts/contracts.toml
@@ -372,7 +372,7 @@ evidence  = [
 [[contract]]
 id        = "C-023"
 spec      = "ALS-T13"
-title     = "float.to_string is shortest round-tripping decimal (Dragon4)"
+title     = "float.to_string is shortest round-tripping decimal, byte-equal to Rust Display"
 statement = "`float.to_string` produces the SAME bytes as native Rust f64 Display — the shortest round-tripping decimal in fixed notation, with the `.0` integer suffix — byte-identical native == wasm. The wasm runtime implements Dragon4 with exact big-integer arithmetic (rt_dragon.rs); there is no fixed-precision drift (native 0.30000000000000004 vs the old wasm 0.3) and no `i64_trunc` trap for |x| >= 2^63."
 since     = "0.24.0"
 status    = "active"

--- a/proofs/STAGE-STATUS.md
+++ b/proofs/STAGE-STATUS.md
@@ -13,21 +13,21 @@ by `scripts/gen-ledger-counts.sh` (a release step, or the answer to the nightly
 re-measured 2026-08-12) and `proofs/TOR.md` (the operational contract).
 
 <!-- stages:generated:start — derived from the proofs/ ledgers by scripts/gen-claims.sh; DO NOT EDIT between the markers -->
-<!-- counts:generated:start (as of 2026-09-06) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
+<!-- counts:generated:start (as of 2026-09-08) — stamped totals from proofs/ledger-counts.toml; refreshed only by scripts/gen-ledger-counts.sh, never by a fixture/contract PR; DO NOT EDIT between the markers -->
 > **Stage 1 (accept-and-wrong extinction): audits COMPLETE and gated** —
 > scalar-read 63 arms / 0 UNGUARDED; WAT prelude 63 fns classified;
 > platform-libm 5 sites classified. New entries cannot land unclassified.
 >
-> **Stage 2 (translation validation): 663/682 fixtures cast a real 3-way vote (97%)** —
+> **Stage 2 (translation validation): 672/693 fixtures cast a real 3-way vote (96%)** —
 > the abstain remainder is classified and shrink-only (the interp-heap arc, #1226).
 >
-> **Stage 3 (semantics freeze): 342/342 contracts spec-keyed; syntax-element coverage
+> **Stage 3 (semantics freeze): 347/347 contracts spec-keyed; syntax-element coverage
 > 72/72 sectioned (0 UNWRITTEN, shrink-only — the freeze precondition is 0).**
 >
 > **Stage 4 (durability): fuzz true-green streak = 0 day(s)** (dated meter;
 > the correctness-only night verdict shipped 2026-08-12 — 90 days is the milestone).
 >
-> **Stage 5 (auditability): 10 release seal(s); 75 verification gates classified
+> **Stage 5 (auditability): 11 release seal(s); 78 verification gates classified
 > (0 UNVERIFIED under a shrink-only ceiling); TOR with 9 enforced rows;
 > gap analysis consolidated in proofs/DO330-GAP.md (reference-gated).**
 <!-- counts:generated:end -->

--- a/proofs/als-pin.txt
+++ b/proofs/als-pin.txt
@@ -1,4 +1,4 @@
 # The almide/als commit this tree's contract ledger is judged against
 # (scripts/check-als-pin.sh). Advance it AFTER the als PR that carries a
 # new contract id has merged — never in the same PR that mints the id.
-12099f37a7f86ce586175c6d2b1575df146f5a01
+52af321db00a452aa41d591a3ec4591354c8dbd8

--- a/proofs/ledger-counts.toml
+++ b/proofs/ledger-counts.toml
@@ -11,26 +11,26 @@
 #           whenever the nightly scripts/check-ledger-counts.sh reports drift).
 # A fixture or contract PR must NOT refresh it. Measurement recipes:
 # scripts/lib/ledger-counts.sh.
-date                       = "2026-09-06"
-contracts                  = 342
-contracts_active           = 342
+date                       = "2026-09-08"
+contracts                  = 347
+contracts_active           = 347
 contracts_flagged          = 0
-contracts_spec_keyed       = 342
-wasm_cross_fixtures        = 682
-interp_abstains            = 19
-conformance_sections       = 114
-conformance_fixtures       = 735
+contracts_spec_keyed       = 347
+wasm_cross_fixtures        = 693
+interp_abstains            = 21
+conformance_sections       = 128
+conformance_fixtures       = 751
 stdlib_functions           = 985
 stdlib_modules             = 43
-spec_test_files            = 433
+spec_test_files            = 436
 scalar_read_arms           = 63
 scalar_read_unguarded      = 0
 wat_prelude_fns            = 63
 libm_sites                 = 5
 als_elements               = 72
 als_elements_unwritten     = 0
-release_seals              = 10
-verification_gates         = 75
+release_seals              = 11
+verification_gates         = 78
 verification_unverified    = 0
 tor_rows                   = 9
 fuzz_green_streak_days     = 0

--- a/proofs/releases/v0.62.0.toml
+++ b/proofs/releases/v0.62.0.toml
@@ -1,0 +1,27 @@
+# Release evidence seal — v0.62.0. IMMUTABLE: every [derived] field is
+# re-measured from the tag's tree by `scripts/release-seal.sh check`;
+# an edit that disagrees with the tag fails CI. [recorded] fields are
+# facts the tag cannot re-derive (fill them in before committing).
+
+[release]
+version = "0.62.0"
+tag = "v0.62.0"
+tag_commit = "f32cedf533c973bcf9aa785179e5ab3f3c0e4792"
+date = "2026-09-08"
+url = "https://github.com/almide/almide/releases/tag/v0.62.0"
+
+[derived]
+cargo_version = "0.62.0"
+contracts_sha256 = "2b24e1f4ab8ba5e89ede53bf19809f842a0a34c56bdf475a0f60fb039d56e249"
+contracts_total = "347"
+contracts_flagged = "0"
+abstain_ledger_sha256 = "2d28d541b12f29b9d4aacef7e6b590a2891657fcb47a49ec58eb127702bde720"
+abstain_ledger_entries = "21"
+wasm_cross_fixtures = "693"
+rust_toolchain = "1.94.0"
+wasmtime = "v47.0.3"
+
+[recorded]
+release_gate = "Minor release through the rc channel (#1484): v0.62.0-rc1 (fb9532068, 2026-09-08) soaked; the soak found #2028 (sequential allocation +51 % on the structural wasm leg, a regression of the #2010 drop-glue arc) — fixed before the final tag by parameter borrow inference on the structural leg (#2030: a droppable param the callee only reads is borrowed; module arms, assignments and true tail sites keep the owned convention; tree walk 142 -> 81 ms; treealloc row added to the runtime ratchet), plus the stale mutants the arc moved (#2029, #2031). On the owner's call the final also carries the native region window (#2032, closes #1991: binarytrees native 252 -> 71 ms, 0.81x Zig's arena, prelude bump arena over Copy twin enums) and the table-free Schubfach float printer (#2033, closes #1985: one-float probe 7,783 -> 5,508 B, size corpus -13.9 %, byte-exact against Rust Display over 2,736,458 differential values, to_fixed byte-identical). Blocker gate at the tag: 0 (#1482). Interface diff v0.61.1 -> v0.62.0: additive (added=14 removed=0; #1488): the http *_response family, int.is_even/is_odd, testing.assert_snapshot, zlib.adler32/crc32. Tag-tree CI: the release PR (#2034) ran the full battery on the content-identical develop head f32cedf5's parent 8b086836e; every required check green; the one red is Test Rust (windows-latest), a spec-only portability defect (fan_mapper_matrix_test asserts the OS's ENOENT prose) present since cd050b8ce before rc1, fixed on develop as #2035 right after the tag. Fuzz: no dedicated tag dispatch — latest nightly generative differential fuzz 34096107214 (2026-09-07): 10,133 programs over 7/8 shards, findings=0 correctness=0 slow=0; the ALMIDE_RC_TRAP_DOUBLE_FREE corpus burn-up is a CI step since #2022 and ran green on every rider."
+assets = "7: almide-linux-x86_64.tar.gz, almide-linux-aarch64.tar.gz, almide-macos-x86_64.tar.gz, almide-macos-aarch64.tar.gz, almide-windows-x86_64.zip, almide-checksums.sha256, almide-dossier-v0.62.0.md (the qualification dossier, the minor-release Trust Spine artifact)"
+known_problems = "None release-blocking. Standing, all visible-by-design: (1) #1696 step 4 — the structural leg's witness does not yet cover the full wasm_cross corpus, and step 5 (incumbent retirement) waits on it; (2) #1963 — the MSR thesis has no current measurement (the MiniGit bench saturates at 20/20 for every language); (3) Test Rust (windows-latest) red on the tag tree for the spec-only reason above (#2035 on develop); (4) the region window's native perf-ratchet row is REPORTED, not anchored — the Box-reference ratio flips 0.33 (macOS) / 0.61 (glibc) with the allocator; (5) C-023's title named Dragon4 at the tag; the statement (byte-equality with Rust Display) is unchanged and the title follows in the seal commit (als #63)."


### PR DESCRIPTION
Post-tag housekeeping for v0.62.0 (f32cedf53): `proofs/releases/v0.62.0.toml` with the [recorded] fields filled (rc1 soak → #2028 → #2030, the two owner-called riders #2032/#2033, blockers 0, interface diff additive 14/0, the Windows spec-only red and its fix #2035, fuzz 34096107214); `gen-ledger-counts.sh` (release seals 10 → 11, verification gates 75 → 78, spec test files 436); C-023's title names the promise rather than Dragon4 (als #63 merged, pin advanced to 52af321 — id set unchanged, `check-als-pin.sh` and `check-contracts.sh` green).