### PR TITLE
Cross-language modification-survival harness for #1963: go/zig in the multi runner, runner_edits with a hidden-oracle bank gate, ledger aggregator

### DIFF
--- a/research/benchmark/lang-bench/README.md
+++ b/research/benchmark/lang-bench/README.md
@@ -101,3 +101,24 @@ ruby runner_multi.rb --lang gleam --trials 20      # one language
 ruby aggregate_multi.rb                            # summary table
 python3 plot_snapshot.py                           # regenerate the chart
 ```
+
+`runner_multi.rb` also knows `go` (`go version`) and `zig` (`zig version`) so
+the MiniGit lane can be extended to the current comparison set; neither has a
+committed 20-trial snapshot yet.
+
+## Modification-survival lane
+
+MiniGit saturates (every language 20/20 on v1 and v2 — [#1963](https://github.com/almide/almide/issues/1963)):
+the spec and the scoring script are both handed to the model, so it iterates
+against the oracle in-session, and there is no cross-file invariant to break.
+It measures conciseness and cost, not modification survival.
+
+The discriminating lane is a separate task set — a seed program per language
+plus an ORDERED sequence of edits, each scored against a hidden oracle the model
+never sees, with prefix survival (an edit that fails fails every later horizon).
+The tasks live in Dojo (`tasks/xlang/` in
+[almide/almide-dojo](https://github.com/almide/almide-dojo) — all MSR task
+material belongs there, see the repo-boundary rule in the top-level `CLAUDE.md`);
+the cross-language driver lives here in lang-bench because Dojo's harness is
+Almide-only by rule. The design, the scoring conjunction, the ledger format and
+the run cost are laid out on #1963.

--- a/research/benchmark/lang-bench/README.md
+++ b/research/benchmark/lang-bench/README.md
@@ -122,3 +122,25 @@ material belongs there, see the repo-boundary rule in the top-level `CLAUDE.md`)
 the cross-language driver lives here in lang-bench because Dojo's harness is
 Almide-only by rule. The design, the scoring conjunction, the ledger format and
 the run cost are laid out on #1963.
+
+| Path | Purpose |
+|---|---|
+| `lib/bench_common.rb` | `run_cmd` / `run_claude` / `run_tests` / `count_loc` / `parse_claude_json`, shared by both runners |
+| `runner_edits.rb` | task-dir driven driver: seed + ordered edits, accumulating tree, hidden oracle, prefix survival; `--dry-run` is the bank gate |
+| `aggregate_edits.rb` | ledger: MSR-seq with Wilson 95 % CI, MSR-edit, first failure mode, $/sequence; prints `INCONCLUSIVE_BANK_SATURATED` at the ceiling |
+| `tasks-example/xlang/` | a two-language smoke fixture so the gate can be exercised locally |
+| `test/aggregate_edits_test.rb` | `ruby -Itest test/aggregate_edits_test.rb` |
+
+```bash
+ruby runner_edits.rb --tasks tasks-example/xlang --dry-run        # gate, no model call
+ruby runner_edits.rb --tasks ../../../../almide-dojo/tasks/xlang --lang rust --trials 5   # measure (spends money)
+ruby aggregate_edits.rb --tasks ../../../../almide-dojo/tasks/xlang                        # ledger
+```
+
+Per edit `k`: `survive_k = compile ∧ visible ∧ hidden ∧ scope_clean`, where
+`scope_clean` means every file the model changed (git diff against the
+pre-edit snapshot, new files included) matches a glob in `scope.txt`. The tree
+contract is language-agnostic: `bash build.sh` leaves an executable at `./app`;
+`visible.sh` / `hidden.sh` run with the tree as cwd, drive `./app` over stdin
+and report `PASSED:`/`FAILED:`. For interpreted languages `build.sh` type-checks
+and writes a `./app` wrapper script.

--- a/research/benchmark/lang-bench/aggregate_edits.rb
+++ b/research/benchmark/lang-bench/aggregate_edits.rb
@@ -1,0 +1,168 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Aggregate runner_edits.rb records (raw/xlang/<lang>-<model>.jsonl) into the
+# modification-survival ledger of #1963.
+#
+# Per (task, language) cell:
+#   n               sequences (trials) recorded
+#   msr_seq         fraction of sequences that survived ALL K edits, Wilson 95 % CI
+#   msr_edit        mean over sequences of k*/K, k* = edits survived before the first failure
+#   first_fail_mode the most common (edit, mode) at which failed sequences died
+#   usd/seq         mean model spend per sequence
+#   status          measured | not-run | harness-limitation | inconclusive-saturated
+#
+# INCONCLUSIVE_BANK_SATURATED is printed when every measured cell is at or
+# above the saturation ceiling (98 %): the bank is then a regression suite,
+# not ranking evidence (almide-dojo#3).
+#
+# Usage:
+#   ruby aggregate_edits.rb                          # ledger from raw/xlang/
+#   ruby aggregate_edits.rb --raw DIR --tasks DIR    # DIR/xlang tasks enumerate not-run cells
+#   ruby aggregate_edits.rb --json
+
+require 'json'
+
+module EditsStats
+  SATURATION = 0.98
+  Z95        = 1.959964
+
+  module_function
+
+  # Wilson score interval for k successes in n trials.
+  def wilson(k, n, z: Z95)
+    return [0.0, 0.0] if n <= 0
+
+    p = k.to_f / n
+    denom  = 1 + z * z / n
+    centre = (p + z * z / (2 * n)) / denom
+    half   = z * Math.sqrt(p * (1 - p) / n + z * z / (4.0 * n * n)) / denom
+    [[centre - half, 0.0].max, [centre + half, 1.0].min]
+  end
+
+  def mean(a) = a.empty? ? 0.0 : a.sum.to_f / a.length
+
+  # Edits survived before the first failure (prefix survival).
+  def survived_prefix(record)
+    edits = record['edits'] || []
+    k = 0
+    edits.each do |e|
+      break unless e['survived']
+
+      k += 1
+    end
+    k
+  end
+
+  def first_failure(record)
+    e = (record['edits'] || []).find { |x| !x['survived'] }
+    return nil unless e
+
+    "#{e['k']}:#{e['first_fail_mode']}"
+  end
+
+  # One ledger row for a cell of records sharing (task, language).
+  def summarize_cell(task, language, records)
+    limitations = records.select { |r| r['status'] == 'harness-limitation' }
+    measured    = records.reject { |r| r['status'] == 'harness-limitation' }
+    if measured.empty?
+      status = limitations.empty? ? 'not-run' : 'harness-limitation'
+      return { 'task' => task, 'language' => language, 'status' => status, 'n' => 0,
+               'msr_seq' => nil, 'ci95' => nil, 'msr_edit' => nil, 'first_fail_mode' => nil,
+               'usd_per_seq' => nil, 'note' => limitations.first&.dig('note') }
+    end
+
+    n   = measured.length
+    ks  = measured.map { |r| [r['K'] || (r['edits'] || []).length, 1].max }
+    ok  = measured.count { |r| survived_prefix(r) == (r['K'] || (r['edits'] || []).length) }
+    lo, hi = wilson(ok, n)
+    msr_edit = mean(measured.each_with_index.map { |r, i| survived_prefix(r).to_f / ks[i] })
+    modes = measured.filter_map { |r| first_failure(r) }.tally
+    usd = mean(measured.map { |r| (r['edits'] || []).sum { |e| e['usd'] || 0.0 } })
+    {
+      'task' => task, 'language' => language, 'status' => 'measured', 'n' => n,
+      'seq_ok' => ok, 'K' => ks.max,
+      'msr_seq' => ok.to_f / n, 'ci95' => [lo, hi], 'msr_edit' => msr_edit,
+      'first_fail_mode' => modes.max_by { |_, c| c }&.first,
+      'usd_per_seq' => usd,
+    }
+  end
+
+  # rows: from summarize_cell. Marks a task's measured rows inconclusive when
+  # every measured language of that task is at the ceiling; returns
+  # [rows, saturated_globally].
+  def apply_saturation(rows)
+    by_task = rows.group_by { |r| r['task'] }
+    by_task.each_value do |trs|
+      m = trs.select { |r| r['status'] == 'measured' }
+      next if m.empty? || m.any? { |r| r['msr_seq'] < SATURATION }
+
+      m.each { |r| r['status'] = 'inconclusive-saturated' }
+    end
+    measured = rows.select { |r| %w[measured inconclusive-saturated].include?(r['status']) }
+    saturated = !measured.empty? && measured.all? { |r| r['msr_seq'] >= SATURATION }
+    [rows, saturated]
+  end
+
+  def build_ledger(records, cells: nil)
+    grouped = records.group_by { |r| [r['task'], r['language']] }
+    keys = grouped.keys
+    keys |= cells if cells
+    rows = keys.sort.map { |task, lang| summarize_cell(task, lang, grouped[[task, lang]] || []) }
+    apply_saturation(rows)
+  end
+
+  def fmt_pct(x) = x.nil? ? '-' : format('%.2f', x)
+
+  def render(rows, saturated)
+    out = +''
+    out << "| task | language | status | n | msr_seq | ci95 | msr_edit | first_fail_mode | usd/seq |\n"
+    out << "|---|---|---|---|---|---|---|---|---|\n"
+    rows.each do |r|
+      ci = r['ci95'] ? "#{fmt_pct(r['ci95'][0])}–#{fmt_pct(r['ci95'][1])}" : '-'
+      usd = r['usd_per_seq'] ? format('$%.2f', r['usd_per_seq']) : '-'
+      out << "| #{r['task']} | #{r['language']} | #{r['status']} | #{r['n']} | #{fmt_pct(r['msr_seq'])} | #{ci} | " \
+             "#{fmt_pct(r['msr_edit'])} | #{r['first_fail_mode'] || '-'} | #{usd} |\n"
+    end
+    out << "\nINCONCLUSIVE_BANK_SATURATED: every measured cell is at or above #{(SATURATION * 100).round} %; " \
+           "the bank ranks nothing (regression suite only)\n" if saturated
+    out
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  script_dir = File.expand_path(__dir__)
+  raw_dir    = File.join(script_dir, 'raw', 'xlang')
+  tasks_dir  = nil
+  emit_json  = false
+  i = 0
+  while i < ARGV.length
+    case ARGV[i]
+    when '--raw'   then raw_dir = File.expand_path(ARGV[i + 1]); i += 2
+    when '--tasks' then tasks_dir = File.expand_path(ARGV[i + 1]); i += 2
+    when '--json'  then emit_json = true; i += 1
+    else
+      warn "unknown arg: #{ARGV[i]}"; i += 1
+    end
+  end
+
+  records = Dir.glob(File.join(raw_dir, '*.jsonl')).sort.flat_map do |path|
+    File.readlines(path).map(&:strip).reject(&:empty?).map { |l| JSON.parse(l) }
+  end
+
+  cells = nil
+  if tasks_dir
+    langs = %w[almide rust go typescript zig]
+    cells = Dir.glob(File.join(tasks_dir, '*', 'seed', '*')).select { |d| File.directory?(d) }.map do |d|
+      [File.basename(File.dirname(File.dirname(d))), File.basename(d)]
+    end
+    cells = cells.select { |_, l| langs.include?(l) }
+  end
+
+  rows, saturated = EditsStats.build_ledger(records, cells: cells)
+  if emit_json
+    puts JSON.pretty_generate({ 'saturated' => saturated, 'rows' => rows })
+  else
+    puts EditsStats.render(rows, saturated)
+  end
+end

--- a/research/benchmark/lang-bench/aggregate_multi.rb
+++ b/research/benchmark/lang-bench/aggregate_multi.rb
@@ -15,6 +15,7 @@ RAW_DIR    = File.join(SCRIPT_DIR, 'raw')
 LANG_DISPLAY = {
   'almide' => 'Almide', 'gleam' => 'Gleam', 'moonbit' => 'MoonBit',
   'rust' => 'Rust', 'typescript' => 'TypeScript',
+  'go' => 'Go', 'zig' => 'Zig',
 }.freeze
 
 emit_json = ARGV.include?('--json')

--- a/research/benchmark/lang-bench/lib/bench_common.rb
+++ b/research/benchmark/lang-bench/lib/bench_common.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+#
+# Shared plumbing for the lang-bench drivers (runner_multi.rb, runner_edits.rb):
+# subprocess execution with a PATH extension, the `claude -p` session wrapper,
+# the PASSED:/FAILED: test-suite reader and the LOC counter.
+#
+# Behaviour is exactly what runner_multi.rb carried inline before the extraction;
+# the only difference is that the model name and the exclude list are parameters
+# with the old values as defaults.
+
+require 'json'
+require 'fileutils'
+require 'open3'
+require 'timeout'
+require 'shellwords'
+
+BENCH_DIR     = File.expand_path('..', __dir__)
+BENCH_NPM_BIN = File.join(BENCH_DIR, '.npm-prefix', 'node_modules', '.bin')
+
+BENCH_EXCLUDE_DIR_FRAGMENTS =
+  %w[/node_modules/ /target/ /build/ /_build/ /.minigit/ /deps/ /zig-out/ /.zig-cache/].freeze
+
+# The cross-language comparison set of #1963. `probe` is the executable whose
+# absence makes a row `harness-limitation` instead of a measurement.
+BENCH_XLANG_LANGUAGES = {
+  'almide'     => { display: 'Almide',     exts: %w[almd], version_cmd: 'almide --version', probe: 'almide',
+                    copy_cheatsheet: true },
+  'rust'       => { display: 'Rust',       exts: %w[rs],   version_cmd: 'rustc --version',  probe: 'rustc' },
+  'go'         => { display: 'Go',         exts: %w[go],   version_cmd: 'go version',       probe: 'go' },
+  'typescript' => { display: 'TypeScript', exts: %w[ts],   version_cmd: 'tsx --version',    probe: 'tsx' },
+  'zig'        => { display: 'Zig',        exts: %w[zig],  version_cmd: 'zig version',      probe: 'zig' },
+}.freeze
+
+def bench_extra_path
+  "#{File.join(Dir.home, '.moon', 'bin')}:#{BENCH_NPM_BIN}:/opt/homebrew/bin"
+end
+
+def run_cmd(cmd, dir: nil, timeout: 600, extra_path: bench_extra_path)
+  opts = {}
+  opts[:chdir] = dir if dir
+  stdin, stdout, stderr, wait_thr = Open3.popen3("export PATH=#{extra_path}:$PATH && #{cmd}", **opts)
+  stdin.close
+  stdout.set_encoding('UTF-8')
+  stderr.set_encoding('UTF-8')
+  out = err = +''
+  begin
+    Timeout.timeout(timeout) do
+      out = stdout.read
+      err = stderr.read
+    end
+  rescue Timeout::Error
+    (Process.kill('TERM', wait_thr.pid) rescue nil)
+    out = (stdout.read rescue '')
+    err = "Timeout after #{timeout}s"
+  end
+  stdout.close
+  stderr.close
+  status = wait_thr.value
+  { stdout: out, stderr: err, exit_code: status.exitstatus, success: status.success? }
+end
+
+def parse_claude_json(raw)
+  raw = raw.dup.force_encoding('UTF-8')
+  events = JSON.parse(raw.strip)
+  events = [events] unless events.is_a?(Array)
+  result = events.reverse.find { |e| e.is_a?(Hash) && e['type'] == 'result' }
+  return nil unless result
+
+  usage = result['usage'] || {}
+  {
+    'input_tokens' => usage['input_tokens'] || 0,
+    'output_tokens' => usage['output_tokens'] || 0,
+    'cache_creation_tokens' => usage['cache_creation_input_tokens'] || 0,
+    'cache_read_tokens' => usage['cache_read_input_tokens'] || 0,
+    'cost_usd' => result['total_cost_usd'] || 0.0,
+    'num_turns' => result['num_turns'] || 0,
+    'duration_ms' => result['duration_ms'] || 0,
+  }
+rescue JSON::ParserError => e
+  warn "warn: failed to parse Claude JSON: #{e.message}"
+  nil
+end
+
+def run_claude(prompt, dir:, model:, log_path: nil, timeout: 1800, extra_path: bench_extra_path)
+  cmd = "unset CLAUDECODE && claude -p #{Shellwords.escape(prompt)} " \
+        "--dangerously-skip-permissions --output-format json --model #{model}"
+  puts "  Running Claude (#{model})..."
+  t0 = Time.now
+  result = run_cmd(cmd, dir: dir, timeout: timeout, extra_path: extra_path)
+  elapsed = (Time.now - t0).round(1)
+  if log_path
+    FileUtils.mkdir_p(File.dirname(log_path))
+    File.write(log_path, result[:stdout])
+  end
+  {
+    success: result[:success],
+    elapsed: elapsed,
+    claude_data: parse_claude_json(result[:stdout]),
+  }
+end
+
+# Runs a shell suite that reports `PASSED: n` / `FAILED: m` (the upstream
+# test-v1.sh idiom). `script` may be a path relative to `dir` or absolute.
+def run_tests(script, dir:, timeout: 300, extra_path: bench_extra_path)
+  result = run_cmd("bash #{Shellwords.escape(script)}", dir: dir, timeout: timeout, extra_path: extra_path)
+  output = result[:stdout] + result[:stderr]
+  passed = output[/PASSED:\s*(\d+)/, 1]&.to_i || 0
+  failed = output[/FAILED:\s*(\d+)/, 1]&.to_i || 0
+  { success: result[:success], passed: passed, failed: failed, total: passed + failed, output: output }
+end
+
+# Non-blank source lines under `dir` for the given extensions. `script_name`
+# names an extensionless executable that may BE the source (scripting
+# languages); pass nil when the task has no such file.
+def count_loc(dir, exts, exclude: BENCH_EXCLUDE_DIR_FRAGMENTS, script_name: 'minigit')
+  files = exts.flat_map { |e| Dir.glob(File.join(dir, '**', "*.#{e}")) }
+  files.reject! { |f| exclude.any? { |frag| f.include?(frag) } }
+
+  if script_name
+    script = File.join(dir, script_name)
+    if File.exist?(script) && !files.include?(script)
+      begin
+        content = File.read(script, encoding: 'UTF-8')
+        files << script if content.valid_encoding?
+      rescue StandardError
+        # skip binary
+      end
+    end
+  end
+
+  files.sum do |f|
+    File.readlines(f).count { |l| !l.strip.empty? }
+  rescue StandardError
+    0
+  end
+end

--- a/research/benchmark/lang-bench/runner_edits.rb
+++ b/research/benchmark/lang-bench/runner_edits.rb
@@ -1,0 +1,430 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Modification-survival runner (#1963) — task-dir driven, cross-language.
+#
+# A task is a seed program per language plus an ORDERED edit sequence. Edit k
+# runs in the model's own tree as it stands after edit k-1 (accumulating); an
+# edit survives when
+#
+#   survive_k = compile ∧ visible ∧ hidden ∧ scope_clean
+#
+# where scope_clean means the files the model changed (git diff against the
+# pre-edit snapshot, new files included) are all matched by scope.txt. The
+# first failure fails every later horizon (prefix survival) and stops the
+# sequence, so no money is spent on edits that cannot count.
+#
+# Task layout (Dojo tasks/xlang/<task>/, mirrored by tasks-example/xlang/):
+#
+#   seed/<lang>/                 the program before edit 1, with build.sh → ./app
+#   edits/0k-<slug>/
+#     prompt.md                  what the model is asked to do (shown)
+#     scope.txt                  globs of files the edit may touch (shown)
+#     visible.sh                 PASSED:/FAILED: suite the model may run (shown)
+#     hidden.sh                  the oracle — never enters the model's tree
+#     solution/<lang>/           reference patch, overlaid on the pre-edit tree
+#     wrong/<lang>/              plausible wrong patch: passes visible, fails hidden
+#
+# An overlay directory may carry a `.remove` file (one path per line) for
+# files the edit deletes. `bash build.sh` in the tree must leave an executable
+# at ./app; visible.sh / hidden.sh run with the tree as cwd and drive ./app.
+#
+# Usage:
+#   ruby runner_edits.rb --tasks DIR --dry-run                # validate every task, no model calls
+#   ruby runner_edits.rb --tasks DIR --lang rust --trials 5   # measure one language
+#   ruby runner_edits.rb --tasks DIR --task t1-ledger --lang almide --trials 5 --start 6
+#
+# Options: --lang L (default: every language present in seed/), --task T
+# (default: every task), --trials N, --start K, --model M, --out DIR
+# (default raw/xlang/), --almide-bin PATH (or ALMIDE_BIN) to pin the compiler.
+#
+# --dry-run is the bank gate: for every language present it proves the seed
+# builds, the pre-edit tree FAILS each edit's visible and hidden suites (the
+# edit is required), the solution builds and passes both, the wrong patch
+# builds, passes visible and fails hidden, and every overlay stays inside
+# scope.txt. A missing toolchain makes the row `harness-limitation`.
+
+require 'json'
+require 'fileutils'
+require 'time'
+require 'tmpdir'
+require_relative 'lib/bench_common'
+
+SCRIPT_DIR = File.expand_path(__dir__)
+LOGS_DIR   = File.join(SCRIPT_DIR, '.logs', 'xlang')
+WORK_DIR   = File.join(SCRIPT_DIR, '.work', 'xlang')
+CHEATSHEET = File.expand_path(File.join(SCRIPT_DIR, '..', '..', '..', 'docs', 'CHEATSHEET.md'))
+
+DEFAULT_MODEL = 'claude-sonnet-5'
+BUILD_TIMEOUT = 300
+TEST_TIMEOUT  = 300
+TREE_IGNORE   = "app\napp.exe\n/target/\n/zig-out/\n/.zig-cache/\n/node_modules/\n*.o\n*.pdb\n"
+
+# --- Args ------------------------------------------------------------------
+
+opts = { tasks: nil, langs: [], tasks_filter: [], trials: 1, start: nil, dry_run: false,
+         model: DEFAULT_MODEL, out: File.join(SCRIPT_DIR, 'raw', 'xlang'),
+         almide_bin: ENV['ALMIDE_BIN'] }
+i = 0
+while i < ARGV.length
+  case ARGV[i]
+  when '--tasks'      then opts[:tasks] = File.expand_path(ARGV[i + 1]); i += 2
+  when '--lang', '-l' then opts[:langs] << ARGV[i + 1]; i += 2
+  when '--task'       then opts[:tasks_filter] << ARGV[i + 1]; i += 2
+  when '--trials'     then opts[:trials] = ARGV[i + 1].to_i; i += 2
+  when '--start'      then opts[:start] = ARGV[i + 1].to_i; i += 2
+  when '--model'      then opts[:model] = ARGV[i + 1]; i += 2
+  when '--out'        then opts[:out] = File.expand_path(ARGV[i + 1]); i += 2
+  when '--almide-bin' then opts[:almide_bin] = File.expand_path(ARGV[i + 1]); i += 2
+  when '--dry-run'    then opts[:dry_run] = true; i += 1
+  when '--help', '-h' then puts File.read(__FILE__).lines.take_while { |l| l.start_with?('#') }.join; exit 0
+  else
+    abort "unknown arg: #{ARGV[i]}"
+  end
+end
+abort 'error: --tasks DIR required' unless opts[:tasks] && File.directory?(opts[:tasks])
+
+EXTRA_PATH = [opts[:almide_bin] && File.dirname(opts[:almide_bin]), bench_extra_path,
+              File.join(Dir.home, '.local', 'bin')].compact.join(':')
+MODEL_TAG  = opts[:model].delete('-').sub('claude', '')
+
+# --- Task model ------------------------------------------------------------
+
+Edit = Struct.new(:k, :slug, :dir) do
+  def prompt   = File.join(dir, 'prompt.md')
+  def scope    = File.join(dir, 'scope.txt')
+  def visible  = File.join(dir, 'visible.sh')
+  def hidden   = File.join(dir, 'hidden.sh')
+  def solution(lang) = File.join(dir, 'solution', lang)
+  def wrong(lang)    = File.join(dir, 'wrong', lang)
+
+  def scope_globs
+    File.readlines(scope).map(&:strip).reject { |l| l.empty? || l.start_with?('#') }
+  end
+end
+
+Task = Struct.new(:name, :dir) do
+  def seed(lang) = File.join(dir, 'seed', lang)
+  def languages  = Dir.glob(File.join(dir, 'seed', '*')).select { |d| File.directory?(d) }.map { |d| File.basename(d) }.sort
+
+  def edits
+    Dir.glob(File.join(dir, 'edits', '*')).select { |d| File.directory?(d) }.sort.each_with_index.map do |d, idx|
+      Edit.new(idx + 1, File.basename(d), d)
+    end
+  end
+end
+
+def load_tasks(root, filter)
+  Dir.glob(File.join(root, '*')).select { |d| File.directory?(File.join(d, 'seed')) }.sort
+     .map { |d| Task.new(File.basename(d), d) }
+     .select { |t| filter.empty? || filter.include?(t.name) }
+end
+
+def in_scope?(path, globs)
+  globs.any? { |g| File.fnmatch?(g, path, File::FNM_PATHNAME | File::FNM_EXTGLOB | File::FNM_DOTMATCH) }
+end
+
+# --- Tree operations -------------------------------------------------------
+
+def sh(cmd, dir:, timeout: BUILD_TIMEOUT)
+  run_cmd(cmd, dir: dir, timeout: timeout, extra_path: EXTRA_PATH)
+end
+
+def copy_tree(src, dst)
+  FileUtils.rm_rf(dst)
+  FileUtils.mkdir_p(dst)
+  FileUtils.cp_r(Dir.glob(File.join(src, '{*,.[!.]*}')), dst)
+end
+
+# Files an overlay directory contributes (relative paths), plus removals.
+def overlay_files(overlay)
+  files = Dir.glob(File.join(overlay, '**', '{*,.[!.]*}'), File::FNM_DOTMATCH)
+             .select { |f| File.file?(f) }
+             .map { |f| f.sub("#{overlay}/", '') }
+             .reject { |f| f == '.remove' }
+  removes = File.exist?(File.join(overlay, '.remove')) ? File.readlines(File.join(overlay, '.remove')).map(&:strip).reject(&:empty?) : []
+  [files, removes]
+end
+
+def apply_overlay(tree, overlay)
+  files, removes = overlay_files(overlay)
+  files.each do |rel|
+    FileUtils.mkdir_p(File.dirname(File.join(tree, rel)))
+    FileUtils.cp(File.join(overlay, rel), File.join(tree, rel))
+  end
+  removes.each { |rel| FileUtils.rm_rf(File.join(tree, rel)) }
+  files + removes
+end
+
+DIAG_RE = /\b(E\d{3,4})\b/
+
+def build(tree)
+  FileUtils.rm_f(File.join(tree, 'app'))
+  r = sh('bash build.sh', dir: tree)
+  out = r[:stdout] + r[:stderr]
+  ok = r[:success] && File.executable?(File.join(tree, 'app'))
+  { ok: ok, diagnostic: (ok ? nil : out[DIAG_RE, 1]), output: out }
+end
+
+def suite(script, tree)
+  r = run_tests(script, dir: tree, timeout: TEST_TIMEOUT, extra_path: EXTRA_PATH)
+  r[:ok] = r[:success] && r[:total].positive? && r[:failed].zero?
+  r
+end
+
+def toolchain(lang)
+  cfg = BENCH_XLANG_LANGUAGES[lang]
+  return [false, "#{lang}: not in the comparison set"] unless cfg
+
+  probe = sh("command -v #{cfg[:probe]}", dir: nil)
+  return [false, "#{cfg[:probe]} not found"] unless probe[:success]
+
+  v = sh(cfg[:version_cmd], dir: nil)
+  [true, (v[:stdout].strip.empty? ? v[:stderr].strip : v[:stdout].strip).lines.first&.strip || 'unknown']
+end
+
+# --- Dry run: the bank gate -------------------------------------------------
+
+def dry_run(tasks)
+  failures = 0
+  rows = []
+  tasks.each do |task|
+    edits = task.edits
+    if edits.empty?
+      puts "#{task.name}: no edits/ — invalid"
+      failures += 1
+      next
+    end
+    edits.each do |e|
+      %w[prompt scope visible hidden].each do |f|
+        next if File.exist?(e.public_send(f))
+
+        puts "#{task.name}/#{e.slug}: missing #{f}"
+        failures += 1
+      end
+    end
+
+    task.languages.each do |lang|
+      ok, ver = toolchain(lang)
+      unless ok
+        rows << [task.name, lang, 'harness-limitation', ver]
+        puts "#{task.name}/#{lang}: harness-limitation (#{ver})"
+        next
+      end
+      errs = []
+      Dir.mktmpdir("xlang-#{task.name}-#{lang}-") do |tmp|
+        tree = File.join(tmp, 'tree')
+        copy_tree(task.seed(lang), tree)
+        errs << 'seed has no build.sh' unless File.exist?(File.join(tree, 'build.sh'))
+        b = build(tree)
+        errs << "seed does not build (#{b[:diagnostic] || 'no code'}): #{b[:output].lines.first&.strip}" unless b[:ok]
+        break unless errs.empty?
+
+        edits.each do |e|
+          label = "edit #{e.k} (#{e.slug})"
+          globs = e.scope_globs
+          # (b) the edit is required: the pre-edit tree fails both suites
+          errs << "#{label}: pre-edit tree already passes visible.sh" if suite(e.visible, tree)[:ok]
+          errs << "#{label}: pre-edit tree already passes hidden.sh" if suite(e.hidden, tree)[:ok]
+
+          # (c) a correct patch exists, inside scope
+          sol = e.solution(lang)
+          unless File.directory?(sol)
+            errs << "#{label}: missing solution/#{lang}"
+            break
+          end
+          sol_tree = File.join(tmp, "sol#{e.k}")
+          copy_tree(tree, sol_tree)
+          touched = apply_overlay(sol_tree, sol)
+          out_of_scope = touched.reject { |p| in_scope?(p, globs) }
+          errs << "#{label}: solution touches files outside scope.txt: #{out_of_scope.join(', ')}" unless out_of_scope.empty?
+          b = build(sol_tree)
+          if b[:ok]
+            v = suite(e.visible, sol_tree)
+            h = suite(e.hidden, sol_tree)
+            errs << "#{label}: solution fails visible.sh (#{v[:passed]}/#{v[:total]})" unless v[:ok]
+            errs << "#{label}: solution fails hidden.sh (#{h[:passed]}/#{h[:total]})" unless h[:ok]
+          else
+            errs << "#{label}: solution does not build (#{b[:diagnostic] || 'no code'}): #{b[:output].lines.first&.strip}"
+          end
+
+          # (d) the bank discriminates
+          wrong = e.wrong(lang)
+          if File.directory?(wrong)
+            wrong_tree = File.join(tmp, "wrong#{e.k}")
+            copy_tree(tree, wrong_tree)
+            touched = apply_overlay(wrong_tree, wrong)
+            out_of_scope = touched.reject { |p| in_scope?(p, globs) }
+            errs << "#{label}: wrong patch touches files outside scope.txt: #{out_of_scope.join(', ')}" unless out_of_scope.empty?
+            b = build(wrong_tree)
+            if b[:ok]
+              errs << "#{label}: wrong patch does not pass visible.sh — not plausible" unless suite(e.visible, wrong_tree)[:ok]
+              errs << "#{label}: wrong patch passes hidden.sh — the oracle does not discriminate" if suite(e.hidden, wrong_tree)[:ok]
+            else
+              errs << "#{label}: wrong patch does not build (#{b[:diagnostic] || 'no code'})"
+            end
+          else
+            errs << "#{label}: missing wrong/#{lang}"
+          end
+
+          tree = sol_tree # accumulate: edit k+1 starts from the reference solution of edit k
+        end
+      end
+      status = errs.empty? ? 'ok' : 'invalid'
+      rows << [task.name, lang, status, ver]
+      puts "#{task.name}/#{lang}: #{status} (#{ver}; #{edits.length} edits)"
+      errs.each { |m| puts "    - #{m}" }
+      failures += errs.length
+    end
+  end
+  puts
+  puts format('%-16s %-12s %-20s %s', 'task', 'language', 'status', 'toolchain')
+  rows.each { |r| puts format('%-16s %-12s %-20s %s', *r) }
+  puts
+  puts(failures.zero? ? 'dry-run OK' : "dry-run FAILED (#{failures} problem(s))")
+  failures.zero?
+end
+
+# --- Live loop ---------------------------------------------------------------
+
+def git(tree, args)
+  sh("git #{args}", dir: tree, timeout: 60)
+end
+
+def snapshot(tree, msg)
+  git(tree, 'add -A')
+  git(tree, "-c user.name=xlang -c user.email=xlang@localhost commit -q --allow-empty -m #{Shellwords.escape(msg)}")
+end
+
+def changed_files(tree)
+  git(tree, 'add -A')
+  git(tree, 'diff --cached --name-only HEAD')[:stdout].lines.map(&:strip).reject(&:empty?)
+end
+
+def model_prompt(edit, lang)
+  cfg = BENCH_XLANG_LANGUAGES[lang]
+  lines = []
+  lines << "You are modifying an existing #{cfg[:display]} program in the current directory."
+  lines << ''
+  lines << File.read(edit.prompt).strip
+  lines << ''
+  lines << 'Rules:'
+  lines << '- Build with: bash build.sh   (it must leave an executable at ./app)'
+  lines << '- Verify with: bash visible.sh   (a hidden suite with the same interface is scored afterwards; do not edit visible.sh)'
+  lines << "- Only files matching these patterns may change: #{edit.scope_globs.join(' ')}"
+  lines << '- Almide is a new language. Read CHEATSHEET.md for the complete language reference.' if cfg[:copy_cheatsheet]
+  lines.join("\n")
+end
+
+def run_sequence(task, lang, trial, opts, toolchain_ver, claude_ver)
+  edits = task.edits
+  slug  = "#{task.name}-#{lang}-#{MODEL_TAG}-#{trial}"
+  tree  = File.join(WORK_DIR, slug)
+  copy_tree(task.seed(lang), tree)
+  File.write(File.join(tree, '.gitignore'), TREE_IGNORE)
+  FileUtils.cp(CHEATSHEET, tree) if BENCH_XLANG_LANGUAGES[lang][:copy_cheatsheet]
+  git(tree, 'init -q')
+  snapshot(tree, 'seed')
+
+  record = {
+    'language' => lang, 'task' => task.name, 'trial' => trial, 'model' => opts[:model],
+    'status' => 'measured', 'timestamp' => Time.now.iso8601,
+    'toolchain_version' => toolchain_ver, 'claude_version' => claude_ver,
+    'K' => edits.length, 'edits' => [],
+  }
+
+  alive = true
+  edits.each do |e|
+    entry = { 'k' => e.k, 'slug' => e.slug, 'attempted' => false, 'survived' => false, 'first_fail_mode' => 'prefix',
+              'usd' => 0.0, 'seconds' => 0.0 }
+    unless alive
+      record['edits'] << entry
+      next
+    end
+
+    puts "  edit #{e.k}/#{edits.length}: #{e.slug}"
+    FileUtils.cp(e.visible, File.join(tree, 'visible.sh'))
+    snapshot(tree, "pre-edit-#{e.k}")
+
+    c = run_claude(model_prompt(e, lang), dir: tree, model: opts[:model],
+                   log_path: File.join(LOGS_DIR, "#{slug}-edit#{e.k}.json"), extra_path: EXTRA_PATH)
+    entry['attempted'] = true
+    entry['seconds']   = c[:elapsed]
+    entry['usd']       = c.dig(:claude_data, 'cost_usd') || 0.0
+    entry['claude']    = c[:claude_data]
+
+    changed = changed_files(tree)
+    entry['changed_files'] = changed
+    out_of_scope = changed.reject { |p| in_scope?(p, e.scope_globs) }
+    entry['out_of_scope'] = out_of_scope
+
+    b = build(tree)
+    entry['compile']    = b[:ok]
+    entry['diagnostic'] = b[:diagnostic]
+    if b[:ok]
+      v = suite(e.visible, tree)
+      h = suite(e.hidden, tree)
+      entry['visible'] = { 'passed' => v[:passed], 'failed' => v[:failed], 'ok' => v[:ok] }
+      entry['hidden']  = { 'passed' => h[:passed], 'failed' => h[:failed], 'ok' => h[:ok] }
+    end
+    entry['scope_clean'] = out_of_scope.empty?
+    entry['loc'] = count_loc(tree, BENCH_XLANG_LANGUAGES[lang][:exts], script_name: nil)
+
+    mode = if !b[:ok] then 'compile'
+           elsif !entry.dig('visible', 'ok') then 'visible'
+           elsif !entry.dig('hidden', 'ok') then 'hidden'
+           elsif !entry['scope_clean'] then 'scope'
+           end
+    entry['survived'] = mode.nil?
+    entry['first_fail_mode'] = mode
+    puts "    #{mode ? "FAIL (#{mode})" : 'survived'}  $#{format('%.2f', entry['usd'])}  #{entry['seconds']}s"
+    snapshot(tree, "post-edit-#{e.k}")
+    record['edits'] << entry
+    alive = false if mode
+  end
+  record['survived_k'] = record['edits'].count { |x| x['survived'] }
+  record
+end
+
+# --- Main --------------------------------------------------------------------
+
+tasks = load_tasks(opts[:tasks], opts[:tasks_filter])
+abort "error: no tasks under #{opts[:tasks]}" if tasks.empty?
+
+if opts[:dry_run]
+  exit(dry_run(tasks) ? 0 : 1)
+end
+
+abort 'error: claude CLI not found in PATH' unless system('command -v claude >/dev/null 2>&1')
+abort "error: CHEATSHEET.md not found at #{CHEATSHEET}" unless File.exist?(CHEATSHEET)
+FileUtils.mkdir_p([opts[:out], WORK_DIR, LOGS_DIR])
+claude_ver = `claude --version 2>/dev/null`.strip
+
+langs = opts[:langs].empty? ? tasks.flat_map(&:languages).uniq.sort : opts[:langs]
+langs.each do |lang|
+  raw = File.join(opts[:out], "#{lang}-#{MODEL_TAG}.jsonl")
+  existing = File.exist?(raw) ? File.readlines(raw).map { |l| JSON.parse(l) } : []
+  ok, ver = toolchain(lang)
+  puts '=' * 60
+  puts "xlang runner — #{lang} (#{opts[:model]})  toolchain: #{ver}"
+  puts '=' * 60
+  tasks.each do |task|
+    next unless task.languages.include?(lang)
+
+    start = opts[:start] || ((existing.select { |r| r['task'] == task.name }.map { |r| r['trial'] }.max || 0) + 1)
+    unless ok
+      rec = { 'language' => lang, 'task' => task.name, 'trial' => start, 'model' => opts[:model],
+              'status' => 'harness-limitation', 'note' => ver, 'timestamp' => Time.now.iso8601, 'K' => task.edits.length, 'edits' => [] }
+      File.open(raw, 'a') { |f| f.puts(JSON.generate(rec)) }
+      puts "#{task.name}: harness-limitation (#{ver}) — recorded"
+      next
+    end
+    opts[:trials].times do |idx|
+      trial = start + idx
+      puts "--- #{task.name} trial #{trial} (#{idx + 1}/#{opts[:trials]}) ---"
+      rec = run_sequence(task, lang, trial, opts, ver, claude_ver)
+      File.open(raw, 'a') { |f| f.puts(JSON.generate(rec)) }
+      puts "  -> #{rec['survived_k']}/#{rec['K']} survived, appended to #{raw}"
+    end
+  end
+end

--- a/research/benchmark/lang-bench/runner_multi.rb
+++ b/research/benchmark/lang-bench/runner_multi.rb
@@ -16,7 +16,7 @@
 # Requirements:
 #   - git submodule initialized (upstream/)
 #   - claude CLI in PATH
-#   - per-language toolchain in PATH (almide / gleam / moon / rustc / tsx)
+#   - per-language toolchain in PATH (almide / gleam / moon / rustc / tsx / go / zig)
 
 require 'json'
 require 'fileutils'
@@ -83,9 +83,15 @@ LANGUAGES = {
   'typescript' => {
     display: 'TypeScript', exts: %w[ts], version_cmd: 'tsx --version',
   },
+  'go' => {
+    display: 'Go', exts: %w[go], version_cmd: 'go version',
+  },
+  'zig' => {
+    display: 'Zig', exts: %w[zig], version_cmd: 'zig version',
+  },
 }.freeze
 
-EXCLUDE_DIR_FRAGMENTS = %w[/node_modules/ /target/ /build/ /_build/ /.minigit/ /deps/].freeze
+EXCLUDE_DIR_FRAGMENTS = %w[/node_modules/ /target/ /build/ /_build/ /.minigit/ /deps/ /zig-out/ /.zig-cache/].freeze
 
 # --- Arg parsing -----------------------------------------------------------
 

--- a/research/benchmark/lang-bench/runner_multi.rb
+++ b/research/benchmark/lang-bench/runner_multi.rb
@@ -21,9 +21,8 @@
 require 'json'
 require 'fileutils'
 require 'time'
-require 'open3'
-require 'timeout'
 require 'shellwords'
+require_relative 'lib/bench_common'
 
 SCRIPT_DIR   = File.expand_path(__dir__)
 UPSTREAM_DIR = File.join(SCRIPT_DIR, 'upstream')
@@ -31,7 +30,6 @@ RAW_DIR      = File.join(SCRIPT_DIR, 'raw')
 WORK_DIR     = File.join(SCRIPT_DIR, '.work')
 LOGS_DIR     = File.join(SCRIPT_DIR, '.logs')
 CHEATSHEET   = File.expand_path(File.join(SCRIPT_DIR, '..', '..', '..', 'docs', 'CHEATSHEET.md'))
-NPM_BIN      = File.join(SCRIPT_DIR, '.npm-prefix', 'node_modules', '.bin')
 
 MODEL     = 'claude-sonnet-5'
 MODEL_TAG = 'sonnet5'
@@ -91,7 +89,7 @@ LANGUAGES = {
   },
 }.freeze
 
-EXCLUDE_DIR_FRAGMENTS = %w[/node_modules/ /target/ /build/ /_build/ /.minigit/ /deps/ /zig-out/ /.zig-cache/].freeze
+EXCLUDE_DIR_FRAGMENTS = BENCH_EXCLUDE_DIR_FRAGMENTS
 
 # --- Arg parsing -----------------------------------------------------------
 
@@ -134,34 +132,6 @@ RAW_JSONL = File.join(RAW_DIR, "#{lang}-#{MODEL_TAG}.jsonl")
 existing = File.exist?(RAW_JSONL) ? File.readlines(RAW_JSONL).map { |l| JSON.parse(l) } : []
 start_trial = start_override || ((existing.map { |r| r['trial'] }.max || 0) + 1)
 
-def extra_path
-  "#{File.join(Dir.home, '.moon', 'bin')}:#{NPM_BIN}:/opt/homebrew/bin"
-end
-
-def run_cmd(cmd, dir: nil, timeout: 600)
-  opts = {}
-  opts[:chdir] = dir if dir
-  stdin, stdout, stderr, wait_thr = Open3.popen3("export PATH=#{extra_path}:$PATH && #{cmd}", **opts)
-  stdin.close
-  stdout.set_encoding('UTF-8')
-  stderr.set_encoding('UTF-8')
-  out = err = +''
-  begin
-    Timeout.timeout(timeout) do
-      out = stdout.read
-      err = stderr.read
-    end
-  rescue Timeout::Error
-    (Process.kill('TERM', wait_thr.pid) rescue nil)
-    out = (stdout.read rescue '')
-    err = "Timeout after #{timeout}s"
-  end
-  stdout.close
-  stderr.close
-  status = wait_thr.value
-  { stdout: out, stderr: err, exit_code: status.exitstatus, success: status.success? }
-end
-
 upstream_rev = `cd #{Shellwords.escape(UPSTREAM_DIR)} && git rev-parse --short HEAD`.strip
 toolchain_ver = begin
   r = run_cmd(config[:version_cmd])
