### PR TITLE
Derived Codec.decode pays its per-field error frame only on the error path (#2050)

### DIFF
--- a/crates/almide-codegen/CLAUDE.md
+++ b/crates/almide-codegen/CLAUDE.md
@@ -18,7 +18,7 @@ PatternLiteralGuard → ResolveCalls → RegionWindow → BoxDeref → LICM → 
 MatrixShapeSpec → ConstFold → IntrinsicLowering → BorrowInsertion →
 TailCallOpt → CaptureClone → CloneInsertion → MatchSubject → EffectInference →
 StdlibLowering → AutoParallel → ResultPropagation → BuiltinLowering →
-DecodeSlotHint → Peephole → RustLowering → FanLowering → NormalizeRuntimeCalls →
+DecodeSlotHint → DecodeErrFrame → Peephole → RustLowering → FanLowering → NormalizeRuntimeCalls →
 IrLinkFlatten → RangeCountingVars → TopLetStorage
 
 - Each pass: `impl NanoPass { fn run(&self, program, target) -> PassResult }`

--- a/crates/almide-codegen/src/lib.rs
+++ b/crates/almide-codegen/src/lib.rs
@@ -31,6 +31,7 @@ pub mod pass_borrow_inference;
 pub mod pass_box_deref;
 pub mod pass_builtin_lowering;
 pub mod pass_decode_slot_hint;
+pub mod pass_decode_err_frame;
 pub mod pass_capture_clone;
 pub mod pass_shared_cell_borrow;
 pub mod pass_clone;

--- a/crates/almide-codegen/src/pass_decode_err_frame.rs
+++ b/crates/almide-codegen/src/pass_decode_err_frame.rs
@@ -1,0 +1,174 @@
+//! DecodeErrFramePass (#2050): the per-field error frame of a derived
+//! `T.decode` costs nothing on the success path.
+//!
+//! #1675 gave every field of a derived decode a path frame: the field's
+//! `Result` goes through a per-type worker `T.__erratw_<mangle>(r, "key")`
+//! that passes an `Ok` through and splices `key` into an `Err`. The worker
+//! is the shape BOTH legs lower (a top-level fn matching on its own param —
+//! see `wrap_err_at` in the frontend), but on the native leg it is paid on
+//! EVERY field, failed or not: the walker renders the pass-through match as
+//! `match _r.clone() { Ok(_) => _r, … }` — a clone of the decoded payload —
+//! and the call site hands the worker an owned `"key".to_string()`. On the
+//! 8-field `decode` perf row that is eleven frames per decode and 2× the
+//! hand-written reference.
+//!
+//! This pass rewrites each `T.__erratw_M(<res>, "key")?` on the native leg
+//! into `<res>.map_err(|_we| almide_rt___err_at(_we, "key".to_string()))?`:
+//! the success path is the plain `?` on the field's own result, the key is
+//! the `&'static str` literal until an error actually needs an owned copy,
+//! and the error bytes are the ones the worker produced (`almide_rt___err_at`
+//! is the runtime the worker called). A worker no call site names any more
+//! is dropped from the program, so the emitted Rust carries no dead
+//! `T___erratw_*` fns.
+//!
+//! Scope: only the exact shape the derive mints — a `Try` over a `Named`
+//! call to a `T.__erratw_*` fn (spelled `T___erratw_*` once BuiltinLowering
+//! has flattened it) with a literal segment. The index twin
+//! (`T.__erratidx_*`, a `match` subject inside the list workers) and any
+//! worker whose call sites take another shape stay as they are. Native
+//! only: the wasm leg lowers the worker unchanged.
+//!
+//! Runs after BuiltinLowering, i.e. after BorrowInsertion (the field lookups
+//! inside `<res>` already carry their borrow decoration; BorrowInsertion
+//! treats `InlineRust` args as opaque, so the rewrite must not precede it)
+//! and before NormalizeRuntimeCalls.
+
+use std::collections::HashSet;
+
+use almide_base::intern::{sym, Sym};
+use almide_ir::*;
+use almide_ir::visit::{walk_expr, walk_stmt, IrVisitor};
+use almide_ir::visit_mut::{walk_expr_mut, walk_stmt_mut, IrMutVisitor};
+use super::pass::{NanoPass, PassResult, Target};
+
+const FRAME_MARK: &str = "__erratw_";
+const ERR_AT_SYM: &str = "almide_rt___err_at";
+
+#[derive(Debug)]
+pub struct DecodeErrFramePass;
+
+impl NanoPass for DecodeErrFramePass {
+    fn name(&self) -> &str { "DecodeErrFrame" }
+    fn targets(&self) -> Option<Vec<Target>> { Some(vec![Target::Rust]) }
+    fn depends_on(&self) -> Vec<&'static str> { vec!["BuiltinLowering"] }
+    fn run_before(&self) -> Vec<&'static str> { vec!["NormalizeRuntimeCalls"] }
+
+    fn run(&self, mut program: IrProgram, _target: Target) -> PassResult {
+        let mut rw = Rewriter { changed: false };
+        for func in &mut program.functions {
+            rw.visit_expr_mut(&mut func.body);
+        }
+        for tl in &mut program.top_lets {
+            rw.visit_expr_mut(&mut tl.value);
+        }
+        for module in &mut program.modules {
+            for func in &mut module.functions {
+                rw.visit_expr_mut(&mut func.body);
+            }
+            for tl in &mut module.top_lets {
+                rw.visit_expr_mut(&mut tl.value);
+            }
+        }
+        if !rw.changed {
+            return PassResult { program, changed: false };
+        }
+
+        // Drop every frame worker no call site names any more.
+        let mut refs = FrameRefs { named: HashSet::new() };
+        for func in &program.functions {
+            refs.visit_expr(&func.body);
+        }
+        for tl in &program.top_lets {
+            refs.visit_expr(&tl.value);
+        }
+        for module in &program.modules {
+            for func in &module.functions {
+                refs.visit_expr(&func.body);
+            }
+            for tl in &module.top_lets {
+                refs.visit_expr(&tl.value);
+            }
+        }
+        // A definition still spells `T.__erratw_M`; BuiltinLowering flattened
+        // the calls to `T___erratw_M` and may have module-prefixed them, so a
+        // worker stays whenever a surviving call name ends in its flat name.
+        let keep = |f: &IrFunction| {
+            if !is_frame_worker(f.name) { return true }
+            let flat = flat_name(f.name);
+            refs.named.iter().any(|n| n.as_str().ends_with(&flat))
+        };
+        program.functions.retain(keep);
+        for module in &mut program.modules {
+            module.functions.retain(keep);
+        }
+        PassResult { program, changed: true }
+    }
+}
+
+/// Both spellings of a frame worker: the definition's `T.__erratw_M` and
+/// the call's flattened `T___erratw_M`.
+fn is_frame_worker(name: Sym) -> bool {
+    name.as_str().contains(FRAME_MARK)
+}
+
+fn flat_name(name: Sym) -> String {
+    name.as_str().replace('.', "_")
+}
+
+/// The segment literal, bare or as the `&str` borrow BorrowInsertion may
+/// wrap it in.
+fn seg_literal(e: &IrExpr) -> Option<&str> {
+    match &e.kind {
+        IrExprKind::LitStr { value } => Some(value),
+        IrExprKind::Borrow { expr, .. } => match &expr.kind {
+            IrExprKind::LitStr { value } => Some(value),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+struct Rewriter {
+    changed: bool,
+}
+
+impl IrMutVisitor for Rewriter {
+    fn visit_expr_mut(&mut self, expr: &mut IrExpr) {
+        walk_expr_mut(self, expr);
+        let IrExprKind::Try { expr: tried } = &mut expr.kind else { return };
+        let IrExprKind::Call { target: CallTarget::Named { name }, args, .. } = &mut tried.kind else { return };
+        if !is_frame_worker(*name) || args.len() != 2 { return }
+        let Some(seg) = seg_literal(&args[1]) else { return };
+        // `{:?}` on a `str` is a valid Rust string literal for any segment
+        // (quotes, backslashes and controls escaped).
+        let template = format!("{{r}}.map_err(|_we| {ERR_AT_SYM}(_we, {seg:?}.to_string()))");
+        let res = args.swap_remove(0);
+        tried.kind = IrExprKind::InlineRust { template, args: vec![(sym("r"), res)] };
+        self.changed = true;
+    }
+    fn visit_stmt_mut(&mut self, stmt: &mut IrStmt) {
+        walk_stmt_mut(self, stmt);
+    }
+}
+
+/// Every frame worker still named by a call after the rewrite.
+struct FrameRefs {
+    named: HashSet<Sym>,
+}
+
+impl IrVisitor for FrameRefs {
+    fn visit_expr(&mut self, expr: &IrExpr) {
+        walk_expr(self, expr);
+        match &expr.kind {
+            IrExprKind::Call { target: CallTarget::Named { name }, .. }
+            | IrExprKind::TailCall { target: CallTarget::Named { name }, .. }
+            | IrExprKind::FnRef { name } if is_frame_worker(*name) => {
+                self.named.insert(*name);
+            }
+            _ => {}
+        }
+    }
+    fn visit_stmt(&mut self, stmt: &IrStmt) {
+        walk_stmt(self, stmt);
+    }
+}

--- a/crates/almide-codegen/src/target.rs
+++ b/crates/almide-codegen/src/target.rs
@@ -19,6 +19,7 @@ use super::pass_shared_cell_borrow::SharedCellBorrowPass;
 use super::pass_clone::CloneInsertionPass;
 use super::pass_builtin_lowering::BuiltinLoweringPass;
 use super::pass_decode_slot_hint::DecodeSlotHintPass;
+use super::pass_decode_err_frame::DecodeErrFramePass;
 use super::pass_result_propagation::ResultPropagationPass;
 use super::pass_intrinsic_lowering::IntrinsicLoweringPass;
 use super::pass_normalize_runtime_calls::NormalizeRuntimeCallsPass;
@@ -151,6 +152,12 @@ fn build_pipeline(target: Target) -> Pipeline {
         // lookups carry their declaration index. After BuiltinLowering
         // (the codec reroutes are final), before NormalizeRuntimeCalls.
         .add(DecodeSlotHintPass)
+        // DecodeErrFrame (#2050): a derived decode's per-field error frame
+        // becomes `.map_err(..)` on the field's own result — the success
+        // path is a plain `?`. After BuiltinLowering (so after
+        // BorrowInsertion: the lookups inside the frame keep their
+        // borrow decoration), before NormalizeRuntimeCalls.
+        .add(DecodeErrFramePass)
         // Peephole: swap/reverse/rotate/copy → specialized IR nodes
                 .add(PeepholePass)
                 // Rust-specific: push optimization, borrow index lift

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -251,14 +251,15 @@ The Wgsl arm is the four rows marked W. Class:
 | 22 | `ResultPropagation` | `pass_result_propagation.rs` | all | Rust by design | effect fn `T → Result[T, String]`, `Try` at call sites | own effect lowering (`effect_raw`, `emit.rs`) |
 | 23 | `BuiltinLowering` | `pass_builtin_lowering.rs` | Rust | Rust by design | `assert_eq`/`println`/… → `RustMacro` | n/a |
 | 24 | `DecodeSlotHint` | `pass_decode_slot_hint.rs` | Rust | Rust by design | a derived `T.decode`'s borrowed field lookups carry their declaration index (`@codec_slots`), rendered as `almide_rt_value_field_ref_at` (#1679); the runtime tries `pairs[i]` before the scan, errors unchanged (C-084) | n/a (the wasm leg reads neither the attribute nor the `_at` symbol) |
-| 25 | `Peephole` | `pass_peephole.rs` | all | optimizer | idiomatic list loops → `ListSwap`/`ListReverse`/`ListRotateLeft`/`ListCopySlice` nodes | **no lowering for those nodes** — see E |
-| 26 | `RustLowering` | `pass_rust_lowering.rs` | Rust | Rust by design | push optimization, borrow index lift | n/a |
-| 27 | `FanLowering` | `pass_fan_lowering.rs` (wrapper in `pass.rs`) | all, W | enabler | strip auto-try from fan spawn closures | own fan lowering (`fan.rs`) |
-| 28 | `NormalizeRuntimeCalls` | `pass_normalize_runtime_calls.rs` | Rust | Rust by design | legacy `Named { almide_rt_* }` → `RuntimeCall` | n/a |
-| 29 | `IrLinkFlatten` | `pass_ir_link_flatten.rs` | Rust | Rust by design | flatten modules into the root for the walker | keeps modules, qualified names |
-| 30 | `SharedCellBorrow` | `pass_shared_cell_borrow.rs` | Rust | Rust by design | borrow a captured cell in place for statement-proven-safe reads (#1143) | n/a |
-| 31 | `RangeCountingVars` | `pass_range_counting.rs` | Rust | optimizer | a `let`-bound range read ONLY as `for-in` heads stays a bare `Range<i64>` instead of a materialized `Vec<i64>` (#1857); mirrors MIR's #1400 `range_counting_vars` admission rule and runs last so the set names the final IR | `ranges.rs` counting loop (#1400) — already has it |
-| 32 | `TopLetStorage` | `pass_top_let_storage.rs` | all | analysis | the unified top-let storage attribute for the walker (§4 Stage 1) | own globals plan (`build_globals`) |
+| 25 | `DecodeErrFrame` | `pass_decode_err_frame.rs` | Rust | Rust by design | a derived `T.decode`'s per-field error frame (`T___erratw_*`, #1675) becomes `.map_err(..)` on the field's own result, so the success path is a plain `?` with no payload clone and no key allocation (#2050) | n/a (the wasm leg lowers the worker itself) |
+| 26 | `Peephole` | `pass_peephole.rs` | all | optimizer | idiomatic list loops → `ListSwap`/`ListReverse`/`ListRotateLeft`/`ListCopySlice` nodes | **no lowering for those nodes** — see E |
+| 27 | `RustLowering` | `pass_rust_lowering.rs` | Rust | Rust by design | push optimization, borrow index lift | n/a |
+| 28 | `FanLowering` | `pass_fan_lowering.rs` (wrapper in `pass.rs`) | all, W | enabler | strip auto-try from fan spawn closures | own fan lowering (`fan.rs`) |
+| 29 | `NormalizeRuntimeCalls` | `pass_normalize_runtime_calls.rs` | Rust | Rust by design | legacy `Named { almide_rt_* }` → `RuntimeCall` | n/a |
+| 30 | `IrLinkFlatten` | `pass_ir_link_flatten.rs` | Rust | Rust by design | flatten modules into the root for the walker | keeps modules, qualified names |
+| 31 | `SharedCellBorrow` | `pass_shared_cell_borrow.rs` | Rust | Rust by design | borrow a captured cell in place for statement-proven-safe reads (#1143) | n/a |
+| 32 | `RangeCountingVars` | `pass_range_counting.rs` | Rust | optimizer | a `let`-bound range read ONLY as `for-in` heads stays a bare `Range<i64>` instead of a materialized `Vec<i64>` (#1857); mirrors MIR's #1400 `range_counting_vars` admission rule and runs last so the set names the final IR | `ranges.rs` counting loop (#1400) — already has it |
+| 33 | `TopLetStorage` | `pass_top_let_storage.rs` | all | analysis | the unified top-let storage attribute for the walker (§4 Stage 1) | own globals plan (`build_globals`) |
 
 ### C. Structural wasm leg — `crates/almide-wasm` (default `--target wasm`)
 

--- a/tests/codec_decode_success_path_test.rs
+++ b/tests/codec_decode_success_path_test.rs
@@ -67,17 +67,17 @@ fn every_field_frame_is_a_map_err_on_the_borrowed_lookup() {
     let rust = emitted(SRC, "frame");
     let decode = body_of(&rust, "User_decode");
     for (key, read) in [
-        ("id", "almide_rt_value_as_int(almide_rt_value_field_ref(_v, \"id\")?)"),
-        ("name", "almide_rt_value_as_string(almide_rt_value_field_ref(_v, \"name\")?)"),
-        ("tags", "almide_rt___decode_list_string(almide_rt_value_field_ref(_v, \"tags\")?)"),
-        ("address", "Address_decode(almide_rt_value_field_ref(_v, \"address\")?)"),
-        ("homes", "almide_rt_value_decode_list_ref(almide_rt_value_field_ref(_v, \"homes\")?, Address_decode)"),
+        ("id", "almide_rt_value_as_int(almide_rt_value_field_ref_at(_v, \"id\", 0)?)"),
+        ("name", "almide_rt_value_as_string(almide_rt_value_field_ref_at(_v, \"name\", 1)?)"),
+        ("tags", "almide_rt___decode_list_string(almide_rt_value_field_ref_at(_v, \"tags\", 2)?)"),
+        ("address", "Address_decode(almide_rt_value_field_ref_at(_v, \"address\", 3)?)"),
+        ("homes", "almide_rt_value_decode_list_ref(almide_rt_value_field_ref_at(_v, \"homes\", 4)?, Address_decode)"),
     ] {
         let frame = format!("({read}.map_err(|_we| almide_rt___err_at(_we, {key:?}.to_string())))?");
         assert!(decode.contains(&frame), "field `{key}` must read its borrowed lookup with the frame as a `.map_err` on it:\n{decode}");
     }
     let nested = body_of(&rust, "Address_decode");
-    assert!(nested.contains("(almide_rt_value_as_string(almide_rt_value_field_ref(_v, \"city\")?).map_err(|_we| almide_rt___err_at(_we, \"city\".to_string())))?"),
+    assert!(nested.contains("(almide_rt_value_as_string(almide_rt_value_field_ref_at(_v, \"city\", 0)?).map_err(|_we| almide_rt___err_at(_we, \"city\".to_string())))?"),
         "the nested record's own decode carries the same frame shape:\n{nested}");
 }
 

--- a/tests/codec_decode_success_path_test.rs
+++ b/tests/codec_decode_success_path_test.rs
@@ -1,0 +1,130 @@
+//! A derived `T.decode` pays its #1675 error frame only when a field fails
+//! (#2050).
+//!
+//! Every field of a derived decode carries a path frame: an `Err` gets the
+//! field's key spliced in (`expected Int, received Str, at x`). The frame was
+//! a per-type worker `T___erratw_<mangle>(r, "key")` that matched a CLONE of
+//! the field's `Result` and took the key as an owned `String` — a payload
+//! clone and a key allocation on the SUCCESS path of every field, 2x the
+//! hand-written reference on the 8-field `decode` perf row. On the native
+//! leg the frame is now `.map_err(|_we| almide_rt___err_at(_we, "key"
+//! .to_string()))` on the field's own result: the success path is the plain
+//! `?`, the key stays a `&'static str` literal until an error needs it, and
+//! the workers no call site names are dropped from the program.
+//!
+//! Emit-shape tests, in the mold of `codec_decode_borrows_input_test.rs`.
+//! Skips cleanly when the `almide` binary is unavailable.
+
+use std::path::Path;
+use std::process::Command;
+
+fn almide_bin() -> String {
+    if let Ok(bin) = std::env::var("ALMIDE_BIN") {
+        return bin;
+    }
+    let cargo_bin = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/release/almide");
+    if cargo_bin.exists() {
+        return cargo_bin.to_str().unwrap().to_string();
+    }
+    "almide".to_string()
+}
+
+fn tool_available() -> bool {
+    Command::new(almide_bin()).arg("--version").output().is_ok()
+}
+
+fn emitted(source: &str, tag: &str) -> String {
+    let dir = std::env::temp_dir().join(format!("almide-decode-frame-{}-{}", tag, std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let src = dir.join("prog.almd");
+    std::fs::write(&src, source).unwrap();
+    let output = Command::new(almide_bin())
+        .args([src.to_str().unwrap(), "--target", "rust"])
+        .output()
+        .expect("failed to spawn almide");
+    let rust = String::from_utf8_lossy(&output.stdout).to_string();
+    std::fs::remove_dir_all(&dir).ok();
+    assert!(output.status.success(), "--target rust emit failed:\n{}", String::from_utf8_lossy(&output.stderr));
+    rust
+}
+
+/// The lines of `rust` from `pub fn <name>(` to the fn's closing brace.
+fn body_of(rust: &str, name: &str) -> String {
+    let head = format!("pub fn {name}(");
+    rust.lines().skip_while(|l| !l.starts_with(&head)).take_while(|l| !l.starts_with('}')).collect::<Vec<_>>().join("\n")
+}
+
+const SRC: &str = "type Address: Codec = { city: String, zip: String }\n\
+    type User: Codec = { id: Int, name: String, tags: List[String], address: Address, homes: List[Address] }\n\
+    fn main() -> Unit = {\n\
+      let v = value.object([(\"id\", value.int(1)), (\"name\", value.str(\"a\")), (\"tags\", value.array([])), (\"address\", value.object([(\"city\", value.str(\"t\")), (\"zip\", value.str(\"z\"))])), (\"homes\", value.array([]))])\n\
+      match User.decode(v) { ok(u) => println(u.name), err(e) => println(e) }\n\
+    }\n";
+
+#[test]
+fn every_field_frame_is_a_map_err_on_the_borrowed_lookup() {
+    if !tool_available() { eprintln!("skipping: almide binary not available"); return; }
+    let rust = emitted(SRC, "frame");
+    let decode = body_of(&rust, "User_decode");
+    for (key, read) in [
+        ("id", "almide_rt_value_as_int(almide_rt_value_field_ref(_v, \"id\")?)"),
+        ("name", "almide_rt_value_as_string(almide_rt_value_field_ref(_v, \"name\")?)"),
+        ("tags", "almide_rt___decode_list_string(almide_rt_value_field_ref(_v, \"tags\")?)"),
+        ("address", "Address_decode(almide_rt_value_field_ref(_v, \"address\")?)"),
+        ("homes", "almide_rt_value_decode_list_ref(almide_rt_value_field_ref(_v, \"homes\")?, Address_decode)"),
+    ] {
+        let frame = format!("({read}.map_err(|_we| almide_rt___err_at(_we, {key:?}.to_string())))?");
+        assert!(decode.contains(&frame), "field `{key}` must read its borrowed lookup with the frame as a `.map_err` on it:\n{decode}");
+    }
+    let nested = body_of(&rust, "Address_decode");
+    assert!(nested.contains("(almide_rt_value_as_string(almide_rt_value_field_ref(_v, \"city\")?).map_err(|_we| almide_rt___err_at(_we, \"city\".to_string())))?"),
+        "the nested record's own decode carries the same frame shape:\n{nested}");
+}
+
+#[test]
+fn the_success_path_clones_no_payload_and_allocates_no_key() {
+    if !tool_available() { eprintln!("skipping: almide binary not available"); return; }
+    let rust = emitted(SRC, "success");
+    for name in ["User_decode", "Address_decode"] {
+        let decode = body_of(&rust, name);
+        assert!(!decode.contains(".clone()"), "{name} must not clone anything on the way to its record:\n{decode}");
+        // The only owned copy of a key is the one inside a `map_err` closure — the error path.
+        for line in decode.lines().filter(|l| l.contains(".to_string()")) {
+            assert!(line.contains(".map_err(|_we|"), "{name} allocates a key outside the error closure:\n{line}");
+        }
+    }
+}
+
+#[test]
+fn the_frame_workers_are_not_emitted() {
+    if !tool_available() { eprintln!("skipping: almide binary not available"); return; }
+    let rust = emitted(SRC, "workers");
+    let workers: Vec<&str> = rust.lines().filter(|l| l.contains("___erratw_")).collect();
+    assert!(workers.is_empty(), "no call site names a frame worker any more, so none may be emitted:\n{}", workers.join("\n"));
+}
+
+/// The frame's bytes are #1675's: a failing field reports `, at <key>`, a
+/// nested failure prepends the parent's key, and the error the wasm leg
+/// (whose worker is unchanged) prints is the one native prints.
+#[test]
+fn the_error_text_is_unchanged() {
+    if !tool_available() { eprintln!("skipping: almide binary not available"); return; }
+    let src = "type Address: Codec = { city: String, zip: String }\n\
+        type User: Codec = { id: Int, name: String, address: Address }\n\
+        fn show(v: Value) -> String = match User.decode(v) { ok(u) => u.name, err(e) => e }\n\
+        fn main() -> Unit = {\n\
+          println(show(value.object([(\"id\", value.str(\"x\")), (\"name\", value.str(\"a\")), (\"address\", value.object([]))])))\n\
+          println(show(value.object([(\"id\", value.int(1)), (\"name\", value.str(\"a\")), (\"address\", value.object([(\"city\", value.int(3))]))])))\n\
+          println(show(value.object([(\"id\", value.int(1)), (\"name\", value.str(\"a\")), (\"address\", value.object([(\"city\", value.str(\"c\"))]))])))\n\
+          println(show(value.object([(\"id\", value.int(1)), (\"name\", value.str(\"a\")), (\"address\", value.object([(\"city\", value.str(\"c\")), (\"zip\", value.str(\"z\"))]))])))\n\
+        }\n";
+    let dir = std::env::temp_dir().join(format!("almide-decode-frame-text-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("prog.almd");
+    std::fs::write(&path, src).unwrap();
+    let output = Command::new(almide_bin()).args(["run", path.to_str().unwrap()]).output().expect("failed to spawn almide");
+    std::fs::remove_dir_all(&dir).ok();
+    assert!(output.status.success(), "run failed:\n{}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout, "expected Int, received Str, at id\nexpected Str, received Int, at address.city\nmissing field 'zip', at address\na\n");
+}


### PR DESCRIPTION
## Why

#1675 gave every field of a derived `T.decode` a path frame: the field's `Result` goes through a per-type worker `T___erratw_<mangle>(r, "key")` that passes an `Ok` through and splices the key into an `Err`. On the native leg that frame is paid on **every** field, failed or not — the walker renders the pass-through match as `match _r.clone() { Ok(_) => _r, … }` (a clone of the decoded payload) and the call site hands the worker an owned `"key".to_string()`. On the 8-field `decode` row (#2047) that is eleven frames per decode and the whole 2x against the hand-written reference.

## What

A native-only nanopass, `DecodeErrFramePass` (`crates/almide-codegen/src/pass_decode_err_frame.rs`), after BuiltinLowering and before NormalizeRuntimeCalls. It rewrites each `T___erratw_M(<res>, "key")?` into

```rust
<res>.map_err(|_we| almide_rt___err_at(_we, "key".to_string()))?
```

so the success path is the plain `?` on the field's own borrowed lookup, the key stays a `&'static str` literal until an error needs an owned copy, and the error bytes are the ones the worker produced (`almide_rt___err_at` is what the worker called). Workers no call site names any more are dropped from the program, so no dead `T___erratw_*` fns are emitted. The frontend IR and the wasm leg are untouched — the worker is still the shape both legs lower; the pass runs after BorrowInsertion so the lookups inside the frame keep their borrow decoration (BorrowInsertion treats `InlineRust` args as opaque).

Before / after for the `User` record of the row:

```rust
let _f_name: String = (User___erratw_string(almide_rt_value_as_string(almide_rt_value_field_ref(_v, "name")?), "name".to_string()))?;
let _f_name: String = (almide_rt_value_as_string(almide_rt_value_field_ref(_v, "name")?).map_err(|_we| almide_rt___err_at(_we, "name".to_string())))?;
```

## Numbers

`research/benchmark/perf/decode` (from #2047, not merged yet), M4 Pro, 2M decodes, floor-subtracted, min of 5 interleaved runs, built the way the row builds (`almide build --release`); the box was shared with sibling agents, so these are mins, not medians:

| variant | ns/op |
|---|---:|
| native before (installed 0.62.0) | 518 |
| native after (this PR) | 224 |
| hand-written reference `rust-ref/decode.rs` | 188 |

2.75x → 1.19x. The derived decode body now matches the reference line for line; compiling the emitted Rust with the reference's own rustc flags reads 181 ns/op against the reference's 182, so the remaining ~35 ns of the row is in the `almide build --release` profile, not the emit — a separate follow-up if the row is to be anchored.

**Ratchet:** the `decode` row and its baseline live on #2047's branch, not on develop, so this PR changes no `scripts/check-perf-ratio.sh` / `perf-ratio-baseline.txt` line. Lowering the row's baseline (2.46 whole-process on the day it landed) depends on #2047 landing first; it should be re-read on that branch with this pass applied.

## Gates

- `tests/codec_decode_success_path_test.rs` (new, in the mold of `codec_decode_borrows_input_test.rs`): every field frame is a `.map_err` on the borrowed lookup, no `.clone()` and no key `.to_string()` outside the error closure in the decode bodies, no `___erratw_` fn emitted, and the error text (`, at id` / `, at address.city` / `missing field 'zip', at address`) unchanged
- `cargo test --release --test codec_decode_success_path_test --test codec_decode_borrows_input_test --test codegen_snapshot_test`: green, no snapshot changes (none covers a derived Codec)
- `almide test spec/stdlib/` (162 files) and `spec/lang/` (211 files): green on the default leg; `spec/stdlib/` also green with `--target native`
- C-084 `codec_decode_errors.almd`, C-085 `codec_float_int.almd`, the four C-087 json fixtures, and #2047's `codec_decode_field_order.almd`: byte-identical across native (this PR), wasm (untouched leg, the oracle) and the installed 0.62.0 native binary
- A module-defined Codec (`import geo` / `geo.parse`) decodes and reports `at y` identically on both legs (the module-prefixed worker name path)
- `bash scripts/check-contracts.sh`, `bash scripts/check-readme-numbers.sh`: green; `cargo clippy --release -p almide-codegen`: no warnings in the new pass

## Found on the way (pre-existing, not this PR)

A record with an `Option[T]` field where `T` has a defaulted field emits invalid Rust on the native leg (`almide_rt_value_decode_option_custom(_v, …)` — the by-value option driver handed a borrowed `_v`; rustc E0308). Reproduces identically on the installed 0.62.0. Repro:

```almide
type Addr: Codec = { city: String, zip: String = "0" }
type Rec: Codec = { name: String, alt: Addr? }
```

Closes #2050
