### PR TITLE
Guard the roadmap index with the twin test and a CI regenerate-and-diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1246,6 +1246,19 @@ jobs:
           git diff --exit-code -- docs/contracts/README.md \
             || { echo "::error::docs/contracts/README.md is stale — run: bash docs/contracts/generate-readme.sh > docs/contracts/README.md"; exit 1; }
 
+      # The same guard the contract index has had, for the roadmap index, which had
+      # only the lefthook pre-commit hook. lefthook is an opt-in local install, so an
+      # author who never ran `lefthook install` bypasses it silently — and did: the
+      # committed index was found stale on 2026-09-12, missing nine rows. Two generated
+      # indexes, one guarded twice and one guarded once, was an oversight rather than a
+      # decision. The Almide twin's half of this comparison is the dogfood test
+      # `the roadmap index rendering is byte-identical …` in the almide-gates job.
+      - name: Roadmap README up to date (regenerate and diff)
+        run: |
+          bash docs/roadmap/generate-readme.sh > docs/roadmap/README.md
+          git diff --exit-code -- docs/roadmap/README.md \
+            || { echo "::error::docs/roadmap/README.md is stale — run: bash docs/roadmap/generate-readme.sh > docs/roadmap/README.md"; exit 1; }
+
       # The three gates below were written but never wired to a job. A gate that
       # has never run is indistinguishable from one that does not exist, so they
       # are attached here rather than left as scripts someone remembers to call.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -16,7 +16,7 @@
 | [The 2026 Async Claim — audit and the runaway plan](active/async-world-claim.md) | Audit of the best-async-of-2026 claim: the axis, the rivals, the five runaway moves |
 | [Behavioral Contract — 機械生成コードの「機能正しさ」を、王者の土俵を避けて取る層](active/behavioral-contract.md) | 機能正しさを王者(Dafny/F*/SPARK/Lean)の土俵を避けて取る層。C-FAITHFUL の上に C-PRESERVED(差分保存)と C-ASSERTED(批准性質)を積む。仕様の出所を機械生成レジームへずらす戦略。 |
 | [Build Speed: Runtime rlib + Hot-Fn Inlining](active/build-speed-runtime-rlib.md) | Native build-speed — precompiled almide_rt runtime rlib, and recovering the shipping-build inlining gap with #[inline] |
-| [Camp-4, generalised: make heap-result `match` total instead of recognised](active/camp4-general-heap-match.md) |  |
+| [Camp-4, generalised: make heap-result `match` total instead of recognised](active/camp4-general-heap-match.md) | Make heap-result match total rather than recognised, in lowering only |
 | [Certificate Format v1 — design](active/certificate-format-v1.md) | The per-function ownership-certificate format — the i/a/d/m alphabet, call/branch/closure extensions, and which bricks have shipped |
 | [Certification-Grade Hardening — 認証級への硬化](active/certification-grade.md) | Certification-grade hardening — adopt the mechanisms of DO-178C / ISO 26262 / IEC 61508 (spec, traceability, coverage, tool qualification, dossier) for the machine-written-software trust layer |
 | [CI Warnings Cleanup](active/ci-warnings-cleanup.md) | Standing ledger of compiler warnings CI tolerates, and the plan to drive each class to zero |
@@ -29,14 +29,14 @@
 | [Cross-Target Completeness (the Lid)](active/cross-target-completeness.md) | Cross-target completeness lid — the staged path from "all known divergences fixed + byte-diff gate" to structural equivalence (drain → interpreter+fuzz → selfhost → kernel proofs), with the live drain queue |
 | [The Determinism / Purity Belt](active/determinism-belt.md) | Determinism/Purity Belt — a Perceus-analog that makes the compiler deterministic & target-portable by construction |
 | [Deterministic Bounds — legalising a bound on computation under byte-identity](active/deterministic-bounds.md) | Legalising fan.timeout under byte-identity — fuel, deterministic allocation, winner order, effect isolation |