@@ -181,77 +151,7 @@ puts "Trials to run:   #{start_trial}..#{start_trial + trials - 1}"
 puts "Dry run:         #{dry_run}"
 puts
 
-# --- Helpers ---------------------------------------------------------------
-
-def parse_claude_json(raw)
-  raw = raw.dup.force_encoding('UTF-8')
-  events = JSON.parse(raw.strip)
-  events = [events] unless events.is_a?(Array)
-  result = events.reverse.find { |e| e.is_a?(Hash) && e['type'] == 'result' }
-  return nil unless result
-
-  usage = result['usage'] || {}
-  {
-    'input_tokens' => usage['input_tokens'] || 0,
-    'output_tokens' => usage['output_tokens'] || 0,
-    'cache_creation_tokens' => usage['cache_creation_input_tokens'] || 0,
-    'cache_read_tokens' => usage['cache_read_input_tokens'] || 0,
-    'cost_usd' => result['total_cost_usd'] || 0.0,
-    'num_turns' => result['num_turns'] || 0,
-    'duration_ms' => result['duration_ms'] || 0,
-  }
-rescue JSON::ParserError => e
-  warn "warn: failed to parse Claude JSON: #{e.message}"
-  nil
-end
-
-def run_claude(prompt, dir:, log_path: nil)
-  cmd = "unset CLAUDECODE && claude -p #{Shellwords.escape(prompt)} " \
-        "--dangerously-skip-permissions --output-format json --model #{MODEL}"
-  puts "  Running Claude (#{MODEL})..."
-  t0 = Time.now
-  result = run_cmd(cmd, dir: dir, timeout: 1800)
-  elapsed = (Time.now - t0).round(1)
-  if log_path
-    FileUtils.mkdir_p(File.dirname(log_path))
-    File.write(log_path, result[:stdout])
-  end
-  {
-    success: result[:success],
-    elapsed: elapsed,
-    claude_data: parse_claude_json(result[:stdout]),
-  }
-end
-
-def run_tests(script, dir:)
-  result = run_cmd("bash #{Shellwords.escape(script)}", dir: dir, timeout: 300)
-  output = result[:stdout] + result[:stderr]
-  passed = output[/PASSED:\s*(\d+)/, 1]&.to_i || 0
-  failed = output[/FAILED:\s*(\d+)/, 1]&.to_i || 0
-  { success: result[:success], passed: passed, failed: failed, total: passed + failed }
-end
-
-def count_loc(dir, exts)
-  files = exts.flat_map { |e| Dir.glob(File.join(dir, '**', "*.#{e}")) }
-  files.reject! { |f| EXCLUDE_DIR_FRAGMENTS.any? { |frag| f.include?(frag) } }
-
-  # For scripting languages the executable `minigit` may BE the source
-  minigit = File.join(dir, 'minigit')
-  if File.exist?(minigit) && !files.include?(minigit)
-    begin
-      content = File.read(minigit, encoding: 'UTF-8')
-      files << minigit if content.valid_encoding?
-    rescue StandardError
-      # skip binary
-    end
-  end
-
-  files.sum do |f|
-    File.readlines(f).count { |l| !l.strip.empty? }
-  rescue StandardError
-    0
-  end
-end
+# run_cmd / run_claude / run_tests / count_loc / parse_claude_json live in lib/bench_common.rb
 
 # --- Warmup ----------------------------------------------------------------
 
