### PR TITLE
An unwrap on recovered Unknown stays Unknown, so E025 stops reporting E002's cascade

### DIFF
--- a/crates/almide-frontend/src/check/infer_calls_closures.rs
+++ b/crates/almide-frontend/src/check/infer_calls_closures.rs
@@ -761,7 +761,21 @@ impl Checker {
         self.check_unwrap_propagation_context(&resolved);
         if let Some(inner_ty) = resolved.option_inner().or_else(|| resolved.result_ok_ty()) {
             inner_ty
-        } else if matches!(&resolved, Ty::Unknown | Ty::TypeVar(_)) {
+        } else if matches!(&resolved, Ty::Unknown) {
+            // Recovery residue in, recovery residue out (#2096). `Unknown` here
+            // means a PRIOR error already reported this expression — an E002 on
+            // the callee, say — and minting a fresh var instead would hand the
+            // post-solve validator an unbound `?N` it cannot distinguish from a
+            // genuinely undecidable slot. It then reported E025 on top of the
+            // E002, with a hint telling the reader to annotate a binding that
+            // only exists because recovery put it there. `validate_unresolved_
+            // binding_types` already skips a wholly-`Unknown` site for exactly
+            // this reason; propagating the marker is what lets that guard see it.
+            Ty::Unknown
+        } else if matches!(&resolved, Ty::TypeVar(_)) {
+            // A bare inference var is NOT recovery: the operand may still be
+            // pinned by context, so the unwrap keeps its own fresh slot and E025
+            // stays available for the genuinely undecidable case.
             self.fresh_var()
         } else if self.is_effect_call_expr(inner) {
             // #1049: `!` on a NEVER-ERR effect call is a silent no-op. The

--- a/tests/e025_recovery_cascade_test.rs
+++ b/tests/e025_recovery_cascade_test.rs
@@ -1,0 +1,100 @@
+//! E025 must not be reported on top of the recovery its own predecessor created (#2096).
+//!
+//! An undefined function is E002; the call's type recovers as `Ty::Unknown`.
+//! `validate_unresolved_binding_types` already skips a wholly-`Unknown` site —
+//! "a prior error was already reported" — but `!` on an `Unknown` operand minted
+//! a FRESH inference var, and an unbound `?N` is indistinguishable from a
+//! genuinely undecidable slot. So the reader got two errors for one defect, and
+//! the second one's hint said to annotate a binding that exists only because
+//! recovery put it there: a plausible instruction that does not fix the program.
+//!
+//! The guard has to cut exactly there. E025 is load-bearing on its own — an
+//! unconstrained slot is never silently defaulted, and the hint cites Rust E0282
+//! deliberately — so the genuine case is asserted in the same file as the
+//! suppression. A fix that silenced both would pass a one-sided test.
+
+use std::process::Command;
+
+fn almide() -> &'static str {
+    env!("CARGO_BIN_EXE_almide")
+}
+
+fn check(dir: &std::path::Path, name: &str, source: &str) -> String {
+    let file = dir.join(name);
+    std::fs::write(&file, source).expect("write fixture");
+    let out = Command::new(almide())
+        .arg("check")
+        .arg(&file)
+        .output()
+        .expect("run almide check");
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
+fn count(haystack: &str, needle: &str) -> usize {
+    haystack.matches(needle).count()
+}
+
+/// The issue's repro: one defect, and it must read as one.
+#[test]
+fn an_undefined_call_under_a_bang_reports_once() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = check(
+        dir.path(),
+        "cascade.almd",
+        "import random\n\
+         effect fn main() -> Unit = {\n\
+        \x20 let xs = [1, 2, 3, 4, 5]\n\
+        \x20 println(\"${random.sample(xs, 3)!}\")\n\
+         }\n",
+    );
+    assert_eq!(count(&out, "error[E002]"), 1, "the real defect must still be reported:\n{out}");
+    assert_eq!(
+        count(&out, "error[E025]"),
+        0,
+        "E025 fired on the Unknown that E002's own recovery created:\n{out}"
+    );
+    assert!(out.contains("1 error(s) found"), "{out}");
+}
+
+/// The same shape without the `!`, so the suppression is not accidentally
+/// specific to the unwrap spelling that exposed it.
+#[test]
+fn an_undefined_call_without_a_bang_also_reports_once() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = check(
+        dir.path(),
+        "plain.almd",
+        "fn main() -> Unit = {\n\
+        \x20 let v = list.nope([1, 2, 3])\n\
+        \x20 println(\"${v}\")\n\
+         }\n",
+    );
+    assert_eq!(count(&out, "error[E002]"), 1, "{out}");
+    assert_eq!(count(&out, "error[E025]"), 0, "{out}");
+}
+
+/// The other direction. An unconstrained slot with NO preceding error is still
+/// undecidable and still refused, hint intact — this is the behaviour the
+/// suppression must not reach.
+#[test]
+fn a_genuine_unconstrained_slot_still_reports_e025() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = check(
+        dir.path(),
+        "genuine.almd",
+        "fn main() -> Unit = {\n\
+        \x20 let xs = []\n\
+        \x20 println(\"${list.len(xs)}\")\n\
+         }\n",
+    );
+    assert_eq!(count(&out, "error[E002]"), 0, "no recovery is involved here:\n{out}");
+    assert_eq!(count(&out, "error[E025]"), 1, "E025 must survive for the real case:\n{out}");
+    assert!(
+        out.contains("Rust E0282"),
+        "the hint's deliberate citation must survive:\n{out}"
+    );
+}


