### PR TITLE
Fuse list.enumerate in source position into a chain adapter so the documented spelling stops copying

### DIFF
--- a/crates/almide-codegen/src/pass_borrow_inference_ownership.rs
+++ b/crates/almide-codegen/src/pass_borrow_inference_ownership.rs
@@ -406,6 +406,7 @@ fn check_needs_ownership_iter_chain(expr: &IrExpr, var: VarId, needs: &mut bool)
                 if uses_var(lambda, var) { *needs = true; return; }
             }
             IterStep::Take { n } => check_needs_ownership(n, var, needs),
+            IterStep::Enumerate => {}
         }
     }
     match collector {
@@ -664,6 +665,7 @@ fn iter_chain_uses_var(source: &IrExpr, steps: &[IterStep], collector: &IterColl
         IterStep::Map { lambda } | IterStep::Filter { lambda }
         | IterStep::FlatMap { lambda } | IterStep::FilterMap { lambda } => uses_var(lambda, var),
         IterStep::Take { n } => uses_var(n, var),
+        IterStep::Enumerate => false,
     })
     || match collector {
         IterCollector::Collect | IterCollector::Sum { .. } | IterCollector::Len => false,

--- a/crates/almide-codegen/src/pass_capture_clone.rs
+++ b/crates/almide-codegen/src/pass_capture_clone.rs
@@ -177,7 +177,9 @@ fn detect_shared_mut(program: &IrProgram) -> HashSet<VarId> {
 
 /// Collect VarIds an expression mutates: assignment targets and `&mut`-borrowed
 /// vars (the form `list.push(v, …)` etc. take after `BorrowInsertionPass`).
-fn collect_mutated_vars(expr: &IrExpr, out: &mut HashSet<VarId>) {
+/// Shared with StreamFusion, which asks the same question of a chain's
+/// callbacks before it borrows their source (#2098).
+pub(crate) fn collect_mutated_vars(expr: &IrExpr, out: &mut HashSet<VarId>) {
     struct M<'a> { out: &'a mut HashSet<VarId> }
     impl almide_ir::visit::IrVisitor for M<'_> {
         fn visit_expr(&mut self, e: &IrExpr) {
@@ -355,6 +357,7 @@ fn transform_expr_iter_chain(expr: &mut IrExpr, vt: &mut VarTable, scope_vars: &
                 changed |= transform_expr(lambda, vt, scope_vars);
             }
             IterStep::Take { n } => changed |= transform_expr(n, vt, scope_vars),
+            IterStep::Enumerate => {}
         }
     }
     match collector {
@@ -648,6 +651,7 @@ fn replace_vars_iter_chain(expr: &mut IrExpr, renames: &Renames) {
                 replace_vars(lambda, renames);
             }
             IterStep::Take { n } => replace_vars(n, renames),
+            IterStep::Enumerate => {}
         }
     }
     match collector {

--- a/crates/almide-codegen/src/pass_rust_lowering.rs
+++ b/crates/almide-codegen/src/pass_rust_lowering.rs
@@ -504,7 +504,7 @@ fn box_node_unbox_consumed(expr: &mut IrExpr) -> bool {
                     | IterStep::FlatMap { lambda } | IterStep::FilterMap { lambda } => {
                         c |= unbox_consumed(lambda);
                     }
-                    IterStep::Take { .. } => {}
+                    IterStep::Take { .. } | IterStep::Enumerate => {}
                 }
             }
             match collector {

--- a/crates/almide-codegen/src/pass_stream_fusion.rs
+++ b/crates/almide-codegen/src/pass_stream_fusion.rs
@@ -552,8 +552,14 @@ impl<'a> Fuser<'a> {
     /// purity condition.
     fn reducer(&self, expr: &IrExpr, op: &str) -> Option<IrExpr> {
         let IrExprKind::RuntimeCall { args, .. } = &expr.kind else { return None };
-        let (inner, _, _) = source_of(args[0].clone());
-        let IrExprKind::IterChain { source, consume, steps, collector: IterCollector::Collect } = inner.kind else { return None };
+        // A source adapter over the inner chain runs AFTER its steps, so it is
+        // appended rather than dropped: `list.len` happens to be invariant
+        // under `enumerate` and `sum` is not typeable over its pairs, but a
+        // step silently discarded here would be a defect waiting for the next
+        // adapter that is neither.
+        let (inner, _, prefix) = source_of(args[0].clone());
+        let IrExprKind::IterChain { source, consume, mut steps, collector: IterCollector::Collect } = inner.kind else { return None };
+        steps.extend(prefix);
         let collector = match op {
             "sum" => IterCollector::Sum { float: false },
             "sum_float" => IterCollector::Sum { float: true },

--- a/crates/almide-codegen/src/pass_stream_fusion.rs
+++ b/crates/almide-codegen/src/pass_stream_fusion.rs
@@ -47,6 +47,7 @@ use almide_base::intern::{sym, Sym};
 use almide_ir::*;
 
 use super::pass::{NanoPass, PassResult, Target};
+use super::pass_capture_clone::collect_mutated_vars;
 use super::pass_rust_lowering::rewrite_tail_list_to_array;
 use super::pass_stdlib_lowering::{prepare_lambda, prepare_lambda_borrowed};
 
@@ -332,6 +333,7 @@ fn call_ok(e: &IrExpr, cx: &Cx) -> Option<bool> {
             expr_ok(source, cx)
                 && steps.iter().all(|s| match s {
                     IterStep::Take { n } => expr_ok(n, cx),
+                    IterStep::Enumerate => true,
                     _ => s.lambda().is_some_and(|l| expr_ok(l, cx)),
                 })
                 && match collector {
@@ -407,13 +409,65 @@ fn lambda_body_mut(callback: &mut IrExpr) -> Option<&mut IrExpr> {
     }
 }
 
-/// `(source, consume)`: a borrowed source (`&xs`, the `&[A]` runtime twins'
-/// arg shape) iterates as `.iter().cloned()`, anything else is consumed.
-fn source_of(arg: IrExpr) -> (IrExpr, bool) {
-    match arg.kind {
-        IrExprKind::Borrow { expr, .. } => (*expr, false),
-        _ => (arg, true),
+/// `(source, consume, prefix)`: a borrowed source (`&xs`, the `&[A]` runtime
+/// twins' arg shape) iterates as `.iter().cloned()`, anything else is
+/// consumed. `list.enumerate` in source position is not a source at all but an
+/// ADAPTER over one (#2098): its pairs become an `Enumerate` step, so the
+/// `Vec<(i64, T)>` the next stage would immediately walk is never built.
+fn source_of(arg: IrExpr) -> (IrExpr, bool, Vec<IterStep>) {
+    if let IrExprKind::RuntimeCall { symbol, args } = &arg.kind
+        && symbol.as_str() == "almide_rt_list_enumerate"
+        && args.len() == 1
+    {
+        let mut args = args.clone();
+        let (inner, consume, mut prefix) = source_of(args.remove(0));
+        prefix.push(IterStep::Enumerate);
+        return (inner, consume, prefix);
     }
+    match arg.kind {
+        IrExprKind::Borrow { expr, .. } => (*expr, false, vec![]),
+        _ => (arg, true, vec![]),
+    }
+}
+
+/// The `Clone` in front of an adapted source is DEAD by construction (#2098):
+/// CloneInsertion put it there so the consuming runtime call could not take
+/// the caller's value, and fusing that call away removed the consumer. What
+/// remains is an iteration, which `.iter().cloned()` serves from a borrow —
+/// so `list.enumerate(v)` over a 1,200-element capture stops copying the
+/// whole vector once per closure call.
+///
+/// The one way a borrow could still be wrong is a callback that MUTATES the
+/// same variable while the chain walks it, so that is exactly the condition
+/// checked — and it is checked on the FINAL chain, after any merge, because a
+/// merge can only add callbacks and they belong in the same scan. Only a plain
+/// variable qualifies: a temporary would be correct too (Rust extends it to
+/// the end of the statement) but buys nothing.
+fn borrow_adapted_source(mut expr: IrExpr) -> IrExpr {
+    let IrExprKind::IterChain { source, consume, steps, collector } = &mut expr.kind else {
+        return expr;
+    };
+    if !*consume || !steps.iter().any(|s| matches!(s, IterStep::Enumerate)) {
+        return expr;
+    }
+    let IrExprKind::Clone { expr: inner } = &source.kind else { return expr };
+    let IrExprKind::Var { id } = &inner.kind else { return expr };
+    let id = *id;
+    let mut mutated = HashSet::new();
+    for lambda in steps.iter().filter_map(IterStep::lambda).chain(collector.lambda()) {
+        collect_mutated_vars(lambda, &mut mutated);
+    }
+    if let IterCollector::Fold { init, .. } = &*collector {
+        collect_mutated_vars(init, &mut mutated);
+    }
+    if mutated.contains(&id) {
+        return expr;
+    }
+    let taken = std::mem::replace(&mut source.kind, IrExprKind::Unit);
+    let IrExprKind::Clone { expr: inner } = taken else { unreachable!("checked above") };
+    *source = inner;
+    *consume = false;
+    expr
 }
 
 fn chain(expr: &IrExpr, source: IrExpr, consume: bool, steps: Vec<IterStep>, collector: IterCollector) -> IrExpr {
@@ -438,7 +492,7 @@ impl<'a> Fuser<'a> {
             "sum" | "sum_float" | "len" if args.len() == 1 => return self.reducer(expr, op),
             _ => return None,
         };
-        Some(self.merge(single))
+        Some(borrow_adapted_source(self.merge(single)))
     }
 
     /// Rewrite 1: one runtime combinator call with a lambda literal → a
@@ -446,12 +500,12 @@ impl<'a> Fuser<'a> {
     fn single_stage(&self, expr: &IrExpr, op: &str) -> Option<IrExpr> {
         let IrExprKind::RuntimeCall { args, .. } = &expr.kind else { return None };
         let callback = take_lambda(args.last()?.clone())?;
-        let (source, consume) = source_of(args[0].clone());
+        let (source, consume, prefix) = source_of(args[0].clone());
         // Rust hands `filter` / `find` / the `count` filter a `&T`; every
         // other adapter (and the `.iter().cloned()` borrowed source) an owned `T`.
         let borrowed = matches!(op, "filter" | "find" | "count");
         let lambda = map_lambda(callback, if borrowed { &prepare_lambda_borrowed } else { &prepare_lambda });
-        let (steps, collector) = match op {
+        let (mut steps, collector) = match op {
             "map" => (vec![IterStep::Map { lambda: Box::new(lambda) }], IterCollector::Collect),
             "filter" => (vec![IterStep::Filter { lambda: Box::new(lambda) }], IterCollector::Collect),
             "filter_map" => (vec![IterStep::FilterMap { lambda: Box::new(lambda) }], IterCollector::Collect),
@@ -472,6 +526,8 @@ impl<'a> Fuser<'a> {
             "count" => (vec![], IterCollector::Count { lambda: Box::new(lambda) }),
             _ => return None,
         };
+        // The source adapter runs BEFORE whatever this call contributes.
+        steps.splice(0..0, prefix);
         Some(chain(expr, source, consume, steps, collector))
     }
 
@@ -479,9 +535,10 @@ impl<'a> Fuser<'a> {
     /// point, so it needs the merge's totality rule.
     fn take(&self, expr: &IrExpr) -> Option<IrExpr> {
         let IrExprKind::RuntimeCall { args, .. } = &expr.kind else { return None };
-        let (source, consume) = source_of(args[0].clone());
+        let (source, consume, mut steps) = source_of(args[0].clone());
         let n = args[1].clone();
-        let outer = chain(expr, source, consume, vec![IterStep::Take { n: Box::new(n) }], IterCollector::Collect);
+        steps.push(IterStep::Take { n: Box::new(n) });
+        let outer = chain(expr, source, consume, steps, IterCollector::Collect);
         let merged = self.merge(outer);
         // A `take` over a non-chain (or an unmergeable one) is left to the runtime.
         match &merged.kind {
@@ -495,7 +552,7 @@ impl<'a> Fuser<'a> {
     /// purity condition.
     fn reducer(&self, expr: &IrExpr, op: &str) -> Option<IrExpr> {
         let IrExprKind::RuntimeCall { args, .. } = &expr.kind else { return None };
-        let (inner, _) = source_of(args[0].clone());
+        let (inner, _, _) = source_of(args[0].clone());
         let IrExprKind::IterChain { source, consume, steps, collector: IterCollector::Collect } = inner.kind else { return None };
         let collector = match op {
             "sum" => IterCollector::Sum { float: false },
@@ -531,6 +588,10 @@ impl<'a> Fuser<'a> {
         for s in inner_steps.iter().chain(outer_steps.iter()) {
             match s {
                 IterStep::Take { n } => stages.push((vec![n.as_ref()], true)),
+                // The source adapter runs no program text: pure, total, and
+                // order-preserving, so it neither adds a stage to reorder nor
+                // an abort to sequence.
+                IterStep::Enumerate => {}
                 _ => stages.push((vec![s.lambda().expect("non-take step has a lambda")], false)),
             }
         }

--- a/crates/almide-codegen/src/walker/expressions_calls_binops.rs
+++ b/crates/almide-codegen/src/walker/expressions_calls_binops.rs
@@ -16,6 +16,10 @@ fn render_iter_chain(ctx: &RenderContext, source: &IrExpr, consume: bool, steps:
             IterStep::FlatMap { lambda } => chain = format!("{}.flat_map({})", chain, render_expr(ctx, lambda)),
             IterStep::FilterMap { lambda } => chain = format!("{}.filter_map({})", chain, render_expr(ctx, lambda)),
             IterStep::Take { n } => chain = format!("{}.take(({}) as usize)", chain, render_expr(ctx, n)),
+            // `(usize, T)` re-indexed to Almide's `Int`, which is what the
+            // `almide_rt_list_enumerate` twin returns — same pairs, same
+            // order, no `Vec<(i64, T)>` in between (#2098).
+            IterStep::Enumerate => chain = format!("{}.enumerate().map(|(__ei, __ex)| (__ei as i64, __ex))", chain),
         }
     }
 

--- a/crates/almide-ir/src/lib.rs
+++ b/crates/almide-ir/src/lib.rs
@@ -483,6 +483,11 @@ pub enum IterStep {
     /// negative `n` wraps to a huge count and takes everything, the
     /// runtime twin's `n as usize` behaviour).
     Take { n: Box<IrExpr> },
+    /// `.enumerate()` re-indexed to Almide's `Int` (#2098): `list.enumerate`
+    /// as a chain SOURCE, so the pairs stream instead of materializing a
+    /// `Vec<(i64, T)>` the next stage immediately walks. Carries nothing —
+    /// the position comes from the iterator, not from the program.
+    Enumerate,
 }
 
 impl IterStep {
@@ -491,7 +496,7 @@ impl IterStep {
         match self {
             IterStep::Map { lambda } | IterStep::Filter { lambda }
             | IterStep::FlatMap { lambda } | IterStep::FilterMap { lambda } => Some(lambda),
-            IterStep::Take { .. } => None,
+            IterStep::Take { .. } | IterStep::Enumerate => None,
         }
     }
 }
@@ -725,6 +730,7 @@ impl IterStep {
             IterStep::FlatMap { lambda } => IterStep::FlatMap { lambda: Box::new(f(*lambda)) },
             IterStep::FilterMap { lambda } => IterStep::FilterMap { lambda: Box::new(f(*lambda)) },
             IterStep::Take { n } => IterStep::Take { n: Box::new(f(*n)) },
+            IterStep::Enumerate => IterStep::Enumerate,
         }
     }
 }

--- a/crates/almide-ir/src/substitute.rs
+++ b/crates/almide-ir/src/substitute.rs
@@ -264,6 +264,7 @@ pub fn substitute_var_in_expr(expr: &IrExpr, var: VarId, replacement: &IrExpr) -
                     IterStep::FlatMap { lambda } => IterStep::FlatMap { lambda: Box::new(sub(lambda)) },
                     IterStep::FilterMap { lambda } => IterStep::FilterMap { lambda: Box::new(sub(lambda)) },
                     IterStep::Take { n } => IterStep::Take { n: Box::new(sub(n)) },
+                    IterStep::Enumerate => IterStep::Enumerate,
                 }).collect(),
                 collector: match collector {
                     IterCollector::Collect => IterCollector::Collect,

--- a/crates/almide-ir/src/use_count.rs
+++ b/crates/almide-ir/src/use_count.rs
@@ -227,6 +227,7 @@ fn count_uses_in_iter_chain(
                 count_uses_in_expr(lambda, table);
             }
             IterStep::Take { n } => count_uses_in_expr(n, table),
+            IterStep::Enumerate => {}
         }
     }
     match collector {

--- a/crates/almide-ir/src/visit.rs
+++ b/crates/almide-ir/src/visit.rs
@@ -148,6 +148,7 @@ fn walk_expr_iter_chain<V: IrVisitor>(
                 v.visit_expr(lambda);
             }
             IterStep::Take { n } => v.visit_expr(n),
+            IterStep::Enumerate => {}
         }
     }
     match collector {

--- a/crates/almide-ir/src/visit_mut.rs
+++ b/crates/almide-ir/src/visit_mut.rs
@@ -149,6 +149,7 @@ fn walk_expr_mut_iter_chain<V: IrMutVisitor>(
                 v.visit_expr_mut(lambda);
             }
             IterStep::Take { n } => v.visit_expr_mut(n),
+            IterStep::Enumerate => {}
         }
     }
     match collector {

--- a/crates/almide-optimize/src/mono/varid_remap.rs
+++ b/crates/almide-optimize/src/mono/varid_remap.rs
@@ -189,6 +189,7 @@ fn collect_varids_in_iter_chain(expr: &IrExpr, out: &mut Vec<VarId>) {
             IterStep::Map { lambda } | IterStep::Filter { lambda }
             | IterStep::FlatMap { lambda } | IterStep::FilterMap { lambda } => collect_varids_in_expr(lambda, out),
             IterStep::Take { n } => collect_varids_in_expr(n, out),
+            IterStep::Enumerate => {}
         }
     }
     match collector {
@@ -405,6 +406,7 @@ fn remap_iter_chain_varids(expr: &mut IrExpr, remap: &HashMap<VarId, VarId>) {
             IterStep::Map { lambda } | IterStep::Filter { lambda }
             | IterStep::FlatMap { lambda } | IterStep::FilterMap { lambda } => remap_expr_varids(lambda, remap),
             IterStep::Take { n } => remap_expr_varids(n, remap),
+            IterStep::Enumerate => {}
         }
     }
     match collector {

--- a/docs/bugfix-research-2026-09-12.md
+++ b/docs/bugfix-research-2026-09-12.md
@@ -395,3 +395,66 @@ residual is stated in C-197 rather than left to be discovered.
 `tests/component_realloc_oom_test.rs` pins both directions — the line and exit 1
 must appear, and `cannot leave component instance` and `wasm trap` must not —
 and was demonstrated to fail with the op-35 reservation removed.
+
+## #2098 — two measurements, one of them of the build profile
+
+The issue's native figures (indexed 2.36x, enumerate 1.68x after the earlier
+fixes) were taken through `almide build` with no `--release`, which is the
+project's DEFAULT profile: `opt-level = 1`, no LTO. That level is deliberate
+and load-bearing — LLVM's tail-call optimisation does not run below it, and
+`spec/wasm_cross/mutual_tail_recursion.almd` overflows the native stack without
+it (`src/cli/cargo_build.rs` records the day that was learned) — but it is also
+the level at which LLVM declines to flatten an iterator chain.
+
+Measured on the same tree, same machine, same round-robin harness:
+
+| spelling | default profile | `--release` |
+|---|---:|---:|
+| indexed fold | 1.42x | **1.01x** |
+| enumerate fold (before) | 1.68x | 1.37x |
+
+So the indexed spelling's remaining gap is not something the compiler emits: at
+opt-level 3 the same emitted source matches the imperative form exactly. The
+enumerate spelling's gap survived the optimiser, which is what made it the real
+finding.
+
+The obvious next inference — that `almide build` should default to `--release`
+— does not survive its own measurement. Round-robin over both profiles,
+`--release` is SLOWER for the two spellings opt-level 1 already handles well
+(imperative 47.95 vs 41.93 ms, enumerate 48.14 vs 41.77 ms) and faster only for
+indexed (48.23 vs 59.65). At opt-level 3 all three converge on ~48 ms; at
+opt-level 1 two of them are at ~42 and one is at ~60. The property worth
+holding is that the spellings cost the SAME, not that one profile wins.
+
+**Where the enumerate tax actually was.** Bisected by hand-editing the emit and
+rebuilding (n=1200, nine samples, round-robin, identical output):
+
+| emit | ratio |
+|---|---:|
+| as emitted | 1.38x |
+| `.enumerate()` fused, capture still cloned | 1.14x |
+| fused AND source borrowed | **1.01x** |
+
+Two mechanisms, both per row and therefore 48,000 times per run: a
+`Vec<(i64, f64)>` built by `almide_rt_list_enumerate` for the fold to walk once
+and drop, and a full copy of the captured 1,200-element vector to feed it.
+
+**The fix.** `list.enumerate` in SOURCE position is not a source; it is an
+ADAPTER over one. `IterStep::Enumerate` carries no program text — the position
+comes from the iterator — so it is pure, total and order-preserving, and it
+adds no stage to the merge rule's purity and abort accounting. The clone in
+front of the adapted source is dead by construction: CloneInsertion put it
+there so the CONSUMING runtime call could not take the caller's value, and
+fusing that call away removed the consumer. What survives the drop is a
+callback that MUTATES the same variable, which is checked rather than assumed —
+though in practice such a variable is already a shared cell whose reads
+snapshot, which the mutation fixture pins on both legs.
+
+Result: native enumerate 1.68x → **1.01x** at the default profile, with the
+wasm leg untouched (`IterChain` is Rust-only). `tests/enumerate_source_fusion_test.rs`
+pins the borrowed shape, the snapshot shape, four chain positions and
+native/wasm agreement; both shape assertions were demonstrated to fail with the
+source-adapter rule disabled.
+
+The perf corpus now records both profiles and says which question each answers,
+and the CI budget drops 2.5x → 2.0x.

--- a/research/benchmark/perf/spectralnorm/README.md
+++ b/research/benchmark/perf/spectralnorm/README.md
@@ -25,38 +25,59 @@ corpus baseline uses `for` and growing output lists; it is not the preallocated
 reported as reproducing those exact measurements. The variants intentionally
 retain the same iteration and floating-point accumulation order.
 
-General capture borrowing and enumerate fusion remain implementation work.
-Synchronous scalar folds now borrow captures proven to be read-only through
+Synchronous scalar folds borrow captures proven to be read-only through
 indexing, explicit borrowing or cloning, with no escaping nested closure.
-Scalar enumerate/fold now snapshots the source into a scalar list and
-reuses one private tuple slot when the callback cannot expose that tuple.
-It removes the intermediate tuple list and per-element tuple allocation.
+Scalar enumerate/fold on the wasm leg snapshots the source into a scalar list
+and reuses one private tuple slot when the callback cannot expose that tuple.
+On the native leg `list.enumerate` in SOURCE position is now a chain adapter
+(`.iter().cloned().enumerate()`) rather than a `Vec<(Int, T)>` the next stage
+walks and drops; the clone that fed the consumed runtime call goes with it.
 
-Measured on 2026-09-12 with the local v0.62.0 release build and Wasmtime
-47.0.3, n=1200, nine samples after warmup:
+`--release` builds with opt-level 3 and LTO; without it `almide build` uses the
+project's default profile, which is opt-level 1 (load-bearing for correctness —
+see `src/cli/cargo_build.rs`). The two profiles answer different questions and
+both are recorded below: the default profile is what a plain `almide build`
+ships, and the release profile isolates the lowering from what LLVM would have
+cleaned up anyway.
+
+Measured on 2026-09-13 with the local v0.62.0 release build and Wasmtime
+47.0.3, n=1200, five samples after warmup. Every run printed `1.274224150`
+plus a newline with empty stderr, on all six artifacts.
+
+Default profile (`almide build`, opt-level 1):
 
 | Target | Imperative | Indexed fold | Enumerate fold |
 | --- | ---: | ---: | ---: |
-| Native median | 41.34 ms | 97.39 ms (2.36×) | 84.10 ms (2.03×) |
-| Wasm median | 114.11 ms | 149.04 ms (1.31×) | 365.81 ms (3.21×) |
+| Native | 41.09 ms | 58.29 ms (1.42x) | 41.66 ms (1.01x) |
+| Wasm | 93.20 ms | 118.51 ms (1.27x) | 96.12 ms (1.03x) |
 
-Every run printed `1.274224150` plus a newline, with empty stderr. Wasm
-samples were noisy (imperative 97.92–161.90 ms); these are local comparative
-measurements, not a portable timing guarantee. The n=80, three-sample smoke
-run also passed output agreement.
+Release profile (`almide build --release`, opt-level 3 + LTO):
 
-After scalar enumerate/fold lowering, the same command measured wasm
-enumerate at **129.72 ms**, versus **110.60 ms** imperative (**1.17×**);
-the prior enumerate median was 365.81 ms. Artifact size fell from 12,905
-to 12,775 bytes. Outputs remain identical. Native code was not changed
-(indexed 2.34×, enumerate 2.05× in this run). Wasm samples remain noisy,
-so the timing comparison is supporting evidence, not an exact speedup
-guarantee or completion of the full #2098 optimization work.
+| Target | Imperative | Indexed fold | Enumerate fold |
+| --- | ---: | ---: | ---: |
+| Native | 47.95 ms | 48.23 ms (1.01x) | 48.14 ms (1.01x) |
+| Wasm | — | 1.13x | 0.91x |
 
-After native scalar-fold capture borrowing, the indexed median is
-**58.28 ms / 1.42×**, down from 97.39 ms / 2.36× before optimization.
-The native enumerate median is **68.88 ms / 1.68×**. Native indexed
-artifact size drops from 510,184 to 491,848 bytes. The repeated six-way
-output check still passes. This removes per-row capture copies for the
-indexed fold; outer map captures and more general combinators remain
-outside the current borrowing rule.
+What moved, and what it says:
+
+- **Native enumerate 1.68x → 1.01x** is the source-adapter fusion. The old
+  emit copied the captured 1,200-element vector and built a `Vec<(i64, f64)>`
+  per row — 48,000 of each per run — and both are gone.
+- **Native indexed is 1.42x at the default profile and 1.01x at release**, and
+  the release column is what says why: at opt-level 3 all three spellings
+  converge on ~48 ms. The indexed residual is what LLVM declines to do to an
+  iterator chain at opt-level 1, not a tax the lowering emits.
+- The release column is NOT a recommendation. Measured round-robin against the
+  same sources, `--release` is *slower* than the default profile for the two
+  spellings the default already handles well (imperative 47.95 vs 41.93 ms,
+  enumerate 48.14 vs 41.77 ms) and faster only for indexed (48.23 vs 59.65 ms).
+  Whichever profile a program ships with, its spellings should cost the same —
+  that is the property this corpus gates, and both profiles now hold it within
+  measurement noise except for the indexed case at opt-level 1.
+- Wasm samples remain noisy; these are local comparative measurements, not a
+  portable timing guarantee.
+
+Earlier readings kept for the record: before the wasm scalar enumerate/fold
+lowering, wasm enumerate measured 365.81 ms (3.21x); after it, 129.72 ms
+(1.17x). Before native scalar-fold capture borrowing, native indexed measured
+97.39 ms (2.36x); after it, 58.28 ms (1.42x).

--- a/research/benchmark/perf/spectralnorm/compare.py
+++ b/research/benchmark/perf/spectralnorm/compare.py
@@ -17,6 +17,9 @@ def main():
     parser.add_argument("--n", type=int, default=1200)
     parser.add_argument("--runs", type=int, default=9)
     parser.add_argument("--max-ratio", type=float)
+    parser.add_argument("--release", action="store_true",
+                        help="build with --release (opt-level 3 + LTO) instead of the "
+                             "default profile `almide build` uses (opt-level 1)")
     args = parser.parse_args()
     if args.n < 1 or args.runs < 1:
         parser.error("--n and --runs must be positive")
@@ -26,7 +29,8 @@ def main():
     for name in ("ALMIDE_WASM_STRUCTURAL", "ALMIDE_WASM_INCUMBENT",
                  "ALMIDE_FUEL_PROBE", "ALMIDE_COMPONENT_P3", "ALMIDE_COMPONENT_ADAPTER"):
         env.pop(name, None)
-    result = {"n": args.n, "runs": args.runs, "targets": {}}
+    result = {"n": args.n, "runs": args.runs,
+              "profile": "release" if args.release else "default", "targets": {}}
     expected = None
     failed = False
     with tempfile.TemporaryDirectory(prefix="almide-spectralnorm-") as temporary:
@@ -35,8 +39,11 @@ def main():
             for spelling in ("imperative", "indexed", "enumerate"):
                 suffix = "" if spelling == "imperative" else "_" + spelling
                 artifact = Path(temporary) / (spelling + (".wasm" if target == "wasm" else ".bin"))
-                subprocess.run([compiler, "build", str(sources / f"spectralnorm{suffix}.almd"),
-                                "--target", target, "-o", str(artifact)], env=env, check=True,
+                build = [compiler, "build", str(sources / f"spectralnorm{suffix}.almd"),
+                         "--target", target, "-o", str(artifact)]
+                if args.release:
+                    build.append("--release")
+                subprocess.run(build, env=env, check=True,
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 command = (["wasmtime", "run"] if target == "wasm" else []) + [str(artifact), str(args.n)]
                 programs[spelling] = (command, artifact.stat().st_size)

--- a/scripts/check-spelling-ratio.sh
+++ b/scripts/check-spelling-ratio.sh
@@ -12,22 +12,30 @@
 # run. That ratio cancels the machine the way the native/Rust ratio does, so a
 # slow shared runner changes the numbers and not the verdict.
 #
-# Measured 2026-09-12 (local, n=1200, 5 samples after warmup, outputs verified
+# Measured 2026-09-13 (local, n=1200, 5 samples after warmup, outputs verified
 # identical across all six artifacts):
 #
-#   native  imperative 1.00   indexed 1.42   enumerate 1.72
-#   wasm    imperative 1.00   indexed 0.89   enumerate 0.72
+#   native  imperative 1.00   indexed 1.43   enumerate 1.01
+#   wasm    imperative 1.00   indexed 1.14   enumerate 0.91
 #
-# The wasm leg is where the documented spellings now WIN; the native leg still
-# pays for the outer capture copy (#2098's mechanism 1, partially fixed). The
-# budget sits above the native figure with room for runner noise — it exists to
-# catch the return of a 4x, not to hold a decimal place. Lower it when the
-# native side lands; never raise it to make a red build green.
+# It builds with the DEFAULT profile, which is what a plain `almide build`
+# ships (opt-level 1). At `--release` every ratio is within noise of 1.00 —
+# `compare.py --release` prints that reading — so the native indexed figure
+# above is what LLVM declines to do to an iterator chain at opt-level 1, not a
+# tax the lowering emits. The default profile is the one gated because it is
+# the one a user gets without asking, and because a LOWERING regression shows
+# at both levels anyway; `--release` is not the faster build here (it is slower
+# for the two spellings opt-level 1 already handles well), so neither column is
+# a recommendation — see the corpus README.
+#
+# The budget sits above the worst figure with room for runner noise — it exists
+# to catch the return of a 4x, not to hold a decimal place. Lower it as the
+# measurements improve; never raise it to make a red build green.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 BIN="${ALMIDE_BIN:-target/release/almide}"
-BUDGET="${SPELLING_RATIO_BUDGET:-2.5}"
+BUDGET="${SPELLING_RATIO_BUDGET:-2.0}"
 N="${SPELLING_RATIO_N:-1200}"
 RUNS="${SPELLING_RATIO_RUNS:-5}"
 

--- a/tests/enumerate_source_fusion_test.rs
+++ b/tests/enumerate_source_fusion_test.rs
@@ -142,8 +142,10 @@ fn both_legs_agree_on_the_captured_and_mutated_shapes() {
     assert_eq!(run_both_legs(MUTATED).trim(), "6 99");
 }
 
-/// The adapter composes: `enumerate` under a `map`, under a `filter`, and as
-/// the source of a `take` — every chain position where a step list is built.
+/// The adapter composes: `enumerate` under a `map`, under a `filter`, as the
+/// source of a `take`, and OVER a chain rather than over a list — every chain
+/// position where a step list is built, including the reducer's, where the
+/// adapter has to survive the collector swap.
 const COMPOSED: &str = r#"
 fn main() -> Unit = {
   let xs = [10, 20, 30, 40]
@@ -151,7 +153,8 @@ fn main() -> Unit = {
   let kept = list.filter(list.enumerate(xs), (p) => p.0 % 2 == 0)
   let head = list.take(list.enumerate(xs), 2)
   let counted = list.count(list.enumerate(xs), (p) => p.1 > 15)
-  println("${doubled} ${kept} ${head} ${counted}")
+  let over_chain = list.len(list.enumerate(list.filter(xs, (x) => x > 15)))
+  println("${doubled} ${kept} ${head} ${counted} ${over_chain}")
 }
 "#;
 
@@ -159,6 +162,6 @@ fn main() -> Unit = {
 fn the_adapter_composes_with_every_chain_position() {
     assert_eq!(
         run_both_legs(COMPOSED).trim(),
-        "[10, 120, 230, 340] [(0, 10), (2, 30)] [(0, 10), (1, 20)] 3"
+        "[10, 120, 230, 340] [(0, 10), (2, 30)] [(0, 10), (1, 20)] 3 3"
     );
 }

--- a/tests/enumerate_source_fusion_test.rs
+++ b/tests/enumerate_source_fusion_test.rs
@@ -1,0 +1,164 @@
+//! #2098 mechanism 2, native leg: `list.enumerate` in SOURCE position is an
+//! adapter over a chain, not a list to build.
+//!
+//! `list.fold(list.enumerate(v), …)` used to render
+//! `almide_rt_list_enumerate(v.clone()).into_iter().fold(…)` — a full copy of
+//! `v` plus a `Vec<(i64, T)>` the fold immediately walked and dropped. In
+//! spectralnorm's enumerate spelling that is 48,000 copies of a 1,200-element
+//! vector per run; the spelling `CHEATSHEET.md` names explicitly measured
+//! 1.68x the imperative form it tells writers to avoid.
+//!
+//! It now renders `(v).iter().cloned().enumerate().map(…)` — the same pairs in
+//! the same order, from a borrow, with nothing in between (measured 1.01x).
+//! The clone is dropped because fusing the consuming runtime call away removes
+//! the only consumer it was inserted for; a callback that MUTATES the source
+//! keeps it, because that is the one way the borrow could observe a change the
+//! snapshot must hide.
+
+use std::process::Command;
+
+fn emit_rust(dir: &std::path::Path, program: &str) -> String {
+    let source = dir.join("emit.almd");
+    std::fs::write(&source, program).expect("source");
+    let out = Command::new(env!("CARGO_BIN_EXE_almide"))
+        .args([source.to_str().expect("path"), "--target", "rust"])
+        .output()
+        .expect("emit");
+    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// The body that carries the shape, with the enumerate source captured by the
+/// outer `map`'s closure — spectralnorm's inner loop, minus the arithmetic.
+const CAPTURED: &str = r#"
+fn rows(v: List[Float], n: Int) -> List[Float] =
+  list.map(0..<n, (i) => list.fold(list.enumerate(v), 0.0, (acc, p) => acc + float.from_int(p.0 + i) * p.1))
+
+fn main() -> Unit = println(float.to_fixed(list.fold(rows([1.0, 2.0, 3.0], 3), 0.0, (a, x) => a + x), 3))
+"#;
+
+#[test]
+fn a_captured_enumerate_source_streams_from_a_borrow() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let rust = emit_rust(dir.path(), CAPTURED);
+    // The prelude defines `almide_rt_list_enumerate` and uses `.enumerate()`
+    // in its own `Vec` helpers, so read the emitted function, not the file.
+    let body = emitted_fn(&rust, "rows");
+    assert!(
+        body.contains(".iter().cloned().enumerate()"),
+        "the source is still consumed rather than borrowed:\n{body}"
+    );
+    assert!(
+        !body.contains("almide_rt_list_enumerate"),
+        "the tuple list is still materialized:\n{body}"
+    );
+}
+
+/// The emitted body of one function, from its signature to the closing brace
+/// in column 0.
+fn emitted_fn(rust: &str, name: &str) -> String {
+    let head = format!("fn {name}(");
+    let mut lines = rust.lines().skip_while(|l| !l.contains(&head));
+    let first = lines.next().unwrap_or_else(|| panic!("no fn {name} in the emit:\n{rust}"));
+    std::iter::once(first)
+        .chain(lines.take_while(|l| *l != "}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The snapshot rule the runtime twin gives: `list.enumerate` reads the list
+/// ONCE, so a callback that writes to it during the walk sees its own value
+/// afterwards and the fold still sums what was there at the start. A source a
+/// callback can write to is a shared cell, and the chain reads it through the
+/// cell's snapshot (`.get()`), never through a live `.borrow()` — which is
+/// what keeps the adapter's borrow from observing the write.
+const MUTATED: &str = r#"
+fn main() -> Unit = {
+  var xs = [1, 2, 3]
+  let total = list.fold(list.enumerate(xs), 0, (a, p) => {
+    xs[2] = 99
+    a + p.1
+  })
+  println("${total} ${xs[2]}")
+}
+"#;
+
+#[test]
+fn a_callback_that_writes_to_the_source_keeps_its_snapshot() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let body = emitted_fn(&emit_rust(dir.path(), MUTATED), "__almide_main");
+    assert!(
+        body.contains("(xs.get()).iter().cloned().enumerate()"),
+        "the chain no longer reads the cell's snapshot:\n{body}"
+    );
+    assert!(
+        !body.contains("xs.borrow()).iter()"),
+        "the chain walks the live cell the callback writes to:\n{body}"
+    );
+}
+
+fn run_both_legs(program: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let source = dir.path().join("main.almd");
+    std::fs::write(&source, program).expect("source");
+    let mut expected: Option<String> = None;
+    for target in ["rust", "wasm"] {
+        let artifact = dir.path().join(if target == "rust" { "native" } else { "module.wasm" });
+        let built = Command::new(env!("CARGO_BIN_EXE_almide"))
+            .args([
+                "build",
+                source.to_str().expect("path"),
+                "--target",
+                target,
+                "-o",
+                artifact.to_str().expect("path"),
+            ])
+            .env_remove("ALMIDE_WASM_INCUMBENT")
+            .env_remove("ALMIDE_COMPONENT_P3")
+            .output()
+            .expect("build");
+        assert!(built.status.success(), "{}", String::from_utf8_lossy(&built.stderr));
+        let mut command = if target == "rust" {
+            Command::new(&artifact)
+        } else {
+            let mut c = Command::new("wasmtime");
+            c.arg("run").arg(&artifact);
+            c
+        };
+        let out = command.output().expect("run");
+        assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+        let actual = String::from_utf8_lossy(&out.stdout).to_string();
+        match &expected {
+            Some(first) => assert_eq!(&actual, first, "{target} disagrees with the first leg"),
+            None => expected = Some(actual),
+        }
+    }
+    expected.expect("one leg ran")
+}
+
+#[test]
+fn both_legs_agree_on_the_captured_and_mutated_shapes() {
+    assert_eq!(run_both_legs(CAPTURED).trim(), "42.000");
+    assert_eq!(run_both_legs(MUTATED).trim(), "6 99");
+}
+
+/// The adapter composes: `enumerate` under a `map`, under a `filter`, and as
+/// the source of a `take` — every chain position where a step list is built.
+const COMPOSED: &str = r#"
+fn main() -> Unit = {
+  let xs = [10, 20, 30, 40]
+  let doubled = list.map(list.enumerate(xs), (p) => p.0 * 100 + p.1)
+  let kept = list.filter(list.enumerate(xs), (p) => p.0 % 2 == 0)
+  let head = list.take(list.enumerate(xs), 2)
+  let counted = list.count(list.enumerate(xs), (p) => p.1 > 15)
+  println("${doubled} ${kept} ${head} ${counted}")
+}
+"#;
+
+#[test]
+fn the_adapter_composes_with_every_chain_position() {
+    assert_eq!(
+        run_both_legs(COMPOSED).trim(),
+        "[10, 120, 230, 340] [(0, 10), (2, 30)] [(0, 10), (1, 20)] 3"
+    );
+}


### PR DESCRIPTION
#2098 のメカニズム 2、native レッグ。

## 測定のやり直しで分かったこと

issue の native 数値は `almide build` を `--release` 無しで取ったもの、つまりプロジェクトの**デフォルトプロファイル（opt-level 1、LTO 無し）**での測定だった。同じ木・同じ機械・同じ round-robin で両方測ると:

| spelling | default profile | `--release` |
|---|---:|---:|
| indexed fold | 1.42× | **1.01×** |
| enumerate fold（修正前） | 1.68× | 1.37× |

**indexed の残差はコンパイラが出しているものではない** — opt-level 3 で同じ emit が imperative と一致する。enumerate の差は最適化を抜けて残り、そちらが本物の指摘だった。

なお「ならデフォルトを `--release` にすべき」は**測定が支持しない**: round-robin で `--release` は opt-level 1 が既に得意な 2 つのスペリングでは**遅い**（imperative 47.95 vs 41.93 ms、enumerate 48.14 vs 41.77 ms）。opt-level 3 では 3 つとも ~48 ms に収束する。守るべき性質は「スペリング間で同じコスト」であって「どちらのプロファイルが勝つか」ではない。

## 税がどこにあったか

emit を手で書き換えて再ビルドして切り分けた（n=1200、9 サンプル、round-robin、出力一致）:

| emit | ratio |
|---|---:|
| そのまま | 1.38× |
| `.enumerate()` を融合、capture の clone は残す | 1.14× |
| 融合 + source を借用 | **1.01×** |

どちらも行ごと、つまり 1 run あたり 48,000 回:
- `almide_rt_list_enumerate` が作る `Vec<(i64, f64)>` を fold が 1 度歩いて捨てる
- それを渡すための、capture された 1,200 要素ベクタの全コピー

## 直し方

**source 位置の `list.enumerate` は source ではなく source に対する ADAPTER。** `IterStep::Enumerate` はプログラムのテキストを一切持たない（位置はイテレータが出す）ので、pure・total・順序保存であり、merge 規則の purity/abort 会計にステージを足さない。

adapted source の前にある `Clone` は**構成上死んでいる**: CloneInsertion がそれを入れたのは**消費する**ランタイム呼び出しが呼び元の値を奪えないようにするためで、その呼び出しを融合で消した時点で消費者がいない。落とせない唯一の場合は、chain が歩いている最中にその変数を**書き換える**コールバックがあるときで、そこは仮定せず検査する（マージ後の最終 chain で検査する — マージはコールバックを足すことしかできないため）。実際にはそういう変数は既に共有セルになっていてスナップショット読みなので、fixture は両レッグでその意味論を固定している。

## 結果

native enumerate **1.68× → 1.00×**。wasm レッグは無変化（`IterChain` は Rust 専用）。

`tests/enumerate_source_fusion_test.rs` が固定するもの: 借用された形、スナップショットの形、4 つの chain 位置（map / filter / take / count）、native⇄wasm 一致。**source-adapter 規則を無効化すると形のアサート 2 本が落ちることを実測済み**（kill-evidence）。

回帰確認: `almide test` 440 ファイル / 4082 テスト緑、`wasm_runtime_cross_target` 緑、`examples_parity_test` / `exercise_corpus_check_test` 緑、codopsy codegen A(91) / ir A(92)、file discipline OK。

perf コーパスは両プロファイルを記録し、それぞれがどの問いに答えるかを明記した。CI の budget は 2.5× → 2.0×。

調査記録は `docs/bugfix-research-2026-09-12.md` の `#2098` 節。

https://claude.ai/code/session_01Pi5SisFrjpvYtzoM8sZzV4