@@ -260,7 +160,7 @@ unless dry_run
   warmup = File.join(WORK_DIR, ".warmup-#{lang}")
   FileUtils.rm_rf(warmup)
   FileUtils.mkdir_p(warmup)
-  w = run_claude('Respond with just the word OK.', dir: warmup)
+  w = run_claude('Respond with just the word OK.', dir: warmup, model: MODEL)
   puts "  done in #{w[:elapsed]}s (success=#{w[:success]})"
   FileUtils.rm_rf(warmup)
   puts
@@ -301,7 +201,7 @@ trials.times do |idx|
     record['v1_time'] = 0
   else
     v1 = run_claude(config[:v1_prompt] || generic_v1_prompt(config[:display]),
-                    dir: v1_dir, log_path: File.join(LOGS_DIR, "#{slug}-v1.json"))
+                    dir: v1_dir, model: MODEL, log_path: File.join(LOGS_DIR, "#{slug}-v1.json"))
     record['v1_time'] = v1[:elapsed]
     record['v1_claude'] = v1[:claude_data]
 
@@ -327,7 +227,7 @@ trials.times do |idx|
     record['v2_time'] = 0
   else
     v2 = run_claude(config[:v2_prompt] || GENERIC_V2_PROMPT,
-                    dir: v2_dir, log_path: File.join(LOGS_DIR, "#{slug}-v2.json"))
+                    dir: v2_dir, model: MODEL, log_path: File.join(LOGS_DIR, "#{slug}-v2.json"))
     record['v2_time'] = v2[:elapsed]
     record['v2_claude'] = v2[:claude_data]
 

