### PR TITLE
E002 points its caret at the callee, and suggests names related by containment

### DIFF
--- a/crates/almide-base/src/diagnostic.rs
+++ b/crates/almide-base/src/diagnostic.rs
@@ -33,11 +33,33 @@ pub fn suggest<'a>(name: &str, candidates: impl Iterator<Item = &'a str>) -> Opt
     for c in candidates {
         let dist = levenshtein(name, c);
         let closer = best.is_none_or(|(_, d)| dist < d);
-        if dist > 0 && dist < threshold && closer {
+        if dist > 0 && (dist < threshold || contained(name, c)) && closer {
             best = Some((c, dist));
         }
     }
     best.map(|(s, _)| s.to_string())
+}
+
+/// A written name that is a substring of a real one (or the reverse) is a
+/// *remembered-concept* miss rather than a typo, and edit distance charges it
+/// the whole length gap: `get_str` → `get_string` is 3 and `array` →
+/// `get_array` is 4, both at or past a threshold of 3, so neither got a
+/// candidate while the one-character `get_strin` did (#2089). Those are the
+/// misses that actually happen — the writer knew what the function does and
+/// not how it is spelled.
+///
+/// Containment admits them without widening the threshold for unrelated
+/// names. The length gap is capped by the SHORTER of the two so a fragment
+/// cannot glom onto anything that merely contains it: `get` does not suggest
+/// `get_string`, and a long name does not suggest a short substring of itself.
+fn contained(name: &str, candidate: &str) -> bool {
+    if name.len() < 3 || candidate.len() < 3 {
+        return false;
+    }
+    if candidate.len().abs_diff(name.len()) > name.len().min(candidate.len()) {
+        return false;
+    }
+    candidate.contains(name) || name.contains(candidate)
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -521,5 +543,37 @@ mod apply_try_tests {
         let suggested = Diagnostic::error("e", "h", "c").with_suggested_fix(1, 4, 5, "not ");
         assert!(suggested.display().contains("\n  try:\n"), "{}", suggested.display());
         assert!(!suggested.display().contains("machine-applicable"));
+    }
+}
+
+#[cfg(test)]
+mod suggest_tests {
+    use super::suggest;
+
+    /// #2089. The suggester used to be pure edit distance under a threshold
+    /// of `max(3, len/2)`, which fires on a typo and goes silent on the miss
+    /// that actually happens: a name recalled by meaning rather than by
+    /// spelling. `get_str` sits 3 edits from `get_string` and `array` sits 4
+    /// from `get_array` — both at or past the threshold — while the
+    /// one-character `get_strin` was inside it. Containment closes that.
+    #[test]
+    fn a_name_contained_in_a_real_one_is_suggested() {
+        let json = || ["parse", "stringify", "get_string", "get_int", "get_array", "to_map"].into_iter();
+        assert_eq!(suggest("get_str", json()).as_deref(), Some("get_string"));
+        assert_eq!(suggest("array", json()).as_deref(), Some("get_array"));
+        // The typo the old threshold already caught stays caught.
+        assert_eq!(suggest("get_strin", json()).as_deref(), Some("get_string"));
+    }
+
+    /// The guard rails on containment: a fragment must not glom onto every
+    /// name that happens to contain it. The length gap is capped by the
+    /// SHORTER of the two names, so `get` — ambiguous between five
+    /// candidates — stays silent rather than picking one, and a name with no
+    /// relative at all still returns nothing.
+    #[test]
+    fn containment_stays_silent_on_a_fragment_and_on_a_stranger() {
+        let json = || ["parse", "stringify", "get_string", "get_int", "get_array", "to_map"].into_iter();
+        assert_eq!(suggest("get", json()), None);
+        assert_eq!(suggest("to_string", ["fold", "map", "filter", "len"].into_iter()), None);
     }
 }

--- a/crates/almide-frontend/src/check/calls.rs
+++ b/crates/almide-frontend/src/check/calls.rs
@@ -786,6 +786,23 @@ impl Checker {
             return Ty::Unknown;
         }
         let mut diag = super::err(format!("undefined function '{}'", name), hint, format!("call to {}()", name)).with_code("E002");
