### PR TITLE
Advance ALS pin for the checked byte slice specification

### DIFF
--- a/proofs/als-pin.txt
+++ b/proofs/als-pin.txt
@@ -1,4 +1,4 @@
 # The almide/als commit this tree's contract ledger is judged against
 # (scripts/check-als-pin.sh). Advance it AFTER the als PR that carries a
 # new contract id has merged — never in the same PR that mints the id.
-52af321db00a452aa41d591a3ec4591354c8dbd8
+e3cda7f5980133cbd2c0d35efc9e250644c6028a


### PR DESCRIPTION
Advance the independent ALS judge pin to `e3cda7f5980133cbd2c0d35efc9e250644c6028a`, after [almide/als#64](https://github.com/almide/als/pull/64) merged with all gates passing. The judge now specifies and independently evaluates C-348, the checked UTF-8 byte-slicing contract.

This pin-only change precedes the implementation in #2081, as required by `scripts/check-als-pin.sh`. No implementation, contract IDs, or ceilings change here.

Validation: the ALS pin gate fetches the merged judge ledger and confirms all 347 existing implementation contracts are present among its 348 contracts.