--- a/research/benchmark/lang-bench/tasks-example/xlang/README.md
+++ b/research/benchmark/lang-bench/tasks-example/xlang/README.md
@@ -1,0 +1,13 @@
+# tasks-example/xlang
+
+A fixture for `runner_edits.rb`, not a benchmark task: `t0-smoke` is a
+two-language (Almide, Rust) seed with two ordered edits, a reference solution
+and a plausible wrong patch per edit, so that
+
+```bash
+ruby runner_edits.rb --tasks tasks-example/xlang --dry-run
+```
+
+exercises the whole bank gate locally without a model call. The real task set
+of #1963 lives in Dojo under `tasks/xlang/` with the same layout (see the
+header of `runner_edits.rb`).

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/hidden.sh
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/hidden.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Hidden oracle for edit 01 — never copied into the model's tree. cwd = the program tree.
+pass=0; fail=0
+check() { # name, stdin (printf %b), expected stdout
+  local got; got="$(printf '%b' "$2" | ./app 2>&1)"
+  if [ "$got" = "$(printf '%b' "$3")" ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL $1: expected [$(printf '%b' "$3")] got [$got]"; fi
+}
+check "sub after add"      'add 5\nsub 2\nshow\n'            '3'
+check "sub goes negative"  'sub 5\nshow\n'                   '-5'
+check "negative then back" 'add 1\nsub 3\nadd 2\nshow\n'     '0'
+check "no clamping"        'sub 1\nsub 1\nshow\nadd 5\nshow\n' '-2\n3'
+check "sub bad amount"     'sub y\nshow\n'                   'error: bad amount y\n0'
+check "unknown untouched"  'foo\nshow\n'                     'error: unknown command foo\n0'
+echo "PASSED: $pass"
+echo "FAILED: $fail"
+[ "$fail" -eq 0 ]

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/prompt.md
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/prompt.md
@@ -1,0 +1,6 @@
+Add a `sub <n>` command that subtracts n from the running total.
+
+Preserve:
+- `add`, `show` and the error lines behave exactly as before.
+- The total is a plain integer: it may go negative, and it is never clamped.
+- A non-numeric amount is reported as `error: bad amount <arg>` and skipped, as for `add`.

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/scope.txt
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/scope.txt
@@ -1,0 +1,2 @@
+# files this edit may touch (glob per line; File.fnmatch with FNM_PATHNAME)
+main.*

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/solution/almide/main.almd
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/solution/almide/main.almd
@@ -1,0 +1,31 @@
+import io
+
+// A running total driven by one command per stdin line.
+//   add <n>   adds n to the total
+//   sub <n>   subtracts n from the total
+//   show      prints the total
+// Any other line is reported as an error and skipped.
+effect fn main() -> Unit = {
+  let lines = io.read_all() |> string.split("\n")
+  var total = 0
+  for raw in lines {
+    let line = string.trim(raw)
+    if line != "" then {
+      let parts = string.split(line, " ")
+      let cmd = list.get(parts, 0) ?? ""
+      let arg = list.get(parts, 1) ?? ""
+      match cmd {
+        "add" => match int.parse(arg) {
+          ok(n) => { total = total + n },
+          err(_) => println("error: bad amount ${arg}"),
+        },
+        "sub" => match int.parse(arg) {
+          ok(n) => { total = total - n },
+          err(_) => println("error: bad amount ${arg}"),
+        },
+        "show" => println(int.to_string(total)),
+        _ => println("error: unknown command ${cmd}"),
+      }
+    }
+  }
+}

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/solution/rust/main.rs
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/solution/rust/main.rs
@@ -1,0 +1,33 @@
+// A running total driven by one command per stdin line.
+//   add <n>   adds n to the total
+//   sub <n>   subtracts n from the total
+//   show      prints the total
+// Any other line is reported as an error and skipped.
+use std::io::Read;
+
+fn main() {
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input).unwrap();
+    let mut total: i64 = 0;
+    for raw in input.lines() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.split(' ');
+        let cmd = parts.next().unwrap_or("");
+        let arg = parts.next().unwrap_or("");
+        match cmd {
+            "add" => match arg.parse::<i64>() {
+                Ok(n) => total += n,
+                Err(_) => println!("error: bad amount {}", arg),
+            },
+            "sub" => match arg.parse::<i64>() {
+                Ok(n) => total -= n,
+                Err(_) => println!("error: bad amount {}", arg),
+            },
+            "show" => println!("{}", total),
+            _ => println!("error: unknown command {}", cmd),
+        }
+    }
+}

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/visible.sh
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/visible.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Visible suite for edit 01 (the model may read and run this). cwd = the program tree.
+pass=0; fail=0
+check() { # name, stdin (printf %b), expected stdout
+  local got; got="$(printf '%b' "$2" | ./app 2>&1)"
+  if [ "$got" = "$(printf '%b' "$3")" ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL $1: expected [$(printf '%b' "$3")] got [$got]"; fi
+}
+check "sub after add"   'add 5\nsub 2\nshow\n'          '3'
+check "sub to zero"     'add 4\nsub 4\nshow\n'          '0'
+check "add still works" 'add 1\nadd 2\nshow\n'          '3'
+check "sub bad amount"  'add 1\nsub x\nshow\n'          'error: bad amount x\n1'
+echo "PASSED: $pass"
+echo "FAILED: $fail"
+[ "$fail" -eq 0 ]

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/wrong/almide/main.almd
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/wrong/almide/main.almd
@@ -1,0 +1,28 @@
+import io
+
+// WRONG patch: clamps the total at zero on sub — passes the visible suite,
+// violates "never clamped" in the hidden oracle.
+effect fn main() -> Unit = {
+  let lines = io.read_all() |> string.split("\n")
+  var total = 0
+  for raw in lines {
+    let line = string.trim(raw)
+    if line != "" then {
+      let parts = string.split(line, " ")
+      let cmd = list.get(parts, 0) ?? ""
+      let arg = list.get(parts, 1) ?? ""
+      match cmd {
+        "add" => match int.parse(arg) {
+          ok(n) => { total = total + n },
+          err(_) => println("error: bad amount ${arg}"),
+        },
+        "sub" => match int.parse(arg) {
+          ok(n) => { total = if total - n < 0 then 0 else total - n },
+          err(_) => println("error: bad amount ${arg}"),
+        },
+        "show" => println(int.to_string(total)),
+        _ => println("error: unknown command ${cmd}"),
+      }
+    }
+  }
+}

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/wrong/rust/main.rs
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/01-add-sub/wrong/rust/main.rs
@@ -1,0 +1,30 @@
+// WRONG patch: clamps the total at zero on sub — passes the visible suite,
+// violates "never clamped" in the hidden oracle.
+use std::io::Read;
+
+fn main() {
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input).unwrap();
+    let mut total: i64 = 0;
+    for raw in input.lines() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.split(' ');
+        let cmd = parts.next().unwrap_or("");
+        let arg = parts.next().unwrap_or("");
+        match cmd {
+            "add" => match arg.parse::<i64>() {
+                Ok(n) => total += n,
+                Err(_) => println!("error: bad amount {}", arg),
+            },
+            "sub" => match arg.parse::<i64>() {
+                Ok(n) => total = (total - n).max(0),
+                Err(_) => println!("error: bad amount {}", arg),
+            },
+            "show" => println!("{}", total),
+            _ => println!("error: unknown command {}", cmd),
+        }
+    }
+}

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/hidden.sh
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/hidden.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Hidden oracle for edit 02 — never copied into the model's tree. cwd = the program tree.
+pass=0; fail=0
+check() { # name, stdin (printf %b), expected stdout
+  local got; got="$(printf '%b' "$2" | ./app 2>&1)"
+  if [ "$got" = "$(printf '%b' "$3")" ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL $1: expected [$(printf '%b' "$3")] got [$got]"; fi
+}
+check "print after add"     'add 5\nprint\n'                 '5'
+check "show is gone"        'add 5\nshow\nprint\n'           'error: unknown command show\n5'
+check "negative preserved"  'sub 3\nprint\n'                 '-3'
+check "bad amount preserved" 'add q\nprint\n'                'error: bad amount q\n0'
+check "unknown preserved"   'foo\nprint\n'                   'error: unknown command foo\n0'
+echo "PASSED: $pass"
+echo "FAILED: $fail"
+[ "$fail" -eq 0 ]

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/prompt.md
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/prompt.md
@@ -1,0 +1,5 @@
+Rename the `show` command to `print`. The old name goes away: a `show` line is now an unknown command.
+
+Preserve:
+- `add`, `sub`, the error lines and the integer semantics behave exactly as before.
+- Unknown commands (now including `show`) are reported as `error: unknown command <cmd>` and skipped.

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/scope.txt
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/scope.txt
@@ -1,0 +1,2 @@
+# files this edit may touch (glob per line; File.fnmatch with FNM_PATHNAME)
+main.*

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/solution/almide/main.almd
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/solution/almide/main.almd
@@ -1,0 +1,31 @@
+import io
+
+// A running total driven by one command per stdin line.
+//   add <n>   adds n to the total
+//   sub <n>   subtracts n from the total
+//   print     prints the total
+// Any other line is reported as an error and skipped.
+effect fn main() -> Unit = {
+  let lines = io.read_all() |> string.split("\n")
+  var total = 0
+  for raw in lines {
+    let line = string.trim(raw)
+    if line != "" then {
+      let parts = string.split(line, " ")
+      let cmd = list.get(parts, 0) ?? ""
+      let arg = list.get(parts, 1) ?? ""
+      match cmd {
+        "add" => match int.parse(arg) {
+          ok(n) => { total = total + n },
+          err(_) => println("error: bad amount ${arg}"),
+        },
+        "sub" => match int.parse(arg) {
+          ok(n) => { total = total - n },
+          err(_) => println("error: bad amount ${arg}"),
+        },
+        "print" => println(int.to_string(total)),
+        _ => println("error: unknown command ${cmd}"),
+      }
+    }
+  }
+}

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/solution/rust/main.rs
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/solution/rust/main.rs
@@ -1,0 +1,33 @@
+// A running total driven by one command per stdin line.
+//   add <n>   adds n to the total
+//   sub <n>   subtracts n from the total
+//   print     prints the total
+// Any other line is reported as an error and skipped.
+use std::io::Read;
+
+fn main() {
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input).unwrap();
+    let mut total: i64 = 0;
+    for raw in input.lines() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.split(' ');
+        let cmd = parts.next().unwrap_or("");
+        let arg = parts.next().unwrap_or("");
+        match cmd {
+            "add" => match arg.parse::<i64>() {
+                Ok(n) => total += n,
+                Err(_) => println!("error: bad amount {}", arg),
+            },
+            "sub" => match arg.parse::<i64>() {
+                Ok(n) => total -= n,
+                Err(_) => println!("error: bad amount {}", arg),
+            },
+            "print" => println!("{}", total),
+            _ => println!("error: unknown command {}", cmd),
+        }
+    }
+}

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/visible.sh
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/visible.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Visible suite for edit 02 (the model may read and run this). cwd = the program tree.
+pass=0; fail=0
+check() { # name, stdin (printf %b), expected stdout
+  local got; got="$(printf '%b' "$2" | ./app 2>&1)"
+  if [ "$got" = "$(printf '%b' "$3")" ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL $1: expected [$(printf '%b' "$3")] got [$got]"; fi
+}
+check "print after add" 'add 5\nprint\n'            '5'
+check "print after sub" 'add 5\nsub 7\nprint\n'     '-2'
+check "print twice"     'add 1\nprint\nadd 1\nprint\n' '1\n2'
+echo "PASSED: $pass"
+echo "FAILED: $fail"
+[ "$fail" -eq 0 ]

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/wrong/almide/main.almd
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/wrong/almide/main.almd
@@ -1,0 +1,29 @@
+import io
+
+// WRONG patch: keeps `show` as an alias of `print` — passes the visible suite,
+// violates "the old name goes away" in the hidden oracle.
+effect fn main() -> Unit = {
+  let lines = io.read_all() |> string.split("\n")
+  var total = 0
+  for raw in lines {
+    let line = string.trim(raw)
+    if line != "" then {
+      let parts = string.split(line, " ")
+      let cmd = list.get(parts, 0) ?? ""
+      let arg = list.get(parts, 1) ?? ""
+      match cmd {
+        "add" => match int.parse(arg) {
+          ok(n) => { total = total + n },
+          err(_) => println("error: bad amount ${arg}"),
+        },
+        "sub" => match int.parse(arg) {
+          ok(n) => { total = total - n },
+          err(_) => println("error: bad amount ${arg}"),
+        },
+        "print" => println(int.to_string(total)),
+        "show" => println(int.to_string(total)),
+        _ => println("error: unknown command ${cmd}"),
+      }
+    }
+  }
+}

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/wrong/rust/main.rs
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/edits/02-rename-show-to-print/wrong/rust/main.rs
@@ -1,0 +1,30 @@
+// WRONG patch: keeps `show` as an alias of `print` — passes the visible suite,
+// violates "the old name goes away" in the hidden oracle.
+use std::io::Read;
+
+fn main() {
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input).unwrap();
+    let mut total: i64 = 0;
+    for raw in input.lines() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.split(' ');
+        let cmd = parts.next().unwrap_or("");
+        let arg = parts.next().unwrap_or("");
+        match cmd {
+            "add" => match arg.parse::<i64>() {
+                Ok(n) => total += n,
+                Err(_) => println!("error: bad amount {}", arg),
+            },
+            "sub" => match arg.parse::<i64>() {
+                Ok(n) => total -= n,
+                Err(_) => println!("error: bad amount {}", arg),
+            },
+            "print" | "show" => println!("{}", total),
+            _ => println!("error: unknown command {}", cmd),
+        }
+    }
+}

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/seed/almide/build.sh
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/seed/almide/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Harness contract: `bash build.sh` exits 0 and leaves an executable at ./app
+set -e
+almide build main.almd -o app

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/seed/almide/main.almd
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/seed/almide/main.almd
@@ -1,0 +1,26 @@
+import io
+
+// A running total driven by one command per stdin line.
+//   add <n>   adds n to the total
+//   show      prints the total
+// Any other line is reported as an error and skipped.
+effect fn main() -> Unit = {
+  let lines = io.read_all() |> string.split("\n")
+  var total = 0
+  for raw in lines {
+    let line = string.trim(raw)
+    if line != "" then {
+      let parts = string.split(line, " ")
+      let cmd = list.get(parts, 0) ?? ""
+      let arg = list.get(parts, 1) ?? ""
+      match cmd {
+        "add" => match int.parse(arg) {
+          ok(n) => { total = total + n },
+          err(_) => println("error: bad amount ${arg}"),
+        },
+        "show" => println(int.to_string(total)),
+        _ => println("error: unknown command ${cmd}"),
+      }
+    }
+  }
+}

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/seed/rust/build.sh
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/seed/rust/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Harness contract: `bash build.sh` exits 0 and leaves an executable at ./app
+set -e
+rustc --edition 2021 -O main.rs -o app

