### PR TITLE
A read-only heap parameter of a mutually recursive group is borrowed on native

### DIFF
--- a/crates/almide-codegen/src/pass_borrow_inference.rs
+++ b/crates/almide-codegen/src/pass_borrow_inference.rs
@@ -87,6 +87,15 @@ thread_local! {
     // keep `data: &Vec<u8>` instead of collapsing to `Vec<u8>` on the first
     // pass and never recovering.
     static CURRENT_FN: RefCell<Option<String>> = RefCell::new(None);
+    // Every fn this pass WILL analyse (bare name for program fns,
+    // `mod::name` for module fns). A call to one of these whose signature
+    // is not in the snapshot yet is a forward or MUTUALLY RECURSIVE
+    // reference inside the same fixed-point round — treated optimistically
+    // like a self-call (#2040): the first round seeds it as borrowed, and a
+    // callee that turns out to consume the slot promotes the caller to Own
+    // in the next round. Seeding it Own on the first miss locked every
+    // `parse_rule ↔ parse_seq ↔ …` group to by-value + clone per call.
+    static PENDING_USER_FNS: RefCell<std::collections::HashSet<String>> = RefCell::new(std::collections::HashSet::new());
     // Names of user-declared RECORD types (`type Tok = { … }`). A param of such a
     // type is `Ty::Named("Tok")` (not a structural `Ty::Record`), so without this
     // set `is_borrow_eligible`/`intrinsic_borrow_mode` treat it as Own and every reader
@@ -99,6 +108,51 @@ thread_local! {
 /// Is `name` a user-declared record type (eligible for record borrow inference)?
 fn is_record_type_name(name: &str) -> bool {
     RECORD_NAMES.with(|r| r.borrow().contains(name))
+}
+
+/// Is `callee` a fn this pass analyses whose signature the snapshot does not
+/// hold YET (a forward reference or a mutual-recursion partner in the current
+/// round)? Same `mod::name`-then-bare resolution as `lookup_user_borrows`.
+pub(crate) fn is_pending_user_fn(callee: &str) -> bool {
+    PENDING_USER_FNS.with(|p| {
+        let p = p.borrow();
+        MOD_SCOPE.with(|m| {
+            let m = m.borrow();
+            if let Some(mod_name) = m.as_deref()
+                && p.contains(&format!("{}::{}", mod_name, callee))
+            {
+                return true;
+            }
+            p.contains(callee)
+        })
+    })
+}
+
+/// The predicate `infer_program_fn_borrows` / `infer_program_module_borrows`
+/// apply: a fn whose borrows this pass infers (tests, generics and
+/// monomorphized instances are left to their own routes).
+fn is_analysed_fn(func: &IrFunction) -> bool {
+    let derived = is_derive_fn(func);
+    !func.is_test
+        && (derived
+            || !(is_monomorphized(&func.name) || func.generics.as_ref().map_or(false, |g| !g.is_empty())))
+}
+
+fn seed_pending_user_fns(program: &IrProgram) {
+    let mut set = std::collections::HashSet::new();
+    for func in &program.functions {
+        if is_analysed_fn(func) {
+            set.insert(func.name.to_string());
+        }
+    }
+    for module in &program.modules {
+        for func in &module.functions {
+            if is_analysed_fn(func) {
+                set.insert(format!("{}::{}", module.name, func.name));
+            }
+        }
+    }
+    PENDING_USER_FNS.with(|p| *p.borrow_mut() = set);
 }
 
 fn lookup_user_borrows(callee: &str) -> Option<Vec<ParamBorrow>> {
@@ -511,8 +565,13 @@ pub fn infer_borrow_signatures(program: &mut IrProgram) -> HashMap<String, Vec<P
     seed_record_names(program);
     seed_intrinsic_sigs(&mut sigs);
     alias_float_variant_sigs(&mut sigs);
+    seed_pending_user_fns(program);
 
-    for _iter in 0..6 {
+    // The lattice is finite — a slot moves Ref → Own at most once — so the
+    // rounds converge; the cap only bounds a pathological chain. (#2040:
+    // the optimistic first round makes the cap load-bearing, where the
+    // pessimistic seed used to leave a stale Own behind harmlessly.)
+    for _iter in 0..64 {
         // Snapshot current sigs into thread-local so check_needs_ownership can see them.
         SIGS_SNAPSHOT.with(|s| *s.borrow_mut() = sigs.clone());
         let prev_sigs = sigs.clone();
@@ -536,6 +595,7 @@ pub fn infer_borrow_signatures(program: &mut IrProgram) -> HashMap<String, Vec<P
     // Clean up thread-locals so they don't leak across separate compilations.
     SIGS_SNAPSHOT.with(|s| s.borrow_mut().clear());
     MOD_SCOPE.with(|m| *m.borrow_mut() = None);
+    PENDING_USER_FNS.with(|p| p.borrow_mut().clear());
 
     sigs
 }

--- a/crates/almide-codegen/src/pass_borrow_inference_ownership.rs
+++ b/crates/almide-codegen/src/pass_borrow_inference_ownership.rs
@@ -328,7 +328,19 @@ fn check_needs_ownership_call_self_recursive(target: &CallTarget, args: &[IrExpr
 /// Same `bool` return convention as the other branches.
 fn check_needs_ownership_call_user_named(target: &CallTarget, args: &[IrExpr], var: VarId, needs: &mut bool) -> bool {
     let CallTarget::Named { name } = target else { return false; };
-    let Some(borrows) = lookup_user_borrows(name.as_str()) else { return false; };
+    let Some(borrows) = lookup_user_borrows(name.as_str()) else {
+        // A user fn this pass analyses whose signature is not in the
+        // snapshot yet: a forward reference or a mutual-recursion partner
+        // (#2040). Optimistic, exactly like the self-recursive branch — the
+        // next round sees its real signature and promotes this param to Own
+        // if the callee consumes the slot. An unknown NON-user name keeps
+        // the pessimistic fallback.
+        if crate::pass_borrow_inference::is_pending_user_fn(name.as_str()) {
+            for arg in args { check_needs_ownership(arg, var, needs); }
+            return true;
+        }
+        return false;
+    };
     for (i, arg) in args.iter().enumerate() {
         // The callee borrows slot `i` (Ref/RefSlice/RefStr)
         // → forwarding a heap-typed var into it does NOT

--- a/tests/mutual_recursion_borrow_test.rs
+++ b/tests/mutual_recursion_borrow_test.rs
@@ -1,0 +1,91 @@
+//! A read-only heap parameter of a MUTUALLY recursive group is borrowed
+//! (#2040). Self-recursive fns already took `xs: &[T]` (#647); a group
+//! `rec_a ↔ rec_b` fell to `Vec<T>` + `.clone()` at every call because the
+//! first fixed-point round met the partner before its signature existed
+//! and seeded the slot as Own, which no later round could undo — a
+//! recursive-descent parser threading its grammar and token list through
+//! five helpers spent 140× its runtime deep-copying them.
+//!
+//! Emit-shape tests in the mold of `codec_decode_borrows_input_test.rs`.
+//! Skips cleanly when the `almide` binary is unavailable.
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn tool_available() -> bool {
+    Command::new(almide_bin()).arg("--version").output().is_ok()
+}
+
+fn emitted(source: &str, tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!("almide-mutual-borrow-{}-{}", tag, std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let src = dir.join("prog.almd");
+    std::fs::write(&src, source).unwrap();
+    let output = Command::new(almide_bin())
+        .args([src.to_str().unwrap(), "--target", "rust"])
+        .output()
+        .expect("failed to spawn almide");
+    let rust = String::from_utf8_lossy(&output.stdout).to_string();
+    std::fs::remove_dir_all(&dir).ok();
+    assert!(output.status.success(), "--target rust emit failed:\n{}", String::from_utf8_lossy(&output.stderr));
+    rust
+}
+
+/// The issue's repro: a self-recursive reader, a mutually recursive pair
+/// of readers, and a pair whose second member CONSUMES the list.
+const SRC: &str = "type T = { k: String, v: Int }\n\
+    fn rec_self(xs: List[T], i: Int) -> Int =\n\
+      if i >= 100 then 0 else { let a = rec_self(xs, i + 1); a + (option.map(list.get(xs, i), (t) => t.v) ?? 0) }\n\
+    fn rec_a(xs: List[T], i: Int) -> Int =\n\
+      if i >= 100 then 0 else { let a = rec_b(xs, i + 1); a + (option.map(list.get(xs, i), (t) => t.v) ?? 0) }\n\
+    fn rec_b(xs: List[T], i: Int) -> Int =\n\
+      if i >= 100 then 0 else { let a = rec_a(xs, i + 1); a + 1 }\n\
+    fn keep_a(xs: List[T], i: Int) -> List[T] =\n\
+      if i >= 3 then xs else keep_b(xs, i + 1)\n\
+    fn keep_b(xs: List[T], i: Int) -> List[T] =\n\
+      if i >= 3 then xs + [T { k: \"z\", v: i }] else keep_a(xs, i + 1)\n\
+    effect fn main() -> Unit = {\n\
+      let xs = [T { k: \"a\", v: 1 }]\n\
+      println(int.to_string(rec_self(xs, 0) + rec_a(xs, 0) + list.len(keep_a(xs, 0))))\n\
+    }\n";
+
+#[test]
+fn a_mutually_recursive_reader_group_borrows_its_list() {
+    if !tool_available() { eprintln!("skipping: almide binary not available"); return; }
+    let rust = emitted(SRC, "readers");
+    assert!(rust.contains("pub fn rec_self(xs: &[T]"), "the self-recursive reader keeps its borrow:\n{}", grep(&rust, "pub fn rec_"));
+    assert!(rust.contains("pub fn rec_a(xs: &[T]"), "rec_a only reads xs and hands it to rec_b: borrowed:\n{}", grep(&rust, "pub fn rec_"));
+    assert!(rust.contains("pub fn rec_b(xs: &[T]"), "rec_b only hands xs back to rec_a: borrowed:\n{}", grep(&rust, "pub fn rec_"));
+    let group = rust
+        .lines()
+        .skip_while(|l| !l.starts_with("pub fn rec_a("))
+        .take_while(|l| !l.starts_with("pub fn keep_a("))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(!group.contains("xs.clone()"), "no per-call clone survives in the reader group:\n{group}");
+}
+
+#[test]
+fn a_group_that_consumes_the_list_stays_owned() {
+    if !tool_available() { eprintln!("skipping: almide binary not available"); return; }
+    let rust = emitted(SRC, "consumers");
+    // keep_b returns `xs + [..]` (consumes) and keep_a returns xs itself:
+    // the optimistic first round must be corrected by the next one.
+    assert!(rust.contains("pub fn keep_b(xs: Vec<T>"), "a member that consumes the list owns it:\n{}", grep(&rust, "pub fn keep_"));
+    assert!(rust.contains("pub fn keep_a(xs: Vec<T>"), "its partner, which returns the list, owns it too:\n{}", grep(&rust, "pub fn keep_"));
+}
+
+fn grep(rust: &str, needle: &str) -> String {
+    rust.lines().filter(|l| l.contains(needle)).collect::<Vec<_>>().join("\n")
+}


### PR DESCRIPTION
Closes #2040. Borrow inference seeded a call to a user fn whose signature was not in the snapshot yet as Own (the pessimistic fallback), so the first fixed-point round locked every `parse_rule ↔ parse_seq ↔ …` group to by-value + `.clone()` per call, and no later round could undo it — a self-recursive fn was already optimistic (#647), a mutually recursive one never was. Now a call to a fn this pass WILL analyse (a forward reference or a mutual-recursion partner) is treated like a self-call: borrowed in the first round, promoted to Own in the next round if the callee consumes the slot (the lattice is finite, a slot moves Ref → Own at most once; the round cap goes 6 → 64 so convergence, not the cap, ends the loop). An unknown NON-user name keeps the pessimistic fallback. `tests/mutual_recursion_borrow_test.rs` pins the issue's repro (`rec_a`/`rec_b` emit `xs: &[T]`, no `xs.clone()`) and a pair whose second member consumes the list (`keep_a`/`keep_b` stay `Vec<T>`). Verified: `almide test` 437/437, codec_decode_borrows_input/for_in_clone_elision/shared_cell_borrow/tuple_capture_clone/codegen_snapshot/examples_parity/nanopass/critical_profile/convention_extension/tco_accumulator_move tests, `check-perf-ratio.sh` green on a quiet machine.