### PR TITLE
The test report reads the snapshot header behind a glued libtest ok verdict

### DIFF
--- a/src/cli/test_report.rs
+++ b/src/cli/test_report.rs
@@ -379,10 +379,13 @@ fn strip_libtest_progress(l: &str) -> &str {
     if !l.starts_with("test ") {
         return l;
     }
-    match l.find(" ... Error: ") {
-        Some(pos) => &l[pos + " ... ".len()..],
-        None => l,
-    }
+    // Three interleavings reach here: `... Error:` (the fragment flushed
+    // before the abort), `... okError:` (the PREVIOUS test's verdict flushed
+    // without its newline — one queue run, PR #2038), and the plain line.
+    let Some(pos) = l.find(" ... ") else { return l };
+    let tail = &l[pos + " ... ".len()..];
+    let tail = tail.strip_prefix("ok").filter(|t| t.starts_with("Error: ")).unwrap_or(tail);
+    if tail.starts_with("Error: ") { tail } else { l }
 }
 
 /// The `  key: value` tail of a T18 block. `expected` ends where `  found: `
@@ -699,6 +702,15 @@ mod tests {
         assert!(r.contains("accept: snapshot drift — run `almide test --update-snapshots plain_test.almd`"), "{r}");
         // A program line that merely mentions the words is not a header.
         assert!(parse("f.almd", "", "note: Error: snapshot mismatch is what it prints\n").is_empty());
+        // The previous test's `ok` verdict flushed without its newline and the
+        // header followed it directly (one queue run, PR #2038).
+        let glued = "running 3 tests\ntest tests::__test_a ... okError: snapshot mismatch\n  at: line 10\n  expected: item 1\nitem 2\n  found: item 1\nitem 2\nitem 3\n";
+        let fs = parse("plain_test.almd", "", glued);
+        assert_eq!(fs.len(), 1, "{fs:?}");
+        assert_eq!(fs[0].line, Some(10));
+        assert!(fs[0].render().contains("accept: snapshot drift"), "{}", fs[0].render());
+        // `test x ... ok` alone is a verdict line, not a header.
+        assert!(parse("f.almd", "", "test tests::__test_a ... ok\n").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Why

The merge-queue run for #2038 (CI 34189709937, `Test Rust (shard 0/4)`) failed `snapshot_update_test::a_plain_run_fails_with_the_accept_hint_and_writes_nothing`: the captured output read

```
test tests::__test_almd_already_matching ... okError: snapshot mismatch
```

The previous test's `ok` verdict was flushed without its newline and the T18 header followed it on the same line. `strip_libtest_progress` knew two interleavings (`... Error:` and a clean line, PR #1892) and not this third one, so the block went unrecognised and the report fell back to the raw output without the accept hint.

## What

- `strip_libtest_progress` splits at ` ... `, drops a leading `ok` when the header follows it, and only accepts a tail that starts with `Error: `. A plain `test x ... ok` verdict line stays a non-header.
- Unit test covers the glued `okError:` line and the bare verdict line.

## Gates

- `cargo test --release --bin almide test_report`: 19/19
- `cargo test --release --test snapshot_update_test`: 5/5