--- a/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/seed/rust/main.rs
+++ b/research/benchmark/lang-bench/tasks-example/xlang/t0-smoke/seed/rust/main.rs
@@ -1,0 +1,28 @@
+// A running total driven by one command per stdin line.
+//   add <n>   adds n to the total
+//   show      prints the total
+// Any other line is reported as an error and skipped.
+use std::io::Read;
+
+fn main() {
+    let mut input = String::new();
+    std::io::stdin().read_to_string(&mut input).unwrap();
+    let mut total: i64 = 0;
+    for raw in input.lines() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.split(' ');
+        let cmd = parts.next().unwrap_or("");
+        let arg = parts.next().unwrap_or("");
+        match cmd {
+            "add" => match arg.parse::<i64>() {
+                Ok(n) => total += n,
+                Err(_) => println!("error: bad amount {}", arg),
+            },
+            "show" => println!("{}", total),
+            _ => println!("error: unknown command {}", cmd),
+        }
+    }
+}

--- a/research/benchmark/lang-bench/test/aggregate_edits_test.rb
+++ b/research/benchmark/lang-bench/test/aggregate_edits_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+#
+# ruby -Itest test/aggregate_edits_test.rb   (from research/benchmark/lang-bench)
+
+require 'minitest/autorun'
+require_relative '../aggregate_edits'
+
+class WilsonTest < Minitest::Test
+  def test_15_of_20
+    lo, hi = EditsStats.wilson(15, 20)
+    assert_in_delta 0.53, lo, 0.01
+    assert_in_delta 0.88, hi, 0.01
+  end
+
+  def test_30_of_40
+    lo, hi = EditsStats.wilson(30, 40)
+    assert_in_delta 0.60, lo, 0.01
+    assert_in_delta 0.86, hi, 0.01
+  end
+
+  def test_edges
+    assert_equal [0.0, 0.0], EditsStats.wilson(0, 0)
+    lo, hi = EditsStats.wilson(20, 20)
+    assert_equal 1.0, hi
+    assert lo > 0.8
+    lo, = EditsStats.wilson(0, 20)
+    assert_equal 0.0, lo
+  end
+end
+
+class LedgerTest < Minitest::Test
+  def rec(task, lang, survived, k: 3, usd: 0.5, status: nil)
+    edits = (1..k).map do |i|
+      s = i <= survived
+      { 'k' => i, 'survived' => s, 'first_fail_mode' => (s ? nil : (i == survived + 1 ? 'hidden' : 'prefix')),
+        'usd' => (i <= survived + 1 ? usd : 0.0) }
+    end
+    r = { 'task' => task, 'language' => lang, 'K' => k, 'edits' => edits }
+    r['status'] = status if status
+    r
+  end
+
+  def test_prefix_and_msr_edit
+    records = [rec('t', 'almide', 3), rec('t', 'almide', 1), rec('t', 'almide', 3), rec('t', 'almide', 0)]
+    rows, saturated = EditsStats.build_ledger(records)
+    row = rows.first
+    assert_equal 'measured', row['status']
+    assert_equal 4, row['n']
+    assert_in_delta 0.5, row['msr_seq'], 1e-9
+    assert_in_delta (3 + 1 + 3 + 0) / 12.0, row['msr_edit'], 1e-9
+    assert_includes %w[2:hidden 1:hidden], row['first_fail_mode']
+    refute saturated
+  end
+
+  def test_status_rows
+    records = [{ 'task' => 't', 'language' => 'zig', 'status' => 'harness-limitation', 'note' => 'zig not found' }]
+    rows, = EditsStats.build_ledger(records, cells: [['t', 'zig'], ['t', 'go']])
+    by = rows.to_h { |r| [r['language'], r['status']] }
+    assert_equal 'harness-limitation', by['zig']
+    assert_equal 'not-run', by['go']
+  end
+
+  def test_saturation
+    records = (1..50).map { rec('t', 'rust', 3) } + (1..50).map { rec('t', 'almide', 3) }
+    rows, saturated = EditsStats.build_ledger(records)
+    assert saturated
+    assert rows.all? { |r| r['status'] == 'inconclusive-saturated' }
+    assert_match(/INCONCLUSIVE_BANK_SATURATED/, EditsStats.render(rows, saturated))
+  end
+end


