### PR TITLE
Prepare shared fan inputs before spawning sibling closures

### DIFF
--- a/.github/workflows/ci-feature.yml
+++ b/.github/workflows/ci-feature.yml
@@ -52,6 +52,26 @@ jobs:
       - name: Build
         run: cargo build --release
 
+      - name: Cache wasmtime tarball
+        uses: actions/cache@v6
+        with:
+          path: wasmtime-v47.0.3-x86_64-linux.tar.xz
+          key: wasmtime-v47.0.3-x86_64-linux
+
+      - name: Install runtime required by cargo tests
+        run: |
+          set -euo pipefail
+          VERSION=v47.0.3
+          TARBALL="wasmtime-${VERSION}-x86_64-linux.tar.xz"
+          if ! tar -tf "$TARBALL" >/dev/null 2>&1; then
+            curl --fail --location --retry 5 --retry-all-errors \
+              "https://github.com/bytecodealliance/wasmtime/releases/download/${VERSION}/${TARBALL}" \
+              --output "$TARBALL"
+          fi
+          tar -xf "$TARBALL"
+          sudo install -m 755 "wasmtime-${VERSION}-x86_64-linux/wasmtime" /usr/local/bin/wasmtime
+          wasmtime --version
+
       - name: Cargo tests
         # Parallel-safe on Unix: the shared build scratch dir is serialized
         # across processes by an advisory flock (src/cli/run.rs BuildDirLock).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1513,10 +1513,24 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Cache stock WASI runtime
+        uses: actions/cache@v6
+        with:
+          path: /tmp/wasmtime.tar.xz
+          key: wasmtime-v27.0.0-x86_64-linux
       - name: Install wasmtime (stock CLI — the WASI gate's third-party runtime)
         run: |
-          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v27.0.0
-          echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+          set -euo pipefail
+          VERSION=v27.0.0
+          TARBALL=/tmp/wasmtime.tar.xz
+          if ! tar -tf "$TARBALL" >/dev/null 2>&1; then
+            curl --fail --location --retry 5 --retry-all-errors \
+              "https://github.com/bytecodealliance/wasmtime/releases/download/${VERSION}/wasmtime-${VERSION}-x86_64-linux.tar.xz" \
+              --output "$TARBALL"
+          fi
+          tar -xf "$TARBALL" -C /tmp
+          sudo install -m 755 "/tmp/wasmtime-${VERSION}-x86_64-linux/wasmtime" /usr/local/bin/wasmtime
+          wasmtime --version
       - name: Carried gates in release shape
         run: cargo test --release --locked -p almide-wasm -p almide-wasm-run -p almide-spine -p almide-syntax -p almide-corpus -p almide-layout
       # #2010 stage 2b: under the double-free trap a second release of a

--- a/crates/almide-codegen/src/pass_capture_clone.rs
+++ b/crates/almide-codegen/src/pass_capture_clone.rs
@@ -21,6 +21,10 @@ use almide_lang::types::Ty;
 use almide_base::intern::Sym;
 use super::pass::{NanoPass, PassResult, Target};
 
+#[path = "pass_capture_clone_bindings.rs"]
+mod bindings;
+use bindings::{capture_bindings, wrap_fan_with_clones};
+
 #[derive(Debug)]
 pub struct CaptureClonePass;
 
@@ -492,6 +496,8 @@ fn transform_expr(expr: &mut IrExpr, vt: &mut VarTable, scope_vars: &HashSet<Var
         }
     }
 
+    changed |= wrap_fan_with_clones(expr, vt, scope_vars);
+
     changed
 }
 
