### PR TITLE
Derive the import hint from the registry, and measure the caret against the source

### DIFF
--- a/crates/almide-frontend/src/import_table.rs
+++ b/crates/almide-frontend/src/import_table.rs
@@ -37,11 +37,21 @@ pub struct ImportTable {
     pub direct: HashMap<Sym, Sym>,
 }
 
+/// Tier-1 modules every file can reach without writing an `import`, held as a
+/// named const rather than a literal inside `ImportTable::new` so the
+/// diagnostics side can ask the same question the resolver answers. Together
+/// with `AUTO_IMPORT_BUNDLED` this is the whole auto-import surface, and
+/// `stdlib::is_import_suggestable` derives its complement from the two.
+pub const TIER1_ALWAYS_ACCESSIBLE: &[&str] = &[
+    "string", "int", "float", "list", "bytes", "matrix",
+    "map", "set", "option", "result", "value", "prim",
+];
+
 impl ImportTable {
     /// Create with Tier 1 auto-imported stdlib modules.
     pub fn new() -> Self {
         let mut stdlib = HashSet::new();
-        for m in &["string", "int", "float", "list", "bytes", "matrix", "map", "set", "option", "result", "value", "prim"] {
+        for m in TIER1_ALWAYS_ACCESSIBLE {
             stdlib.insert(sym(m));
         }
         ImportTable {

--- a/crates/almide-frontend/src/stdlib.rs
+++ b/crates/almide-frontend/src/stdlib.rs
@@ -10,11 +10,39 @@ pub use almide_lang::stdlib_info::{
     resolve_ufcs_module, resolve_ufcs_candidates,
 };
 
-/// Modules that can safely be suggested via "Add `import X`" in error hints.
-/// Excludes auto-imported modules and names that are common as variable names
-/// (e.g. `value`, `error`, `string`, `list`, `map`, `set`, `option`, `result`).
+/// Modules the compiler does not intend a user to import: they exist to give
+/// the pipeline a spelling, not to be written. `prim` is the v1 primitive
+/// floor. The test below pins this against `docs/stdlib/` — a module with a
+/// user-facing doc page is user-facing.
+const NOT_USER_IMPORTABLE: &[&str] = &["prim"];
+
+/// Whether "Add `import X`" is the right hint for an unresolved `X`.
+///
+/// This used to be a hand-written list of twelve names, and it had drifted
+/// both ways: `bytes` / `matrix` / `datetime` are auto-imported and could
+/// never need the hint, while `hash`, `hex`, `url`, `base64`, `zlib`, `net`,
+/// `path`, `args`, `html` and `mem` — all real modules that DO need an
+/// `import` — were missing, so `hash.sha256(b)` reported "undefined variable
+/// 'hash'" and told the reader to check the variable name. That is worse than
+/// silence: it sends them looking for a typo'd binding when the fix is a line
+/// at the top of the file.
+///
+/// So derive it. A module is suggestable exactly when it is a real stdlib
+/// module, is NOT already reachable without an import, and is meant to be
+/// written by a user. A module added to the registry tomorrow is covered the
+/// day it lands, which a `matches!` arm never was.
 pub fn is_import_suggestable(name: &str) -> bool {
-    matches!(name, "json" | "http" | "fs" | "process" | "regex" | "datetime" | "io" | "random" | "testing" | "bytes" | "matrix" | "env")
+    if NOT_USER_IMPORTABLE.contains(&name) { return false; }
+    if !is_any_stdlib(name) && !is_bundled_module(name) { return false; }
+    !is_auto_imported(name)
+}
+
+/// The whole auto-import surface: the resolver's Tier-1 set plus the bundled
+/// modules it loads eagerly. Kept as one predicate so callers cannot consult
+/// half of it.
+fn is_auto_imported(name: &str) -> bool {
+    crate::import_table::TIER1_ALWAYS_ACCESSIBLE.contains(&name)
+        || AUTO_IMPORT_BUNDLED.contains(&name)
 }
 
 /// One-line description of each stdlib module, for error hints.
@@ -370,5 +398,54 @@ mod tests {
             .filter(|m| !BUNDLED_MODULES.contains(m) && !STDLIB_MODULES.contains(m))
             .collect();
         assert!(stale.is_empty(), "descriptions for unknown modules: {stale:?}");
+    }
+
+    /// Every module that needs an `import` gets the hint that says so, and no
+    /// module that is already reachable wastes one. The predicate is derived,
+    /// so this asserts the derivation rather than a list — a module added to
+    /// the registry is covered without touching this file.
+    ///
+    /// The hand-written list this replaced had drifted in both directions at
+    /// once: `hash`, `hex`, `url`, `base64`, `zlib`, `net`, `path`, `args`,
+    /// `html` and `mem` needed the hint and never got it, while `bytes`,
+    /// `matrix` and `datetime` were listed and can never need it.
+    #[test]
+    fn every_module_needing_an_import_is_suggestable() {
+        for m in BUNDLED_MODULES.iter().chain(STDLIB_MODULES.iter()).copied() {
+            if NOT_USER_IMPORTABLE.contains(&m) {
+                assert!(!is_import_suggestable(m), "{m} is internal but suggestable");
+                continue;
+            }
+            assert_eq!(
+                is_import_suggestable(m), !is_auto_imported(m),
+                "{m}: suggestable={} but auto-imported={}",
+                is_import_suggestable(m), is_auto_imported(m)
+            );
+        }
+        // The misses that prompted this, pinned by name so a future
+        // "simplification" back to a literal list fails here first.
+        for m in ["hash", "hex", "url", "base64", "zlib", "net", "path", "args", "html", "mem"] {
+            assert!(is_import_suggestable(m), "{m} still gets no import hint");
+        }
+        for m in ["bytes", "matrix", "datetime", "string", "list"] {
+            assert!(!is_import_suggestable(m), "{m} is auto-imported and needs no hint");
+        }
+    }
+
+    /// `NOT_USER_IMPORTABLE` is the one judgement call in the derivation, so
+    /// it is pinned to an external fact rather than to itself: a module with a
+    /// page under `docs/stdlib/` is documented FOR a user, and a documented
+    /// module the compiler refuses to suggest is a contradiction.
+    #[test]
+    fn internal_modules_have_no_user_facing_doc_page() {
+        let docs = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../docs/stdlib");
+        for m in NOT_USER_IMPORTABLE {
+            let page = docs.join(format!("{m}.md"));
+            assert!(
+                !page.exists(),
+                "{m} is marked internal but docs/stdlib/{m}.md exists — it is user-facing"
+            );
+        }
     }
 }

--- a/src/diagnostic_render.rs
+++ b/src/diagnostic_render.rs
@@ -279,14 +279,26 @@ fn render_span_source_line(out: &mut String, line_num: usize, trimmed: &str, wid
     }
 }
 
-/// `render_primary_span`'s caret-underline row. Extracted verbatim.
-fn render_span_carets(out: &mut String, d: &Diagnostic, col: usize, width: usize, color: bool) {
+/// `render_primary_span`'s caret-underline row.
+///
+/// The caret measures SOURCE, so its width may only ever come from a span or
+/// from the line. The no-`end_col` arm used to fall back to
+/// `d.context.len()` — the length of a human-readable string — which drew as
+/// many carets as the message happened to have characters: 19 under
+/// `list.nope([1])}")` for "call to list.nope()", and 42 running past the end
+/// of a 37-column line for "this expression with an unconstrained type". A
+/// span the checker could not measure is a span of unknown width, and the
+/// honest rendering of unknown width is to point at where it starts.
+fn render_span_carets(out: &mut String, d: &Diagnostic, col: usize, width: usize, line_len: usize, color: bool) {
     let gutter_pad = " ".repeat(width);
     let col0 = col.saturating_sub(1);
     let caret_len = match d.end_col {
         Some(end_col) => { let end0 = end_col.saturating_sub(1); if end0 > col0 { end0 - col0 } else { 1 } }
-        None => if !d.context.is_empty() { d.context.len().max(1) } else { 1 },
+        None => 1,
     };
+    // Never underline past the end of the line: an end_col from a re-based
+    // sub-parse (string interpolation) can overshoot the text it names.
+    let caret_len = caret_len.min(line_len.saturating_sub(col0)).max(1);
     let pad = " ".repeat(col0);
     let carets = "^".repeat(caret_len);
     let (caret_color, caret_reset) = if color {
@@ -319,7 +331,7 @@ fn render_primary_span(out: &mut String, d: &Diagnostic, source_lines: &[&str], 
 
     // Caret underline
     let Some(col) = d.col else { return; };
-    render_span_carets(out, d, col, width, color);
+    render_span_carets(out, d, col, width, trimmed.chars().count(), color);
 }
 
 pub fn display_with_source(d: &Diagnostic, source: &str) -> String {
@@ -340,4 +352,58 @@ pub fn display_with_source(d: &Diagnostic, source: &str) -> String {
     // Render primary span
     render_primary_span(&mut out, d, &source_lines, color);
     out
+}
+
+#[cfg(test)]
+mod caret_tests {
+    use super::display_with_source;
+    use almide_base::diagnostic::Diagnostic;
+
+    /// (1-based column the caret run starts at, its length) — everything the
+    /// caret row asserts, with the gutter and padding read rather than
+    /// trimmed away.
+    fn caret(rendered: &str) -> (usize, usize) {
+        let row = rendered.lines().rev().find(|l| l.contains('^')).expect("a caret row");
+        let body = row.split_once("| ").expect("a gutter").1;
+        let start = body.find('^').expect("a caret");
+        (start + 1, body[start..].chars().take_while(|c| *c == '^').count())
+    }
+
+    /// The caret measures source. A span the checker could not measure has
+    /// unknown width, and the width of the message is not a substitute: the
+    /// fallback used to be `context.len()`, which drew 19 carets for "call to
+    /// list.nope()" and 42 for "this expression with an unconstrained type",
+    /// covering text the diagnostic was never about.
+    #[test]
+    fn an_unmeasured_span_points_rather_than_guessing_a_width() {
+        let src = "  println(\"${list.nope([1])}\")";
+        let mut d = Diagnostic::error("undefined function 'list.nope'", "h", "call to list.nope()");
+        d.line = Some(1);
+        d.col = Some(14);
+        d.end_col = None;
+        assert_eq!(caret(&display_with_source(&d, src)), (14, 1));
+    }
+
+    /// A span from a re-based sub-parse can overshoot the line it names, and a
+    /// caret row longer than the source line is nonsense on its face.
+    #[test]
+    fn a_caret_never_runs_past_the_end_of_the_line() {
+        let src = "let x = 1";
+        let mut d = Diagnostic::error("m", "h", "c");
+        d.line = Some(1);
+        d.col = Some(9);
+        d.end_col = Some(400);
+        assert_eq!(caret(&display_with_source(&d, src)), (9, 1));
+    }
+
+    /// A measured span still underlines exactly what it measured.
+    #[test]
+    fn a_measured_span_underlines_its_own_width() {
+        let src = "  let a = list.nope([1])";
+        let mut d = Diagnostic::error("m", "h", "call to list.nope()");
+        d.line = Some(1);
+        d.col = Some(11);
+        d.end_col = Some(20);
+        assert_eq!(caret(&display_with_source(&d, src)), (11, 9));
+    }
 }


### PR DESCRIPTION
A second turn of the same loop as #2093: write scripts from memory, watch where
the compiler sends you, fix the misdirection. Twelve scripts this time, aimed at
modules the previous round never touched (datetime, regex, set, hash, env, url,
random, math, bytes, string, io, path). Four compiled first try; the eight that
did not produced three distinct shapes of misdirection. Two are fixed here.

Diagnostic-only: no codegen, no runtime, no observable program behaviour.

## A module that needs importing reported "undefined variable"

```
$ almide check t04_hash.almd
error[E003]: undefined variable 'hash'
  hint: Check the variable name
```

`hash` is a registered stdlib module. The hint that says so already exists —
`is_import_suggestable` — but it was twelve names in a `matches!` arm, and it had
drifted in both directions at once:

| | |
|---|---|
| listed, but auto-imported (can never need the hint) | `bytes`, `matrix`, `datetime` |
| needs an `import`, never listed | `hash`, `hex`, `url`, `base64`, `zlib`, `net`, `path`, `args`, `html`, `mem` |

"Check the variable name" is worse than silence here: it sends the reader looking
for a typo'd binding when the fix is a line at the top of the file. Two of twelve
scripts hit it.

The predicate is now derived — a real stdlib module, not already reachable
without an import, meant to be written by a user — so a module added to the
registry is covered the day it lands. `ImportTable::new`'s Tier-1 seed moves into
a named const so the diagnostics side asks the resolver's own question instead of
restating it.

`prim` is the single judgement call, and it is pinned to an external fact rather
than to itself: a module with a page under `docs/stdlib/` is user-facing, so an
internal module that grows one fails the test.

```
hint: Add `import hash` (stdlib: non-cryptographic digests and SHA-256)
Or run `almide fmt` to auto-add missing imports
try:
    import hash
```

## The caret was as wide as the message was long

Chasing the above surfaced this. When a diagnostic has a column but no `end_col`,
the caret length fell back to `d.context.len()` — the length of a prose string:

```
3 |   println("${list.nope([1])}")
  |              ^^^^^^^^^^^^^^^^^^^     ← 19, because "call to list.nope()" is 19 chars
```

and on an E025 whose context is "this expression with an unconstrained type", 42
carets across a 37-column line.

A span the checker could not measure has unknown width, and the honest rendering
of unknown width is to point at where it starts. A measured span keeps its width
but is now clamped to the line, because a span re-based from a sub-parse can
overshoot the text it names.

## Not fixed here

The measurement turned up three more, filed separately: spans inside `${}` carry
no `end_col` at all (so no fix-it is offered there — the root cause the clamp
above only renders honestly), E025 cascading on top of a reported E002, and E005
declining to name a sibling that takes the type you actually have.

## Verification

- `cargo test --workspace --release --no-fail-fast` — no failures
- `almide test` — 440/440 files, 4081 tests
- new: 2 derivation tests in `stdlib.rs`, 3 caret tests in `diagnostic_render.rs`