-| [edit-locality theory — the theorem Almide exists to prove](active/edit-locality-theory.md) |  |
+| [edit-locality theory — the theorem Almide exists to prove](active/edit-locality-theory.md) | Turn bounded edit blast radius from design instinct into a proven theorem |
 | [Capability-Based Effect System](active/effect-system-capability.md) | Capability-based effect system for sandboxed AI agent containers |
 | [Blueprint — making the ~27 effectful / raw-pointer stdlib fns FUNCTIONAL in v1](active/effectful-27-blueprint.md) | Blueprint for making the ~27 effectful / raw-pointer stdlib fns functional on the v1 leg, split by real cause |
 | [Execution Inception — as-if 規則を、並行と target の向こうまで完成させる](active/execution-inception.md) | The execution inception: the as-if rule completed across concurrency and targets |
 | [Fan v2 — reference examples](active/fan-v2-examples.md) | Reference examples for the fan v2 surface: every head, edge semantics, diagnostics |
 | [Fan v2 — one execution-policy grammar](active/fan-v2.md) | Fan v2: the execution-policy grammar — heads x forms, thunk-free, typed budgets |
 | [Flight Evidence Gaps — 実地監査所見台帳](active/flight-evidence-gaps.md) | Hands-on internal audit findings (2026-07-03) — the measured distance between DAL-A philosophy and DAL-A evidence, as 7 findings with corrective work items and acceptance criteria |
-| [Flight-grade: the organization and track-record rungs](active/flight-organization.md) |  |
+| [Flight-grade: the organization and track-record rungs](active/flight-organization.md) | Flight-grade sections B and C: legal entity, engagement, funding, customer |
 | [Flight Profile — 航空品質への接地分析と2つのキーストーン](active/flight-profile.md) | DO-178C flight-grade gap analysis: 6 pillars status + 2 engineering keystones |
 | [Flight Qualification — DO-178C/DO-330/DO-333 マッピング + 資格化キット(G-F5 + G-F6)](active/flight-qualification.md) | Flight gates G-F5 + G-F6 — how the PCC certificate/receipt maps to DO-178C Table A objectives, the DO-330 "prove-the-checker" tool-qualification argument (compiler→TQL-5 output-verified, checker→qualified-by-proof), the DO-333 formal-methods credit per proven property, and the G-F6 qualification kit as a product (AbsInt/SCADE-KCG model): what's in the kit, the boundary (kit provides vs customer's domain process), and the customer integration story. |
 | [Flight Reference App — PID 制御則カーネル + make verify + receipt(G-F4)](active/flight-reference-app.md) | Flight gate G-F4 — the reference application (a fixed-point Q16.16 PID control-law kernel over a counted sim loop) that passes `make verify` end-to-end, the 7-stage verify pipeline (exist vs gated on keystones), the receipt it emits (C-SAFE/C-PROVEN green, C-WCET/C-FAITHFUL pending), and the de-risking order (Slice 0 scalar-no-print green now → Slice 1 print=G-F0 frontier → Slice 2 keystone-あ unlocks C-WCET → Slice 3 keystone-い unlocks Ferrocene). |
