### PR TITLE
Split the allocation ledger sweep into the ledger read, the verdict and the generated row

### DIFF
--- a/crates/almide-wasm/tests/alloc_ledger.rs
+++ b/crates/almide-wasm/tests/alloc_ledger.rs
@@ -29,6 +29,63 @@ fn watermark(bytes: &[u8]) -> u64 {
     r.heap_end.expect("__heap export present")
 }
 
+/// The pinned side of the ledger: `rel -> Some(watermark)` for a pinned row,
+/// `rel -> None` for a calibrated-out one, plus the set of `!` rows the
+/// structural leg is expected to keep refusing.
+type Ledger = (std::collections::BTreeMap<String, Option<u64>>, std::collections::BTreeSet<String>);
+
+fn read_ledger(path: &std::path::Path) -> Ledger {
+    let mut pinned = std::collections::BTreeMap::new();
+    let mut refused = std::collections::BTreeSet::new();
+    let text = std::fs::read_to_string(path)
+        .expect("golden/alloc-baseline.txt — generate with ALMIDE_UPDATE_ALLOC=1");
+    for l in text.lines() {
+        let (v, rel) = l.split_once('\t').expect("baseline row");
+        if v == "!" {
+            refused.insert(rel.to_string());
+        } else {
+            pinned.insert(rel.to_string(), if v == "~" { None } else { Some(v.parse().expect("watermark")) });
+        }
+    }
+    (pinned, refused)
+}
+
+/// Host-boundary fixtures allocate HOST-SHAPED strings (cwd and temp-dir
+/// lengths, directory listings) — their watermarks vary per machine, which
+/// same-machine double-run calibration cannot see (11 fs_/env_ rows drifted on
+/// the ubuntu runner). Excluded by principle, not by list.
+fn is_host_variant(text: &str) -> bool {
+    text.lines().any(|l| matches!(l.trim(), "import fs" | "import env" | "import process"))
+}
+
+/// One fixture's verdict against the ledger, as the offence it raises (if any).
+/// `want` is the row the ledger holds for it — `None` means the row is missing.
+fn verdict(rel: &str, want: Option<Option<u64>>, got: Option<u64>) -> Option<String> {
+    match (want, got) {
+        (Some(Some(want)), Some(w)) if want == w => None,
+        (Some(Some(want)), Some(w)) => Some(format!("{rel}: watermark {w} != pinned {want}")),
+        // A calibrated-out row accepts any watermark, and a host-variant
+        // fixture (got = None) accepts only a calibrated-out row.
+        (Some(None), _) => None,
+        (Some(Some(_)), None) => {
+            Some(format!("{rel}: host-variant fixture carries a pinned watermark — regenerate"))
+        }
+        (None, _) => Some(format!("{rel}: not in the ledger — regenerate to ratify")),
+    }
+}
+
+/// The generation side: the row this fixture's measurement writes. A second
+/// watermark separates deterministic totals from entropy-fed ones.
+fn generated_row(rel: &str, bytes: Option<&[u8]>) -> String {
+    match bytes {
+        None => format!("~\t{rel}\n"),
+        Some(bytes) => {
+            let (w, w2) = (watermark(bytes), watermark(bytes));
+            if w == w2 { format!("{w}\t{rel}\n") } else { format!("~\t{rel}\n") }
+        }
+    }
+}
+
 #[cfg_attr(debug_assertions, ignore = "ledger sweep is release-only (CI: release-shape job)")]
 #[test]
 fn corpus_allocation_watermarks_hold() {
@@ -40,87 +97,43 @@ fn corpus_allocation_watermarks_hold() {
 
     let update = std::env::var("ALMIDE_UPDATE_ALLOC").is_ok();
     let bp = baseline_path();
-    let mut baseline: std::collections::BTreeMap<String, Option<u64>> = std::collections::BTreeMap::new();
-    let mut refused: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-    if !update {
-        for l in std::fs::read_to_string(&bp)
-            .expect("golden/alloc-baseline.txt — generate with ALMIDE_UPDATE_ALLOC=1")
-            .lines()
-        {
-            let (v, rel) = l.split_once('\t').expect("baseline row");
-            if v == "!" {
-                refused.insert(rel.to_string());
-            } else {
-                baseline
-                    .insert(rel.to_string(), if v == "~" { None } else { Some(v.parse().expect("watermark")) });
-            }
-        }
-    }
+    let (mut baseline, mut refused) =
+        if update { Default::default() } else { read_ledger(&bp) };
 
     let mut rows = String::new();
     let mut offences = Vec::new();
     for line in manifest.lines() {
         let rel = line.splitn(3, '\t').nth(2).expect("manifest row");
         let text = std::fs::read_to_string(almide_corpus::resolve(&root, rel)).expect("fixture readable");
-        // Host-boundary fixtures allocate HOST-SHAPED strings (cwd and
-        // temp-dir lengths, directory listings) — their watermarks vary
-        // per machine, which same-machine double-run calibration cannot
-        // see (11 fs_/env_ rows drifted on the ubuntu runner). Excluded
-        // by principle, not by list.
-        let host_variant = text
-            .lines()
-            .any(|l| matches!(l.trim(), "import fs" | "import env" | "import process"));
-        if host_variant {
-            if update {
-                rows.push_str(&format!("~\t{rel}\n"));
-            } else {
-                match baseline.remove(rel) {
-                    Some(None) => {}
-                    Some(Some(_)) => offences.push(format!(
-                        "{rel}: host-variant fixture carries a pinned watermark — regenerate"
-                    )),
-                    None => offences.push(format!("{rel}: not in the ledger — regenerate to ratify")),
-                }
-            }
-            continue;
-        }
-        let ir = almide_spine::s5::lower_to_ir(rel, &text).expect("front");
         // A `!` row: the structural leg REFUSES this fixture (the CLI
         // reroutes it to the incumbent — sql_highlight_tokens' unfoldable
         // mut write-back under a loop branch, #1688). The ledger asserts
         // the refusal STAYS a refusal: this shape silently emitting again
         // is exactly the regression the wall exists to prevent.
-        let bytes = match almide_wasm::emit_program(&ir) {
-            Ok(b) => b,
-            Err(_) => {
-                if update {
-                    rows.push_str(&format!("!\t{rel}\n"));
-                } else if !refused.remove(rel) {
-                    offences.push(format!(
-                        "{rel}: structural leg refuses it but the ledger has no `!` row — regenerate"
-                    ));
+        let emitted = if is_host_variant(&text) {
+            None
+        } else {
+            let ir = almide_spine::s5::lower_to_ir(rel, &text).expect("front");
+            match almide_wasm::emit_program(&ir) {
+                Ok(b) => Some(b),
+                Err(_) => {
+                    if update {
+                        rows.push_str(&format!("!\t{rel}\n"));
+                    } else if !refused.remove(rel) {
+                        offences.push(format!(
+                            "{rel}: structural leg refuses it but the ledger has no `!` row — regenerate"
+                        ));
+                    }
+                    continue;
                 }
-                continue;
             }
         };
-        let w = watermark(&bytes);
         if update {
-            // Self-calibration: a second run separates deterministic
-            // watermarks from entropy-fed ones.
-            let w2 = watermark(&bytes);
-            if w == w2 {
-                rows.push_str(&format!("{w}\t{rel}\n"));
-            } else {
-                rows.push_str(&format!("~\t{rel}\n"));
-            }
+            rows.push_str(&generated_row(rel, emitted.as_deref()));
             continue;
         }
-        match baseline.remove(rel) {
-            Some(Some(want)) if want == w => {}
-            Some(Some(want)) => offences.push(format!("{rel}: watermark {w} != pinned {want}")),
-            Some(None) => {} // calibrated-out (nondeterministic) row
-            None => offences.push(format!("{rel}: not in the ledger — regenerate to ratify")),
-        }
+        let got = emitted.as_deref().map(watermark);
+        offences.extend(verdict(rel, baseline.remove(rel), got));
     }
     if update {
         std::fs::write(&bp, &rows).expect("write baseline");


### PR DESCRIPTION
codopsy の計測では `crates/almide-wasm` は **A (90/100) ちょうど**、つまり A の下限に張り付いている。この木で **cyclomatic と cognitive の両方**を超えている関数は 1 つだけで、それがこの `corpus_allocation_watermarks_hold`（24/20 と 40/30）。両方超過はこのリポジトリが「直す」と決めている唯一のクラス（cyclomatic のみのフラットな dispatch 表は触らない）なので、そこを落とす。

1 つの関数が 4 つのことをしていた: 台帳の読み込み、fixture ごとの分類、判定、再生成行の組み立て。それぞれに名前を付けた:

- `read_ledger` — pinned 行 / `~` 行 / `!` 行のパース
- `is_host_variant` — ホスト形状の文字列を確保する fixture（機械ごとに watermark が変わる）の判定
- `verdict` — 台帳が持つ行と実測の組み合わせ 1 つにつき 1 アーム。host-variant が pinned 行を持つ場合も同じ表の中のセルになる
- `generated_row` — 二度計測してエントロピー由来を `~` に落とす生成側

**振る舞いは同一**。検証パスはグリーンのまま（20s、corpus 全量）、さらに `ALMIDE_UPDATE_ALLOC=1` で再生成した台帳が既存ファイルと **byte-identical** であることを確認済み（生成側の等価性は台帳全体が乗っている性質なので、検証パスの緑だけでは足りない）。

計測: 総 issue 70 → 68、両閾値超過 1 → 0。スコアはバケットなので A(90) のまま。

https://claude.ai/code/session_01Pi5SisFrjpvYtzoM8sZzV4