@@ -536,98 +542,7 @@ fn wrap_lambda_with_clones(
     vt: &mut VarTable,
     lam_mutated: &HashSet<VarId>,
 ) {
-    let mut stmts = Vec::new();
-    let mut renames = std::collections::HashMap::new();
-
-    for &var_id in captures {
-        let ty = vt.get(var_id).ty.clone();
-        let cap_name = format!("__cap_{}", var_id.0);
-        let cap_var = vt.alloc(
-            almide_base::intern::sym(&cap_name),
-            ty.clone(),
-            Mutability::Let,
-            None,
-        );
-        renames.insert(var_id, cap_var);
-
-        // The clone of a shared-mut capture is itself a shared cell (`Rc<Cell>`),
-        // so reads/writes of `__cap` inside the closure go through `.get()`/`.set()`
-        // too. (Closure v2, P3.)
-        if SHARED_MUT.with(|m| m.borrow().contains(&var_id)) {
-            SHARED_MUT.with(|m| { m.borrow_mut().insert(cap_var); });
-        }
-
-        // If the captured var is a fn param with a borrowed runtime
-        // representation (`&[T]` / `&str` / `&T`), the bare `Var` IR
-        // renders as the borrow — but `__cap_N: Vec<T>` / `String` / `T`
-        // (the Almide-level owned type) expects an owned value. Materialise
-        // the owned form explicitly so the `move |..|` closure can take it.
-        let borrow = PARAM_BORROWS.with(|m| m.borrow().get(&var_id).copied());
-        let bind_value = match borrow {
-            Some(ParamBorrow::RefSlice) => IrExpr {
-                kind: IrExprKind::ToVec {
-                    expr: Box::new(IrExpr { kind: IrExprKind::Var { id: var_id }, ty: ty.clone(), span: None, def_id: None }),
-                },
-                ty: ty.clone(), span: None, def_id: None,
-            },
-            Some(ParamBorrow::RefStr) => IrExpr {
-                kind: IrExprKind::Call {
-                    target: CallTarget::Method {
-                        object: Box::new(IrExpr { kind: IrExprKind::Var { id: var_id }, ty: ty.clone(), span: None, def_id: None }),
-                        // Use `to_owned` instead of `to_string` to avoid
-                        // StdlibLowering converting this into a module call
-                        // (e.g. `int.to_string()`) when the Almide-level type
-                        // differs from the Rust-level &str representation.
-                        method: almide_base::intern::sym("to_owned"),
-                    },
-                    args: vec![],
-                    type_args: vec![],
-                },
-                ty: ty.clone(), span: None, def_id: None,
-            },
-            // The default capture bind CLONES explicitly (#809): CloneInsertion's
-            // last-use analysis would MOVE the var here when this is its last
-            // syntactic use — but a runtime-template borrow (`&{m}` — e.g.
-            // `map.fold`'s first arg) in the SAME statement is invisible at the
-            // IR level and stays live until the call, so the move was an E0505.
-            // READ-ONLY captures only: a capture THIS lambda mutates keeps the
-            // bare `Var` bind — the shared-cell wiring (Closure v2 P3/P6)
-            // pattern-matches it, and a `Clone` wrapper severed the sharing
-            // (each closure mutated its own copy — the wasm_runtime
-            // closure-capture cross-target mismatches). NOTE the mutability
-            // FLAG cannot gate this: a non-Copy `var` mutated only through a
-            // method (`list.push`) is recorded `Mutability::Let`.
-            _ if !lam_mutated.contains(&var_id) => IrExpr {
-                kind: IrExprKind::Clone {
-                    expr: Box::new(IrExpr {
-                        kind: IrExprKind::Var { id: var_id },
-                        ty: ty.clone(),
-                        span: None,
-                        def_id: None,
-                    }),
-                },
-                ty: ty.clone(),
-                span: None,
-                def_id: None,
-            },
-            _ => IrExpr {
-                kind: IrExprKind::Var { id: var_id },
-                ty: ty.clone(),
-                span: None,
-                def_id: None,
-            },
-        };
-
-        stmts.push(IrStmt {
-            kind: IrStmtKind::Bind {
-                var: cap_var,
-                mutability: Mutability::Let,
-                ty: ty.clone(),
-                value: bind_value,
-            },
-            span: None,
-        });
-    }
+    let (stmts, renames) = capture_bindings(captures, vt, lam_mutated, None);
 
     // Rename captured vars inside the lambda body
     if let IrExprKind::Lambda { body, .. } = &mut expr.kind {

--- a/crates/almide-codegen/src/pass_capture_clone_bindings.rs
+++ b/crates/almide-codegen/src/pass_capture_clone_bindings.rs
@@ -1,0 +1,129 @@
+//! Owned capture bindings shared by explicit lambdas and implicit fan closures.
+use super::*;
+
+/// Fan arms are implicit move closures. Their capture bindings must be
+/// outside the entire Fan node, so every clone runs before any spawn.
+pub(super) fn wrap_fan_with_clones(expr: &mut IrExpr, vt: &mut VarTable, scope: &HashSet<VarId>) -> bool {
+    let IrExprKind::Fan { exprs } = &mut expr.kind else { return false };
+    let mut bindings = Vec::new();
+    for arm in exprs {
+        let mut mutated = HashSet::new();
+        collect_mutated_vars(arm, &mut mutated);
+        let captures: Vec<VarId> = almide_ir::free_vars::free_vars(arm, &HashSet::new())
+            .into_iter().filter(|v| scope.contains(v)
+                && needs_clone_type(&vt.get(*v).ty) && !mutated.contains(v)).collect();
+        let (stmts, renames) = capture_bindings(&captures, vt, &mutated, Some("__fan_cap"));
+        replace_vars(arm, &renames);
+        bindings.extend(stmts);
+    }
+    if bindings.is_empty() { return false; }
+    let body = std::mem::take(expr);
+    *expr = IrExpr { ty: body.ty.clone(), span: body.span, def_id: body.def_id,
+        kind: IrExprKind::Block { stmts: bindings, expr: Some(Box::new(body)) } };
+    true
+}
+
+pub(super) fn capture_bindings(
+    captures: &[VarId],
+    vt: &mut VarTable,
+    lam_mutated: &HashSet<VarId>,
+    prefix: Option<&str>,
+) -> (Vec<IrStmt>, std::collections::HashMap<VarId, VarId>) {
+    let mut stmts = Vec::new();
+    let mut renames = std::collections::HashMap::new();
+
+    for &var_id in captures {
+        let ty = vt.get(var_id).ty.clone();
+        let cap_name = match prefix {
+            Some(prefix) => format!("{prefix}_{}", vt.len()),
+            None => format!("__cap_{}", var_id.0),
+        };
+        let cap_var = vt.alloc(
+            almide_base::intern::sym(&cap_name),
+            ty.clone(),
+            Mutability::Let,
+            None,
+        );
+        renames.insert(var_id, cap_var);
+
+        // The clone of a shared-mut capture is itself a shared cell (`Rc<Cell>`),
+        // so reads/writes of `__cap` inside the closure go through `.get()`/`.set()`
+        // too. (Closure v2, P3.)
+        if SHARED_MUT.with(|m| m.borrow().contains(&var_id)) {
+            SHARED_MUT.with(|m| { m.borrow_mut().insert(cap_var); });
+        }
+
+        // If the captured var is a fn param with a borrowed runtime
+        // representation (`&[T]` / `&str` / `&T`), the bare `Var` IR
+        // renders as the borrow — but `__cap_N: Vec<T>` / `String` / `T`
+        // (the Almide-level owned type) expects an owned value. Materialise
+        // the owned form explicitly so the `move |..|` closure can take it.
+        let borrow = PARAM_BORROWS.with(|m| m.borrow().get(&var_id).copied());
+        let bind_value = match borrow {
+            Some(ParamBorrow::RefSlice) => IrExpr {
+                kind: IrExprKind::ToVec {
+                    expr: Box::new(IrExpr { kind: IrExprKind::Var { id: var_id }, ty: ty.clone(), span: None, def_id: None }),
+                },
+                ty: ty.clone(), span: None, def_id: None,
+            },
+            Some(ParamBorrow::RefStr) => IrExpr {
+                kind: IrExprKind::Call {
+                    target: CallTarget::Method {
+                        object: Box::new(IrExpr { kind: IrExprKind::Var { id: var_id }, ty: ty.clone(), span: None, def_id: None }),
+                        // Use `to_owned` instead of `to_string` to avoid
+                        // StdlibLowering converting this into a module call
+                        // (e.g. `int.to_string()`) when the Almide-level type
+                        // differs from the Rust-level &str representation.
+                        method: almide_base::intern::sym("to_owned"),
+                    },
+                    args: vec![],
+                    type_args: vec![],
+                },
+                ty: ty.clone(), span: None, def_id: None,
+            },
+            // The default capture bind CLONES explicitly (#809): CloneInsertion's
+            // last-use analysis would MOVE the var here when this is its last
+            // syntactic use — but a runtime-template borrow (`&{m}` — e.g.
+            // `map.fold`'s first arg) in the SAME statement is invisible at the
+            // IR level and stays live until the call, so the move was an E0505.
+            // READ-ONLY captures only: a capture THIS lambda mutates keeps the
+            // bare `Var` bind — the shared-cell wiring (Closure v2 P3/P6)
+            // pattern-matches it, and a `Clone` wrapper severed the sharing
+            // (each closure mutated its own copy — the wasm_runtime
+            // closure-capture cross-target mismatches). NOTE the mutability
+            // FLAG cannot gate this: a non-Copy `var` mutated only through a
+            // method (`list.push`) is recorded `Mutability::Let`.
+            _ if !lam_mutated.contains(&var_id) => IrExpr {
+                kind: IrExprKind::Clone {
+                    expr: Box::new(IrExpr {
+                        kind: IrExprKind::Var { id: var_id },
+                        ty: ty.clone(),
+                        span: None,
+                        def_id: None,
+                    }),
+                },
+                ty: ty.clone(),
+                span: None,
+                def_id: None,
+            },
+            _ => IrExpr {
+                kind: IrExprKind::Var { id: var_id },
+                ty: ty.clone(),
+                span: None,
+                def_id: None,
+            },
+        };
+
+        stmts.push(IrStmt {
+            kind: IrStmtKind::Bind {
+                var: cap_var,
+                mutability: Mutability::Let,
+                ty: ty.clone(),
+                value: bind_value,
+            },
+            span: None,
+        });
+    }
+
+    (stmts, renames)
+}

--- a/crates/almide-codegen/src/pass_clone.rs
+++ b/crates/almide-codegen/src/pass_clone.rs
@@ -13,6 +13,10 @@ use almide_lang::types::Ty;
 use super::pass::{NanoPass, PassResult, Target};
 use super::pass_clone_loops::{insert_clones_for_in, insert_clones_while, take_borrowed_loop_vars};
 
+#[path = "pass_clone_calls.rs"]
+mod calls;
+use calls::{insert_clones_call, insert_clones_runtime_call};
+
 #[derive(Debug)]
 pub struct CloneInsertionPass;
 
@@ -582,98 +586,6 @@ fn insert_clones_match(subject: IrExpr, arms: Vec<IrMatchArm>, ctx: &mut CloneCt
     IrExprKind::Match { subject: Box::new(new_subject), arms: new_arms }
 }
 
-/// The E0505 guard's borrow scan (#809/#866): the vars passed BY BORROW at
-/// the top level of a call's arguments (or its method receiver). Such a var
-/// stays borrowed until the call itself executes, so a MOVE of it anywhere in
-/// a SIBLING argument conflicts — rustc's borrow live-range, not the flat
-/// last-use count, is the authority INSIDE one call.
-fn call_borrowed_vars(args: &[IrExpr], target: Option<&CallTarget>) -> HashSet<VarId> {
-    let mut borrowed: HashSet<VarId> = HashSet::new();
-    for a in args {
-        if let IrExprKind::Borrow { expr, .. } = &a.kind {
-            if let IrExprKind::Var { id } = &expr.kind {
-                borrowed.insert(*id);
-            }
-        }
-    }
-    if let Some(CallTarget::Method { object, .. }) = target {
-        if let IrExprKind::Borrow { expr, .. } = &object.kind {
-            if let IrExprKind::Var { id } = &expr.kind {
-                borrowed.insert(*id);
-            }
-        }
-    }
-    borrowed
-}
-
-/// `RuntimeCall { symbol, args }` arm of [`insert_clones_live`]: the same
-/// E0505 guard as [`insert_clones_call`]. An intrinsic-lowered stdlib call
-/// (`map.fold` → `almide_rt_map_fold`) reaches this pass as a `RuntimeCall`,
-/// and its borrowed subject conflicts with a sibling-arg move exactly the
-/// same way — `map.fold(acc, (if … else acc), λ)` moved `acc` in the seed
-/// while `&acc` from the subject argument was still live (#866).
-fn insert_clones_runtime_call(args: Vec<IrExpr>, ctx: &mut CloneCtx) -> Vec<IrExpr> {
-    let borrowed = call_borrowed_vars(&args, None);
-    if borrowed.is_empty() {
-        return args.into_iter().map(|a| insert_clones_live(a, ctx)).collect();
-    }
-    let merged: HashSet<VarId> = ctx.always.union(&borrowed).copied().collect();
-    let mut call_ctx = CloneCtx {
-        always: &merged,
-        eligible: ctx.eligible,
-        remaining: ctx.remaining,
-        in_loop: ctx.in_loop,
-        memo: ctx.memo,
-        fresh: ctx.fresh,
-    };
-    args.into_iter().map(|a| insert_clones_live(a, &mut call_ctx)).collect()
-}
-
-/// `Call { target, args, type_args }` arm of [`insert_clones_live`].
-fn insert_clones_call(target: CallTarget, args: Vec<IrExpr>, type_args: Vec<Ty>, ctx: &mut CloneCtx) -> IrExprKind {
-    // E0505 guard (#809): see `call_borrowed_vars`. Force-clone every var
-    // borrowed at the top level of an argument (or the method receiver) for
-    // the duration of this call's transform (`map.fold(acc, acc, (…) => acc)`
-    // moved `acc` into the closure's capture bind while `&acc` from the first
-    // argument was still live). The Borrow arm strips any clone inserted
-    // directly under it, so the borrowed occurrence itself stays a plain `&x`.
-    let borrowed = call_borrowed_vars(&args, Some(&target));
-    if !borrowed.is_empty() {
-        let merged: HashSet<VarId> = ctx.always.union(&borrowed).copied().collect();
-        let mut call_ctx = CloneCtx {
-            always: &merged,
-            eligible: ctx.eligible,
-            remaining: ctx.remaining,
-            in_loop: ctx.in_loop,
-            memo: ctx.memo,
-            fresh: ctx.fresh,
-        };
-        let args = args.into_iter().map(|a| insert_clones_live(a, &mut call_ctx)).collect();
-        let target = match target {
-            CallTarget::Method { object, method } => CallTarget::Method {
-                object: Box::new(insert_clones_live(*object, &mut call_ctx)),
-                method,
-            },
-            CallTarget::Computed { callee } => CallTarget::Computed {
-                callee: Box::new(insert_clones_live(*callee, &mut call_ctx)),
-            },
-            other => other,
-        };
-        return IrExprKind::Call { target, args, type_args };
-    }
-    let args = args.into_iter().map(|a| insert_clones_live(a, ctx)).collect();
-    let target = match target {
-        CallTarget::Method { object, method } => CallTarget::Method {
-            object: Box::new(insert_clones_live(*object, ctx)), method,
-        },
-        CallTarget::Computed { callee } => CallTarget::Computed {
-            callee: Box::new(insert_clones_live(*callee, ctx)),
-        },
-        other => other,
-    };
-    IrExprKind::Call { target, args, type_args }
-}
-
 /// `IndexAccess { object, index }` arm of [`insert_clones_live`]: borrow the
 /// container, clone the element.
 fn insert_clones_index_access(object: IrExpr, index: IrExpr, ty: Ty, span: Option<Span>, ctx: &mut CloneCtx) -> IrExpr {
@@ -774,6 +686,15 @@ pub(crate) fn insert_clones_live(expr: IrExpr, ctx: &mut CloneCtx) -> IrExpr {
             let new_fields: Vec<_> = fields.into_iter().map(|(k, v)| (k, insert_clones_live(v, ctx))).collect();
             let new_base = insert_clones_live(*base, ctx);
             IrExprKind::SpreadRecord { base: Box::new(new_base), fields: new_fields }
+        },
+        IrExprKind::Clone { expr } => {
+            let mut inner = insert_clones_live(*expr, ctx);
+            // An existing clone already preserves ownership. The liveness
+            // walk still consumes the use, but must not add a second clone.
+            if let IrExprKind::Clone { expr: unwrapped } = inner.kind {
+                inner = *unwrapped;
+            }
+            IrExprKind::Clone { expr: Box::new(inner) }
         },
         IrExprKind::Borrow { expr, as_str, mutable } => {
             let mut inner = insert_clones_live(*expr, ctx);

--- a/crates/almide-codegen/src/pass_clone_calls.rs
+++ b/crates/almide-codegen/src/pass_clone_calls.rs
@@ -1,0 +1,94 @@
+//! Call argument borrow lifetimes during clone insertion.
+use super::*;
+
+/// The E0505 guard's borrow scan (#809/#866): the vars passed BY BORROW at
+/// the top level of a call's arguments (or its method receiver). Such a var
+/// stays borrowed until the call itself executes, so a MOVE of it anywhere in
+/// a SIBLING argument conflicts — rustc's borrow live-range, not the flat
+/// last-use count, is the authority INSIDE one call.
+fn call_borrowed_vars(args: &[IrExpr], target: Option<&CallTarget>) -> HashSet<VarId> {
+    let mut borrowed: HashSet<VarId> = HashSet::new();
+    for a in args {
+        if let IrExprKind::Borrow { expr, .. } = &a.kind {
+            if let IrExprKind::Var { id } = &expr.kind {
+                borrowed.insert(*id);
+            }
+        }
+    }
+    if let Some(CallTarget::Method { object, .. }) = target {
+        if let IrExprKind::Borrow { expr, .. } = &object.kind {
+            if let IrExprKind::Var { id } = &expr.kind {
+                borrowed.insert(*id);
+            }
+        }
+    }
+    borrowed
+}
+
+/// `RuntimeCall { symbol, args }` arm of [`insert_clones_live`]: the same
+/// E0505 guard as [`insert_clones_call`]. An intrinsic-lowered stdlib call
+/// (`map.fold` → `almide_rt_map_fold`) reaches this pass as a `RuntimeCall`,
+/// and its borrowed subject conflicts with a sibling-arg move exactly the
+/// same way — `map.fold(acc, (if … else acc), λ)` moved `acc` in the seed
+/// while `&acc` from the subject argument was still live (#866).
+pub(super) fn insert_clones_runtime_call(args: Vec<IrExpr>, ctx: &mut CloneCtx) -> Vec<IrExpr> {
+    let borrowed = call_borrowed_vars(&args, None);
+    if borrowed.is_empty() {
+        return args.into_iter().map(|a| insert_clones_live(a, ctx)).collect();
+    }
+    let merged: HashSet<VarId> = ctx.always.union(&borrowed).copied().collect();
+    let mut call_ctx = CloneCtx {
+        always: &merged,
+        eligible: ctx.eligible,
+        remaining: ctx.remaining,
+        in_loop: ctx.in_loop,
+        memo: ctx.memo,
+        fresh: ctx.fresh,
+    };
+    args.into_iter().map(|a| insert_clones_live(a, &mut call_ctx)).collect()
+}
+
+/// `Call { target, args, type_args }` arm of [`insert_clones_live`].
+pub(super) fn insert_clones_call(target: CallTarget, args: Vec<IrExpr>, type_args: Vec<Ty>, ctx: &mut CloneCtx) -> IrExprKind {
+    // E0505 guard (#809): see `call_borrowed_vars`. Force-clone every var
+    // borrowed at the top level of an argument (or the method receiver) for
+    // the duration of this call's transform (`map.fold(acc, acc, (…) => acc)`
+    // moved `acc` into the closure's capture bind while `&acc` from the first
+    // argument was still live). The Borrow arm strips any clone inserted
+    // directly under it, so the borrowed occurrence itself stays a plain `&x`.
+    let borrowed = call_borrowed_vars(&args, Some(&target));
+    if !borrowed.is_empty() {
+        let merged: HashSet<VarId> = ctx.always.union(&borrowed).copied().collect();
+        let mut call_ctx = CloneCtx {
+            always: &merged,
+            eligible: ctx.eligible,
+            remaining: ctx.remaining,
+            in_loop: ctx.in_loop,
+            memo: ctx.memo,
+            fresh: ctx.fresh,
+        };
+        let args = args.into_iter().map(|a| insert_clones_live(a, &mut call_ctx)).collect();
+        let target = match target {
+            CallTarget::Method { object, method } => CallTarget::Method {
+                object: Box::new(insert_clones_live(*object, &mut call_ctx)),
+                method,
+            },
+            CallTarget::Computed { callee } => CallTarget::Computed {
+                callee: Box::new(insert_clones_live(*callee, &mut call_ctx)),
+            },
+            other => other,
+        };
+        return IrExprKind::Call { target, args, type_args };
+    }
+    let args = args.into_iter().map(|a| insert_clones_live(a, ctx)).collect();
+    let target = match target {
+        CallTarget::Method { object, method } => CallTarget::Method {
+            object: Box::new(insert_clones_live(*object, ctx)), method,
+        },
+        CallTarget::Computed { callee } => CallTarget::Computed {
+            callee: Box::new(insert_clones_live(*callee, ctx)),
+        },
+        other => other,
+    };
+    IrExprKind::Call { target, args, type_args }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -242,8 +242,8 @@ The Wgsl arm is the four rows marked W. Class:
 | 13 | `IntrinsicLowering` | `pass_intrinsic_lowering.rs` | all | enabler | `@intrinsic` stdlib calls → `RuntimeCall { symbol }` | self-host registry link (`src/wasm_leg.rs`); intrinsics are walls |
 | 14 | `BorrowInsertion` | `pass_borrow_inference.rs`, `pass_borrow_inference_call_sites.rs`, `pass_borrow_inference_ownership.rs` (wrapper in `pass.rs`) | Rust | Rust by design | Roc-style borrow-by-default signatures, `Borrow` nodes at call sites | RC-3 borrow/fresh classifier (`rc_ownership.rs`) |
 | 15 | `TailCallOpt` | `pass_tco.rs`, `pass_tco_loop_rewrite.rs`, `pass_tco_owned_reads.rs` | all | optimizer | self-recursive tail calls → loop | equivalent: `tco.rs` (`loop_convert` over the encoded body; `return_call` otherwise) |
-| 16 | `CaptureClone` | `pass_capture_clone.rs` | Rust | Rust by design | pre-clone variables captured by `move` closures | n/a |
-| 17 | `CloneInsertion` | `pass_clone.rs`, `pass_clone_interp.rs`, `pass_clone_loops.rs` | Rust | Rust by design | `Clone` nodes for heap-typed reuse (loops, interpolation, E0505 guards) | RC inc/share guards (`rc_ownership.rs`) |
+| 16 | `CaptureClone` | `pass_capture_clone.rs`, `pass_capture_clone_bindings.rs` | Rust | Rust by design | pre-clone variables captured by `move` closures | n/a |
+| 17 | `CloneInsertion` | `pass_clone.rs`, `pass_clone_calls.rs`, `pass_clone_interp.rs`, `pass_clone_loops.rs` | Rust | Rust by design | `Clone` nodes for heap-typed reuse (loops, interpolation, E0505 guards) | RC inc/share guards (`rc_ownership.rs`) |
 | 18 | `MatchSubject` | `pass_match_subject.rs` | Rust | Rust by design | `.as_str()` / `.as_deref()` on match subjects | n/a |
 | 19 | `EffectInference` | `pass_effect_inference.rs` | all | analysis | infer capability categories from transitive stdlib use | shared by another route: `cli::check_permissions` runs this pass standalone on the pre-mono IR for every leg |
 | 20 | `StdlibLowering` | `pass_stdlib_lowering.rs`, `pass_stdlib_lowering_ufcs.rs` | Rust | Rust by design | `Module` calls → `Named` runtime calls with arg decoration | self-hosted stdlib bodies are emitted as wasm fns |

--- a/docs/fan-capture-ownership-review.md
+++ b/docs/fan-capture-ownership-review.md
@@ -1,0 +1,45 @@
+# Fan sibling capture ownership (#2061)
+
+`fan { list.sum(rows), list.len(rows) }` passed type checking but emitted
+two `move` closures sharing the same Rust `rows` binding, causing E0382.
+The first spawn moved the binding even though both calls only borrowed it.
+
+CaptureClone now treats fan arms as implicit closures and prepares owned
+read-only captures outside the entire Fan expression. Each arm receives a
+distinct VarId and emitted name; each clone therefore precedes all spawns.
+The original remains available after the fan expression. Borrowed slice
+and string parameters use the same owned materialization as explicit
+lambdas. Captures directly mutated by an arm retain their existing handling;
+this change does not invent shared mutable state between threads.
+
+The existing capture-binding implementation is shared by lambda and fan
+lowering. CloneInsertion still counts uses inside existing Clone nodes,
+but no longer inserts an extra clone beneath them. Call-argument ownership
+logic and capture binding construction now have separate modules, keeping
+each source below Codopsy's 800-line limit without changing its thresholds.
+
+## Reference research
+
+The cloned Rust reference at commit
+`0d31508599a7814a7044e9a7a871e3dc5f037753` now includes
+`library/std/src/thread/scoped.rs`: `Scope::spawn` takes a closure value
+with `FnOnce + Send` bounds (lines 201–206). Scoped lifetime support does
+not let two move closures consume one owned value. Capture preparation
+must happen before the closure value is passed into `spawn`. The existing
+Gleam reference's `javascript/decision.rs::assign_subject` similarly binds
+computed subjects before reuse to preserve evaluation. Both repos live in
+`../almide-references`.
+
+## Regression coverage
+
+`tests/fan_sibling_capture_test.rs` executes List, String, Map and record
+captures, borrowed parameters, use after fan, and nested fan expressions
+on native and structural WASM. It also inspects the user portion of emitted
+Rust to reject repeated `.clone().clone()`. Map callbacks return scalar
+values: returning an Option directly from a fan arm currently reaches a
+separate structural `bind:unmapped` wall and is not claimed as supported.
+
+Codopsy 2.2.0, unchanged configuration: CaptureClone, capture bindings,
+CloneInsertion, and call-argument helpers each score 100/A. The codegen
+crate scores 90/A; the all-crates aggregate is 83/B (two files unparsed by
+Codopsy), so repository-wide A is still outstanding.

--- a/tests/fan_sibling_capture_test.rs
+++ b/tests/fan_sibling_capture_test.rs
@@ -1,0 +1,61 @@
+//! #2061: each implicit fan closure owns its read-only captures before spawning.
+use std::process::Command;
+
+#[test]
+fn fan_siblings_preserve_shared_heap_inputs_on_both_targets() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("main.almd");
+    std::fs::write(&source, r#"type Row = { values: List[Int], label: String }
+
+effect fn measure(rows: List[Int]) -> (Int, Int) = fan { list.sum(rows), list.len(rows) }
+
+effect fn label_pair(label: String) -> (String, String) = fan { label + "a", label + "b" }
+
+effect fn main() -> Unit = {
+  let rows = [1, 2, 3]
+  let (sum, size) = fan { list.sum(rows), list.len(rows) }
+  assert_eq((sum, size), (6, 3))
+  let measured = measure(rows)!
+  assert_eq(measured, (6, 3))
+  assert_eq(rows, [1, 2, 3])
+  let label = "x"
+  let (left, right) = fan { label + "a", label + "b" }
+  assert_eq((left, right), ("xa", "xb"))
+  let labels = label_pair(label)!
+  assert_eq(labels, ("xa", "xb"))
+  assert_eq(label, "x")
+  let counts = ["x": 7]
+  let (count, entries) = fan { map.get(counts, "x") ?? 0, map.len(counts) }
+  assert_eq(count, 7)
+  assert_eq(entries, 1)
+  assert_eq(map.get(counts, "x"), some(7))
+  let row = Row { values: rows, label: label }
+  let (row_sum, row_label) = fan { list.sum(row.values), row.label + "!" }
+  assert_eq((row_sum, row_label), (6, "x!"))
+  assert_eq(row.label, "x")
+  let (nested, outer) = fan {
+    {
+      let (a, b) = fan { list.sum(rows), list.len(rows) }
+      a + b
+    },
+    list.len(rows),
+  }
+  assert_eq((nested, outer), (9, 3))
+  println("fan captures ok")
+}
+"#).unwrap();
+    let bin = std::env::var("ALMIDE_BIN")
+        .unwrap_or_else(|_| format!("{}/target/release/almide", env!("CARGO_MANIFEST_DIR")));
+    let emitted = Command::new(&bin).arg("emit").arg(&source)
+        .output().expect("emit capture matrix");
+    assert!(emitted.status.success());
+    let rust = String::from_utf8(emitted.stdout).unwrap();
+    let user_rust = rust.split("//__ALMIDE_RT_BOUNDARY__").last().unwrap();
+    assert!(!user_rust.contains(".clone().clone()"), "capture must be cloned only once");
+    for target in ["rust", "wasm"] {
+        let out = Command::new(&bin).arg("run").arg(&source)
+            .args(["--target", target]).output().expect("run compiler");
+        assert!(out.status.success(), "{target}: {}", String::from_utf8_lossy(&out.stderr));
+        assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "fan captures ok", "{target}");
+    }
+}


### PR DESCRIPTION
`fan { list.sum(rows), list.len(rows) }` passed checking but failed native compilation with E0382: the first generated move closure consumed `rows` before the second closure captured it.

CaptureClone now prepares a distinct owned read-only capture for each fan arm before any spawn. The original remains usable afterwards; borrowed slice and string parameters use the existing lambda materialization rules. The shared binding code and call-argument ownership logic live in focused modules. CloneInsertion also avoids adding a second clone beneath an existing clone while retaining its liveness accounting.

Validation: the capture matrix runs on native and structural WASM, covering List/String/Map/record inputs, borrowed parameters, later use and nested fan; emitted Rust has no doubled capture clones. Codegen 63 tests, nanopass 34 tests, snapshots 13 tests; Clippy, file discipline and pass roster pass. Default suite: 437/437 (425 WASM, 12 fallback). Native suite: 437/437.

Codopsy 2.2.0 with unchanged configuration: all four changed compiler files 100/A; codegen aggregate 90/A; all-crates aggregate 83/B, so repository-wide A remains outstanding. Pinned Rust scoped-thread research and evaluation-order reasoning are recorded in `docs/fan-capture-ownership-review.md`.

Closes #2061


CI setup follow-up: feature-branch tests now install the Wasmtime runtime they require. The commissioned WASI job retains v27.0.0, but downloads it directly with retries and verifies installation before running tests. This fixes the missing-runtime failures observed in jobs 102372072580 and 102376645991; YAML parsing and extracted shell syntax checks pass.