@@ -47,14 +47,14 @@
 | [Integer literal domain — cross-language survey and Almide's target](active/integer-literal-domain.md) | How other languages range-check integer literals, and where Almide should land |
 | [StringInterp is NOT special syntax — desugar it to `concat + to_string(part)`](active/interp-is-desugar-to-tostring.md) | Retiring StringInterp as special syntax by desugaring it to concat + to_string(part) |
 | [Issue Ledger Burn-down — 完全性キャンペーンの残量計](active/issue-ledger-burndown.md) | The issue-ledger burn-down gauge: keeping the open-issue count an honest measure of remaining work |
-| [#1437: the lifted carrier's ABI — declaration-driven, one readable layout](active/lifted-carrier-abi.md) |  |
+| [#1437: the lifted carrier's ABI — declaration-driven, one readable layout](active/lifted-carrier-abi.md) | #1437: one declaration-driven carrier layout instead of producer drift |
 | [LLM-first Language](active/llm-first-language.md) | Plan to make Almide the language LLMs write most accurately, measured by dojo MSR |
 | [Logical-Time Async — the async grammar design](active/logical-time-async.md) | The async grammar: fuel as the logical clock, deterministic race, oracle tier |
 | [Logical-Time Async — the implementation blueprint](active/logical-time-implementation.md) | Implementation blueprint: Op::Charge, fuel ABI, metered clones, race lowering, gates |
 | [Logical-Time Async — the proof ledger](active/logical-time-proofs.md) | Proof ledger for the logical-time async semantics: theorems, Lean core, model gate |
 | [Map / Set data-structure roadmap](active/map-data-structure-roadmap.md) | Map / Set data-structure roadmap, including the rejected seq-in-entry design and why it was wrong |
 | [Reviving the monkey regression suite: what `spec/` actually is](active/mir-caps-call-count-breach.md) | spec/ is the trust spine's v0 corpus, not a test directory — the revived monkey suite grows two shrink-only ratchets and breaches the caps-soundness backstop |
-| [Mission-critical attack list](active/mission-critical-attack-list.md) |  |
+| [Mission-critical attack list](active/mission-critical-attack-list.md) | Tiered list making Almide defensibly usable in mission-critical domains |
 | [native: nested ctor/literal pattern at a Box'd (recursive-variant) field](active/native-boxed-pattern-lowering.md) | Native lowering for a nested ctor/literal pattern at a Box'd recursive-variant field |
 | [Native Trust Spine — Perceus as the single memory model (#764)](active/native-trust-spine.md) | Routing almide build --target rust through the same v1 Perceus MIR as wasm, so one memory model serves both legs |
 | [Outside-Review Audit 2026-07 — 証拠層の負債バーンダウン](active/outside-review-audit-2026-07.md) | The 2026-07-27 five-lens outside-reviewer audit — the evidence layer lagged the v0→v1 transition and the honesty gradient inverted (internal docs honest, outward claims false); the layered burn-down to "zero false claims, every gate real" with issue links #913-#932 |
@@ -63,12 +63,12 @@
 | [Protocols: declared conformance + opt-in `any P`](active/protocol-any-existentials.md) | Declared conformance + opt-in `any P` existentials — take Go's interface-value ergonomics without its implicit-satisfaction and nil-interface traps; the one Swift idea worth stealing, none of the rest |
 | [Receipt Logic — 受領書の論理](active/receipt-logic.md) | Formal foundation for the trust layer — receipt logic: claim types, threat model, trust bases, falsification procedures, completeness relative to use-case |
 | [reconciliation follow-up — v0.28.0 で見送った develop 側の残件](active/reconciliation-followup.md) | v0.28.0 reconciliation follow-up: deferred develop commits for 0.28.1 |
-| [result-family-from-type — layout is a function of the type, names only choose code](active/result-family-from-type.md) |  |
-| [Return-op eradication: one desugar for `!`, position zoo deleted](active/return-op-eradication.md) |  |
-| [rot-eradication — the decay map and its reference-backed cures](active/rot-eradication.md) |  |
+| [result-family-from-type — layout is a function of the type, names only choose code](active/result-family-from-type.md) | Derive call-result layout from the type, not from module/func name tables |
+| [Return-op eradication: one desugar for `!`, position zoo deleted](active/return-op-eradication.md) | One desugar for the ! operator, deleting the per-position return-op zoo |
+| [rot-eradication — the decay map and its reference-backed cures](active/rot-eradication.md) | The decay map of compiler rot and its reference-backed cures |
 | [Self-host linking v2 — link the mono instances, retire the twin matrix](active/selfhost-link-v2.md) | Self-host linking v2 — retire the shim registry's per-type twins by linking the monomorphized generic bodies the renderer already produces |
 | [Shell scripting stance: structured pipelines, no interactive shell](active/shell-scripting-surface.md) | Take Nushell's data model for scripts; do not build an interactive shell |
-| [Test-surface 25× — the road to reference-compiler scale](active/test-surface-25x.md) |  |
+| [Test-surface 25× — the road to reference-compiler scale](active/test-surface-25x.md) | Grow the committed test surface 25x toward reference-compiler scale |
 | [Ticks interface audit — is the demanded API shape different?](active/ticks-interface-audit.md) | Audit of ticks against timeout-shaped APIs: the unwritable-number problem, three fixes |
 | [Trust Layer — 機械が書くソフトウェアの信頼層](active/trust-layer.md) | Category strategy — winning "the trust layer for machine-written software": MWS Trust Levels, receipts, critical path |
 | [Type Where Constraints](active/type-where-constraints.md) | where clauses on type/fn definitions for type constraints |

--- a/docs/roadmap/active/camp4-general-heap-match.md
+++ b/docs/roadmap/active/camp4-general-heap-match.md
@@ -1,3 +1,4 @@
+<!-- description: Make heap-result match total rather than recognised, in lowering only -->
 # Camp-4, generalised: make heap-result `match` total instead of recognised
 
 Status: **plan + first landed arc.** Written 2026-08-17 from a fresh outside wall

--- a/docs/roadmap/active/edit-locality-theory.md
+++ b/docs/roadmap/active/edit-locality-theory.md
@@ -1,3 +1,4 @@
+<!-- description: Turn bounded edit blast radius from design instinct into a proven theorem -->
 # edit-locality theory — the theorem Almide exists to prove
 
 **Status**: active (constitution written 2026-08-15; Stage 1 landed as

--- a/docs/roadmap/active/flight-organization.md
+++ b/docs/roadmap/active/flight-organization.md
@@ -1,3 +1,4 @@
+<!-- description: Flight-grade sections B and C: legal entity, engagement, funding, customer -->
 # Flight-grade: the organization and track-record rungs
 
 The [flight-grade program](https://github.com/almide/almide/issues/586) has three

--- a/docs/roadmap/active/lifted-carrier-abi.md
+++ b/docs/roadmap/active/lifted-carrier-abi.md
@@ -1,3 +1,4 @@
+<!-- description: #1437: one declaration-driven carrier layout instead of producer drift -->
 # #1437: the lifted carrier's ABI — declaration-driven, one readable layout
 
 Status: DESIGN (scouted 2026-08-24; direction per the issue's recorded candidate —

--- a/docs/roadmap/active/mission-critical-attack-list.md
+++ b/docs/roadmap/active/mission-critical-attack-list.md
@@ -1,3 +1,4 @@
+<!-- description: Tiered list making Almide defensibly usable in mission-critical domains -->
 # Mission-critical attack list
 
 Written 2026-08-18, at the close of the deep-wash campaign (7 compiler-bug

--- a/docs/roadmap/active/result-family-from-type.md
+++ b/docs/roadmap/active/result-family-from-type.md
@@ -1,3 +1,4 @@
+<!-- description: Derive call-result layout from the type, not from module/func name tables -->
 # result-family-from-type — layout is a function of the type, names only choose code
 
 **Status**: active (phase 0 landed 2026-08-14; this doc is the arc's constitution)

--- a/docs/roadmap/active/return-op-eradication.md
+++ b/docs/roadmap/active/return-op-eradication.md
@@ -1,3 +1,4 @@
+<!-- description: One desugar for the ! operator, deleting the per-position return-op zoo -->
 # Return-op eradication: one desugar for `!`, position zoo deleted
 
 Status: R2 IN PROGRESS (ratified ○ 2026-08-15; R1 landed 3358f26f6+53439f582 —

--- a/docs/roadmap/active/rot-eradication.md
+++ b/docs/roadmap/active/rot-eradication.md
@@ -1,3 +1,4 @@
+<!-- description: The decay map of compiler rot and its reference-backed cures -->
 # rot-eradication — the decay map and its reference-backed cures
 
 **Status**: active (constitution written 2026-08-15, after the result-family

--- a/docs/roadmap/active/test-surface-25x.md
+++ b/docs/roadmap/active/test-surface-25x.md
@@ -1,3 +1,4 @@
+<!-- description: Grow the committed test surface 25x toward reference-compiler scale -->
 # Test-surface 25× — the road to reference-compiler scale
 
 Set 2026-08-17, after the reference-suite mining sweep (#1508) measured the

--- a/tools/almide-gates/src/main.almd
+++ b/tools/almide-gates/src/main.almd
@@ -234,6 +234,20 @@ test "the index rendering is byte-identical to the committed docs/contracts/READ
   assert_eq(first_divergence(fs.read_text("docs/contracts/README.md")!, gen_contracts_readme("docs/contracts")!), "")
 }
 
+// The roadmap index is this tool's DEFAULT subcommand and was the one twin with no
+// acceptance check at all — #1843 covered the two contracts renderings and left this one
+// out. The omission was not theoretical: docs/roadmap/README.md was found stale on
+// 2026-09-12, missing nine rows, because its only guard was the lefthook pre-commit hook,
+// which an author who has not run `lefthook install` never fires. This test closes both
+// holes at once — it re-renders from active/, on-hold/ and done/ and compares against the
+// committed index, so a roadmap item added without regenerating fails here, and a port
+// that drifts from the bash original fails here too. The bash generator's own freshness is
+// the `checks` job's "Roadmap README up to date" step; green on both means all three
+// renderings agree.
+test "the roadmap index rendering is byte-identical to the committed docs/roadmap/README.md" {
+  assert_eq(first_divergence(fs.read_text("docs/roadmap/README.md")!, gen_roadmap_readme("docs/roadmap")!), "")
+}
+
 test "the ledger is well-formed under the subset reader — no block shape had to be recovered" {
   assert_eq(toml.parse_doc(fs.read_text("docs/contracts/contracts.toml")!).problems, [])
 }


### PR DESCRIPTION
> **#2126 の上に積んでいます。** base は当初 #2126 のブランチにしていましたが、CI のトリガーが `branches: [main, develop]` なので**そのままでは検査が一切走らない**ことが分かり、`develop` に付け替えました。そのため diff には #2126 の 2 コミットも含まれます（この PR 固有の変更は最新 1 コミット）。#2126 がマージされれば自動的に畳まれます。

## 何を直したか

`docs/roadmap/README.md` は自動生成物ですが、守りが lefthook の pre-commit フック**だけ**でした。lefthook はローカル任意インストール（`lefthook install`）なので、入れていない書き手のコミットは素通りします。実際に素通りしていて、**9 行欠落した状態**でコミットされていました（例: `fcb5a6e6b` は `edit-locality-theory.md` を 19 行変更して README を触っていない）。

同じ自動生成物でも `docs/contracts/README.md` は**フック + CI の regenerate-and-diff** の二重で守られています。片方に写し忘れただけの非対称でした。

## 三方向の一致

| 比較 | どこで | docs-only の PR でも走るか |
|---|---|---|
| bash 原本の出力 == コミット済み README | `checks` ジョブの新ステップ（contracts のものと同形） | **走る** |
| Almide twin の出力 == コミット済み README | `almide-gates` ジョブの新しい dogfood テスト | 走らない（docs-only では skip） |

両方が緑なら推移的に **Almide twin == bash 原本**。ロードマップ md だけを触る PR は docs-only 判定になりますが、その場合でも `checks` は走るので、**実際に起きた壊れ方（md を足して README を再生成し忘れる）は必ず捕まります**。

これが `tools/almide-gates/` の 7 本の twin に対する **1 本目の受け入れ検査**です。`main.almd` のコメントが

> the freshness gates compare the bash against the committed docs, never the port against either

と書いている通り、#1843 は contracts の 2 本を塞いで**ロードマップを取り残していました**。しかもこれは `main.almd` の**デフォルトサブコマンド**です。

## 負のプローブ

落ちないゲートは存在しないゲートと区別がつかない（このリポジトリ自身の #976 のクラス）ので、故意に壊して確認しました。README の `91 items` を `92 items` に書き換えると:

```
FAILED: tools/almide-gates/src/main.almd
  test: the roadmap index rendering is byte-identical to the committed docs/roadmap/README.md
  at:   tools/almide-gates/src/main.almd:248
  expected: ""
  found:    "line 10\n  committed: 92 items\n  rendered:  91 items"
```

行番号と両側の値を名指して落ちます。再生成で復旧しバイト一致を確認済み。

## description 9 件

`docs/roadmap/CLAUDE.md` のルール 6 が全ファイルに `<!-- description: ... -->` を要求していますが検査が無く、9 ファイルが違反していました（README の説明欄が空になる）。各ファイルの中身を読んで起こしています（H1 の機械的な写しではありません）。全部 80 字以内。

壊れ方が 2 種類ありました — 8 件は README に**行そのものが無く**、9 件目（`flight-organization.md`）は**行はあるが説明が空**。後者は最初の調査で見落としており、新しいゲートを通して初めて出ました。

## 確認したこと

- `almide test tools/almide-gates/` — 205 tests / 14 files 全通過
- `almide fmt --check tools/almide-gates/src/main.almd` — 整形済み（`tools/almide-gates/` は #1855 の fmt ゲート対象）
- 新 CI ステップのローカル再現 — clean (exit 0)
- 負のプローブ — 上記の通り赤になる

## やっていないこと

`proofs/gate-verification.toml` への分類フィールド追加は #2128。残り 4 本の twin の受け入れ検査と昇格は #2130。方針は #2126 が更新する [the gate language boundary](https://github.com/almide/almide/blob/worktree-shell-scripting-roadmap/docs/roadmap/active/zero-committed-shell.md) に記録してあります。

https://claude.ai/code/session_01HYPaHZQnswSwPACkQyRYMr