### PR DESCRIPTION
The no-spend half of #1963: the cross-language modification-survival harness and its design, without the measurement run (that costs money and needs the owner's go-ahead on the spend and the model pin — see the design comment on the issue).

## What changed

**Commit 1 — the MiniGit lane learns the comparison set**

- `runner_multi.rb`: `LANGUAGES` gains `go` (`go version`, `%w[go]`) and `zig` (`zig version`, `%w[zig]`); `EXCLUDE_DIR_FRAGMENTS` adds `/zig-out/` and `/.zig-cache/`.
- `aggregate_multi.rb`: `LANG_DISPLAY` likewise.
- `README.md`: a "Modification-survival lane" section explaining why MiniGit saturates and pointing at Dojo `tasks/xlang` and #1963.
- No behaviour change for the five existing languages (they have no `go`/`zig` raw files, so the table is byte-identical).

**Commit 2 — the modification-survival driver**

- `lib/bench_common.rb`: `run_cmd` / `run_claude` / `run_tests` / `count_loc` / `parse_claude_json` extracted from `runner_multi.rb`, behaviour identical (model and exclude list became parameters with the old values as defaults; `run_tests` additionally returns the suite output). `runner_multi.rb` requires it.
- `runner_edits.rb`: task-dir driven (`--tasks DIR`), layout `tasks/xlang/<task>/{seed/<lang>/, edits/0k-<slug>/{prompt.md,scope.txt,visible.sh,hidden.sh,solution/<lang>/,wrong/<lang>/}}`. Accumulating loop (edit k runs in the model's own post-edit-(k-1) tree, snapshotted with git), `survive_k = compile ∧ visible ∧ hidden ∧ scope_clean` where `scope_clean` = files changed since the pre-edit snapshot ⊆ `scope.txt` globs, prefix survival (the first failure stops the sequence and fails every later horizon). One JSONL record per (lang, task, trial) with `edits[]` carrying `survived`, `first_fail_mode` (compile / visible / hidden / scope / prefix), `usd`, `seconds`, `diagnostic` (the `E\d{3,4}` code when the compiler refused), `changed_files`. `--dry-run` is the bank gate and makes no model call: for every language present, the seed builds, the pre-edit tree fails each edit's visible and hidden suites (the edit is required), each `solution/<lang>` builds and passes both, each `wrong/<lang>` builds, passes visible and fails hidden, and every overlay stays inside `scope.txt`; a missing toolchain is a `harness-limitation` row.
- `aggregate_edits.rb`: MSR-seq (fraction of sequences surviving all K edits) with Wilson 95 % CI, MSR-edit (mean k*/K), per (task, language); ledger rows `task | language | status | n | msr_seq | ci95 | msr_edit | first_fail_mode | usd/seq` with status ∈ measured / not-run / harness-limitation / inconclusive-saturated, and `INCONCLUSIVE_BANK_SATURATED` when every measured cell is ≥ 98 %.
- `tasks-example/xlang/t0-smoke/`: a two-language (Almide + Rust) fixture — seed + 2 edits (add a variant, rename a command) with solutions and plausible wrong patches — so the gate runs end-to-end locally.
- `test/aggregate_edits_test.rb`: minitest for Wilson (15/20 → 0.53–0.88, 30/40 → 0.60–0.86), prefix survival / MSR-edit, status rows, saturation.

## How verified

- `ruby -c` on `runner_multi.rb`, `runner_edits.rb`, `aggregate_edits.rb`, `aggregate_multi.rb`, `lib/bench_common.rb`: all Syntax OK.
- `ruby aggregate_multi.rb` before and after: identical table for the five existing languages.
- `ruby runner_multi.rb --lang {go,zig,rust} --trials 1 --dry-run`: preflight and both phases run (go 1.27.0, zig 0.16.0 detected via the extra PATH); no record appended.
- `ruby -Itest test/aggregate_edits_test.rb`: 6 runs, 21 assertions, 0 failures.
- `ruby runner_edits.rb --tasks tasks-example/xlang --dry-run --almide-bin target/release/almide` (built from this branch):

```
t0-smoke/almide: ok (almide 0.62.0; 2 edits)
t0-smoke/rust: ok (rustc 1.96.1 (31fca3adb 2026-06-26); 2 edits)

task             language     status               toolchain
t0-smoke         almide       ok                   almide 0.62.0
t0-smoke         rust         ok                   rustc 1.96.1 (31fca3adb 2026-06-26)

dry-run OK
```

- Negative gate tests (scratch script, mutated copies of the fixture): wrong == solution → "wrong patch passes hidden.sh", a solution file outside `scope.txt` → "outside scope.txt", an edit whose pre-edit tree already passes → "pre-edit tree already passes", a language with no toolchain → `harness-limitation` row, a wrong patch failing visible → "not plausible". All five rejected as expected.
- `ruby aggregate_edits.rb --tasks tasks-example/xlang` with no records renders two `not-run` rows.

Not verified: the live loop (`run_claude` path of `runner_edits.rb`) has not been exercised against a model — by design of this PR. The `go` / `zig` MiniGit entries have no committed trials.
