### PR TITLE
The wasm test leg honours --run instead of dropping it at the signature

### DIFF
--- a/crates/almide-base/src/lib.rs
+++ b/crates/almide-base/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod intern;
 pub mod span;
 pub mod diagnostic;
+pub mod names;
 pub mod profile;
 
 // Re-export commonly used items at crate root

--- a/crates/almide-base/src/names.rs
+++ b/crates/almide-base/src/names.rs
@@ -1,0 +1,79 @@
+// Symbol spelling shared by the Rust emitter and the wasm test-runner synthesis.
+//
+// `rust_safe_fn_name` lives here — not in almide-codegen where it is emitted —
+// because the two test legs must agree on ONE spelling. The native leg compiles
+// `test "…"` to a Rust fn whose name is this function's output and hands
+// `--run <pattern>` to the Rust test harness, which substring-matches THAT name;
+// the wasm leg synthesizes its runner in almide-mir and must select exactly the
+// same tests. When the two spellings drifted apart the filter was simply dropped
+// on the wasm side and nothing noticed (#2085), so the rule now has one home and
+// `test_name_matches_filter` is the only admitted way to ask the question.
+
+/// Sanitize an IR function name into a Rust-emittable identifier.
+///
+/// Spaces and punctuation fold to `_`; parentheses vanish; operator characters
+/// spell out. A name containing any non-ASCII character also gets an FNV-1a
+/// suffix, because the fold above maps every non-ASCII byte to `_` and two
+/// distinct names would otherwise collide on one skeleton.
+pub fn rust_safe_fn_name(raw: &str) -> String {
+    let s = raw
+        .replace([' ', '-', '.', ',', ':', '[', ']'], "_")
+        .replace(['(', ')'], "")
+        .replace('+', "_plus_").replace('/', "_div_").replace('*', "_mul_")
+        .replace('=', "_eq_").replace('!', "_bang_").replace('?', "_q_")
+        .replace('<', "_lt_").replace('>', "_gt_")
+        .replace('|', "_pipe_").replace('&', "_amp_").replace('%', "_mod_");
+    let mut safe: String = s.chars().map(|c| if c.is_ascii_alphanumeric() || c == '_' { c } else { '_' }).collect();
+    if raw.chars().any(|c| !c.is_ascii()) {
+        let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+        for b in raw.as_bytes() {
+            h ^= *b as u64;
+            h = h.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        safe.push_str(&format!("_{:08x}", (h >> 32) as u32 ^ h as u32));
+    }
+    safe
+}
+
+/// Does the test whose IR name is `ir_name` run under `--run <pattern>`?
+///
+/// The native leg's answer is the Rust test harness's: a case-sensitive
+/// substring test against the EMITTED fn name, so the pattern is compared
+/// against `rust_safe_fn_name(ir_name)` and not against the `test "…"` label.
+/// A pattern spelled with the label's spaces therefore selects nothing on both
+/// legs — surprising, but identically surprising, which is the property the
+/// wasm leg has to reproduce.
+pub fn test_name_matches_filter(ir_name: &str, pattern: &str) -> bool {
+    rust_safe_fn_name(ir_name).contains(pattern)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{rust_safe_fn_name, test_name_matches_filter};
+
+    #[test]
+    fn same_skeleton_nonascii_names_stay_distinct() {
+        let a = rust_safe_fn_name("__test_almd_a: 値を取る旗に値が無ければ断る");
+        let b = rust_safe_fn_name("__test_almd_a: 旗の値は位置引数に混ざらない");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn ascii_names_are_untouched_by_the_hash_rule() {
+        assert_eq!(rust_safe_fn_name("__test_almd_a + b (fast)"), "__test_almd_a__plus__b_fast");
+        assert_eq!(rust_safe_fn_name("string mismatch"), "string_mismatch");
+    }
+
+    // The filter contract both legs implement. `beta fails` selecting nothing is
+    // not a bug to fix here: it is what the native harness already does, and
+    // #2085 is about the two legs agreeing, not about redefining the pattern.
+    #[test]
+    fn the_pattern_is_matched_against_the_emitted_name() {
+        let n = "__test_almd_beta fails";
+        assert!(test_name_matches_filter(n, "beta"));
+        assert!(test_name_matches_filter(n, "beta_fails"));
+        assert!(test_name_matches_filter(n, "__test_almd_"));
+        assert!(!test_name_matches_filter(n, "beta fails"));
+        assert!(!test_name_matches_filter(n, "BETA"));
+    }
+}

--- a/crates/almide-codegen/src/walker/mod.rs
+++ b/crates/almide-codegen/src/walker/mod.rs
@@ -340,25 +340,12 @@ fn render_fn_generics_str(ctx: &RenderContext, fn_ctx: &RenderContext, func: &Ir
 /// non-ASCII character, an 8-hex FNV-1a of its UTF-8 bytes is appended so
 /// the mapping is injective per distinct original. ASCII-only names keep
 /// their exact historical spelling (zero churn for the existing corpus).
-pub fn rust_safe_fn_name(raw: &str) -> String {
-    let s = raw
-        .replace([' ', '-', '.', ',', ':', '[', ']'], "_")
-        .replace(['(', ')'], "")
-        .replace('+', "_plus_").replace('/', "_div_").replace('*', "_mul_")
-        .replace('=', "_eq_").replace('!', "_bang_").replace('?', "_q_")
-        .replace('<', "_lt_").replace('>', "_gt_")
-        .replace('|', "_pipe_").replace('&', "_amp_").replace('%', "_mod_");
-    let mut safe: String = s.chars().map(|c| if c.is_ascii_alphanumeric() || c == '_' { c } else { '_' }).collect();
-    if raw.chars().any(|c| !c.is_ascii()) {
-        let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-        for b in raw.as_bytes() {
-            h ^= *b as u64;
-            h = h.wrapping_mul(0x0000_0100_0000_01b3);
-        }
-        safe.push_str(&format!("_{:08x}", (h >> 32) as u32 ^ h as u32));
-    }
-    safe
-}
+///
+/// The body now lives in `almide_base::names` (#2085): the wasm test-runner
+/// synthesis in almide-mir has to select the SAME tests `--run` selects here,
+/// and almide-mir cannot see this crate. Re-exported so every caller — the
+/// walker below and the test-report name recovery — keeps its spelling.
+pub use almide_base::names::rust_safe_fn_name;
 
 #[cfg(test)]
 mod rust_safe_fn_name_tests {

--- a/crates/almide-mir/examples/render_program.rs
+++ b/crates/almide-mir/examples/render_program.rs
@@ -91,7 +91,7 @@ fn main() {
         .unwrap_or_else(|e| die(format!("parse error: {e:?}")));
     let self_modules = discover_self_modules(&path, &probe_prog);
     let rendered = if test_mode {
-        almide_mir::pipeline::try_render_wasm_source_tests(&source, &self_modules, true)
+        almide_mir::pipeline::try_render_wasm_source_tests(&source, &self_modules, true, None)
     } else {
         almide_mir::pipeline::try_render_wasm_source(&source, &self_modules, true)
     };

--- a/crates/almide-mir/src/pipeline.rs
+++ b/crates/almide-mir/src/pipeline.rs
@@ -610,7 +610,7 @@ pub fn try_render_wasm_source(
     self_modules: &[(String, almide_lang::ast::Program, bool)],
     verbose: bool,
 ) -> Result<String, LowerError> {
-    try_render_wasm_source_impl(source, self_modules, verbose, RenderMode::Run)
+    try_render_wasm_source_impl(source, self_modules, verbose, RenderMode::Run, None)
 }
 
 /// LIBRARY-mode variant for `almide build --target wasm` (#881): a module with
@@ -625,7 +625,7 @@ pub fn try_render_wasm_source_library(
     self_modules: &[(String, almide_lang::ast::Program, bool)],
     verbose: bool,
 ) -> Result<String, LowerError> {
-    try_render_wasm_source_impl(source, self_modules, verbose, RenderMode::Library)
+    try_render_wasm_source_impl(source, self_modules, verbose, RenderMode::Library, None)
 }
 
 /// TEST-mode variant for the `almide test` wasm harness: when the file has NO `main`,
@@ -637,12 +637,17 @@ pub fn try_render_wasm_source_library(
 /// Programs with top-let globals WALL in test mode (v0 re-inits globals before EVERY
 /// test; the v1 `_start` inits once — shipping that silently would leak one test's
 /// mutations into the next).
+/// `run_filter` is `almide test --run <pattern>`: `None` runs every test, and
+/// `Some(p)` synthesizes a runner over exactly the tests the NATIVE leg's Rust
+/// harness would select for the same `p` (`almide_base::names`). Dropping it
+/// here was #2085 — this leg ran every test whatever the caller asked for.
 pub fn try_render_wasm_source_tests(
     source: &str,
     self_modules: &[(String, almide_lang::ast::Program, bool)],
     verbose: bool,
+    run_filter: Option<&str>,
 ) -> Result<String, LowerError> {
-    try_render_wasm_source_impl(source, self_modules, verbose, RenderMode::Tests)
+    try_render_wasm_source_impl(source, self_modules, verbose, RenderMode::Tests, run_filter)
 }
 
 /// How the caller intends to use the rendered module — decides main synthesis.
@@ -662,6 +667,7 @@ fn try_render_wasm_source_impl(
     self_modules: &[(String, almide_lang::ast::Program, bool)],
     verbose: bool,
     mode: RenderMode,
+    run_filter: Option<&str>,
 ) -> Result<String, LowerError> {
     crate::charge_probe::reset_budget_used();
     // STRICT VALUE MODE spans the WHOLE render, not just the IR phase. `strict_values()`
@@ -676,7 +682,7 @@ fn try_render_wasm_source_impl(
     // finding, seed 1785217538023450905). Own it here, at the entrypoint that spans both
     // phases, so the scope matches what the mode actually protects.
     let _strict = crate::lower::StrictValuesGuard::set(true);
-    let mut ir = build_ir_with_drops(source, self_modules, mode == RenderMode::Tests)?;
+    let mut ir = build_ir_with_drops(source, self_modules, mode == RenderMode::Tests, run_filter)?;
     if mode == RenderMode::Library {
         synthesize_library_main(&mut ir);
     }

--- a/crates/almide-mir/src/pipeline_tail.rs
+++ b/crates/almide-mir/src/pipeline_tail.rs
@@ -9,6 +9,7 @@ fn build_ir_with_drops(
     source: &str,
     self_modules: &[(String, almide_lang::ast::Program, bool)],
     test_mode: bool,
+    run_filter: Option<&str>,
 ) -> Result<almide_ir::IrProgram, LowerError> {
     // STRICT VALUE MODE is owned by the caller, not by this phase. Nothing between here
     // and the return reads `strict_values()`: this builds the linked IR, and the mode
@@ -203,7 +204,7 @@ fn build_ir_with_drops(
     // foldable const reference leaves the init untouched (walls as before).
     fold_const_str_toplets(&mut ir);
     if test_mode {
-        synthesize_test_runner_main(&mut ir)?;
+        synthesize_test_runner_main(&mut ir, run_filter)?;
     }
     Ok(ir)
 }

--- a/crates/almide-mir/src/pipeline_test_runner.rs
+++ b/crates/almide-mir/src/pipeline_test_runner.rs
@@ -7,7 +7,10 @@
 /// `self_modules` are the caller-resolved `import self.<submodule>` siblings (empty ⇒ single file).
 /// Promote a NO-`main` test file's `test` fns to ordinary effect fns and synthesize the
 /// runner `main` (v0 `__test_runner` protocol). See [`try_render_wasm_source_tests`].
-fn synthesize_test_runner_main(ir: &mut almide_ir::IrProgram) -> Result<(), LowerError> {
+fn synthesize_test_runner_main(
+    ir: &mut almide_ir::IrProgram,
+    run_filter: Option<&str>,
+) -> Result<(), LowerError> {
     use almide_ir::{CallTarget, IrExpr, IrExprKind, IrStmt, IrStmtKind};
     use almide_lang::intern::sym;
     use almide_lang::types::Ty;
@@ -191,6 +194,18 @@ fn synthesize_test_runner_main(ir: &mut almide_ir::IrProgram) -> Result<(), Lowe
         },
         span: None,
     };
+    // `--run <pattern>` (#2085). Dropped here rather than before the wall checks
+    // above so a filtered run walls exactly where an unfiltered one does —
+    // otherwise `--run` would quietly change WHICH files reach the wasm leg.
+    // The predicate is `almide_base::names`, the same one the native leg's
+    // emitted fn name comes from: the two legs must select the same tests, and
+    // when this leg selected all of them regardless, no gate could see it.
+    if let Some(pattern) = run_filter {
+        ir.functions.retain(|f| {
+            !f.is_test
+                || almide_lang::almide_base::names::test_name_matches_filter(f.name.as_str(), pattern)
+        });
+    }
     let mut stmts: Vec<IrStmt> = Vec::new();
     let mut idx = 0usize;
     for f in ir.functions.iter_mut() {

--- a/docs/specs/cli.md
+++ b/docs/specs/cli.md
@@ -107,12 +107,24 @@ almide test --update-snapshots x_test.almd  # スナップショットの受理(
 
 | オプション | 説明 |
 |---|---|
-| `-r, --run <pattern>` | テスト名のパターンフィルタ |
+| `-r, --run <pattern>` | テスト名のパターンフィルタ(下記) |
 | `--no-check` | 型チェックをスキップ |
 | `--json` | JSON 形式で結果出力 |
 | `--target wasm` | wasmtime で実行 |
 | `--update-snapshots` | `testing.assert_snapshot` の不一致を受理し、呼び出し側の期待値リテラルをソース内で書き換える(`ALMIDE_UPDATE_SNAPSHOTS=1` でも同じ) |
 | `--ci` | CI モード: スナップショットを一切書かない(`CI=true` でも同じ)。新規・乖離はどちらも失敗 |
+
+`--run <pattern>` は **生成された関数名に対する大文字小文字を区別する部分文字列一致**で、
+`test "…"` のラベルそのものではない。ラベルは `__test_almd_` を前置し、空白・記号を `_` に
+畳んだ綴りになる（`crates/almide-base/src/names.rs`）。したがって `test "beta fails"` は
+`--run beta` と `--run beta_fails` では選ばれるが、`--run "beta fails"`（空白のまま）では
+選ばれない。`--run __test_almd_` は全件を選ぶ。
+
+この規則は **native レグと wasm レグで同一**である（#2085）。native はパターンを Rust の
+テストハーネスに渡し、wasm はランナー合成の時点で同じ述語で絞る。どちらのレグでも、
+1件も一致しないパターンは 0 件を実行して成功終了する。
+
+テスト: `tests/wasm_test_filter_parity_test.rs`
 
 スクラッチ成果物（wasm レグが wasmtime に渡す `.wasm` モジュール）は実行ごとに固有の
 `$TMPDIR/almide-test-<pid>-<nonce>/` 配下に、ファイルの**絶対パス**のハッシュで命名して

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -362,7 +362,7 @@ fn lower_wasm_test_modules(program: &almide_lang::ast::Program, checker: &mut ch
     Ok(ir_program)
 }
 
-fn compile_and_run_wasm_test(test_file: &str, wasm_path: std::path::PathBuf) -> WasmTestOutcome {
+fn compile_and_run_wasm_test(test_file: &str, wasm_path: std::path::PathBuf, run_filter: Option<&str>) -> WasmTestOutcome {
     let skip = |reason: String| WasmTestOutcome::Skip { file: test_file.to_string(), reason };
     let compile_error = |detail: String| WasmTestOutcome::CompileError { file: test_file.to_string(), detail };
     let prof = std::env::var_os("ALMIDE_PROFILE").is_some();
@@ -433,7 +433,7 @@ fn compile_and_run_wasm_test(test_file: &str, wasm_path: std::path::PathBuf) -> 
     let explain = std::env::var_os("ALMIDE_WALL_REASON").is_some();
 
     let v1_bytes: Option<Vec<u8>> =
-        match almide_mir::pipeline::try_render_wasm_source_tests(&source_text, &v1_self_modules, explain) {
+        match almide_mir::pipeline::try_render_wasm_source_tests(&source_text, &v1_self_modules, explain, run_filter) {
             Err(e) => {
                 if explain { err(&format!("[wall] {}: render: {:?}", test_file, e)); }
                 None
@@ -515,8 +515,10 @@ fn compile_and_run_wasm_test(test_file: &str, wasm_path: std::path::PathBuf) -> 
     }
 }
 
-pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
+pub fn cmd_test_wasm(file: &str, run_filter: Option<&str>) {
     let test_files: Vec<String> = discover_test_files(file, &[]);
+    // Owned so each worker thread can carry it (#2085 — this leg used to drop it).
+    let run_filter: Option<String> = run_filter.map(str::to_string);
 
     let scratch = std::sync::Arc::new(TestScratch::new());
 
@@ -534,9 +536,10 @@ pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
         let scratch = scratch.clone();
         let sem_rx = sem_rx.clone();
         let sem_tx = sem_tx.clone();
+        let run_filter = run_filter.clone();
         handles.push(std::thread::spawn(move || {
             let _ = sem_rx.lock().unwrap().recv();
-            let outcome = compile_and_run_wasm_test(&test_file, scratch.wasm_module_path(&test_file));
+            let outcome = compile_and_run_wasm_test(&test_file, scratch.wasm_module_path(&test_file), run_filter.as_deref());
             let _ = sem_tx.send(());
             let _ = tx.send(outcome);
         }));
@@ -596,7 +599,8 @@ pub fn cmd_test_wasm(file: &str, _run_filter: Option<&str>) {
 
 /// `cmd_test_fast`'s Phase 1: run every file on the fast rustc-free WASM
 /// path, in parallel (bounded by `cpus`). Extracted verbatim.
-fn run_wasm_test_phase(test_files: &[String], scratch: &std::sync::Arc<TestScratch>, cpus: usize) -> Vec<WasmTestOutcome> {
+fn run_wasm_test_phase(test_files: &[String], scratch: &std::sync::Arc<TestScratch>, cpus: usize, run_filter: Option<&str>) -> Vec<WasmTestOutcome> {
+    let run_filter: Option<String> = run_filter.map(str::to_string);
     let (tx, rx) = std::sync::mpsc::channel();
     let (sem_tx, sem_rx) = std::sync::mpsc::sync_channel::<()>(cpus);
     for _ in 0..cpus { let _ = sem_tx.send(()); }
@@ -608,9 +612,10 @@ fn run_wasm_test_phase(test_files: &[String], scratch: &std::sync::Arc<TestScrat
         let scratch = scratch.clone();
         let sr = sem_rx.clone();
         let st = sem_tx.clone();
+        let run_filter = run_filter.clone();
         handles.push(std::thread::spawn(move || {
             let _ = sr.lock().unwrap().recv();
-            let o = compile_and_run_wasm_test(&tf, scratch.wasm_module_path(&tf));
+            let o = compile_and_run_wasm_test(&tf, scratch.wasm_module_path(&tf), run_filter.as_deref());
             let _ = st.send(());
             let _ = tx.send(o);
         }));
@@ -666,7 +671,7 @@ pub fn cmd_test_fast(file: &str, no_check: bool, run_filter: Option<&str>) {
     let scratch = std::sync::Arc::new(TestScratch::new());
 
     // Phase 1: WASM (fast, rustc-free), parallel.
-    let wasm_outcomes = run_wasm_test_phase(&test_files, &scratch, cpus);
+    let wasm_outcomes = run_wasm_test_phase(&test_files, &scratch, cpus, run_filter);
 
     let mut wasm_pass = 0usize;
     let mut fallback: Vec<String> = Vec::new();
@@ -854,7 +859,7 @@ fn run_test_file_once(
     // The scratch layout (#1877) hands the wasm module path to the runner;
     // the accept loop keeps its own per-invocation dir and mirrors the name.
     let wasm_path = tmp_dir.join(file.replace(['/', '.'], "_") + ".wasm");
-    match compile_and_run_wasm_test(file, wasm_path) {
+    match compile_and_run_wasm_test(file, wasm_path, super::test_report::harness_filter(program_args)) {
         WasmTestOutcome::Pass { .. } => return Ok((0, String::new())),
         WasmTestOutcome::Fail { raw, .. } => return Ok((1, raw)),
         WasmTestOutcome::CompileError { detail, .. } => {

--- a/src/cli/test_report.rs
+++ b/src/cli/test_report.rs
@@ -50,6 +50,16 @@ pub fn test_harness_args(run_filter: Option<&str>) -> std::sync::Arc<Vec<String>
     std::sync::Arc::new(args)
 }
 
+/// The inverse of [`test_harness_args`]: recover `--run <pattern>` from an argv
+/// that was already built for the native harness.
+///
+/// The wasm leg does not take argv — it selects at synthesis (#2085) — so the
+/// paths that carry only the built argv (the snapshot-accept loop) need the
+/// pattern back. Kept adjacent to its producer so the two cannot drift.
+pub fn harness_filter(program_args: &[String]) -> Option<&str> {
+    program_args.iter().find(|a| *a != "--nocapture").map(String::as_str)
+}
+
 /// Report one failing test file as a STRUCTURED record: the assertion's `.almd`
 /// site, expected/found, and a real diff for multi-line strings, lists and
 /// records. Falls back to the raw captured output when nothing parses — a

--- a/tests/wasm_test_filter_parity_test.rs
+++ b/tests/wasm_test_filter_parity_test.rs
@@ -1,0 +1,92 @@
+// `almide test --run <pattern>` must select the SAME tests on both legs (#2085).
+//
+// The wasm leg has no argv: it selects at runner-synthesis time, so the check is
+// "which tests did the synthesized runner get built out of". The native leg hands
+// the pattern to the Rust test harness, which substring-matches the EMITTED fn
+// name — so `almide_base::names` owns the predicate and both legs read it.
+//
+// The bug this pins was invisible to every other gate: `cmd_test_wasm` took the
+// filter as `_run_filter` and dropped it at the signature, so the wasm leg ran
+// every test whatever the caller asked. A green suite proved nothing, because
+// running MORE tests than asked still passes when they all pass.
+//
+// Test labels are not greppable in the module — the runner's `println` lowers to
+// a run of `i32.store8`, not a data string — so selection is asserted by MODULE
+// IDENTITY instead, which is a stronger claim than any substring: filtering a
+// two-test file down to one test must render byte-for-byte the module that a
+// file containing only that test renders.
+
+use almide_base::names::{rust_safe_fn_name, test_name_matches_filter};
+
+const BOTH: &str = "fn main() -> Unit = println(\"x\")\n\
+\n\
+test \"alpha passes\" {\n\
+  assert_eq(1, 1)\n\
+}\n\
+\n\
+test \"beta fails\" {\n\
+  assert_eq(1, 2)\n\
+}\n";
+
+const ONLY_ALPHA: &str = "fn main() -> Unit = println(\"x\")\n\
+\n\
+test \"alpha passes\" {\n\
+  assert_eq(1, 1)\n\
+}\n";
+
+const ONLY_BETA: &str = "fn main() -> Unit = println(\"x\")\n\
+\n\
+test \"beta fails\" {\n\
+  assert_eq(1, 2)\n\
+}\n";
+
+fn render(source: &str, filter: Option<&str>) -> String {
+    almide_mir::pipeline::try_render_wasm_source_tests(source, &[], false, filter)
+        .expect("the fixture renders on the v1 wasm leg")
+}
+
+/// Each synthesized test contributes its `__almd_test_<i>` name to the module,
+/// so this counts what the runner was built out of without depending on labels.
+fn tests_built_in(source: &str, filter: Option<&str>) -> usize {
+    render(source, filter).matches("__almd_test").count()
+}
+
+#[test]
+fn no_filter_builds_every_test() {
+    assert_eq!(tests_built_in(BOTH, None), tests_built_in(ONLY_ALPHA, None) * 2);
+}
+
+#[test]
+fn filtering_to_one_test_renders_that_test_s_module_exactly() {
+    assert_eq!(render(BOTH, Some("alpha")), render(ONLY_ALPHA, None));
+    assert_eq!(render(BOTH, Some("beta")), render(ONLY_BETA, None));
+    // …and the two are genuinely different modules, so the equalities above are
+    // not both satisfied by some degenerate empty render.
+    assert_ne!(render(ONLY_ALPHA, None), render(ONLY_BETA, None));
+}
+
+/// Zero selected is a legal render, not a wall: the runner is simply empty, the
+/// module exits 0, and the harness reports a pass over zero tests. Erroring here
+/// would turn a mistyped `--run` into a compile failure.
+#[test]
+fn a_filter_matching_nothing_still_renders_an_empty_runner() {
+    assert_eq!(tests_built_in(BOTH, Some("zzz-no-such-test")), 0);
+}
+
+/// The predicate is the native leg's, not a lookalike: the pattern is compared
+/// against the emitted fn name. `beta fails` (with the space) selecting nothing
+/// is native's existing behaviour — surprising, but the point of #2085 is that
+/// both legs are surprising in the SAME way.
+#[test]
+fn the_predicate_matches_the_emitted_name_on_both_legs() {
+    let ir_name = "__test_almd_beta fails";
+    assert_eq!(rust_safe_fn_name(ir_name), "__test_almd_beta_fails");
+    assert!(test_name_matches_filter(ir_name, "beta"));
+    assert!(test_name_matches_filter(ir_name, "beta_fails"));
+    assert!(!test_name_matches_filter(ir_name, "beta fails"));
+    assert!(!test_name_matches_filter(ir_name, "BETA"));
+
+    // The wasm leg agrees with the predicate on the same spellings.
+    assert_eq!(tests_built_in(BOTH, Some("beta fails")), 0);
+    assert_eq!(render(BOTH, Some("beta_fails")), render(ONLY_BETA, None));
+}


### PR DESCRIPTION
Closes #2085.

`almide test --run <pattern>` selected tests on the native legs and was discarded on the wasm leg, so one command line ran two different test sets.

```
$ almide test filt.almd --run alpha --target wasm   ; echo $?
  trapped at: test: beta fails ...                    1     ← before: FALSE RED
$ almide test filt.almd --run alpha --target wasm   ; echo $?
                                                      0     ← after
```

`cmd_test_wasm` dropped the parameter at its signature (`_run_filter`), and the wasm leg shells out to the wasmtime CLI with no program args, so there was nowhere for a pattern to arrive. The native paths build harness argv through `test_harness_args`.

### Where the fix had to go

Not argv. The synthesized `__test_runner` (`crates/almide-mir/src/pipeline_test_runner.rs`) reads no program arguments at all — it emits one unconditional call per `test` fn. So the wasm leg selects at **synthesis time**: non-matching test fns are dropped from the IR before the runner is built.

That makes the predicate the parity risk. The native leg's answer comes from the Rust test harness substring-matching the *emitted* fn name, so `rust_safe_fn_name` moves from almide-codegen (which almide-mir cannot see) to `almide_base::names`, re-exported so every existing caller keeps its spelling. `test_name_matches_filter` is now the only admitted way to ask "does this test run under this pattern", and both legs call it.

The drop happens after the wall checks, not before, so `--run` cannot quietly change which files reach the wasm leg.

### Consequences fixed

- **False red.** `--target wasm` with `--run` failed on a test the filter excluded.
- **False green with a fabricated divergence.** On the default dual run the wasm leg trapped on the excluded test, the native fallback honoured the filter and passed, and the summary printed `1 after a wasm TRAP` — an argument-plumbing artifact in the counter that is supposed to mean "the targets disagree on observable behaviour". `ALMIDE_TEST_STRICT_WASM` (#1166) turned that artifact into a hard failure.

Verified: `--run alpha --target wasm` → 0, `--run alpha` default → 0 with no TRAP note, `ALMIDE_TEST_STRICT_WASM=1 --run alpha` → 0, `--run beta --target wasm` → 1, unfiltered → 1.

### The gate

A signature that ignores a parameter is invisible to every existing gate — running MORE tests than asked still passes when they all pass, so a green suite proved nothing. `tests/wasm_test_filter_parity_test.rs` asserts by **module identity** rather than by grepping labels (test labels lower to runs of `i32.store8`, not to data strings): filtering a two-test file down to one test must render byte-for-byte the module a file containing only that test renders. A/B against the pre-fix behaviour: 3 of its 4 tests fail, all 4 pass after.

`docs/specs/cli.md` now states the matching rule, which was undocumented: a case-sensitive substring match against the emitted name, so `test "beta fails"` is selected by `beta` and `beta_fails` but not by `beta fails`. That is native's existing behaviour; this PR makes the wasm leg surprising in the same way rather than differently.

### Test status

- `cargo test --workspace`: green except `charge_probe_gate`, which fails identically on unmodified `origin/develop` (`spec/wasm_cross/fuel_bounded_boundary.almd` asserts `expected: 2, found: 1` on both binaries) — pre-existing, untouched here.
- `almide test`: 440/440 files pass (428 via WASM, 12 via native fallback).
- No output text changed, so the summary-parsing callers (`scripts/ci-acceptance-ring.sh`) are unaffected.

#2084 (the summary counting files rather than tests) follows on top of this branch.