+        // #2088: the caret must cover the CALLEE. `emit` fills an unset span from
+        // `current_span`, which by this point is the last argument the checker
+        // walked — so `list.nope(xs)` underlined `xs` (and a call inside a `${}`
+        // interpolation underlined 22 columns of unrelated text) while the
+        // zero-argument `list.nope()` happened to be right, because there was no
+        // argument to move the cursor. The message names the function and the
+        // caret has to point at it, or the reader edits the argument instead.
+        if let Some(span) = self.callee_span_hint {
+            if let Some(file) = &self.source_file {
+                diag.file = Some(file.clone());
+            }
+            diag.line = Some(span.line);
+            diag.col = Some(span.col);
+            if span.end_col > span.col {
+                diag.end_col = Some(span.end_col);
+            }
+        }
         // `try_replace` (Phase 3): when the hint is a clean rename and the callee's source span is available, emit both a concise `try` and the exact replacement range so `Diagnostic::apply_try_to` can rewrite the source. Rich multi-line snippets (conversion wrappers, operator suggestions) stay display-only via `with_try`.
         if let Some(rich) = rich_snippet {
             diag = diag.with_try(rich.to_string());

--- a/crates/almide-frontend/src/check/calls_ufcs.rs
+++ b/crates/almide-frontend/src/check/calls_ufcs.rs
@@ -270,6 +270,21 @@ impl Checker {
             hint,
             format!("method call .{}()", field)
         ).with_code("E002");
+        // #2088, method-UFCS arm: the whole `x.field()` expression is what the
+        // message is about and what the rewrite below replaces, so it is what
+        // the caret must cover. `emit` would otherwise fill the span from
+        // `current_span` — the OBJECT — and underline one column of `s` under
+        // a message about `to_uppercase`.
+        if let Some(span) = self.call_span_hint {
+            if let Some(file) = &self.source_file {
+                diag.file = Some(file.clone());
+            }
+            diag.line = Some(span.line);
+            diag.col = Some(span.col);
+            if span.end_col > span.col {
+                diag.end_col = Some(span.end_col);
+            }
+        }
         if let Some(close) = suggestion {
             // Mechanical rewrite path: if we have the object's source text AND the full call span, substitute `x.field()` → `module.close(x)` in place. Falls back to the comment-headed display form when the source isn't reachable (IDE / playground).
             let rewrite = object.span

--- a/tests/diagnostic_harness_test.rs
+++ b/tests/diagnostic_harness_test.rs
@@ -219,11 +219,24 @@ struct DiagJson {
     /// #1312: the applicability tag that decides whether an unattended
     /// fixer may apply this. "unspecified" means nothing applies it.
     applicability: Option<String>,
+    /// #2088: the PRIMARY span — the region the caret underlines. Emitted
+    /// at the top level of the payload, after the nested `try_replace` and
+    /// `suggestions` objects that carry the same field names, so it is read
+    /// from the LAST occurrence of each key.
+    span: Option<(usize, usize, usize)>,
 }
 
 impl DiagJson {
     fn parse(line: &str) -> Option<Self> {
         if !line.trim_start().starts_with('{') { return None; }
+        let span = match (
+            json_uint_last(line, "\"line\":"),
+            json_uint_last(line, "\"col\":"),
+            json_uint_last(line, "\"end_col\":"),
+        ) {
+            (Some(l), Some(c), Some(e)) => Some((l, c, e)),
+            _ => None,
+        };
         Some(DiagJson {
             code: json_string(line, "\"code\":"),
             hint: json_string(line, "\"hint\":"),
@@ -231,6 +244,7 @@ impl DiagJson {
             try_replace: json_obj_uints(line, "\"try_replace\":", &["line", "col", "end_col"])
                 .map(|v| (v[0], v[1], v[2])),
             applicability: json_string(line, "\"applicability\":"),
+            span,
         })
     }
 }
@@ -260,6 +274,16 @@ fn json_string(blob: &str, key: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Read a top-level unsigned field. `rfind`, not `find`: `line` / `col` /
+/// `end_col` also name fields inside the `try_replace` object and every entry
+/// of `suggestions`, and the top-level pair is emitted last.
+fn json_uint_last(blob: &str, key: &str) -> Option<usize> {
+    let i = blob.rfind(key)?;
+    let tail = &blob[i + key.len()..];
+    let digits: String = tail.chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse().ok()
 }
 
 fn json_obj_uints(blob: &str, key: &str, fields: &[&str]) -> Option<Vec<usize>> {
@@ -377,6 +401,35 @@ fn try_snippets_with_replace_span_apply_cleanly() {
             }
         }
     }
+}
+
+/// #2088. For `E002` the caret and the replacement range name the same
+/// region — the callee — because the message is `undefined function 'X'` and
+/// `X` is what the `try` rewrites. The primary span used to be filled from
+/// whatever the checker had walked last, which for a call WITH arguments was
+/// an argument: `list.nope(xs)` underlined `xs` while offering to rewrite
+/// `list.nope`, and inside a `${}` interpolation the caret ran clear off the
+/// name. A reader who follows the caret edits the argument.
+///
+/// The zero-argument form was always right, which is exactly why this went
+/// unnoticed — the hand-checked examples had no argument to move the cursor.
+#[test]
+fn e002_underlines_the_span_it_offers_to_replace() {
+    let mut checked = 0usize;
+    for case in &collect_cases() {
+        let broken = case.join("broken.almd");
+        for d in run_check_json(&broken) {
+            if d.code.as_deref() != Some("E002") { continue; }
+            let (Some(replace), Some(span)) = (d.try_replace, d.span) else { continue };
+            assert_eq!(
+                span, replace,
+                "E002 in {} underlines {:?} but offers to replace {:?}",
+                case.display(), span, replace
+            );
+            checked += 1;
+        }
+    }
+    assert!(checked > 0, "no E002 fixture carried a replacement span — this test went vacuous");
 }
 
 /// #1312 ratchet. `almide fix` applies `machine-applicable` fix-its and

--- a/tests/diagnostics/e043-try-fold-removed/broken.almd
+++ b/tests/diagnostics/e043-try-fold-removed/broken.almd
@@ -1,4 +1,4 @@
-// E043 variant: list.try_fold.
+// E043 variant: the removed try_ spelling of list.fold.
 fn main() -> Unit = {
   let r = list.try_fold(["a", "bb"], 0, (acc, s) => acc + string.len(s))
   println(int.to_string(r))

--- a/tests/diagnostics/e043-try-fold-removed/fixed.almd
+++ b/tests/diagnostics/e043-try-fold-removed/fixed.almd
@@ -1,4 +1,4 @@
-// E043 variant: list.fold.
+// E043 variant: the removed try_ spelling of list.fold.
 fn main() -> Unit = {
   let r = list.fold(["a", "bb"], 0, (acc, s) => acc + string.len(s))
   println(int.to_string(r))


### PR DESCRIPTION
Two `E002` defects found by writing shell-style scripts against the stdlib and
watching where the compiler sent me. Both are diagnostic-only: no codegen, no
runtime, no observable program behaviour, so no contract ledger entry.

## The caret pointed at the wrong thing (#2088)

`emit` fills an unset primary span from `current_span`, which by the time the
undefined-call diagnostic is built is the last argument the checker walked.

```
error[E002]: undefined function 'list.nope'
  --> span1.almd:3:21
3 |   println(list.nope(xs))
  |                     ^^          ← xs
```

The zero-argument form was right, which is why this survived: the hand-checked
examples had no argument to move the cursor. Inside a `${}` interpolation the
caret ran 22 columns wide over unrelated text.

Both arms now set the span themselves — the named-call arm from
`callee_span_hint`, the method-UFCS arm from `call_span_hint` (the whole
`x.field()` expression, which is what its rewrite replaces).

The harness gains the invariant as a test: **for E002 the caret and the
replacement range name the same region.** It immediately found the second arm,
which I had not noticed by hand.

## The suggester missed the misses that happen (#2089)

`suggest` accepted an edit distance below `max(3, name.len() / 2)`.

| written | real | relation | before | after |
|---|---|---|---|---|
| `get_strin` | `get_string` | distance 1 | ✅ | ✅ |
| `get_str` | `get_string` | prefix, distance 3 | ❌ | ✅ |
| `array` | `get_array` | suffix, distance 4 | ❌ | ✅ |
| `get` | — | ambiguous fragment | ❌ | ❌ |

The two that failed are what you write when you know what the function does and
not how it is spelled; `get_strin` is a typo nobody makes. Containment accepts
them without widening the threshold for unrelated names, and the length gap is
capped by the shorter of the two so a fragment cannot glom onto everything that
contains it.

Writing five scripts produced exactly two name misses — `json.get_str` and
`json.array` — and both landed in the ❌ column. Recovery cost three steps each
(read hint, open the cheatsheet, search it) where the ✅ row costs zero.

## Fixture note

`e043-try-fold-removed`'s two files now carry the same comment. `list.try_fold`
gains a suggestion, so that case reaches the applied-equals-`fixed.almd`
assertion for the first time — and that assertion compares mechanical output
against a file whose comment had been edited by hand. Aligning the comment makes
the fixture measure the code rewrite, which is what it is for.

## Verification

- `cargo test --workspace --release --no-fail-fast` — no failures
- `almide test` — 440/440 files, 4081 tests
- `cargo test --test diagnostic_harness_test` — 7/7, including the new invariant

Closes #2088, closes #2089.