### PR DESCRIPTION
Closes #2096. Follows #2100 (#2095), which is why the E002 below underlines its callee instead of a single column.

An undefined function is E002 and its type recovers as `Ty::Unknown`. The post-solve validator then reported the recovery itself:

```
error[E002]: undefined function 'random.sample'
error[E025]: cannot infer a concrete type for this expression (type ?0)
  hint: Bind the expression to an explicitly-typed `let`, e.g. `let r: Int = ...`, …
2 error(s) found
```

Two errors for one defect, and the second one's hint is the damaging part: it tells the reader to annotate a binding that exists only because recovery put it there. For our primary reader that is not noise — it is a *plausible instruction* pointing away from the one-word fix, and following it produces a program that still does not compile.

### The guard already existed; one path walked around it

`validate_unresolved_binding_types` skips a wholly-`Unknown` site, with the reason written down: *"error-recovery (a prior error was already reported)"*. The site here resolved to `?0`, not `Unknown`, so the guard never saw it.

`crates/almide-frontend/src/check/infer_calls_closures.rs:764` — `!` on an `Unknown` operand minted a fresh inference var:

```rust
-} else if matches!(&resolved, Ty::Unknown | Ty::TypeVar(_)) {
-    self.fresh_var()
+} else if matches!(&resolved, Ty::Unknown) {
+    Ty::Unknown            // recovery residue in, recovery residue out
+} else if matches!(&resolved, Ty::TypeVar(_)) {
+    self.fresh_var()       // a bare var may still be pinned by context
```

An unbound `?N` is indistinguishable from a genuinely undecidable slot, so propagating the marker is what lets the existing guard do its job. `crates/almide-frontend/CLAUDE.md` states the invariant this restores: *"Error recovery with `Unknown`. When inference fails, the checker emits a diagnostic and assigns `Ty::Unknown`. This prevents cascade errors."*

The two arms are split rather than merged because they are not the same case: `Unknown` is a reported failure, while a bare `TypeVar` is an operand context may still resolve — that one keeps its fresh slot, and E025 stays available for it.

### E025 is not weakened

The suppression is asserted against its own opposite in the same file. `tests/e025_recovery_cascade_test.rs`:

- the repro reports exactly one error, and it is the E002;
- the same shape without `!` also reports once, so the fix is not accidentally specific to the spelling that exposed it;
- an empty-collection slot with **no** preceding E002 still reports E025, with its `Rust E0282` citation intact.

A fix that silenced both would pass a one-sided test, which is why the third case is there.

A/B: the first test fails with the `Unknown` arm restored to `fresh_var()`, and passes with it. The other two are green either way — honest, and it is what tells you the defect was specific to `!`.

### Suite

`cargo test --workspace --no-fail-fast`: 294 binaries, zero failures. `almide test`: 440/440 files, 4081 tests.
